### PR TITLE
feat(logs): add compare_to_previous to GET /api/logs/stats

### DIFF
--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -204,9 +204,7 @@
         "operationId": "listModels",
         "summary": "List available models",
         "description": "Lists available models. If provider is not specified, lists all models from all configured providers.\n\nIf a virtual key is provided, Bifrost only lists (and only queries) providers allowed by that virtual key.\n",
-        "tags": [
-          "Models"
-        ],
+        "tags": ["Models"],
         "parameters": [
           {
             "name": "provider",
@@ -287,9 +285,7 @@
         "operationId": "createChatCompletion",
         "summary": "Create a chat completion",
         "description": "Creates a completion for the provided messages. Supports streaming via SSE.\n",
-        "tags": [
-          "Chat Completions"
-        ],
+        "tags": ["Chat Completions"],
         "requestBody": {
           "required": true,
           "content": {
@@ -498,9 +494,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -593,9 +587,7 @@
         "operationId": "createTextCompletion",
         "summary": "Create a text completion",
         "description": "Creates a completion for the provided prompt. Supports streaming via SSE.\n",
-        "tags": [
-          "Text Completions"
-        ],
+        "tags": ["Text Completions"],
         "requestBody": {
           "required": true,
           "content": {
@@ -804,9 +796,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -896,9 +886,7 @@
         "operationId": "createResponse",
         "summary": "Create a response",
         "description": "Creates a response using the OpenAI Responses API format. Supports streaming via SSE.\n",
-        "tags": [
-          "Responses"
-        ],
+        "tags": ["Responses"],
         "requestBody": {
           "required": true,
           "content": {
@@ -1036,12 +1024,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -1052,9 +1035,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -1097,17 +1078,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -1228,9 +1203,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -1273,17 +1246,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -1389,9 +1356,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -1425,16 +1390,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -1455,9 +1415,7 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -1500,17 +1458,11 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": [
-                            "format",
-                            "data"
-                          ],
+                          "required": ["format", "data"],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": [
-                                "mp3",
-                                "wav"
-                              ]
+                              "enum": ["mp3", "wav"]
                             },
                             "data": {
                               "type": "string"
@@ -1771,9 +1723,7 @@
         "operationId": "createResponseWebSocket",
         "summary": "Responses API over WebSocket",
         "description": "Upgrades the connection to a WebSocket and runs the OpenAI Responses API\nin WebSocket Mode. Clients send `response.create` events on the socket and\nreceive streamed events through the standard inference pipeline (PreLLMHook,\nkey selection, provider call, PostLLMHook).\n\nAuth is identical to the HTTP POST variant — Bearer/Basic/Virtual Key/API Key\nmay be supplied as request headers on the upgrade request. The OpenAI SDK can\nalso pass an API key via the `openai-insecure-api-key.<key>` WebSocket\nsubprotocol.\n\nThis GET endpoint shares its path with the POST inference endpoint; route\nselection is based on the `Upgrade: websocket` request header.\n",
-        "tags": [
-          "Responses"
-        ],
+        "tags": ["Responses"],
         "parameters": [
           {
             "name": "Upgrade",
@@ -1782,9 +1732,7 @@
             "description": "Must be `websocket`",
             "schema": {
               "type": "string",
-              "enum": [
-                "websocket"
-              ]
+              "enum": ["websocket"]
             }
           },
           {
@@ -1829,9 +1777,7 @@
         "operationId": "performOCR",
         "summary": "Perform OCR",
         "description": "Extracts text and content from documents or images using optical character recognition.\nSupports PDF URLs, base64-encoded documents, and image URLs.\n",
-        "tags": [
-          "OCR"
-        ],
+        "tags": ["OCR"],
         "requestBody": {
           "required": true,
           "content": {
@@ -1895,9 +1841,7 @@
         "operationId": "rerankDocuments",
         "summary": "Rerank documents",
         "description": "Reorders input documents by relevance to a query.\n",
-        "tags": [
-          "Rerank"
-        ],
+        "tags": ["Rerank"],
         "requestBody": {
           "required": true,
           "content": {
@@ -1961,9 +1905,7 @@
         "operationId": "createEmbedding",
         "summary": "Create embeddings",
         "description": "Creates an embedding vector representing the input text.\n",
-        "tags": [
-          "Embeddings"
-        ],
+        "tags": ["Embeddings"],
         "requestBody": {
           "required": true,
           "content": {
@@ -2027,9 +1969,7 @@
         "operationId": "createSpeech",
         "summary": "Create speech",
         "description": "Generates audio from the input text. Returns audio data or streams via SSE.\n",
-        "tags": [
-          "Audio"
-        ],
+        "tags": ["Audio"],
         "requestBody": {
           "required": true,
           "content": {
@@ -2061,10 +2001,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "speech.audio.delta",
-                        "speech.audio.done"
-                      ]
+                      "enum": ["speech.audio.delta", "speech.audio.done"]
                     },
                     "audio": {
                       "type": "string",
@@ -2134,9 +2071,7 @@
         "operationId": "createTranscription",
         "summary": "Create transcription",
         "description": "Transcribes audio into text in the input language.\n",
-        "tags": [
-          "Audio"
-        ],
+        "tags": ["Audio"],
         "requestBody": {
           "required": true,
           "content": {
@@ -2162,10 +2097,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "transcript.text.delta",
-                        "transcript.text.done"
-                      ]
+                      "enum": ["transcript.text.delta", "transcript.text.done"]
                     },
                     "delta": {
                       "type": "string"
@@ -2198,10 +2130,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "tokens",
-                            "duration"
-                          ]
+                          "enum": ["tokens", "duration"]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -2278,9 +2207,7 @@
         "operationId": "imageGeneration",
         "summary": "Generate an image",
         "description": "Generates images from text prompts using the specified model.\n",
-        "tags": [
-          "Images"
-        ],
+        "tags": ["Images"],
         "requestBody": {
           "required": true,
           "content": {
@@ -2289,10 +2216,7 @@
                 "allOf": [
                   {
                     "type": "object",
-                    "required": [
-                      "model",
-                      "prompt"
-                    ],
+                    "required": ["model", "prompt"],
                     "properties": {
                       "model": {
                         "type": "string",
@@ -2324,31 +2248,17 @@
                       },
                       "quality": {
                         "type": "string",
-                        "enum": [
-                          "auto",
-                          "high",
-                          "medium",
-                          "low",
-                          "hd",
-                          "standard"
-                        ],
+                        "enum": ["auto", "high", "medium", "low", "hd", "standard"],
                         "description": "Quality of the generated image"
                       },
                       "style": {
                         "type": "string",
-                        "enum": [
-                          "natural",
-                          "vivid"
-                        ],
+                        "enum": ["natural", "vivid"],
                         "description": "Style of the generated image"
                       },
                       "response_format": {
                         "type": "string",
-                        "enum": [
-                          "url",
-                          "b64_json",
-                          "data_uri"
-                        ],
+                        "enum": ["url", "b64_json", "data_uri"],
                         "default": "url",
                         "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                       },
@@ -2369,19 +2279,12 @@
                       },
                       "background": {
                         "type": "string",
-                        "enum": [
-                          "transparent",
-                          "opaque",
-                          "auto"
-                        ],
+                        "enum": ["transparent", "opaque", "auto"],
                         "description": "Background type for the image"
                       },
                       "moderation": {
                         "type": "string",
-                        "enum": [
-                          "low",
-                          "auto"
-                        ],
+                        "enum": ["low", "auto"],
                         "description": "Content moderation level"
                       },
                       "partial_images": {
@@ -2398,13 +2301,7 @@
                       },
                       "output_format": {
                         "type": "string",
-                        "enum": [
-                          "png",
-                          "webp",
-                          "jpeg",
-                          "tiff",
-                          "svg"
-                        ],
+                        "enum": ["png", "webp", "jpeg", "tiff", "svg"],
                         "description": "Output image format. `svg` applies to vectorize operations"
                       },
                       "user": {
@@ -2521,11 +2418,7 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": [
-                        "png",
-                        "webp",
-                        "jpeg"
-                      ],
+                      "enum": ["png", "webp", "jpeg"],
                       "description": "Output image format"
                     },
                     "quality": {
@@ -2659,11 +2552,7 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": [
-                        "png",
-                        "webp",
-                        "jpeg"
-                      ],
+                      "enum": ["png", "webp", "jpeg"],
                       "description": "Output format used"
                     },
                     "revised_prompt": {
@@ -2768,9 +2657,7 @@
         "operationId": "imageEdit",
         "summary": "Edit an image",
         "description": "Edits an image using a text prompt and optional mask. Accepts either `application/json` (sources\nas URLs or base64 under `images`) or `multipart/form-data` (to upload the image as `image` or\n`image[]`). Requires at least `model`, one image, and `prompt` - the latter except for the\noperation types driven purely by the input image, e.g. `background_removal`. Only the JSON body\npreserves the types of provider-native extra params; multipart carries every value as a string.\n",
-        "tags": [
-          "Images"
-        ],
+        "tags": ["Images"],
         "requestBody": {
           "required": true,
           "content": {
@@ -2778,10 +2665,7 @@
               "schema": {
                 "type": "object",
                 "description": "JSON encoding of an image edit. Sources are supplied as an `images` array, the same nested form\n/v1/videos/edits uses for its source video. Unrecognised top-level fields are forwarded to the\nprovider as extra params with their JSON types intact, which is what a model's nested tuning\nobject needs (e.g. Runware's `settings` and `providerSettings`). To upload the image as a file,\npost `multipart/form-data` instead - see `ImageEditMultipartRequest`.\n",
-                "required": [
-                  "model",
-                  "images"
-                ],
+                "required": ["model", "images"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -2868,23 +2752,12 @@
                   },
                   "size": {
                     "type": "string",
-                    "enum": [
-                      "256x256",
-                      "512x512",
-                      "1024x1024",
-                      "1536x1024",
-                      "1024x1536",
-                      "auto"
-                    ],
+                    "enum": ["256x256", "512x512", "1024x1024", "1536x1024", "1024x1536", "auto"],
                     "description": "Size of the output image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": [
-                      "url",
-                      "b64_json",
-                      "data_uri"
-                    ],
+                    "enum": ["url", "b64_json", "data_uri"],
                     "default": "url",
                     "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                   },
@@ -2895,19 +2768,12 @@
                   },
                   "background": {
                     "type": "string",
-                    "enum": [
-                      "transparent",
-                      "opaque",
-                      "auto"
-                    ],
+                    "enum": ["transparent", "opaque", "auto"],
                     "description": "Background type for the image"
                   },
                   "input_fidelity": {
                     "type": "string",
-                    "enum": [
-                      "low",
-                      "high"
-                    ],
+                    "enum": ["low", "high"],
                     "description": "How closely to follow the original image"
                   },
                   "partial_images": {
@@ -2918,24 +2784,12 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": [
-                      "auto",
-                      "high",
-                      "medium",
-                      "low",
-                      "standard"
-                    ],
+                    "enum": ["auto", "high", "medium", "low", "standard"],
                     "description": "Quality of the output image"
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": [
-                      "png",
-                      "webp",
-                      "jpeg",
-                      "tiff",
-                      "svg"
-                    ],
+                    "enum": ["png", "webp", "jpeg", "tiff", "svg"],
                     "description": "Output image format. `svg` applies to vectorize operations"
                   },
                   "num_inference_steps": {
@@ -2974,9 +2828,7 @@
               "schema": {
                 "type": "object",
                 "description": "Multipart encoding of an image edit, and the only encoding that can upload the image as a file.\nThis is what the official OpenAI SDKs send unconditionally. Every value crosses the wire as a\nstring, so provider-native extra params arrive as strings; post `application/json` instead when\na provider expects them as numbers, booleans or nested objects - see `ImageEditRequest`.\n",
-                "required": [
-                  "model"
-                ],
+                "required": ["model"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -3044,23 +2896,12 @@
                   },
                   "size": {
                     "type": "string",
-                    "enum": [
-                      "256x256",
-                      "512x512",
-                      "1024x1024",
-                      "1536x1024",
-                      "1024x1536",
-                      "auto"
-                    ],
+                    "enum": ["256x256", "512x512", "1024x1024", "1536x1024", "1024x1536", "auto"],
                     "description": "Size of the output image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": [
-                      "url",
-                      "b64_json",
-                      "data_uri"
-                    ],
+                    "enum": ["url", "b64_json", "data_uri"],
                     "default": "url",
                     "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                   },
@@ -3071,19 +2912,12 @@
                   },
                   "background": {
                     "type": "string",
-                    "enum": [
-                      "transparent",
-                      "opaque",
-                      "auto"
-                    ],
+                    "enum": ["transparent", "opaque", "auto"],
                     "description": "Background type for the image"
                   },
                   "input_fidelity": {
                     "type": "string",
-                    "enum": [
-                      "low",
-                      "high"
-                    ],
+                    "enum": ["low", "high"],
                     "description": "How closely to follow the original image"
                   },
                   "partial_images": {
@@ -3094,24 +2928,12 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": [
-                      "auto",
-                      "high",
-                      "medium",
-                      "low",
-                      "standard"
-                    ],
+                    "enum": ["auto", "high", "medium", "low", "standard"],
                     "description": "Quality of the output image"
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": [
-                      "png",
-                      "webp",
-                      "jpeg",
-                      "tiff",
-                      "svg"
-                    ],
+                    "enum": ["png", "webp", "jpeg", "tiff", "svg"],
                     "description": "Output image format. `svg` applies to vectorize operations"
                   },
                   "num_inference_steps": {
@@ -3227,11 +3049,7 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": [
-                        "png",
-                        "webp",
-                        "jpeg"
-                      ],
+                      "enum": ["png", "webp", "jpeg"],
                       "description": "Output image format"
                     },
                     "quality": {
@@ -3312,11 +3130,7 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "image_edit.partial_image",
-                        "image_edit.completed",
-                        "error"
-                      ],
+                      "enum": ["image_edit.partial_image", "image_edit.completed", "error"],
                       "description": "Type of stream event"
                     },
                     "partial_image_index": {
@@ -3355,11 +3169,7 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": [
-                        "png",
-                        "webp",
-                        "jpeg"
-                      ],
+                      "enum": ["png", "webp", "jpeg"],
                       "description": "Output format used"
                     },
                     "revised_prompt": {
@@ -3464,19 +3274,14 @@
         "operationId": "imageVariation",
         "summary": "Create Variation",
         "description": "Creates variations of an image. Request must be sent as multipart/form-data with `model` and `image` (or `image[]`).\nDoes not support streaming.\n",
-        "tags": [
-          "Images"
-        ],
+        "tags": ["Images"],
         "requestBody": {
           "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model",
-                  "image"
-                ],
+                "required": ["model", "image"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -3509,10 +3314,7 @@
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": [
-                      "url",
-                      "b64_json"
-                    ],
+                    "enum": ["url", "b64_json"],
                     "default": "url",
                     "description": "Format of the response"
                   },
@@ -3611,11 +3413,7 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": [
-                        "png",
-                        "webp",
-                        "jpeg"
-                      ],
+                      "enum": ["png", "webp", "jpeg"],
                       "description": "Output image format"
                     },
                     "quality": {
@@ -3729,18 +3527,14 @@
         "operationId": "videoGeneration",
         "summary": "Generate a video",
         "description": "Creates a video generation job from a text prompt. This is an asynchronous operation\nthat returns immediately with a job ID. Use the retrieve endpoint to check the status\nand get the video URL when generation is complete.\n",
-        "tags": [
-          "Videos"
-        ],
+        "tags": ["Videos"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model"
-                ],
+                "required": ["model"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -3763,11 +3557,7 @@
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": [
-                      "mp4",
-                      "webm",
-                      "mov"
-                    ],
+                    "enum": ["mp4", "webm", "mov"],
                     "description": "Output container format"
                   },
                   "input_reference": {
@@ -3824,9 +3614,7 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": [
-                        "video"
-                      ],
+                      "enum": ["video"],
                       "description": "Object type, always \"video\""
                     },
                     "model": {
@@ -3835,12 +3623,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "queued",
-                        "in_progress",
-                        "completed",
-                        "failed"
-                      ],
+                      "enum": ["queued", "in_progress", "completed", "failed"],
                       "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                     },
                     "progress": {
@@ -3889,10 +3672,7 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "url",
-                              "base64"
-                            ],
+                            "enum": ["url", "base64"],
                             "description": "Output format of this video"
                           },
                           "url": {
@@ -3989,9 +3769,7 @@
         "operationId": "videoList",
         "summary": "List video generation jobs",
         "description": "Lists video generation jobs for a specific provider. Results are paginated\nand can be filtered using query parameters.\n",
-        "tags": [
-          "Videos"
-        ],
+        "tags": ["Videos"],
         "parameters": [
           {
             "name": "provider",
@@ -4029,10 +3807,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "desc"
             },
             "description": "Sort order by creation time"
@@ -4048,9 +3823,7 @@
                   "properties": {
                     "object": {
                       "type": "string",
-                      "enum": [
-                        "list"
-                      ],
+                      "enum": ["list"],
                       "description": "Object type, always \"list\""
                     },
                     "data": {
@@ -4064,9 +3837,7 @@
                           },
                           "object": {
                             "type": "string",
-                            "enum": [
-                              "video"
-                            ],
+                            "enum": ["video"],
                             "description": "Object type, always \"video\""
                           },
                           "model": {
@@ -4075,12 +3846,7 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "queued",
-                              "in_progress",
-                              "completed",
-                              "failed"
-                            ],
+                            "enum": ["queued", "in_progress", "completed", "failed"],
                             "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                           },
                           "progress": {
@@ -4200,9 +3966,7 @@
         "operationId": "videoRetrieve",
         "summary": "Retrieve a video generation job",
         "description": "Retrieves the status and metadata for a video generation job.\nUse this endpoint to poll for completion status after creating a video generation job.\nWhen the status is \"completed\", the response will include a URL to download the video.\n",
-        "tags": [
-          "Videos"
-        ],
+        "tags": ["Videos"],
         "parameters": [
           {
             "name": "video_id",
@@ -4228,9 +3992,7 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": [
-                        "video"
-                      ],
+                      "enum": ["video"],
                       "description": "Object type, always \"video\""
                     },
                     "model": {
@@ -4239,12 +4001,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "queued",
-                        "in_progress",
-                        "completed",
-                        "failed"
-                      ],
+                      "enum": ["queued", "in_progress", "completed", "failed"],
                       "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                     },
                     "progress": {
@@ -4293,10 +4050,7 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "url",
-                              "base64"
-                            ],
+                            "enum": ["url", "base64"],
                             "description": "Output format of this video"
                           },
                           "url": {
@@ -4403,9 +4157,7 @@
         "operationId": "videoDelete",
         "summary": "Delete a video generation job",
         "description": "Deletes a video generation job and its associated assets.\nThis operation cannot be undone.\n",
-        "tags": [
-          "Videos"
-        ],
+        "tags": ["Videos"],
         "parameters": [
           {
             "name": "video_id",
@@ -4431,9 +4183,7 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": [
-                        "video.deleted"
-                      ],
+                      "enum": ["video.deleted"],
                       "description": "Object type, always \"video.deleted\""
                     },
                     "deleted": {
@@ -4500,9 +4250,7 @@
         "operationId": "videoDownload",
         "summary": "Download video content",
         "description": "Downloads the binary content of a generated video.\nThe video must have a status of \"completed\" to be downloadable.\nReturns the raw video file (typically MP4 format).\n",
-        "tags": [
-          "Videos"
-        ],
+        "tags": ["Videos"],
         "parameters": [
           {
             "name": "video_id",
@@ -4519,11 +4267,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [
-                "video",
-                "thumbnail",
-                "spritesheet"
-              ]
+              "enum": ["video", "thumbnail", "spritesheet"]
             },
             "description": "Variant of the video content to download (provider-specific)"
           }
@@ -4598,9 +4342,7 @@
         "operationId": "videoRemix",
         "summary": "Remix a video",
         "description": "Creates a new video generation job by remixing an existing video with a new prompt.\nThe source video must have a status of \"completed\" to be remixed.\nReturns a new video generation job that can be polled for completion.\n",
-        "tags": [
-          "Videos"
-        ],
+        "tags": ["Videos"],
         "parameters": [
           {
             "name": "video_id",
@@ -4618,9 +4360,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "prompt"
-                ],
+                "required": ["prompt"],
                 "properties": {
                   "prompt": {
                     "type": "string",
@@ -4645,9 +4385,7 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": [
-                        "video"
-                      ],
+                      "enum": ["video"],
                       "description": "Object type, always \"video\""
                     },
                     "model": {
@@ -4656,12 +4394,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "queued",
-                        "in_progress",
-                        "completed",
-                        "failed"
-                      ],
+                      "enum": ["queued", "in_progress", "completed", "failed"],
                       "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                     },
                     "progress": {
@@ -4710,10 +4443,7 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "url",
-                              "base64"
-                            ],
+                            "enum": ["url", "base64"],
                             "description": "Output format of this video"
                           },
                           "url": {
@@ -4822,9 +4552,7 @@
         "operationId": "videoEdit",
         "summary": "Edit a video",
         "description": "Edits an existing video - prompt-driven editing, upscaling, or background removal, selected\nwith `type`. Accepts either `application/json` (with the source as a provider-side ID or a\nURL) or `multipart/form-data` (to upload the source as `video`). Like generation this is an\nasynchronous operation that returns a job ID; poll the retrieve endpoint for completion.\n",
-        "tags": [
-          "Videos"
-        ],
+        "tags": ["Videos"],
         "requestBody": {
           "required": true,
           "content": {
@@ -4832,10 +4560,7 @@
               "schema": {
                 "type": "object",
                 "description": "JSON encoding of a video edit. The source is supplied as a nested `video` object holding either\nan `id` or a `url`. To upload the source as a file, post `multipart/form-data` instead - see\n`VideoEditMultipartRequest`.\n",
-                "required": [
-                  "model",
-                  "video"
-                ],
+                "required": ["model", "video"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -4861,12 +4586,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "upscale",
-                      "background_removal",
-                      "remove_background",
-                      "remove_bg"
-                    ],
+                    "enum": ["upscale", "background_removal", "remove_background", "remove_bg"],
                     "description": "Operation selector. Omit for prompt-driven editing. Support varies by provider; unsupported\nvalues fall back to a standard edit.\n"
                   },
                   "seed": {
@@ -4875,11 +4595,7 @@
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": [
-                      "mp4",
-                      "webm",
-                      "mov"
-                    ],
+                    "enum": ["mp4", "webm", "mov"],
                     "description": "Output container format"
                   },
                   "upscale_factor": {
@@ -4904,9 +4620,7 @@
               "schema": {
                 "type": "object",
                 "description": "Multipart encoding of a video edit, and the only encoding that can upload a source file. This\nis what the official OpenAI SDKs send unconditionally, flattening the reference form to a\n`video[id]` field. Supply exactly one of `video`, `video[id]` or `video[url]`.\n",
-                "required": [
-                  "model"
-                ],
+                "required": ["model"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -4931,12 +4645,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "upscale",
-                      "background_removal",
-                      "remove_background",
-                      "remove_bg"
-                    ],
+                    "enum": ["upscale", "background_removal", "remove_background", "remove_bg"],
                     "description": "Operation selector. Omit for prompt-driven editing"
                   },
                   "seed": {
@@ -4945,11 +4654,7 @@
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": [
-                      "mp4",
-                      "webm",
-                      "mov"
-                    ],
+                    "enum": ["mp4", "webm", "mov"],
                     "description": "Output container format"
                   },
                   "upscale_factor": {
@@ -4979,9 +4684,7 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": [
-                        "video"
-                      ],
+                      "enum": ["video"],
                       "description": "Object type, always \"video\""
                     },
                     "model": {
@@ -4990,12 +4693,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "queued",
-                        "in_progress",
-                        "completed",
-                        "failed"
-                      ],
+                      "enum": ["queued", "in_progress", "completed", "failed"],
                       "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                     },
                     "progress": {
@@ -5044,10 +4742,7 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "url",
-                              "base64"
-                            ],
+                            "enum": ["url", "base64"],
                             "description": "Output format of this video"
                           },
                           "url": {
@@ -5146,9 +4841,7 @@
         "operationId": "countTokens",
         "summary": "Count tokens",
         "description": "Counts the number of tokens in the provided messages.\n",
-        "tags": [
-          "Count Tokens"
-        ],
+        "tags": ["Count Tokens"],
         "requestBody": {
           "required": true,
           "content": {
@@ -5212,18 +4905,14 @@
         "operationId": "createCompaction",
         "summary": "Compact context",
         "description": "Compresses a conversation into an opaque encrypted compaction item using the\nOpenAI-compatible context compaction API.\n\nThe response `output` array contains the original user messages plus a final item\nwith `type: \"response.compaction\"` and an `encrypted_content` field. Pass the\nfull `output` array as `input` to future Responses API requests to continue the\nconversation without retransmitting the full history.\n\n**Supported providers:** OpenAI, Azure OpenAI, xAI. Requests to unsupported\nproviders return a 400 error.\n",
-        "tags": [
-          "Compaction"
-        ],
+        "tags": ["Compaction"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model"
-                ],
+                "required": ["model"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -5280,12 +4969,7 @@
                             },
                             "role": {
                               "type": "string",
-                              "enum": [
-                                "assistant",
-                                "user",
-                                "system",
-                                "developer"
-                              ]
+                              "enum": ["assistant", "user", "system", "developer"]
                             },
                             "content": {
                               "oneOf": [
@@ -5296,9 +4980,7 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "properties": {
                                       "type": {
                                         "type": "string",
@@ -5341,17 +5023,11 @@
                                       },
                                       "input_audio": {
                                         "type": "object",
-                                        "required": [
-                                          "format",
-                                          "data"
-                                        ],
+                                        "required": ["format", "data"],
                                         "properties": {
                                           "format": {
                                             "type": "string",
-                                            "enum": [
-                                              "mp3",
-                                              "wav"
-                                            ]
+                                            "enum": ["mp3", "wav"]
                                           },
                                           "data": {
                                             "type": "string"
@@ -5472,9 +5148,7 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "properties": {
                                       "type": {
                                         "type": "string",
@@ -5517,17 +5191,11 @@
                                       },
                                       "input_audio": {
                                         "type": "object",
-                                        "required": [
-                                          "format",
-                                          "data"
-                                        ],
+                                        "required": ["format", "data"],
                                         "properties": {
                                           "format": {
                                             "type": "string",
-                                            "enum": [
-                                              "mp3",
-                                              "wav"
-                                            ]
+                                            "enum": ["mp3", "wav"]
                                           },
                                           "data": {
                                             "type": "string"
@@ -5633,9 +5301,7 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "computer_screenshot"
-                                      ]
+                                      "enum": ["computer_screenshot"]
                                     },
                                     "file_id": {
                                       "type": "string"
@@ -5669,16 +5335,11 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type",
-                                  "text"
-                                ],
+                                "required": ["type", "text"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "summary_text"
-                                    ]
+                                    "enum": ["summary_text"]
                                   },
                                   "text": {
                                     "type": "string"
@@ -5792,12 +5453,7 @@
                           },
                           "role": {
                             "type": "string",
-                            "enum": [
-                              "assistant",
-                              "user",
-                              "system",
-                              "developer"
-                            ]
+                            "enum": ["assistant", "user", "system", "developer"]
                           },
                           "content": {
                             "oneOf": [
@@ -5808,9 +5464,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "properties": {
                                     "type": {
                                       "type": "string",
@@ -5853,17 +5507,11 @@
                                     },
                                     "input_audio": {
                                       "type": "object",
-                                      "required": [
-                                        "format",
-                                        "data"
-                                      ],
+                                      "required": ["format", "data"],
                                       "properties": {
                                         "format": {
                                           "type": "string",
-                                          "enum": [
-                                            "mp3",
-                                            "wav"
-                                          ]
+                                          "enum": ["mp3", "wav"]
                                         },
                                         "data": {
                                           "type": "string"
@@ -5984,9 +5632,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "properties": {
                                     "type": {
                                       "type": "string",
@@ -6029,17 +5675,11 @@
                                     },
                                     "input_audio": {
                                       "type": "object",
-                                      "required": [
-                                        "format",
-                                        "data"
-                                      ],
+                                      "required": ["format", "data"],
                                       "properties": {
                                         "format": {
                                           "type": "string",
-                                          "enum": [
-                                            "mp3",
-                                            "wav"
-                                          ]
+                                          "enum": ["mp3", "wav"]
                                         },
                                         "data": {
                                           "type": "string"
@@ -6145,9 +5785,7 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "computer_screenshot"
-                                    ]
+                                    "enum": ["computer_screenshot"]
                                   },
                                   "file_id": {
                                     "type": "string"
@@ -6181,16 +5819,11 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "type",
-                                "text"
-                              ],
+                              "required": ["type", "text"],
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "summary_text"
-                                  ]
+                                  "enum": ["summary_text"]
                                 },
                                 "text": {
                                   "type": "string"
@@ -6320,9 +5953,7 @@
         "operationId": "retrieveResponse",
         "summary": "Retrieve a response",
         "description": "Retrieves a stored response by ID.\n",
-        "tags": [
-          "Responses"
-        ],
+        "tags": ["Responses"],
         "parameters": [
           {
             "name": "response_id",
@@ -6504,12 +6135,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -6520,9 +6146,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -6565,17 +6189,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -6696,9 +6314,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -6741,17 +6357,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -6857,9 +6467,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -6893,16 +6501,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -6923,9 +6526,7 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -6968,17 +6569,11 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": [
-                            "format",
-                            "data"
-                          ],
+                          "required": ["format", "data"],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": [
-                                "mp3",
-                                "wav"
-                              ]
+                              "enum": ["mp3", "wav"]
                             },
                             "data": {
                               "type": "string"
@@ -7249,9 +6844,7 @@
         "operationId": "deleteResponse",
         "summary": "Delete a response",
         "description": "Deletes a stored response.\n",
-        "tags": [
-          "Responses"
-        ],
+        "tags": ["Responses"],
         "parameters": [
           {
             "name": "response_id",
@@ -7334,9 +6927,7 @@
         "operationId": "cancelResponse",
         "summary": "Cancel a response",
         "description": "Cancels an in-flight response. Only responses created with `background: true`\ncan be cancelled.\n",
-        "tags": [
-          "Responses"
-        ],
+        "tags": ["Responses"],
         "parameters": [
           {
             "name": "response_id",
@@ -7419,9 +7010,7 @@
         "operationId": "listResponseInputItems",
         "summary": "List response input items",
         "description": "Lists the input items of a stored response.\n",
-        "tags": [
-          "Responses"
-        ],
+        "tags": ["Responses"],
         "parameters": [
           {
             "name": "response_id",
@@ -7474,10 +7063,7 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             }
           }
         ],
@@ -7544,9 +7130,7 @@
         "operationId": "createBatch",
         "summary": "Create a batch job",
         "description": "Creates a batch job for asynchronous processing.\n",
-        "tags": [
-          "Batch"
-        ],
+        "tags": ["Batch"],
         "requestBody": {
           "required": true,
           "content": {
@@ -7608,9 +7192,7 @@
         "operationId": "listBatches",
         "summary": "List batch jobs",
         "description": "Lists batch jobs for a provider.\n",
-        "tags": [
-          "Batch"
-        ],
+        "tags": ["Batch"],
         "parameters": [
           {
             "name": "provider",
@@ -7700,9 +7282,7 @@
         "operationId": "retrieveBatch",
         "summary": "Retrieve a batch job",
         "description": "Retrieves a specific batch job by ID.\n",
-        "tags": [
-          "Batch"
-        ],
+        "tags": ["Batch"],
         "parameters": [
           {
             "name": "batch_id",
@@ -7776,9 +7356,7 @@
         "operationId": "cancelBatch",
         "summary": "Cancel a batch job",
         "description": "Cancels a batch job.\n",
-        "tags": [
-          "Batch"
-        ],
+        "tags": ["Batch"],
         "parameters": [
           {
             "name": "batch_id",
@@ -7911,9 +7489,7 @@
         "operationId": "getBatchResults",
         "summary": "Get batch results",
         "description": "Retrieves results from a completed batch job.\n",
-        "tags": [
-          "Batch"
-        ],
+        "tags": ["Batch"],
         "parameters": [
           {
             "name": "batch_id",
@@ -8048,9 +7624,7 @@
         "operationId": "uploadFile",
         "summary": "Upload a file",
         "description": "Uploads a file to be used with batch operations or other features.\n",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "parameters": [
           {
             "name": "provider",
@@ -8122,9 +7696,7 @@
         "operationId": "listFiles",
         "summary": "List files",
         "description": "Lists files for a provider.\n",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -8176,10 +7748,7 @@
             "description": "Sort order (asc/desc)",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             }
           }
         ],
@@ -8236,9 +7805,7 @@
         "operationId": "retrieveFile",
         "summary": "Retrieve file metadata",
         "description": "Retrieves metadata for a specific file.\n",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "parameters": [
           {
             "name": "file_id",
@@ -8299,13 +7866,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "uploaded",
-                        "processed",
-                        "processing",
-                        "error",
-                        "deleted"
-                      ]
+                      "enum": ["uploaded", "processed", "processing", "error", "deleted"]
                     },
                     "status_details": {
                       "type": "string"
@@ -8368,9 +7929,7 @@
         "operationId": "deleteFile",
         "summary": "Delete a file",
         "description": "Deletes a file.\n",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "parameters": [
           {
             "name": "file_id",
@@ -8458,9 +8017,7 @@
         "operationId": "getFileContent",
         "summary": "Download file content",
         "description": "Downloads the content of a file.\n",
-        "tags": [
-          "Files"
-        ],
+        "tags": ["Files"],
         "parameters": [
           {
             "name": "file_id",
@@ -8535,19 +8092,14 @@
         "operationId": "createContainer",
         "summary": "Create a container",
         "description": "Creates a new container for storing files and data.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "provider",
-                  "name"
-                ],
+                "required": ["provider", "name"],
                 "properties": {
                   "provider": {
                     "$ref": "#/components/schemas/ModelProvider"
@@ -8620,9 +8172,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "running"
-                      ],
+                      "enum": ["running"],
                       "description": "The status of a container"
                     },
                     "expires_after": {
@@ -8703,9 +8253,7 @@
         "operationId": "listContainers",
         "summary": "List containers",
         "description": "Lists containers for a provider.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "parameters": [
           {
             "name": "provider",
@@ -8741,10 +8289,7 @@
             "description": "Sort order (asc/desc)",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             }
           }
         ],
@@ -8785,9 +8330,7 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "running"
-                            ],
+                            "enum": ["running"],
                             "description": "The status of a container"
                           },
                           "expires_after": {
@@ -8886,9 +8429,7 @@
         "operationId": "retrieveContainer",
         "summary": "Retrieve a container",
         "description": "Retrieves a specific container by ID.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "parameters": [
           {
             "name": "container_id",
@@ -8936,9 +8477,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "running"
-                      ],
+                      "enum": ["running"],
                       "description": "The status of a container"
                     },
                     "expires_after": {
@@ -9019,9 +8558,7 @@
         "operationId": "deleteContainer",
         "summary": "Delete a container",
         "description": "Deletes a container.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "parameters": [
           {
             "name": "container_id",
@@ -9112,9 +8649,7 @@
         "operationId": "createContainerFile",
         "summary": "Create a file in a container",
         "description": "Creates a new file in a container. You can either upload file content directly\nvia multipart/form-data or reference an existing file by its ID.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "parameters": [
           {
             "name": "container_id",
@@ -9159,9 +8694,7 @@
               "schema": {
                 "type": "object",
                 "description": "Request to create a file in a container by referencing an existing file",
-                "required": [
-                  "file_id"
-                ],
+                "required": ["file_id"],
                 "properties": {
                   "file_id": {
                     "type": "string",
@@ -9263,9 +8796,7 @@
         "operationId": "listContainerFiles",
         "summary": "List files in a container",
         "description": "Lists all files in a container.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "parameters": [
           {
             "name": "container_id",
@@ -9309,10 +8840,7 @@
             "description": "Sort order (asc/desc)",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             }
           }
         ],
@@ -9431,9 +8959,7 @@
         "operationId": "retrieveContainerFile",
         "summary": "Retrieve a file from a container",
         "description": "Retrieves metadata for a specific file in a container.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "parameters": [
           {
             "name": "container_id",
@@ -9550,9 +9076,7 @@
         "operationId": "deleteContainerFile",
         "summary": "Delete a file from a container",
         "description": "Deletes a file from a container.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "parameters": [
           {
             "name": "container_id",
@@ -9653,9 +9177,7 @@
         "operationId": "getContainerFileContent",
         "summary": "Download file content from a container",
         "description": "Downloads the content of a file from a container.\n",
-        "tags": [
-          "Containers"
-        ],
+        "tags": ["Containers"],
         "parameters": [
           {
             "name": "container_id",
@@ -9739,9 +9261,7 @@
         "operationId": "createAsyncChatCompletion",
         "summary": "Create async chat completion",
         "description": "Submits a chat completion request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9813,9 +9333,7 @@
         "operationId": "createAsyncTextCompletion",
         "summary": "Create async text completion",
         "description": "Submits a text completion request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9887,9 +9405,7 @@
         "operationId": "createAsyncResponse",
         "summary": "Create async response",
         "description": "Submits a response request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9961,9 +9477,7 @@
         "operationId": "createAsyncEmbedding",
         "summary": "Create async embedding",
         "description": "Submits an embedding request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -10035,9 +9549,7 @@
         "operationId": "createAsyncSpeech",
         "summary": "Create async speech",
         "description": "Submits a speech synthesis request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nSSE streaming is not supported for async requests.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -10109,9 +9621,7 @@
         "operationId": "createAsyncTranscription",
         "summary": "Create async transcription",
         "description": "Submits a transcription request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -10183,9 +9693,7 @@
         "operationId": "createAsyncImageGeneration",
         "summary": "Create async image generation",
         "description": "Submits an image generation request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -10202,10 +9710,7 @@
                 "allOf": [
                   {
                     "type": "object",
-                    "required": [
-                      "model",
-                      "prompt"
-                    ],
+                    "required": ["model", "prompt"],
                     "properties": {
                       "model": {
                         "type": "string",
@@ -10237,31 +9742,17 @@
                       },
                       "quality": {
                         "type": "string",
-                        "enum": [
-                          "auto",
-                          "high",
-                          "medium",
-                          "low",
-                          "hd",
-                          "standard"
-                        ],
+                        "enum": ["auto", "high", "medium", "low", "hd", "standard"],
                         "description": "Quality of the generated image"
                       },
                       "style": {
                         "type": "string",
-                        "enum": [
-                          "natural",
-                          "vivid"
-                        ],
+                        "enum": ["natural", "vivid"],
                         "description": "Style of the generated image"
                       },
                       "response_format": {
                         "type": "string",
-                        "enum": [
-                          "url",
-                          "b64_json",
-                          "data_uri"
-                        ],
+                        "enum": ["url", "b64_json", "data_uri"],
                         "default": "url",
                         "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                       },
@@ -10282,19 +9773,12 @@
                       },
                       "background": {
                         "type": "string",
-                        "enum": [
-                          "transparent",
-                          "opaque",
-                          "auto"
-                        ],
+                        "enum": ["transparent", "opaque", "auto"],
                         "description": "Background type for the image"
                       },
                       "moderation": {
                         "type": "string",
-                        "enum": [
-                          "low",
-                          "auto"
-                        ],
+                        "enum": ["low", "auto"],
                         "description": "Content moderation level"
                       },
                       "partial_images": {
@@ -10311,13 +9795,7 @@
                       },
                       "output_format": {
                         "type": "string",
-                        "enum": [
-                          "png",
-                          "webp",
-                          "jpeg",
-                          "tiff",
-                          "svg"
-                        ],
+                        "enum": ["png", "webp", "jpeg", "tiff", "svg"],
                         "description": "Output image format. `svg` applies to vectorize operations"
                       },
                       "user": {
@@ -10408,9 +9886,7 @@
         "operationId": "createAsyncImageEdit",
         "summary": "Create async image edit",
         "description": "Submits an image edit request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -10426,10 +9902,7 @@
               "schema": {
                 "type": "object",
                 "description": "JSON encoding of an image edit. Sources are supplied as an `images` array, the same nested form\n/v1/videos/edits uses for its source video. Unrecognised top-level fields are forwarded to the\nprovider as extra params with their JSON types intact, which is what a model's nested tuning\nobject needs (e.g. Runware's `settings` and `providerSettings`). To upload the image as a file,\npost `multipart/form-data` instead - see `ImageEditMultipartRequest`.\n",
-                "required": [
-                  "model",
-                  "images"
-                ],
+                "required": ["model", "images"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -10516,23 +9989,12 @@
                   },
                   "size": {
                     "type": "string",
-                    "enum": [
-                      "256x256",
-                      "512x512",
-                      "1024x1024",
-                      "1536x1024",
-                      "1024x1536",
-                      "auto"
-                    ],
+                    "enum": ["256x256", "512x512", "1024x1024", "1536x1024", "1024x1536", "auto"],
                     "description": "Size of the output image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": [
-                      "url",
-                      "b64_json",
-                      "data_uri"
-                    ],
+                    "enum": ["url", "b64_json", "data_uri"],
                     "default": "url",
                     "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                   },
@@ -10543,19 +10005,12 @@
                   },
                   "background": {
                     "type": "string",
-                    "enum": [
-                      "transparent",
-                      "opaque",
-                      "auto"
-                    ],
+                    "enum": ["transparent", "opaque", "auto"],
                     "description": "Background type for the image"
                   },
                   "input_fidelity": {
                     "type": "string",
-                    "enum": [
-                      "low",
-                      "high"
-                    ],
+                    "enum": ["low", "high"],
                     "description": "How closely to follow the original image"
                   },
                   "partial_images": {
@@ -10566,24 +10021,12 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": [
-                      "auto",
-                      "high",
-                      "medium",
-                      "low",
-                      "standard"
-                    ],
+                    "enum": ["auto", "high", "medium", "low", "standard"],
                     "description": "Quality of the output image"
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": [
-                      "png",
-                      "webp",
-                      "jpeg",
-                      "tiff",
-                      "svg"
-                    ],
+                    "enum": ["png", "webp", "jpeg", "tiff", "svg"],
                     "description": "Output image format. `svg` applies to vectorize operations"
                   },
                   "num_inference_steps": {
@@ -10622,9 +10065,7 @@
               "schema": {
                 "type": "object",
                 "description": "Multipart encoding of an image edit, and the only encoding that can upload the image as a file.\nThis is what the official OpenAI SDKs send unconditionally. Every value crosses the wire as a\nstring, so provider-native extra params arrive as strings; post `application/json` instead when\na provider expects them as numbers, booleans or nested objects - see `ImageEditRequest`.\n",
-                "required": [
-                  "model"
-                ],
+                "required": ["model"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -10692,23 +10133,12 @@
                   },
                   "size": {
                     "type": "string",
-                    "enum": [
-                      "256x256",
-                      "512x512",
-                      "1024x1024",
-                      "1536x1024",
-                      "1024x1536",
-                      "auto"
-                    ],
+                    "enum": ["256x256", "512x512", "1024x1024", "1536x1024", "1024x1536", "auto"],
                     "description": "Size of the output image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": [
-                      "url",
-                      "b64_json",
-                      "data_uri"
-                    ],
+                    "enum": ["url", "b64_json", "data_uri"],
                     "default": "url",
                     "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                   },
@@ -10719,19 +10149,12 @@
                   },
                   "background": {
                     "type": "string",
-                    "enum": [
-                      "transparent",
-                      "opaque",
-                      "auto"
-                    ],
+                    "enum": ["transparent", "opaque", "auto"],
                     "description": "Background type for the image"
                   },
                   "input_fidelity": {
                     "type": "string",
-                    "enum": [
-                      "low",
-                      "high"
-                    ],
+                    "enum": ["low", "high"],
                     "description": "How closely to follow the original image"
                   },
                   "partial_images": {
@@ -10742,24 +10165,12 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": [
-                      "auto",
-                      "high",
-                      "medium",
-                      "low",
-                      "standard"
-                    ],
+                    "enum": ["auto", "high", "medium", "low", "standard"],
                     "description": "Quality of the output image"
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": [
-                      "png",
-                      "webp",
-                      "jpeg",
-                      "tiff",
-                      "svg"
-                    ],
+                    "enum": ["png", "webp", "jpeg", "tiff", "svg"],
                     "description": "Output image format. `svg` applies to vectorize operations"
                   },
                   "num_inference_steps": {
@@ -10849,9 +10260,7 @@
         "operationId": "createAsyncImageVariation",
         "summary": "Create async image variation",
         "description": "Submits an image variation request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -10866,10 +10275,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model",
-                  "image"
-                ],
+                "required": ["model", "image"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -10902,10 +10308,7 @@
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": [
-                      "url",
-                      "b64_json"
-                    ],
+                    "enum": ["url", "b64_json"],
                     "default": "url",
                     "description": "Format of the response"
                   },
@@ -10978,9 +10381,7 @@
         "operationId": "getAsyncChatCompletionJob",
         "summary": "Get async chat completion job",
         "description": "Retrieves the status and result of an async chat completion job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11039,9 +10440,7 @@
         "operationId": "getAsyncTextCompletionJob",
         "summary": "Get async text completion job",
         "description": "Retrieves the status and result of an async text completion job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11100,9 +10499,7 @@
         "operationId": "getAsyncResponseJob",
         "summary": "Get async response job",
         "description": "Retrieves the status and result of an async response job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11161,9 +10558,7 @@
         "operationId": "getAsyncEmbeddingJob",
         "summary": "Get async embedding job",
         "description": "Retrieves the status and result of an async embedding job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11222,9 +10617,7 @@
         "operationId": "getAsyncSpeechJob",
         "summary": "Get async speech job",
         "description": "Retrieves the status and result of an async speech job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11283,9 +10676,7 @@
         "operationId": "getAsyncTranscriptionJob",
         "summary": "Get async transcription job",
         "description": "Retrieves the status and result of an async transcription job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11344,9 +10735,7 @@
         "operationId": "getAsyncImageGenerationJob",
         "summary": "Get async image generation job",
         "description": "Retrieves the status and result of an async image generation job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11405,9 +10794,7 @@
         "operationId": "getAsyncImageEditJob",
         "summary": "Get async image edit job",
         "description": "Retrieves the status and result of an async image edit job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11466,9 +10853,7 @@
         "operationId": "getAsyncImageVariationJob",
         "summary": "Get async image variation job",
         "description": "Retrieves the status and result of an async image variation job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11527,9 +10912,7 @@
         "operationId": "createAsyncRerank",
         "summary": "Create async rerank",
         "description": "Submits a rerank request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -11601,9 +10984,7 @@
         "operationId": "getAsyncRerankJob",
         "summary": "Get async rerank job",
         "description": "Retrieves the status and result of an async rerank job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11662,9 +11043,7 @@
         "operationId": "createAsyncOCR",
         "summary": "Create async OCR job",
         "description": "Submits an OCR request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -11733,9 +11112,7 @@
         "operationId": "getAsyncOCRJob",
         "summary": "Get async OCR job",
         "description": "Retrieves the status and result of an async OCR job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": [
-          "Async Jobs"
-        ],
+        "tags": ["Async Jobs"],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11794,9 +11171,7 @@
         "operationId": "connectRealtime",
         "summary": "Realtime API WebSocket",
         "description": "Opens a bidirectional WebSocket session to a realtime-capable provider\n(e.g. OpenAI Realtime, Azure Realtime preview). Bifrost proxies the upstream\nsocket and applies governance, observability, and key selection on connect.\n\nThe target model is provided via the `model` query parameter (or `deployment`\nfor Azure-style routes). The OpenAI SDK sends the API key over the\n`openai-insecure-api-key.<key>` WebSocket subprotocol; Bifrost extracts it and\ntreats it the same as a Bearer header.\n\nInference auth applies — Bearer/Basic/Virtual Key/API Key headers are all\naccepted, plus the subprotocol form above.\n",
-        "tags": [
-          "Realtime"
-        ],
+        "tags": ["Realtime"],
         "parameters": [
           {
             "name": "model",
@@ -11823,9 +11198,7 @@
             "description": "Must be `websocket`",
             "schema": {
               "type": "string",
-              "enum": [
-                "websocket"
-              ]
+              "enum": ["websocket"]
             }
           },
           {
@@ -11870,19 +11243,14 @@
         "operationId": "createRealtimeCall",
         "summary": "Realtime WebRTC SDP exchange",
         "description": "Negotiates a WebRTC peer connection with the realtime provider on behalf of\nthe client. Implements the OpenAI GA `/realtime/calls` contract: the request\nbody is `multipart/form-data` with `sdp` (client SDP offer) and `session`\n(JSON session description containing `model`).\n\nBifrost forwards the offer to the upstream provider, returns the upstream\nSDP answer to the client, and pipes RTP media between the two peers for the\nlifetime of the session.\n\nInference auth applies (Bearer/Basic/Virtual Key/API Key).\n",
-        "tags": [
-          "Realtime"
-        ],
+        "tags": ["Realtime"],
         "requestBody": {
           "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "sdp",
-                  "session"
-                ],
+                "required": ["sdp", "session"],
                 "properties": {
                   "sdp": {
                     "type": "string",
@@ -11952,9 +11320,7 @@
         "operationId": "createRealtimeClientSecret",
         "summary": "Mint a realtime ephemeral client secret",
         "description": "Calls the upstream realtime provider's `client_secrets` endpoint to mint a\nshort-lived ephemeral token (e.g. for browser-based WebRTC clients).\nBifrost selects a provider key, evaluates governance, and proxies the\nresponse. The returned token is cached and mapped to the originating\nvirtual key for downstream attribution.\n\nRequest body must be JSON. `session.model` (or top-level `model`) must use\n`provider/model` form.\n",
-        "tags": [
-          "Realtime"
-        ],
+        "tags": ["Realtime"],
         "requestBody": {
           "required": true,
           "content": {
@@ -12023,9 +11389,7 @@
         "operationId": "createRealtimeSession",
         "summary": "Mint a realtime session (legacy alias)",
         "description": "Legacy alias for the realtime client-secret minting endpoint. Behaves\nidentically to `createRealtimeClientSecret` but uses the `sessions` route\nshape; provided for compatibility with older OpenAI Realtime client\nlibraries.\n",
-        "tags": [
-          "Realtime"
-        ],
+        "tags": ["Realtime"],
         "requestBody": {
           "required": true,
           "content": {
@@ -12094,9 +11458,7 @@
         "operationId": "openaiCreateChatCompletion",
         "summary": "Create chat completion (OpenAI format)",
         "description": "Creates a chat completion using OpenAI-compatible format.\nSupports streaming via SSE.\n\n**Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response will have an empty `choices` array. When completed, `choices` will contain the full result. See [Async Inference](/features/async-inference) for details.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/chat/completions`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "x-bf-async",
@@ -12104,9 +11466,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [
-                "true"
-              ]
+              "enum": ["true"]
             },
             "description": "Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming."
           },
@@ -12338,9 +11698,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -12433,10 +11791,7 @@
         "operationId": "azureCreateChatCompletion",
         "summary": "Create chat completion (Azure OpenAI)",
         "description": "Creates a chat completion using Azure OpenAI deployment.\n",
-        "tags": [
-          "OpenAI Integration",
-          "Azure Integration"
-        ],
+        "tags": ["OpenAI Integration", "Azure Integration"],
         "parameters": [
           {
             "name": "deployment-id",
@@ -12664,9 +12019,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -12759,9 +12112,7 @@
         "operationId": "openaiCreateTextCompletion",
         "summary": "Create text completion (OpenAI format)",
         "description": "Creates a text completion using OpenAI-compatible format.\nThis is the legacy completions API.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/completions`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -12970,9 +12321,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -13061,10 +12410,7 @@
       "post": {
         "operationId": "azureCreateTextCompletion",
         "summary": "Create text completion (Azure OpenAI)",
-        "tags": [
-          "OpenAI Integration",
-          "Azure Integration"
-        ],
+        "tags": ["OpenAI Integration", "Azure Integration"],
         "parameters": [
           {
             "name": "deployment-id",
@@ -13291,9 +12637,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -13383,9 +12727,7 @@
         "operationId": "openaiCreateResponse",
         "summary": "Create response (OpenAI Responses API)",
         "description": "Creates a response using OpenAI Responses API format.\nSupports streaming via SSE.\n\n**Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response `status` will not be `completed`. When completed, the full response with `output_text` will be returned. See [Async Inference](/features/async-inference) for details.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "x-bf-async",
@@ -13393,9 +12735,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [
-                "true"
-              ]
+              "enum": ["true"]
             },
             "description": "Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming."
           },
@@ -13556,12 +12896,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -13572,9 +12907,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -13617,17 +12950,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -13748,9 +13075,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -13793,17 +13118,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -13909,9 +13228,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -13945,16 +13262,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -13975,9 +13287,7 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -14020,17 +13330,11 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": [
-                            "format",
-                            "data"
-                          ],
+                          "required": ["format", "data"],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": [
-                                "mp3",
-                                "wav"
-                              ]
+                              "enum": ["mp3", "wav"]
                             },
                             "data": {
                               "type": "string"
@@ -14291,9 +13595,7 @@
         "operationId": "openaiResponsesWebSocket",
         "summary": "WebSocket Responses (OpenAI alias)",
         "description": "WebSocket upgrade endpoint for the Responses API. Mirrors the canonical\n`GET /v1/responses` WS endpoint; the OpenAI-prefixed path is selected\nwhen the request includes an `Upgrade: websocket` header.\nAuthentication accepts the same headers as the inference HTTP surface\nplus the `openai-insecure-api-key.<key>` subprotocol fallback.\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "Upgrade",
@@ -14301,9 +13603,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": [
-                "websocket"
-              ]
+              "enum": ["websocket"]
             }
           },
           {
@@ -14347,10 +13647,7 @@
       "post": {
         "operationId": "azureCreateResponse",
         "summary": "Create response (Azure OpenAI)",
-        "tags": [
-          "OpenAI Integration",
-          "Azure Integration"
-        ],
+        "tags": ["OpenAI Integration", "Azure Integration"],
         "parameters": [
           {
             "name": "deployment-id",
@@ -14506,12 +13803,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -14522,9 +13814,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -14567,17 +13857,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -14698,9 +13982,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -14743,17 +14025,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -14859,9 +14135,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -14895,16 +14169,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -14925,9 +14194,7 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -14970,17 +14237,11 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": [
-                            "format",
-                            "data"
-                          ],
+                          "required": ["format", "data"],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": [
-                                "mp3",
-                                "wav"
-                              ]
+                              "enum": ["mp3", "wav"]
                             },
                             "data": {
                               "type": "string"
@@ -15243,9 +14504,7 @@
         "operationId": "openaiCountInputTokens",
         "summary": "Count input tokens",
         "description": "Counts the number of tokens in a Responses API request.\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -15309,9 +14568,7 @@
         "operationId": "openaiRetrieveResponse",
         "summary": "Retrieve a response (OpenAI format)",
         "description": "Retrieves a stored response by ID.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "response_id",
@@ -15493,12 +14750,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -15509,9 +14761,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -15554,17 +14804,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -15685,9 +14929,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -15730,17 +14972,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -15846,9 +15082,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -15882,16 +15116,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -15912,9 +15141,7 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -15957,17 +15184,11 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": [
-                            "format",
-                            "data"
-                          ],
+                          "required": ["format", "data"],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": [
-                                "mp3",
-                                "wav"
-                              ]
+                              "enum": ["mp3", "wav"]
                             },
                             "data": {
                               "type": "string"
@@ -16238,9 +15459,7 @@
         "operationId": "openaiDeleteResponse",
         "summary": "Delete a response (OpenAI format)",
         "description": "Deletes a stored response.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "response_id",
@@ -16323,9 +15542,7 @@
         "operationId": "openaiCancelResponse",
         "summary": "Cancel a response (OpenAI format)",
         "description": "Cancels an in-flight response. Only responses created with `background: true`\ncan be cancelled.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}/cancel`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "response_id",
@@ -16408,9 +15625,7 @@
         "operationId": "openaiListResponseInputItems",
         "summary": "List response input items (OpenAI format)",
         "description": "Lists the input items of a stored response.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}/input_items`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "response_id",
@@ -16463,10 +15678,7 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             }
           }
         ],
@@ -16533,18 +15745,14 @@
         "operationId": "openaiCreateCompaction",
         "summary": "Compact context (OpenAI)",
         "description": "Compresses a conversation into an opaque compaction item using the OpenAI-compatible\n`/v1/responses/compact` endpoint. Drop-in compatible with the OpenAI SDK.\n\nThe response `output` contains the user messages plus a final item with\n`type: \"response.compaction\"` and `encrypted_content`. Pass this output as `input`\nto future Responses API calls to continue the conversation using the compacted context.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/compact`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model"
-                ],
+                "required": ["model"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -16601,12 +15809,7 @@
                             },
                             "role": {
                               "type": "string",
-                              "enum": [
-                                "assistant",
-                                "user",
-                                "system",
-                                "developer"
-                              ]
+                              "enum": ["assistant", "user", "system", "developer"]
                             },
                             "content": {
                               "oneOf": [
@@ -16617,9 +15820,7 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "properties": {
                                       "type": {
                                         "type": "string",
@@ -16662,17 +15863,11 @@
                                       },
                                       "input_audio": {
                                         "type": "object",
-                                        "required": [
-                                          "format",
-                                          "data"
-                                        ],
+                                        "required": ["format", "data"],
                                         "properties": {
                                           "format": {
                                             "type": "string",
-                                            "enum": [
-                                              "mp3",
-                                              "wav"
-                                            ]
+                                            "enum": ["mp3", "wav"]
                                           },
                                           "data": {
                                             "type": "string"
@@ -16793,9 +15988,7 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": [
-                                      "type"
-                                    ],
+                                    "required": ["type"],
                                     "properties": {
                                       "type": {
                                         "type": "string",
@@ -16838,17 +16031,11 @@
                                       },
                                       "input_audio": {
                                         "type": "object",
-                                        "required": [
-                                          "format",
-                                          "data"
-                                        ],
+                                        "required": ["format", "data"],
                                         "properties": {
                                           "format": {
                                             "type": "string",
-                                            "enum": [
-                                              "mp3",
-                                              "wav"
-                                            ]
+                                            "enum": ["mp3", "wav"]
                                           },
                                           "data": {
                                             "type": "string"
@@ -16954,9 +16141,7 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "computer_screenshot"
-                                      ]
+                                      "enum": ["computer_screenshot"]
                                     },
                                     "file_id": {
                                       "type": "string"
@@ -16990,16 +16175,11 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type",
-                                  "text"
-                                ],
+                                "required": ["type", "text"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "summary_text"
-                                    ]
+                                    "enum": ["summary_text"]
                                   },
                                   "text": {
                                     "type": "string"
@@ -17113,12 +16293,7 @@
                           },
                           "role": {
                             "type": "string",
-                            "enum": [
-                              "assistant",
-                              "user",
-                              "system",
-                              "developer"
-                            ]
+                            "enum": ["assistant", "user", "system", "developer"]
                           },
                           "content": {
                             "oneOf": [
@@ -17129,9 +16304,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "properties": {
                                     "type": {
                                       "type": "string",
@@ -17174,17 +16347,11 @@
                                     },
                                     "input_audio": {
                                       "type": "object",
-                                      "required": [
-                                        "format",
-                                        "data"
-                                      ],
+                                      "required": ["format", "data"],
                                       "properties": {
                                         "format": {
                                           "type": "string",
-                                          "enum": [
-                                            "mp3",
-                                            "wav"
-                                          ]
+                                          "enum": ["mp3", "wav"]
                                         },
                                         "data": {
                                           "type": "string"
@@ -17305,9 +16472,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "type"
-                                  ],
+                                  "required": ["type"],
                                   "properties": {
                                     "type": {
                                       "type": "string",
@@ -17350,17 +16515,11 @@
                                     },
                                     "input_audio": {
                                       "type": "object",
-                                      "required": [
-                                        "format",
-                                        "data"
-                                      ],
+                                      "required": ["format", "data"],
                                       "properties": {
                                         "format": {
                                           "type": "string",
-                                          "enum": [
-                                            "mp3",
-                                            "wav"
-                                          ]
+                                          "enum": ["mp3", "wav"]
                                         },
                                         "data": {
                                           "type": "string"
@@ -17466,9 +16625,7 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": [
-                                      "computer_screenshot"
-                                    ]
+                                    "enum": ["computer_screenshot"]
                                   },
                                   "file_id": {
                                     "type": "string"
@@ -17502,16 +16659,11 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "type",
-                                "text"
-                              ],
+                              "required": ["type", "text"],
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "summary_text"
-                                  ]
+                                  "enum": ["summary_text"]
                                 },
                                 "text": {
                                   "type": "string"
@@ -17641,9 +16793,7 @@
         "operationId": "openaiCreateEmbedding",
         "summary": "Create embeddings (OpenAI format)",
         "description": "Creates embedding vectors for the input text.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/embeddings`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -17706,10 +16856,7 @@
       "post": {
         "operationId": "azureCreateEmbedding",
         "summary": "Create embeddings (Azure OpenAI)",
-        "tags": [
-          "OpenAI Integration",
-          "Azure Integration"
-        ],
+        "tags": ["OpenAI Integration", "Azure Integration"],
         "parameters": [
           {
             "name": "deployment-id",
@@ -17791,9 +16938,7 @@
         "operationId": "openaiCreateSpeech",
         "summary": "Create speech (OpenAI TTS)",
         "description": "Generates audio from text using OpenAI TTS.\nSupports streaming via SSE when stream_format is set to 'sse'.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/audio/speech`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -17838,10 +16983,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "speech.audio.delta",
-                        "speech.audio.done"
-                      ]
+                      "enum": ["speech.audio.delta", "speech.audio.done"]
                     },
                     "audio": {
                       "type": "string",
@@ -17910,10 +17052,7 @@
       "post": {
         "operationId": "azureCreateSpeech",
         "summary": "Create speech (Azure OpenAI TTS)",
-        "tags": [
-          "OpenAI Integration",
-          "Azure Integration"
-        ],
+        "tags": ["OpenAI Integration", "Azure Integration"],
         "parameters": [
           {
             "name": "deployment-id",
@@ -17976,10 +17115,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "speech.audio.delta",
-                        "speech.audio.done"
-                      ]
+                      "enum": ["speech.audio.delta", "speech.audio.done"]
                     },
                     "audio": {
                       "type": "string",
@@ -18049,9 +17185,7 @@
         "operationId": "openaiCreateTranscription",
         "summary": "Create transcription (OpenAI Whisper)",
         "description": "Transcribes audio into text using OpenAI Whisper.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/audio/transcriptions`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -18077,10 +17211,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "transcript.text.delta",
-                        "transcript.text.done"
-                      ]
+                      "enum": ["transcript.text.delta", "transcript.text.done"]
                     },
                     "delta": {
                       "type": "string"
@@ -18113,10 +17244,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "tokens",
-                            "duration"
-                          ]
+                          "enum": ["tokens", "duration"]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -18192,10 +17320,7 @@
       "post": {
         "operationId": "azureCreateTranscription",
         "summary": "Create transcription (Azure OpenAI)",
-        "tags": [
-          "OpenAI Integration",
-          "Azure Integration"
-        ],
+        "tags": ["OpenAI Integration", "Azure Integration"],
         "parameters": [
           {
             "name": "deployment-id",
@@ -18239,10 +17364,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "transcript.text.delta",
-                        "transcript.text.done"
-                      ]
+                      "enum": ["transcript.text.delta", "transcript.text.done"]
                     },
                     "delta": {
                       "type": "string"
@@ -18275,10 +17397,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "tokens",
-                            "duration"
-                          ]
+                          "enum": ["tokens", "duration"]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -18355,9 +17474,7 @@
         "operationId": "openaiListModels",
         "summary": "List models (OpenAI format)",
         "description": "Lists available models in OpenAI format.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/models`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -18410,10 +17527,7 @@
       "get": {
         "operationId": "azureListModels",
         "summary": "List models (Azure OpenAI)",
-        "tags": [
-          "OpenAI Integration",
-          "Azure Integration"
-        ],
+        "tags": ["OpenAI Integration", "Azure Integration"],
         "parameters": [
           {
             "name": "deployment-id",
@@ -18485,9 +17599,7 @@
         "operationId": "openaiCreateBatch",
         "summary": "Create batch job (OpenAI format)",
         "description": "Creates a batch processing job.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/batches`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -18549,9 +17661,7 @@
         "operationId": "openaiListBatches",
         "summary": "List batch jobs (OpenAI format)",
         "description": "Lists batch processing jobs.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/batches`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "limit",
@@ -18632,9 +17742,7 @@
         "operationId": "openaiRetrieveBatch",
         "summary": "Retrieve batch job (OpenAI format)",
         "description": "Retrieves details of a batch processing job.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/batches/{batch_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "batch_id",
@@ -18707,9 +17815,7 @@
         "operationId": "openaiCancelBatch",
         "summary": "Cancel batch job (OpenAI format)",
         "description": "Cancels a batch processing job.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/batches/{batch_id}/cancel`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "batch_id",
@@ -18841,19 +17947,14 @@
         "operationId": "openaiCreateImage",
         "summary": "Create image",
         "description": "Generates images from text prompts using OpenAI-compatible format.\n\n**Note:** Azure OpenAI deployments are also supported via the Azure integration endpoint.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/images/generations`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model",
-                  "prompt"
-                ],
+                "required": ["model", "prompt"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -18886,26 +17987,17 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": [
-                      "standard",
-                      "hd"
-                    ],
+                    "enum": ["standard", "hd"],
                     "description": "Quality of the generated image"
                   },
                   "style": {
                     "type": "string",
-                    "enum": [
-                      "natural",
-                      "vivid"
-                    ],
+                    "enum": ["natural", "vivid"],
                     "description": "Style of the generated image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": [
-                      "url",
-                      "b64_json"
-                    ],
+                    "enum": ["url", "b64_json"],
                     "default": "url",
                     "description": "Format of the response. This parameter is not supported for streaming requests."
                   },
@@ -19195,10 +18287,7 @@
         "operationId": "azureCreateImage",
         "summary": "Create image (Azure OpenAI)",
         "description": "Generates images from text prompts using Azure OpenAI deployment.\n",
-        "tags": [
-          "OpenAI Integration",
-          "Azure Integration"
-        ],
+        "tags": ["OpenAI Integration", "Azure Integration"],
         "parameters": [
           {
             "name": "deployment-id",
@@ -19224,10 +18313,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model",
-                  "prompt"
-                ],
+                "required": ["model", "prompt"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -19260,26 +18346,17 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": [
-                      "standard",
-                      "hd"
-                    ],
+                    "enum": ["standard", "hd"],
                     "description": "Quality of the generated image"
                   },
                   "style": {
                     "type": "string",
-                    "enum": [
-                      "natural",
-                      "vivid"
-                    ],
+                    "enum": ["natural", "vivid"],
                     "description": "Style of the generated image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": [
-                      "url",
-                      "b64_json"
-                    ],
+                    "enum": ["url", "b64_json"],
                     "default": "url",
                     "description": "Format of the response. This parameter is not supported for streaming requests."
                   },
@@ -19569,19 +18646,14 @@
         "operationId": "openaiUploadFile",
         "summary": "Upload file (OpenAI format)",
         "description": "Uploads a file for use with batch processing or other features.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "file",
-                  "purpose"
-                ],
+                "required": ["file", "purpose"],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -19705,9 +18777,7 @@
         "operationId": "openaiListFiles",
         "summary": "List files (OpenAI format)",
         "description": "Lists uploaded files.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "purpose",
@@ -19738,10 +18808,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             }
           },
           {
@@ -19806,9 +18873,7 @@
         "operationId": "openaiRetrieveFile",
         "summary": "Retrieve file metadata (OpenAI format)",
         "description": "Retrieves metadata for an uploaded file.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files/{file_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "file_id",
@@ -19868,13 +18933,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "uploaded",
-                        "processed",
-                        "processing",
-                        "error",
-                        "deleted"
-                      ]
+                      "enum": ["uploaded", "processed", "processing", "error", "deleted"]
                     },
                     "status_details": {
                       "type": "string"
@@ -19937,9 +18996,7 @@
         "operationId": "openaiDeleteFile",
         "summary": "Delete file (OpenAI format)",
         "description": "Deletes an uploaded file.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files/{file_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "file_id",
@@ -20026,9 +19083,7 @@
         "operationId": "openaiGetFileContent",
         "summary": "Get file content (OpenAI format)",
         "description": "Retrieves the content of an uploaded file.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files/{file_id}/content`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "file_id",
@@ -20102,19 +19157,14 @@
         "operationId": "openaiCreateContainer",
         "summary": "Create container (OpenAI format)",
         "description": "Creates a new container for storing files and data.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "provider",
-                  "name"
-                ],
+                "required": ["provider", "name"],
                 "properties": {
                   "provider": {
                     "$ref": "#/components/schemas/ModelProvider"
@@ -20187,9 +19237,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "running"
-                      ],
+                      "enum": ["running"],
                       "description": "The status of a container"
                     },
                     "expires_after": {
@@ -20270,9 +19318,7 @@
         "operationId": "openaiListContainers",
         "summary": "List containers (OpenAI format)",
         "description": "Lists containers for a provider.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "provider",
@@ -20303,10 +19349,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             },
             "description": "Sort order"
           }
@@ -20348,9 +19391,7 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "running"
-                            ],
+                            "enum": ["running"],
                             "description": "The status of a container"
                           },
                           "expires_after": {
@@ -20449,9 +19490,7 @@
         "operationId": "openaiRetrieveContainer",
         "summary": "Retrieve container (OpenAI format)",
         "description": "Retrieves a specific container by ID.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "container_id",
@@ -20498,9 +19537,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "running"
-                      ],
+                      "enum": ["running"],
                       "description": "The status of a container"
                     },
                     "expires_after": {
@@ -20581,9 +19618,7 @@
         "operationId": "openaiDeleteContainer",
         "summary": "Delete container (OpenAI format)",
         "description": "Deletes a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "container_id",
@@ -20673,9 +19708,7 @@
         "operationId": "openaiCreateContainerFile",
         "summary": "Create file in container (OpenAI format)",
         "description": "Creates a new file in a container. You can either upload file content directly\nvia multipart/form-data or reference an existing file by its ID.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "container_id",
@@ -20719,9 +19752,7 @@
               "schema": {
                 "type": "object",
                 "description": "Request to create a file in a container by referencing an existing file",
-                "required": [
-                  "file_id"
-                ],
+                "required": ["file_id"],
                 "properties": {
                   "file_id": {
                     "type": "string",
@@ -20823,9 +19854,7 @@
         "operationId": "openaiListContainerFiles",
         "summary": "List files in container (OpenAI format)",
         "description": "Lists all files in a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "container_id",
@@ -20865,10 +19894,7 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             },
             "description": "Sort order"
           }
@@ -20988,9 +20014,7 @@
         "operationId": "openaiRetrieveContainerFile",
         "summary": "Retrieve file from container (OpenAI format)",
         "description": "Retrieves metadata for a specific file in a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files/{file_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "container_id",
@@ -21106,9 +20130,7 @@
         "operationId": "openaiDeleteContainerFile",
         "summary": "Delete file from container (OpenAI format)",
         "description": "Deletes a file from a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files/{file_id}`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "container_id",
@@ -21208,9 +20230,7 @@
         "operationId": "openaiGetContainerFileContent",
         "summary": "Get file content from container (OpenAI format)",
         "description": "Downloads the content of a file from a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files/{file_id}/content`).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "container_id",
@@ -21293,19 +20313,14 @@
         "operationId": "openaiCreateVideo",
         "summary": "Create a video generation",
         "description": "Submits a video generation job using OpenAI's Videos API.\nThe request is multipart/form-data and may include reference images.\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "prompt",
-                  "model"
-                ],
+                "required": ["prompt", "model"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -21387,9 +20402,7 @@
         "operationId": "openaiListVideos",
         "summary": "List video generations",
         "description": "Lists previously submitted video generation jobs.",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "limit",
@@ -21413,10 +20426,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             }
           }
         ],
@@ -21475,9 +20485,7 @@
         "operationId": "openaiRetrieveVideo",
         "summary": "Retrieve a video generation",
         "description": "Returns metadata for a previously submitted video generation job.",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "video_id",
@@ -21543,9 +20551,7 @@
         "operationId": "openaiDeleteVideo",
         "summary": "Delete a video generation",
         "description": "Deletes a previously generated video.",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "video_id",
@@ -21613,9 +20619,7 @@
         "operationId": "openaiDownloadVideo",
         "summary": "Download generated video content",
         "description": "Streams the binary video bytes for a completed generation job.",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "video_id",
@@ -21679,9 +20683,7 @@
         "operationId": "openaiRemixVideo",
         "summary": "Remix an existing video",
         "description": "Creates a new generation by remixing a prior video with new prompt parameters.",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "video_id",
@@ -21758,9 +20760,7 @@
         "operationId": "openaiRealtimeWebSocket",
         "summary": "WebSocket Realtime (OpenAI alias)",
         "description": "OpenAI-prefixed alias of `GET /v1/realtime`. WebSocket upgrade endpoint\nfor OpenAI Realtime; selects the model via the `model` query parameter\n(Azure GA) or `deployment` (preview).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -21784,9 +20784,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": [
-                "websocket"
-              ]
+              "enum": ["websocket"]
             }
           },
           {
@@ -21837,9 +20835,7 @@
         "operationId": "openaiRealtimeCall",
         "summary": "WebRTC Realtime SDP exchange (OpenAI alias)",
         "description": "OpenAI-prefixed alias of `POST /v1/realtime/calls`. Performs the WebRTC\nSDP exchange for OpenAI Realtime calls. Accepts either multipart form\ndata with `sdp` + `session` parts (GA) or a raw SDP body (legacy).\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -21919,9 +20915,7 @@
         "operationId": "openaiRealtimeClientSecret",
         "summary": "Create realtime client secret (OpenAI alias)",
         "description": "OpenAI-prefixed alias of `POST /v1/realtime/client_secrets`. Mints an\nephemeral client secret used to authorize a downstream Realtime client.\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -21988,9 +20982,7 @@
         "operationId": "openaiRealtimeSession",
         "summary": "Create realtime session (OpenAI alias)",
         "description": "OpenAI-prefixed alias of `POST /v1/realtime/sessions`. Creates a\npre-configured realtime session that can be joined by clients.\n",
-        "tags": [
-          "OpenAI Integration"
-        ],
+        "tags": ["OpenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -22057,9 +21049,7 @@
         "operationId": "anthropicCreateMessage",
         "summary": "Create message (Anthropic format)",
         "description": "Creates a message using Anthropic Messages API format.\nSupports streaming via SSE.\n\n**Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response will have an empty `content` array. When completed, `content` will contain the full result. See [Async Inference](/features/async-inference) for details.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "x-bf-async",
@@ -22067,9 +21057,7 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": [
-                "true"
-              ]
+              "enum": ["true"]
             },
             "description": "Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming."
           },
@@ -22297,9 +21285,7 @@
         "operationId": "anthropicCreateMessageWildcard",
         "summary": "Create message (Anthropic format) - wildcard",
         "description": "Handles extended messages API paths.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "path",
@@ -22515,9 +21501,7 @@
         "operationId": "anthropicCreateComplete",
         "summary": "Create completion (Anthropic legacy format)",
         "description": "Creates a text completion using Anthropic's legacy Complete API.\nSupports streaming via SSE.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -22548,11 +21532,7 @@
                     },
                     "stop_reason": {
                       "type": "string",
-                      "enum": [
-                        "stop_sequence",
-                        "max_tokens",
-                        null
-                      ]
+                      "enum": ["stop_sequence", "max_tokens", null]
                     },
                     "model": {
                       "type": "string"
@@ -22589,11 +21569,7 @@
                     },
                     "stop_reason": {
                       "type": "string",
-                      "enum": [
-                        "stop_sequence",
-                        "max_tokens",
-                        null
-                      ]
+                      "enum": ["stop_sequence", "max_tokens", null]
                     },
                     "model": {
                       "type": "string"
@@ -22696,9 +21672,7 @@
         "operationId": "anthropicListModels",
         "summary": "List models (Anthropic format)",
         "description": "Lists available models in Anthropic format.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "limit",
@@ -22816,9 +21790,7 @@
         "operationId": "anthropicCountTokens",
         "summary": "Count tokens (Anthropic format)",
         "description": "Counts the number of tokens in a message request.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -22930,9 +21902,7 @@
         "operationId": "anthropicCreateBatch",
         "summary": "Create batch job (Anthropic format)",
         "description": "Creates a batch processing job using Anthropic format.\nUse x-model-provider header to specify the provider.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -22949,18 +21919,13 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "requests"
-                ],
+                "required": ["requests"],
                 "properties": {
                   "requests": {
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "custom_id",
-                        "params"
-                      ],
+                      "required": ["custom_id", "params"],
                       "properties": {
                         "custom_id": {
                           "type": "string",
@@ -22996,11 +21961,7 @@
                     },
                     "processing_status": {
                       "type": "string",
-                      "enum": [
-                        "in_progress",
-                        "ended",
-                        "canceling"
-                      ]
+                      "enum": ["in_progress", "ended", "canceling"]
                     },
                     "request_counts": {
                       "type": "object",
@@ -23132,9 +22093,7 @@
         "operationId": "anthropicListBatches",
         "summary": "List batch jobs (Anthropic format)",
         "description": "Lists batch processing jobs.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -23184,11 +22143,7 @@
                           },
                           "processing_status": {
                             "type": "string",
-                            "enum": [
-                              "in_progress",
-                              "ended",
-                              "canceling"
-                            ]
+                            "enum": ["in_progress", "ended", "canceling"]
                           },
                           "request_counts": {
                             "type": "object",
@@ -23334,9 +22289,7 @@
         "operationId": "anthropicRetrieveBatch",
         "summary": "Retrieve batch job (Anthropic format)",
         "description": "Retrieves details of a batch processing job.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "batch_id",
@@ -23373,11 +22326,7 @@
                     },
                     "processing_status": {
                       "type": "string",
-                      "enum": [
-                        "in_progress",
-                        "ended",
-                        "canceling"
-                      ]
+                      "enum": ["in_progress", "ended", "canceling"]
                     },
                     "request_counts": {
                       "type": "object",
@@ -23511,9 +22460,7 @@
         "operationId": "anthropicCancelBatch",
         "summary": "Cancel batch job (Anthropic format)",
         "description": "Cancels a batch processing job.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "batch_id",
@@ -23550,11 +22497,7 @@
                     },
                     "processing_status": {
                       "type": "string",
-                      "enum": [
-                        "in_progress",
-                        "ended",
-                        "canceling"
-                      ]
+                      "enum": ["in_progress", "ended", "canceling"]
                     },
                     "request_counts": {
                       "type": "object",
@@ -23688,9 +22631,7 @@
         "operationId": "anthropicGetBatchResults",
         "summary": "Get batch results (Anthropic format)",
         "description": "Retrieves results of a completed batch job.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "batch_id",
@@ -23801,9 +22742,7 @@
         "operationId": "anthropicUploadFile",
         "summary": "Upload file (Anthropic format)",
         "description": "Uploads a file. Use x-model-provider header to specify the provider.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -23820,9 +22759,7 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "file"
-                ],
+                "required": ["file"],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -23958,9 +22895,7 @@
         "operationId": "anthropicListFiles",
         "summary": "List files (Anthropic format)",
         "description": "Lists uploaded files.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -24123,9 +23058,7 @@
         "operationId": "anthropicGetFileContent",
         "summary": "Get file content (Anthropic format)",
         "description": "Retrieves file content. Returns raw binary file data when Accept header is set to application/octet-stream,\nor file metadata as JSON when Accept header is set to application/json.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "file_id",
@@ -24149,10 +23082,7 @@
             "in": "header",
             "schema": {
               "type": "string",
-              "enum": [
-                "application/json",
-                "application/octet-stream"
-              ],
+              "enum": ["application/json", "application/octet-stream"],
               "default": "application/json"
             },
             "description": "Response content type - use application/octet-stream for binary download"
@@ -24297,9 +23227,7 @@
         "operationId": "anthropicDeleteFile",
         "summary": "Delete file (Anthropic format)",
         "description": "Deletes an uploaded file.\n",
-        "tags": [
-          "Anthropic Integration"
-        ],
+        "tags": ["Anthropic Integration"],
         "parameters": [
           {
             "name": "file_id",
@@ -24419,9 +23347,7 @@
         "operationId": "geminiGenerateContent",
         "summary": "Generate content (Gemini format)",
         "description": "Generates content using Google Gemini API format.\nThe model is specified in the URL path.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -24496,9 +23422,7 @@
         "operationId": "geminiStreamGenerateContent",
         "summary": "Stream generate content (Gemini format)",
         "description": "Streams content generation using Google Gemini API format.\nThe model is specified in the URL path.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -24573,9 +23497,7 @@
         "operationId": "geminiEmbedContent",
         "summary": "Embed content (Gemini format)",
         "description": "Creates embeddings using Google Gemini API format.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -24650,9 +23572,7 @@
         "operationId": "geminiCountTokens",
         "summary": "Count tokens (Gemini format)",
         "description": "Counts tokens using Google Gemini API format.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -24780,9 +23700,7 @@
         "operationId": "geminiGenerateImage",
         "summary": "Generate image (Gemini format)",
         "description": "For Imagen models, use the `:predict` suffix (e.g., `imagen-3.0-generate-001:predict`).\nFor Gemini models, use `:generateContent` with `generationConfig.responseModalities: [\"IMAGE\"]` in the request body.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -24862,9 +23780,7 @@
         "operationId": "geminiListModels",
         "summary": "List models (Gemini format)",
         "description": "Lists available models in Google Gemini API format.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "pageSize",
@@ -24936,9 +23852,7 @@
         "operationId": "geminiUploadFile",
         "summary": "Upload file (Gemini format)",
         "description": "Uploads a file using Google Gemini API format.\n\nThis is a multipart upload with two parts:\n- \"metadata\": JSON object containing file metadata\n- \"file\": Binary file content\n\nNote: Direct file content download is not supported by Gemini Files API.\nUse the file.uri field from the response to access uploaded files.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -24946,9 +23860,7 @@
               "schema": {
                 "type": "object",
                 "description": "Multipart upload for Gemini Files API. Send two parts: - \"metadata\": JSON object {\"file\": {\"displayName\": \"<optional label>\"}} - \"file\": binary content Note: Direct file content download is not supported by Gemini Files API. Use the file.uri field from the response to access the file.\n",
-                "required": [
-                  "file"
-                ],
+                "required": ["file"],
                 "properties": {
                   "metadata": {
                     "type": "object",
@@ -25027,12 +23939,7 @@
                         },
                         "state": {
                           "type": "string",
-                          "enum": [
-                            "STATE_UNSPECIFIED",
-                            "PROCESSING",
-                            "ACTIVE",
-                            "FAILED"
-                          ]
+                          "enum": ["STATE_UNSPECIFIED", "PROCESSING", "ACTIVE", "FAILED"]
                         },
                         "error": {
                           "type": "object",
@@ -25102,9 +24009,7 @@
         "operationId": "geminiListFiles",
         "summary": "List files (Gemini format)",
         "description": "Lists uploaded files in Google Gemini API format.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "pageSize",
@@ -25171,12 +24076,7 @@
                           },
                           "state": {
                             "type": "string",
-                            "enum": [
-                              "STATE_UNSPECIFIED",
-                              "PROCESSING",
-                              "ACTIVE",
-                              "FAILED"
-                            ]
+                            "enum": ["STATE_UNSPECIFIED", "PROCESSING", "ACTIVE", "FAILED"]
                           },
                           "error": {
                             "type": "object",
@@ -25250,9 +24150,7 @@
         "operationId": "geminiRetrieveFile",
         "summary": "Retrieve file (Gemini format)",
         "description": "Retrieves file metadata in Google Gemini API format.\n\nNote: This endpoint returns file metadata only. Direct file content\ndownload is not supported by Gemini Files API. Use the file.uri\nfield from the response to access the file content.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "file_id",
@@ -25307,12 +24205,7 @@
                     },
                     "state": {
                       "type": "string",
-                      "enum": [
-                        "STATE_UNSPECIFIED",
-                        "PROCESSING",
-                        "ACTIVE",
-                        "FAILED"
-                      ]
+                      "enum": ["STATE_UNSPECIFIED", "PROCESSING", "ACTIVE", "FAILED"]
                     },
                     "error": {
                       "type": "object",
@@ -25378,9 +24271,7 @@
         "operationId": "geminiDeleteFile",
         "summary": "Delete file (Gemini format)",
         "description": "Deletes a file in Google Gemini API format.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "file_id",
@@ -25446,9 +24337,7 @@
         "operationId": "geminiListBatches",
         "summary": "List batch jobs (Gemini format)",
         "description": "Lists batch jobs in Gemini format. Supports `pageSize` / `pageToken` pagination.",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "pageSize",
@@ -25520,9 +24409,7 @@
       "get": {
         "operationId": "geminiRetrieveBatch",
         "summary": "Retrieve a batch job (Gemini format)",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "batch_id",
@@ -25585,9 +24472,7 @@
         "operationId": "geminiCancelBatch",
         "summary": "Cancel a batch job (Gemini format)",
         "description": "Cancels a batch job. Gemini conventionally sends the request as\n`/v1beta/batches/{batch_id}:cancel`; the router matches the `:cancel`\nsuffix into the `batch_id` path parameter.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "batch_id",
@@ -25650,9 +24535,7 @@
       "delete": {
         "operationId": "geminiDeleteBatch",
         "summary": "Delete a batch job (Gemini format)",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "batch_id",
@@ -25717,9 +24600,7 @@
         "operationId": "geminiCreateCachedContent",
         "summary": "Create cached content (Gemini format)",
         "description": "Creates a cached content entry that can be re-used across subsequent\ngenerate-content calls to reduce repeated prefix tokens.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -25737,9 +24618,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model"
-                ],
+                "required": ["model"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -25827,9 +24706,7 @@
       "get": {
         "operationId": "geminiListCachedContents",
         "summary": "List cached content entries (Gemini format)",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "pageSize",
@@ -25899,9 +24776,7 @@
       "get": {
         "operationId": "geminiRetrieveCachedContent",
         "summary": "Retrieve cached content (Gemini format)",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "cached_id",
@@ -25962,9 +24837,7 @@
         "operationId": "geminiUpdateCachedContent",
         "summary": "Update cached content (Gemini format)",
         "description": "Updates the TTL or expiration time of a cached content entry. Only\n`ttl` or `expireTime` may be modified.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "cached_id",
@@ -26044,9 +24917,7 @@
       "delete": {
         "operationId": "geminiDeleteCachedContent",
         "summary": "Delete cached content (Gemini format)",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "cached_id",
@@ -26109,9 +24980,7 @@
         "operationId": "vertexRank",
         "summary": "Rerank documents (Vertex Rank)",
         "description": "Reranks records using Google Vertex AI's Ranking API. The request body\nfollows the Vertex `rankRecords` schema.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -26210,9 +25079,7 @@
         "operationId": "geminiRetrieveVideoOperation",
         "summary": "Retrieve video generation operation (Gemini format)",
         "description": "Polls the status of a long-running video generation operation produced\nby `models/{model}:generateVideos`. The Gemini SDK appends the\noperation name as a wildcard path segment. If the operation name\ncontains `/`, it must be percent-encoded in the request path (for\nexample, `%2F`) to remain conformant with OpenAPI 3.x path-parameter\nsemantics.\n",
-        "tags": [
-          "GenAI Integration"
-        ],
+        "tags": ["GenAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -26287,9 +25154,7 @@
         "operationId": "bedrockConverse",
         "summary": "Converse with model (Bedrock format)",
         "description": "Sends messages to a model using AWS Bedrock Converse API format.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -26364,9 +25229,7 @@
         "operationId": "bedrockConverseStream",
         "summary": "Stream converse with model (Bedrock format)",
         "description": "Streams messages from a model using AWS Bedrock Converse API format.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -26538,9 +25401,7 @@
         "operationId": "bedrockInvokeModel",
         "summary": "Invoke model (Bedrock format)",
         "description": "Invokes a model using AWS Bedrock InvokeModel API format.\nAccepts raw model-specific request body.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -26615,9 +25476,7 @@
         "operationId": "bedrockInvokeModelStream",
         "summary": "Invoke model with streaming (Bedrock format)",
         "description": "Invokes a model with streaming using AWS Bedrock InvokeModelWithResponseStream API format.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -26693,9 +25552,7 @@
         "operationId": "bedrockCountTokens",
         "summary": "Count tokens (Bedrock format)",
         "description": "Counts tokens for a Converse-style request using AWS Bedrock format.\nThe request body must include `input.converse` with a complete Converse\npayload; only Converse-shaped input is supported.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -26713,15 +25570,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "input"
-                ],
+                "required": ["input"],
                 "properties": {
                   "input": {
                     "type": "object",
-                    "required": [
-                      "converse"
-                    ],
+                    "required": ["converse"],
                     "properties": {
                       "converse": {
                         "description": "Converse-shaped request used to compute the token count.",
@@ -26794,9 +25647,7 @@
         "operationId": "bedrockCreateBatchJob",
         "summary": "Create batch inference job (Bedrock format)",
         "description": "Creates a batch inference job using AWS Bedrock format.\nRoutes to native Bedrock by default; set `x-model-provider` to route the\njob to another provider (`openai`, `gemini`, etc.).\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -26871,9 +25722,7 @@
         "operationId": "bedrockListBatchJobs",
         "summary": "List batch inference jobs (Bedrock format)",
         "description": "Lists batch inference jobs using AWS Bedrock format.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "maxResults",
@@ -27022,9 +25871,7 @@
         "operationId": "bedrockRetrieveBatchJob",
         "summary": "Retrieve batch inference job (Bedrock format)",
         "description": "Retrieves a batch inference job using AWS Bedrock format.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "job_arn",
@@ -27098,9 +25945,7 @@
         "operationId": "bedrockCancelBatchJob",
         "summary": "Cancel batch inference job (Bedrock format)",
         "description": "Stops a batch inference job using AWS Bedrock format.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "job_arn",
@@ -27182,9 +26027,7 @@
         "operationId": "bedrockS3ListObjects",
         "summary": "S3-compatible ListObjectsV2",
         "description": "Lists objects in a bucket using S3 ListObjectsV2 semantics. Supports\nthe `prefix` and `max-keys` query parameters used by boto3.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "bucket",
@@ -27272,9 +26115,7 @@
         "operationId": "bedrockS3PutObject",
         "summary": "S3-compatible PutObject",
         "description": "Uploads an object to the Bifrost file store using S3 PutObject semantics.\nThe response is empty with an `ETag` header, mirroring native S3.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "bucket",
@@ -27350,9 +26191,7 @@
         "operationId": "bedrockS3GetObject",
         "summary": "S3-compatible GetObject",
         "description": "Retrieves raw object bytes from the Bifrost file store.",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "bucket",
@@ -27424,9 +26263,7 @@
         "operationId": "bedrockS3HeadObject",
         "summary": "S3-compatible HeadObject",
         "description": "Returns S3 metadata headers (ETag, Content-Length, etc.) without a body.\n",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "bucket",
@@ -27483,9 +26320,7 @@
         "operationId": "bedrockS3DeleteObject",
         "summary": "S3-compatible DeleteObject",
         "description": "Deletes an object from the Bifrost file store.",
-        "tags": [
-          "Bedrock Integration"
-        ],
+        "tags": ["Bedrock Integration"],
         "parameters": [
           {
             "name": "bucket",
@@ -27551,9 +26386,7 @@
         "operationId": "cohereChatV2",
         "summary": "Chat with model (Cohere v2 format)",
         "description": "Sends a chat request using Cohere v2 API format.\n",
-        "tags": [
-          "Cohere Integration"
-        ],
+        "tags": ["Cohere Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -27620,12 +26453,7 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "text",
-                                        "image_url",
-                                        "thinking",
-                                        "document"
-                                      ]
+                                      "enum": ["text", "image_url", "thinking", "document"]
                                     },
                                     "text": {
                                       "type": "string"
@@ -27642,12 +26470,7 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "image_url",
-                                          "thinking",
-                                          "document"
-                                        ]
+                                        "enum": ["text", "image_url", "thinking", "document"]
                                       },
                                       "text": {
                                         "type": "string"
@@ -27675,9 +26498,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "function"
-                                      ]
+                                      "enum": ["function"]
                                     },
                                     "function": {
                                       "type": "object",
@@ -27702,9 +26523,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "function"
-                                        ]
+                                        "enum": ["function"]
                                       },
                                       "function": {
                                         "type": "object",
@@ -27747,10 +26566,7 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "tool",
-                                              "document"
-                                            ],
+                                            "enum": ["tool", "document"],
                                             "description": "Source type"
                                           },
                                           "id": {
@@ -27774,11 +26590,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "TEXT_CONTENT",
-                                        "THINKING_CONTENT",
-                                        "PLAN"
-                                      ],
+                                      "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
                                       "description": "Type of citation"
                                     }
                                   }
@@ -27807,10 +26619,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "tool",
-                                                "document"
-                                              ],
+                                              "enum": ["tool", "document"],
                                               "description": "Source type"
                                             },
                                             "id": {
@@ -27834,11 +26643,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "TEXT_CONTENT",
-                                          "THINKING_CONTENT",
-                                          "PLAN"
-                                        ],
+                                        "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
                                         "description": "Type of citation"
                                       }
                                     }
@@ -27952,9 +26757,7 @@
         "operationId": "cohereEmbedV2",
         "summary": "Create embeddings (Cohere v2 format)",
         "description": "Creates embeddings using Cohere v2 API format.\n",
-        "tags": [
-          "Cohere Integration"
-        ],
+        "tags": ["Cohere Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -28018,20 +26821,14 @@
         "operationId": "cohereRerank",
         "summary": "Rerank documents (Cohere format)",
         "description": "Reranks a list of documents against a query using Cohere's v2 Rerank\nAPI. The request body matches Cohere's native format.\n",
-        "tags": [
-          "Cohere Integration"
-        ],
+        "tags": ["Cohere Integration"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "model",
-                  "query",
-                  "documents"
-                ],
+                "required": ["model", "query", "documents"],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -28051,9 +26848,7 @@
                         },
                         {
                           "type": "object",
-                          "required": [
-                            "text"
-                          ],
+                          "required": ["text"],
                           "properties": {
                             "text": {
                               "type": "string"
@@ -28163,9 +26958,7 @@
         "operationId": "cohereTokenize",
         "summary": "Tokenize text (Cohere format)",
         "description": "Tokenizes text using Cohere v1 API format.\n",
-        "tags": [
-          "Cohere Integration"
-        ],
+        "tags": ["Cohere Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -28229,9 +27022,7 @@
         "operationId": "cursorChatCompletions",
         "summary": "Cursor hybrid chat completions",
         "description": "Accepts Cursor's hybrid chat-completions payload (which is structurally\na Responses API request with `input` blocks) and returns a chat-\ncompletions-shaped response (`choices` + `delta` chunks for streams).\nRoutes the request through the Responses pipeline internally.\n",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -28440,9 +27231,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -28535,9 +27324,7 @@
         "operationId": "cursorListModels",
         "summary": "List models (Cursor)",
         "description": "Lists available models, returning the OpenAI `/v1/models` shape.",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -28582,9 +27369,7 @@
         "operationId": "cursorAnthropicComplete",
         "summary": "Anthropic complete (Cursor mount)",
         "description": "Cursor mount of the legacy Anthropic `POST /v1/complete` endpoint.",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -28615,11 +27400,7 @@
                     },
                     "stop_reason": {
                       "type": "string",
-                      "enum": [
-                        "stop_sequence",
-                        "max_tokens",
-                        null
-                      ]
+                      "enum": ["stop_sequence", "max_tokens", null]
                     },
                     "model": {
                       "type": "string"
@@ -28664,9 +27445,7 @@
         "operationId": "cursorAnthropicMessages",
         "summary": "Anthropic messages (Cursor mount)",
         "description": "Cursor mount of `POST /anthropic/v1/messages`. Same request/response shape and streaming behaviour.",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -28871,9 +27650,7 @@
         "operationId": "cursorAnthropicMessagesWildcard",
         "summary": "Anthropic messages — wildcard (Cursor mount)",
         "description": "Cursor mount of the Anthropic messages wildcard (`POST /anthropic/v1/messages/{path}`).\nRoutes extended Anthropic messages endpoints (e.g. batches, count tokens)\nthrough Cursor.\n",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "parameters": [
           {
             "name": "path",
@@ -28985,9 +27762,7 @@
         "operationId": "cursorAnthropicCountTokens",
         "summary": "Anthropic count tokens (Cursor mount)",
         "description": "Cursor mount of `POST /anthropic/v1/messages/count_tokens`.",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -29032,9 +27807,7 @@
         "operationId": "cursorGeminiListModels",
         "summary": "Gemini list models (Cursor mount)",
         "description": "Cursor mount of `GET /genai/v1beta/models`.",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -29069,9 +27842,7 @@
         "operationId": "cursorGeminiModelAction",
         "summary": "Gemini model action (Cursor mount)",
         "description": "Cursor mount of Gemini's wildcard generate-content/embed/count-tokens/\npredict endpoints. The `model` path parameter includes the action\nsuffix (e.g. `gemini-pro:generateContent`).\n",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "parameters": [
           {
             "name": "model",
@@ -29125,9 +27896,7 @@
       "get": {
         "operationId": "cursorGeminiRetrieveVideoOperation",
         "summary": "Gemini video operation polling (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "parameters": [
           {
             "name": "model",
@@ -29180,9 +27949,7 @@
         "operationId": "cursorVertexRank",
         "summary": "Vertex rank (Cursor mount)",
         "description": "Cursor mount of `POST /genai/v1/rank` — Vertex AI ranking.",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -29227,9 +27994,7 @@
       "post": {
         "operationId": "cursorBedrockConverse",
         "summary": "Bedrock converse (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -29282,9 +28047,7 @@
       "post": {
         "operationId": "cursorBedrockConverseStream",
         "summary": "Bedrock converse stream (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -29338,9 +28101,7 @@
       "post": {
         "operationId": "cursorBedrockInvoke",
         "summary": "Bedrock invoke (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -29395,9 +28156,7 @@
       "post": {
         "operationId": "cursorBedrockInvokeStream",
         "summary": "Bedrock invoke-with-response-stream (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -29452,9 +28211,7 @@
       "post": {
         "operationId": "cursorBedrockRerank",
         "summary": "Bedrock rerank (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -29499,9 +28256,7 @@
       "post": {
         "operationId": "cursorBedrockCountTokens",
         "summary": "Bedrock count tokens (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -29570,9 +28325,7 @@
       "post": {
         "operationId": "cursorCohereChat",
         "summary": "Cohere chat (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -29617,9 +28370,7 @@
       "post": {
         "operationId": "cursorCohereEmbed",
         "summary": "Cohere embed (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -29664,9 +28415,7 @@
       "post": {
         "operationId": "cursorCohereRerank",
         "summary": "Cohere rerank (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -29711,9 +28460,7 @@
       "post": {
         "operationId": "cursorCohereTokenize",
         "summary": "Cohere tokenize (Cursor mount)",
-        "tags": [
-          "Cursor Integration"
-        ],
+        "tags": ["Cursor Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -29759,9 +28506,7 @@
         "operationId": "litellmOpenAITextCompletions",
         "summary": "Text completions (LiteLLM - OpenAI format)",
         "description": "Creates a text completion using OpenAI-compatible format via LiteLLM.\nThis is the legacy completions API.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -29970,9 +28715,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -30062,9 +28805,7 @@
         "operationId": "litellmOpenAIChatCompletions",
         "summary": "Chat completions (LiteLLM - OpenAI format)",
         "description": "Creates a chat completion using OpenAI-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -30273,9 +29014,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -30368,9 +29107,7 @@
         "operationId": "litellmOpenAIEmbeddings",
         "summary": "Create embeddings (LiteLLM - OpenAI format)",
         "description": "Creates embeddings using OpenAI-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -30434,9 +29171,7 @@
         "operationId": "litellmOpenAIListModels",
         "summary": "List models (LiteLLM - OpenAI format)",
         "description": "Lists available models using OpenAI-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -30490,9 +29225,7 @@
         "operationId": "litellmOpenAIResponses",
         "summary": "Create response (LiteLLM - OpenAI Responses API)",
         "description": "Creates a response using OpenAI Responses API format via LiteLLM.\nSupports streaming via SSE.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -30630,12 +29363,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -30646,9 +29374,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -30691,17 +29417,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -30822,9 +29542,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -30867,17 +29585,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -30983,9 +29695,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -31019,16 +29729,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -31049,9 +29754,7 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -31094,17 +29797,11 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": [
-                            "format",
-                            "data"
-                          ],
+                          "required": ["format", "data"],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": [
-                                "mp3",
-                                "wav"
-                              ]
+                              "enum": ["mp3", "wav"]
                             },
                             "data": {
                               "type": "string"
@@ -31367,9 +30064,7 @@
         "operationId": "litellmOpenAICountInputTokens",
         "summary": "Count input tokens (LiteLLM - OpenAI format)",
         "description": "Counts the number of tokens in a Responses API request via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -31433,9 +30128,7 @@
         "operationId": "litellmOpenAISpeech",
         "summary": "Create speech (LiteLLM - OpenAI TTS)",
         "description": "Generates audio from text using OpenAI TTS via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -31462,10 +30155,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "speech.audio.delta",
-                        "speech.audio.done"
-                      ]
+                      "enum": ["speech.audio.delta", "speech.audio.done"]
                     },
                     "audio": {
                       "type": "string",
@@ -31535,9 +30225,7 @@
         "operationId": "litellmOpenAITranscriptions",
         "summary": "Create transcription (LiteLLM - OpenAI Whisper)",
         "description": "Transcribes audio into text using OpenAI Whisper via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -31563,10 +30251,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "transcript.text.delta",
-                        "transcript.text.done"
-                      ]
+                      "enum": ["transcript.text.delta", "transcript.text.done"]
                     },
                     "delta": {
                       "type": "string"
@@ -31599,10 +30284,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "tokens",
-                            "duration"
-                          ]
+                          "enum": ["tokens", "duration"]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -31679,9 +30361,7 @@
         "operationId": "litellmAnthropicMessages",
         "summary": "Create message (LiteLLM - Anthropic format)",
         "description": "Creates a message using Anthropic-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -31886,9 +30566,7 @@
         "operationId": "litellmGeminiListModels",
         "summary": "List models (LiteLLM - Gemini format)",
         "description": "Lists available models in Google Gemini API format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "parameters": [
           {
             "name": "pageSize",
@@ -31960,9 +30638,7 @@
         "operationId": "litellmGeminiGenerateContent",
         "summary": "Generate content (LiteLLM - Gemini format)",
         "description": "Generates content using Google Gemini-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "parameters": [
           {
             "name": "model",
@@ -32037,9 +30713,7 @@
         "operationId": "litellmGeminiStreamGenerateContent",
         "summary": "Stream generate content (LiteLLM - Gemini format)",
         "description": "Streams content generation using Google Gemini-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "parameters": [
           {
             "name": "model",
@@ -32114,9 +30788,7 @@
         "operationId": "litellmBedrockConverse",
         "summary": "Converse with model (LiteLLM - Bedrock format)",
         "description": "Sends messages using AWS Bedrock Converse-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -32191,9 +30863,7 @@
         "operationId": "litellmBedrockConverseStream",
         "summary": "Stream converse with model (LiteLLM - Bedrock format)",
         "description": "Streams messages using AWS Bedrock Converse-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -32365,9 +31035,7 @@
         "operationId": "litellmCohereChat",
         "summary": "Chat with model (LiteLLM - Cohere format)",
         "description": "Sends a chat request using Cohere-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -32434,12 +31102,7 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "text",
-                                        "image_url",
-                                        "thinking",
-                                        "document"
-                                      ]
+                                      "enum": ["text", "image_url", "thinking", "document"]
                                     },
                                     "text": {
                                       "type": "string"
@@ -32456,12 +31119,7 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "image_url",
-                                          "thinking",
-                                          "document"
-                                        ]
+                                        "enum": ["text", "image_url", "thinking", "document"]
                                       },
                                       "text": {
                                         "type": "string"
@@ -32489,9 +31147,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "function"
-                                      ]
+                                      "enum": ["function"]
                                     },
                                     "function": {
                                       "type": "object",
@@ -32516,9 +31172,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "function"
-                                        ]
+                                        "enum": ["function"]
                                       },
                                       "function": {
                                         "type": "object",
@@ -32561,10 +31215,7 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "tool",
-                                              "document"
-                                            ],
+                                            "enum": ["tool", "document"],
                                             "description": "Source type"
                                           },
                                           "id": {
@@ -32588,11 +31239,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "TEXT_CONTENT",
-                                        "THINKING_CONTENT",
-                                        "PLAN"
-                                      ],
+                                      "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
                                       "description": "Type of citation"
                                     }
                                   }
@@ -32621,10 +31268,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "tool",
-                                                "document"
-                                              ],
+                                              "enum": ["tool", "document"],
                                               "description": "Source type"
                                             },
                                             "id": {
@@ -32648,11 +31292,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "TEXT_CONTENT",
-                                          "THINKING_CONTENT",
-                                          "PLAN"
-                                        ],
+                                        "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
                                         "description": "Type of citation"
                                       }
                                     }
@@ -32766,9 +31406,7 @@
         "operationId": "litellmCohereEmbed",
         "summary": "Create embeddings (LiteLLM - Cohere format)",
         "description": "Creates embeddings using Cohere-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -32832,9 +31470,7 @@
         "operationId": "litellmCohereTokenize",
         "summary": "Tokenize text (LiteLLM - Cohere format)",
         "description": "Tokenizes text using Cohere-compatible format via LiteLLM.\n",
-        "tags": [
-          "LiteLLM Integration"
-        ],
+        "tags": ["LiteLLM Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -32898,9 +31534,7 @@
         "operationId": "langchainOpenAITextCompletions",
         "summary": "Text completions (LangChain - OpenAI format)",
         "description": "Creates a text completion using OpenAI-compatible format via LangChain.\nThis is the legacy completions API.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -33109,9 +31743,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -33201,9 +31833,7 @@
         "operationId": "langchainOpenAIChatCompletions",
         "summary": "Chat completions (LangChain - OpenAI format)",
         "description": "Creates a chat completion using OpenAI-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -33412,9 +32042,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -33507,9 +32135,7 @@
         "operationId": "langchainOpenAIEmbeddings",
         "summary": "Create embeddings (LangChain - OpenAI format)",
         "description": "Creates embeddings using OpenAI-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -33573,9 +32199,7 @@
         "operationId": "langchainOpenAIListModels",
         "summary": "List models (LangChain - OpenAI format)",
         "description": "Lists available models using OpenAI-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -33629,9 +32253,7 @@
         "operationId": "langchainOpenAIResponses",
         "summary": "Create response (LangChain - OpenAI Responses API)",
         "description": "Creates a response using OpenAI Responses API format via LangChain.\nSupports streaming via SSE.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -33769,12 +32391,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -33785,9 +32402,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -33830,17 +32445,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -33961,9 +32570,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -34006,17 +32613,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -34122,9 +32723,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -34158,16 +32757,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -34188,9 +32782,7 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -34233,17 +32825,11 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": [
-                            "format",
-                            "data"
-                          ],
+                          "required": ["format", "data"],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": [
-                                "mp3",
-                                "wav"
-                              ]
+                              "enum": ["mp3", "wav"]
                             },
                             "data": {
                               "type": "string"
@@ -34506,9 +33092,7 @@
         "operationId": "langchainOpenAICountInputTokens",
         "summary": "Count input tokens (LangChain - OpenAI format)",
         "description": "Counts the number of tokens in a Responses API request via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -34572,9 +33156,7 @@
         "operationId": "langchainOpenAISpeech",
         "summary": "Create speech (LangChain - OpenAI TTS)",
         "description": "Generates audio from text using OpenAI TTS via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -34601,10 +33183,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "speech.audio.delta",
-                        "speech.audio.done"
-                      ]
+                      "enum": ["speech.audio.delta", "speech.audio.done"]
                     },
                     "audio": {
                       "type": "string",
@@ -34674,9 +33253,7 @@
         "operationId": "langchainOpenAITranscriptions",
         "summary": "Create transcription (LangChain - OpenAI Whisper)",
         "description": "Transcribes audio into text using OpenAI Whisper via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -34702,10 +33279,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "transcript.text.delta",
-                        "transcript.text.done"
-                      ]
+                      "enum": ["transcript.text.delta", "transcript.text.done"]
                     },
                     "delta": {
                       "type": "string"
@@ -34738,10 +33312,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "tokens",
-                            "duration"
-                          ]
+                          "enum": ["tokens", "duration"]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -34818,9 +33389,7 @@
         "operationId": "langchainAnthropicMessages",
         "summary": "Create message (LangChain - Anthropic format)",
         "description": "Creates a message using Anthropic-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -35025,9 +33594,7 @@
         "operationId": "langchainAnthropicCountTokens",
         "summary": "Count tokens (LangChain - Anthropic format)",
         "description": "Counts tokens using Anthropic-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -35139,9 +33706,7 @@
         "operationId": "langchainGeminiListModels",
         "summary": "List models (LangChain - Gemini format)",
         "description": "Lists available models in Google Gemini API format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "parameters": [
           {
             "name": "pageSize",
@@ -35213,9 +33778,7 @@
         "operationId": "langchainGeminiGenerateContent",
         "summary": "Generate content (LangChain - Gemini format)",
         "description": "Generates content using Google Gemini-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "parameters": [
           {
             "name": "model",
@@ -35290,9 +33853,7 @@
         "operationId": "langchainGeminiStreamGenerateContent",
         "summary": "Stream generate content (LangChain - Gemini format)",
         "description": "Streams content generation using Google Gemini-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "parameters": [
           {
             "name": "model",
@@ -35367,9 +33928,7 @@
         "operationId": "langchainBedrockConverse",
         "summary": "Converse with model (LangChain - Bedrock format)",
         "description": "Sends messages using AWS Bedrock Converse-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -35444,9 +34003,7 @@
         "operationId": "langchainBedrockConverseStream",
         "summary": "Stream converse with model (LangChain - Bedrock format)",
         "description": "Streams messages using AWS Bedrock Converse-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -35618,9 +34175,7 @@
         "operationId": "langchainCohereChat",
         "summary": "Chat with model (LangChain - Cohere format)",
         "description": "Sends a chat request using Cohere-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -35687,12 +34242,7 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "text",
-                                        "image_url",
-                                        "thinking",
-                                        "document"
-                                      ]
+                                      "enum": ["text", "image_url", "thinking", "document"]
                                     },
                                     "text": {
                                       "type": "string"
@@ -35709,12 +34259,7 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "image_url",
-                                          "thinking",
-                                          "document"
-                                        ]
+                                        "enum": ["text", "image_url", "thinking", "document"]
                                       },
                                       "text": {
                                         "type": "string"
@@ -35742,9 +34287,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "function"
-                                      ]
+                                      "enum": ["function"]
                                     },
                                     "function": {
                                       "type": "object",
@@ -35769,9 +34312,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "function"
-                                        ]
+                                        "enum": ["function"]
                                       },
                                       "function": {
                                         "type": "object",
@@ -35814,10 +34355,7 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "tool",
-                                              "document"
-                                            ],
+                                            "enum": ["tool", "document"],
                                             "description": "Source type"
                                           },
                                           "id": {
@@ -35841,11 +34379,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "TEXT_CONTENT",
-                                        "THINKING_CONTENT",
-                                        "PLAN"
-                                      ],
+                                      "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
                                       "description": "Type of citation"
                                     }
                                   }
@@ -35874,10 +34408,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "tool",
-                                                "document"
-                                              ],
+                                              "enum": ["tool", "document"],
                                               "description": "Source type"
                                             },
                                             "id": {
@@ -35901,11 +34432,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "TEXT_CONTENT",
-                                          "THINKING_CONTENT",
-                                          "PLAN"
-                                        ],
+                                        "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
                                         "description": "Type of citation"
                                       }
                                     }
@@ -36019,9 +34546,7 @@
         "operationId": "langchainCohereEmbed",
         "summary": "Create embeddings (LangChain - Cohere format)",
         "description": "Creates embeddings using Cohere-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -36085,9 +34610,7 @@
         "operationId": "langchainCohereTokenize",
         "summary": "Tokenize text (LangChain - Cohere format)",
         "description": "Tokenizes text using Cohere-compatible format via LangChain.\n",
-        "tags": [
-          "LangChain Integration"
-        ],
+        "tags": ["LangChain Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -36151,9 +34674,7 @@
         "operationId": "pydanticaiOpenAITextCompletions",
         "summary": "Text completions (PydanticAI - OpenAI format)",
         "description": "Creates a text completion using OpenAI-compatible format via PydanticAI.\nThis is the legacy completions API.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -36362,9 +34883,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -36454,9 +34973,7 @@
         "operationId": "pydanticaiOpenAIChatCompletions",
         "summary": "Chat completions (PydanticAI - OpenAI format)",
         "description": "Creates a chat completion using OpenAI-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -36665,9 +35182,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "function"
-                                  ],
+                                  "required": ["function"],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -36760,9 +35275,7 @@
         "operationId": "pydanticaiOpenAIEmbeddings",
         "summary": "Create embeddings (PydanticAI - OpenAI format)",
         "description": "Creates embeddings using OpenAI-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -36826,9 +35339,7 @@
         "operationId": "pydanticaiOpenAIListModels",
         "summary": "List models (PydanticAI - OpenAI format)",
         "description": "Lists available models using OpenAI-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -36882,9 +35393,7 @@
         "operationId": "pydanticaiOpenAIResponses",
         "summary": "Create response (PydanticAI - OpenAI Responses API)",
         "description": "Creates a response using OpenAI Responses API format via PydanticAI.\nSupports streaming via SSE.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -37022,12 +35531,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -37038,9 +35542,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -37083,17 +35585,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -37214,9 +35710,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -37259,17 +35753,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -37375,9 +35863,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -37411,16 +35897,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -37441,9 +35922,7 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -37486,17 +35965,11 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": [
-                            "format",
-                            "data"
-                          ],
+                          "required": ["format", "data"],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": [
-                                "mp3",
-                                "wav"
-                              ]
+                              "enum": ["mp3", "wav"]
                             },
                             "data": {
                               "type": "string"
@@ -37759,9 +36232,7 @@
         "operationId": "pydanticaiOpenAICountInputTokens",
         "summary": "Count input tokens (PydanticAI - OpenAI format)",
         "description": "Counts the number of tokens in a Responses API request via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -37825,9 +36296,7 @@
         "operationId": "pydanticaiOpenAISpeech",
         "summary": "Create speech (PydanticAI - OpenAI TTS)",
         "description": "Generates audio from text using OpenAI TTS via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -37854,10 +36323,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "speech.audio.delta",
-                        "speech.audio.done"
-                      ]
+                      "enum": ["speech.audio.delta", "speech.audio.done"]
                     },
                     "audio": {
                       "type": "string",
@@ -37927,9 +36393,7 @@
         "operationId": "pydanticaiOpenAITranscriptions",
         "summary": "Create transcription (PydanticAI - OpenAI Whisper)",
         "description": "Transcribes audio into text using OpenAI Whisper via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -37955,10 +36419,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "transcript.text.delta",
-                        "transcript.text.done"
-                      ]
+                      "enum": ["transcript.text.delta", "transcript.text.done"]
                     },
                     "delta": {
                       "type": "string"
@@ -37991,10 +36452,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "tokens",
-                            "duration"
-                          ]
+                          "enum": ["tokens", "duration"]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -38071,9 +36529,7 @@
         "operationId": "pydanticaiAnthropicMessages",
         "summary": "Create message (PydanticAI - Anthropic format)",
         "description": "Creates a message using Anthropic-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -38278,9 +36734,7 @@
         "operationId": "pydanticaiGeminiListModels",
         "summary": "List models (PydanticAI - Gemini format)",
         "description": "Lists available models in Google Gemini API format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "parameters": [
           {
             "name": "pageSize",
@@ -38352,9 +36806,7 @@
         "operationId": "pydanticaiGeminiGenerateContent",
         "summary": "Generate content (PydanticAI - Gemini format)",
         "description": "Generates content using Google Gemini-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -38429,9 +36881,7 @@
         "operationId": "pydanticaiGeminiStreamGenerateContent",
         "summary": "Stream generate content (PydanticAI - Gemini format)",
         "description": "Streams content generation using Google Gemini-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "parameters": [
           {
             "name": "model",
@@ -38506,9 +36956,7 @@
         "operationId": "pydanticaiBedrockConverse",
         "summary": "Converse with model (PydanticAI - Bedrock format)",
         "description": "Sends messages using AWS Bedrock Converse-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -38583,9 +37031,7 @@
         "operationId": "pydanticaiBedrockConverseStream",
         "summary": "Stream converse with model (PydanticAI - Bedrock format)",
         "description": "Streams messages using AWS Bedrock Converse-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "parameters": [
           {
             "name": "modelId",
@@ -38757,9 +37203,7 @@
         "operationId": "pydanticaiCohereChat",
         "summary": "Chat with model (PydanticAI - Cohere format)",
         "description": "Sends a chat request using Cohere-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -38826,12 +37270,7 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "text",
-                                        "image_url",
-                                        "thinking",
-                                        "document"
-                                      ]
+                                      "enum": ["text", "image_url", "thinking", "document"]
                                     },
                                     "text": {
                                       "type": "string"
@@ -38848,12 +37287,7 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "text",
-                                          "image_url",
-                                          "thinking",
-                                          "document"
-                                        ]
+                                        "enum": ["text", "image_url", "thinking", "document"]
                                       },
                                       "text": {
                                         "type": "string"
@@ -38881,9 +37315,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "function"
-                                      ]
+                                      "enum": ["function"]
                                     },
                                     "function": {
                                       "type": "object",
@@ -38908,9 +37340,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "function"
-                                        ]
+                                        "enum": ["function"]
                                       },
                                       "function": {
                                         "type": "object",
@@ -38953,10 +37383,7 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": [
-                                              "tool",
-                                              "document"
-                                            ],
+                                            "enum": ["tool", "document"],
                                             "description": "Source type"
                                           },
                                           "id": {
@@ -38980,11 +37407,7 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": [
-                                        "TEXT_CONTENT",
-                                        "THINKING_CONTENT",
-                                        "PLAN"
-                                      ],
+                                      "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
                                       "description": "Type of citation"
                                     }
                                   }
@@ -39013,10 +37436,7 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": [
-                                                "tool",
-                                                "document"
-                                              ],
+                                              "enum": ["tool", "document"],
                                               "description": "Source type"
                                             },
                                             "id": {
@@ -39040,11 +37460,7 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": [
-                                          "TEXT_CONTENT",
-                                          "THINKING_CONTENT",
-                                          "PLAN"
-                                        ],
+                                        "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
                                         "description": "Type of citation"
                                       }
                                     }
@@ -39158,9 +37574,7 @@
         "operationId": "pydanticaiCohereEmbed",
         "summary": "Create embeddings (PydanticAI - Cohere format)",
         "description": "Creates embeddings using Cohere-compatible format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -39224,9 +37638,7 @@
         "operationId": "pydanticaiCohereTokenize",
         "summary": "Tokenize text (PydanticAI - Cohere format)",
         "description": "Tokenizes text using Cohere v1 API format via PydanticAI.\n",
-        "tags": [
-          "PydanticAI Integration"
-        ],
+        "tags": ["PydanticAI Integration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -39290,9 +37702,7 @@
         "operationId": "getHealth",
         "summary": "Health check",
         "description": "Returns the health status of the Bifrost server. Checks connectivity to config store,\nlog store, and vector store if configured.\n",
-        "tags": [
-          "Health"
-        ],
+        "tags": ["Health"],
         "responses": {
           "200": {
             "description": "Server is healthy",
@@ -39322,9 +37732,7 @@
         "operationId": "getConfig",
         "summary": "Get configuration",
         "description": "Retrieves the current Bifrost configuration including client config, framework config,\nauth config, and connection status for various stores.\n",
-        "tags": [
-          "Configuration"
-        ],
+        "tags": ["Configuration"],
         "parameters": [
           {
             "name": "from_db",
@@ -39332,10 +37740,7 @@
             "description": "If true, fetch configuration directly from the database",
             "schema": {
               "type": "string",
-              "enum": [
-                "true",
-                "false"
-              ]
+              "enum": ["true", "false"]
             }
           }
         ],
@@ -39371,9 +37776,7 @@
         "operationId": "updateConfig",
         "summary": "Update configuration",
         "description": "Updates the Bifrost configuration. Supports hot-reloading of certain settings\nlike drop_excess_requests. Some settings may require a restart to take effect.\n",
-        "tags": [
-          "Configuration"
-        ],
+        "tags": ["Configuration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -39428,9 +37831,7 @@
         "operationId": "getVersion",
         "summary": "Get version",
         "description": "Returns the current Bifrost version information.",
-        "tags": [
-          "Configuration"
-        ],
+        "tags": ["Configuration"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -39455,9 +37856,7 @@
         "operationId": "getProxyConfig",
         "summary": "Get proxy configuration",
         "description": "Retrieves the current global proxy configuration.",
-        "tags": [
-          "Configuration"
-        ],
+        "tags": ["Configuration"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -39477,11 +37876,7 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "http",
-                        "socks5",
-                        "tcp"
-                      ]
+                      "enum": ["http", "socks5", "tcp"]
                     },
                     "url": {
                       "type": "string"
@@ -39542,9 +37937,7 @@
         "operationId": "updateProxyConfig",
         "summary": "Update proxy configuration",
         "description": "Updates the global proxy configuration.",
-        "tags": [
-          "Configuration"
-        ],
+        "tags": ["Configuration"],
         "requestBody": {
           "required": true,
           "content": {
@@ -39558,11 +37951,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "http",
-                      "socks5",
-                      "tcp"
-                    ]
+                    "enum": ["http", "socks5", "tcp"]
                   },
                   "url": {
                     "type": "string"
@@ -39641,9 +38030,7 @@
         "operationId": "forceSyncPricing",
         "summary": "Force pricing sync",
         "description": "Triggers an immediate pricing sync and resets the pricing sync timer.",
-        "tags": [
-          "Configuration"
-        ],
+        "tags": ["Configuration"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -39694,9 +38081,7 @@
         },
         "summary": "List users",
         "description": "Returns a paginated list of users with optional search.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "offset",
@@ -39740,13 +38125,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "users",
-                    "count",
-                    "total_count",
-                    "limit",
-                    "offset"
-                  ],
+                  "required": ["users", "count", "total_count", "limit", "offset"],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -39907,19 +38286,14 @@
         },
         "summary": "Create user",
         "description": "Manually creates a new user in the organization.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name",
-                  "email"
-                ],
+                "required": ["name", "email"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -40115,9 +38489,7 @@
         },
         "summary": "Get user",
         "description": "Returns a single Enterprise user.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -40287,9 +38659,7 @@
         },
         "summary": "Delete user",
         "description": "Permanently removes a user from the organization. This cascades to delete the user's governance settings (budget/rate limits), team memberships, access profiles, and OIDC sessions. Cannot delete yourself.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -40361,9 +38731,7 @@
         },
         "summary": "Get current user permissions",
         "description": "Returns the RBAC permissions for the authenticated user. When SCIM is not enabled, returns full permissions for all resources. Otherwise returns the permissions associated with the user's assigned role.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -40436,9 +38804,7 @@
         },
         "summary": "Assign role to user",
         "description": "Assigns an RBAC role to a user. This also auto-assigns the default access profile for the new role and reloads the RBAC permission cache.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -40456,9 +38822,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "role_id"
-                ],
+                "required": ["role_id"],
                 "properties": {
                   "role_id": {
                     "type": "integer",
@@ -40529,9 +38893,7 @@
         },
         "summary": "Get user's teams",
         "description": "Returns the list of teams a user belongs to, including the membership source.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -40623,9 +38985,7 @@
         },
         "summary": "Update user's team assignments",
         "description": "Replaces the user's manual team assignments. Synced team memberships (from SCIM providers) are preserved and cannot be removed via this endpoint.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -40643,9 +39003,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "team_ids"
-                ],
+                "required": ["team_ids"],
                 "properties": {
                   "team_ids": {
                     "type": "array",
@@ -40718,9 +39076,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Create user governance",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -40950,9 +39306,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Update user governance",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -41172,9 +39526,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Delete user governance",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -41234,10 +39586,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List virtual keys available to a user",
-        "tags": [
-          "Users",
-          "Virtual Keys"
-        ],
+        "tags": ["Users", "Virtual Keys"],
         "parameters": [
           {
             "name": "user_id",
@@ -41287,9 +39636,7 @@
         },
         "summary": "Get user's virtual keys by email",
         "description": "**Enterprise only.**\nReturns all virtual keys associated with a user, looked up by email address. Returns an empty `virtual_keys` array when the user exists but has no virtual keys assigned. Intended for MDM and credential-helper integrations that need to resolve a user's keys without knowing their internal ID.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "email",
@@ -41399,9 +39746,7 @@
         },
         "summary": "Get user by email",
         "description": "Returns a single Enterprise user resolved by URL-encoded email address.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "email",
@@ -41573,9 +39918,7 @@
         },
         "summary": "List team members",
         "description": "Returns all members of a team with their user details and membership source.",
-        "tags": [
-          "Teams"
-        ],
+        "tags": ["Teams"],
         "parameters": [
           {
             "name": "team_id",
@@ -41668,9 +40011,7 @@
         },
         "summary": "Add team member",
         "description": "Adds a user to a team. Both the team and user must exist.",
-        "tags": [
-          "Teams"
-        ],
+        "tags": ["Teams"],
         "parameters": [
           {
             "name": "team_id",
@@ -41688,9 +40029,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "user_id"
-                ],
+                "required": ["user_id"],
                 "properties": {
                   "user_id": {
                     "type": "string",
@@ -41761,9 +40100,7 @@
         },
         "summary": "Remove team member",
         "description": "Removes a user from a team.",
-        "tags": [
-          "Teams"
-        ],
+        "tags": ["Teams"],
         "parameters": [
           {
             "name": "team_id",
@@ -41828,9 +40165,7 @@
         "operationId": "login",
         "summary": "Login",
         "description": "Authenticates a user and returns a session token.\nSets a cookie with the session token for subsequent requests.\n",
-        "tags": [
-          "Session"
-        ],
+        "tags": ["Session"],
         "requestBody": {
           "required": true,
           "content": {
@@ -41901,9 +40236,7 @@
         "operationId": "logout",
         "summary": "Logout",
         "description": "Logs out the current user and invalidates the session token.",
-        "tags": [
-          "Session"
-        ],
+        "tags": ["Session"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -41948,9 +40281,7 @@
         "operationId": "isAuthEnabled",
         "summary": "Check if authentication is enabled",
         "description": "Returns whether authentication is enabled and if the current token is valid.",
-        "tags": [
-          "Session"
-        ],
+        "tags": ["Session"],
         "security": [],
         "responses": {
           "200": {
@@ -41981,9 +40312,7 @@
         "operationId": "issueWSTicket",
         "summary": "Issue WebSocket ticket",
         "description": "Issues a short-lived ticket for authenticating WebSocket connections.\nThe ticket can be used as a query parameter when upgrading to WebSocket.\n",
-        "tags": [
-          "Session"
-        ],
+        "tags": ["Session"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -42037,9 +40366,7 @@
         "operationId": "listProviders",
         "summary": "List all providers",
         "description": "Returns a list of all configured providers with their configurations and status.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -42072,9 +40399,7 @@
         "operationId": "addProvider",
         "summary": "Add a new provider",
         "description": "Adds a new provider with the specified configuration.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "requestBody": {
           "required": true,
           "content": {
@@ -42139,9 +40464,7 @@
         "operationId": "getProvider",
         "summary": "Get a specific provider",
         "description": "Returns the configuration for a specific provider.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "provider",
@@ -42205,9 +40528,7 @@
         "operationId": "updateProvider",
         "summary": "Update a provider",
         "description": "Updates a provider's configuration. Expects ALL fields to be provided,\nincluding both edited and non-edited fields. Partial updates are not supported.\n",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "provider",
@@ -42271,9 +40592,7 @@
         "operationId": "deleteProvider",
         "summary": "Delete a provider",
         "description": "Removes a provider from the configuration.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "provider",
@@ -42339,9 +40658,7 @@
         "operationId": "listProviderKeys",
         "summary": "List keys for a provider",
         "description": "Returns all keys configured for a specific provider.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "provider",
@@ -42405,9 +40722,7 @@
         "operationId": "createProviderKey",
         "summary": "Create a key for a provider",
         "description": "Creates a new API key for the specified provider. The key `id` is auto-generated\nif omitted. `enabled` defaults to `true` if omitted. `value` is required and must\nnot be empty. Keys cannot be created on keyless providers.\n",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "provider",
@@ -42493,9 +40808,7 @@
         "operationId": "getProviderKey",
         "summary": "Get a specific key for a provider",
         "description": "Returns a single key for the specified provider.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "provider",
@@ -42568,9 +40881,7 @@
         "operationId": "updateProviderKey",
         "summary": "Update a key for a provider",
         "description": "Updates an existing key. Send the full key object. Redacted values sent back\nunchanged are automatically preserved (the server merges them with the stored\nraw values).\n",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "provider",
@@ -42653,9 +40964,7 @@
         "operationId": "deleteProviderKey",
         "summary": "Delete a key from a provider",
         "description": "Deletes a key from the specified provider. Returns the deleted key.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "provider",
@@ -42730,9 +41039,7 @@
         "operationId": "listKeys",
         "summary": "List all keys",
         "description": "Returns a list of all configured API keys across all providers.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -42770,9 +41077,7 @@
         "operationId": "listModelsManagement",
         "summary": "List models",
         "description": "Lists available models with optional filtering by query, provider, or keys.\n",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "query",
@@ -42883,9 +41188,7 @@
         "operationId": "listModelDetailsManagement",
         "summary": "List model details",
         "description": "Lists available models with capability metadata, when available from the model catalog, with optional filtering by query, provider, or keys.\n",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "query",
@@ -43053,9 +41356,7 @@
         "operationId": "getModelParameters",
         "summary": "Get model parameters",
         "description": "Returns the available parameter definitions for a model. The model ID is resolved against the model-parameters catalog with fallbacks, so provider-qualified IDs returned by /v1/models (e.g. \"openai/gpt-4o\", \"openrouter/openai/gpt-4o\") and bare aliases of provider-qualified catalog entries resolve to the same record as the stored key.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -43112,9 +41413,7 @@
         "operationId": "listBaseModels",
         "summary": "List base models",
         "description": "Returns a list of base models from the model catalog.",
-        "tags": [
-          "Providers"
-        ],
+        "tags": ["Providers"],
         "parameters": [
           {
             "name": "query",
@@ -43176,9 +41475,7 @@
         "operationId": "listPlugins",
         "summary": "List all plugins",
         "description": "Returns a list of all plugins with their configurations and status.\nThe `actualName` field contains the plugin name from `GetName()` (used as the map key),\nwhile `name` contains the display name from the configuration.\nThe `types` array in the status shows which interfaces the plugin implements (llm, mcp, http).\n",
-        "tags": [
-          "Plugins"
-        ],
+        "tags": ["Plugins"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -43211,9 +41508,7 @@
         "operationId": "createPlugin",
         "summary": "Create a new plugin",
         "description": "Creates a new plugin with the specified configuration.\nSetting `path` on a non-builtin plugin loads native code (a .so, via dlopen) into the\ngateway process and requires genuine admin authentication - it is refused with 403 if\ndashboard authentication is disabled or unconfigured, even though other management\nendpoints remain reachable in that state. Only `http`/`https` URLs are fetched for\nremote paths, and by default only ones resolving to a public address; private,\nloopback, link-local, and CGNAT addresses are additionally allowed if explicitly\nlisted in the deploy-time `server.plugin_download_private_allowlist` config. Local\nfilesystem paths are unaffected.\n",
-        "tags": [
-          "Plugins"
-        ],
+        "tags": ["Plugins"],
         "requestBody": {
           "required": true,
           "content": {
@@ -43290,9 +41585,7 @@
         "operationId": "listBuiltinPlugins",
         "summary": "List built-in plugin names",
         "description": "Returns the canonical list of built-in plugin names available in this Bifrost build.\nUse this to discover which plugins can be enabled without supplying a custom binary.\n",
-        "tags": [
-          "Plugins"
-        ],
+        "tags": ["Plugins"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -43336,9 +41629,7 @@
         "operationId": "getPlugin",
         "summary": "Get a specific plugin",
         "description": "Returns the configuration for a specific plugin.\nThe response includes the plugin status with types array showing which interfaces\nthe plugin implements (llm, mcp, http). The `actualName` field shows the plugin name\nfrom GetName() (used as the map key), which may differ from the display name (`name`).\n",
-        "tags": [
-          "Plugins"
-        ],
+        "tags": ["Plugins"],
         "parameters": [
           {
             "name": "name",
@@ -43402,9 +41693,7 @@
         "operationId": "updatePlugin",
         "summary": "Update a plugin",
         "description": "Updates a plugin's configuration. Will reload or stop the plugin based on enabled status.\nThe response `actualName` field shows the plugin name from GetName() (used as the map key),\nwhich may differ from the display name (`name`).\nSetting `path` on a non-builtin plugin loads native code (a .so, via dlopen) into the\ngateway process and requires genuine admin authentication - it is refused with 403 if\ndashboard authentication is disabled or unconfigured, even though other management\nendpoints remain reachable in that state. Only `http`/`https` URLs are fetched for\nremote paths, and by default only ones resolving to a public address; private,\nloopback, link-local, and CGNAT addresses are additionally allowed if explicitly\nlisted in the deploy-time `server.plugin_download_private_allowlist` config. Local\nfilesystem paths are unaffected.\n",
-        "tags": [
-          "Plugins"
-        ],
+        "tags": ["Plugins"],
         "parameters": [
           {
             "name": "name",
@@ -43490,9 +41779,7 @@
         "operationId": "deletePlugin",
         "summary": "Delete a plugin",
         "description": "Removes a plugin from the configuration and stops it if running.",
-        "tags": [
-          "Plugins"
-        ],
+        "tags": ["Plugins"],
         "parameters": [
           {
             "name": "name",
@@ -43558,9 +41845,7 @@
         "operationId": "executeMCPTool",
         "summary": "Execute MCP tool",
         "description": "Executes an MCP tool and returns the result.",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "format",
@@ -43569,10 +41854,7 @@
             "description": "Format of the tool execution request/response.\n",
             "schema": {
               "type": "string",
-              "enum": [
-                "chat",
-                "responses"
-              ],
+              "enum": ["chat", "responses"],
               "default": "chat"
             }
           }
@@ -43664,12 +41946,7 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": [
-                            "assistant",
-                            "user",
-                            "system",
-                            "developer"
-                          ]
+                          "enum": ["assistant", "user", "system", "developer"]
                         },
                         "content": {
                           "oneOf": [
@@ -43680,9 +41957,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -43725,17 +42000,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -43856,9 +42125,7 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": [
-                                  "type"
-                                ],
+                                "required": ["type"],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -43901,17 +42168,11 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": [
-                                      "format",
-                                      "data"
-                                    ],
+                                    "required": ["format", "data"],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": [
-                                          "mp3",
-                                          "wav"
-                                        ]
+                                        "enum": ["mp3", "wav"]
                                       },
                                       "data": {
                                         "type": "string"
@@ -44017,9 +42278,7 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": [
-                                    "computer_screenshot"
-                                  ]
+                                  "enum": ["computer_screenshot"]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -44053,16 +42312,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type",
-                              "text"
-                            ],
+                            "required": ["type", "text"],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": [
-                                  "summary_text"
-                                ]
+                                "enum": ["summary_text"]
                               },
                               "text": {
                                 "type": "string"
@@ -44149,9 +42403,7 @@
         "operationId": "getMCPClients",
         "summary": "List MCP clients",
         "description": "Returns a paginated list of configured MCP clients with their tools and connection state.\nSupports case-insensitive name search and exact-match filtering by connection type, auth type,\ncode-mode, and enabled/disabled status. Multi-value filters accept a comma-separated list and\nuse OR semantics within a field.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "limit",
@@ -44262,13 +42514,7 @@
                 "schema": {
                   "type": "object",
                   "description": "Paginated list of MCP clients.",
-                  "required": [
-                    "clients",
-                    "count",
-                    "total_count",
-                    "limit",
-                    "offset"
-                  ],
+                  "required": ["clients", "count", "total_count", "limit", "offset"],
                   "properties": {
                     "clients": {
                       "type": "array",
@@ -44326,9 +42572,7 @@
         "operationId": "addMCPClient",
         "summary": "Add MCP client",
         "description": "Adds a new MCP client with the specified configuration.\nNote: tool_pricing is not available when creating a new client; tool\npricing can only be set once the tool list is known. For shared-connection\nclients tools are fetched after client creation; for per-user auth types\nthey are discovered during the create/verify flow itself.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "requestBody": {
           "required": true,
           "content": {
@@ -44339,16 +42583,11 @@
                     "allOf": [
                       {
                         "type": "object",
-                        "required": [
-                          "name",
-                          "connection_type"
-                        ],
+                        "required": ["name", "connection_type"],
                         "allOf": [
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "const": "per_user_headers"
@@ -44356,9 +42595,7 @@
                               }
                             },
                             "then": {
-                              "required": [
-                                "per_user_header_keys"
-                              ],
+                              "required": ["per_user_header_keys"],
                               "properties": {
                                 "per_user_header_keys": {
                                   "type": "array",
@@ -44374,9 +42611,7 @@
                           },
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "const": "token_exchange"
@@ -44384,17 +42619,13 @@
                               }
                             },
                             "then": {
-                              "required": [
-                                "token_exchange"
-                              ],
+                              "required": ["token_exchange"],
                               "description": "When `auth_type` is `token_exchange`, `token_exchange` must declare\nat least `audience`, plus either `client_id` or\n`use_idp_credentials: true` — there is nothing to scope the\nexchange to, or exchange with, otherwise.\n"
                             }
                           },
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "not": {
@@ -44405,9 +42636,7 @@
                             },
                             "then": {
                               "not": {
-                                "required": [
-                                  "token_exchange"
-                                ]
+                                "required": ["token_exchange"]
                               },
                               "description": "A `token_exchange` block only applies to auth_type \"token_exchange\";\nreject it for every other auth_type instead of silently ignoring it.\n"
                             }
@@ -44454,12 +42683,7 @@
                           },
                           "connection_type": {
                             "type": "string",
-                            "enum": [
-                              "http",
-                              "stdio",
-                              "sse",
-                              "inprocess"
-                            ],
+                            "enum": ["http", "stdio", "sse", "inprocess"],
                             "description": "Connection type for MCP client"
                           },
                           "auth_type": {
@@ -44531,9 +42755,7 @@
                           },
                           "token_exchange": {
                             "type": "object",
-                            "required": [
-                              "audience"
-                            ],
+                            "required": ["audience"],
                             "properties": {
                               "audience": {
                                 "type": "string",
@@ -44574,15 +42796,11 @@
                                         "const": true
                                       }
                                     },
-                                    "required": [
-                                      "use_idp_credentials"
-                                    ]
+                                    "required": ["use_idp_credentials"]
                                   }
                                 },
                                 "then": {
-                                  "required": [
-                                    "client_id"
-                                  ],
+                                  "required": ["client_id"],
                                   "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                                 }
                               }
@@ -44601,15 +42819,11 @@
                       },
                       {
                         "type": "object",
-                        "required": [
-                          "connection_string"
-                        ],
+                        "required": ["connection_string"],
                         "properties": {
                           "connection_type": {
                             "type": "string",
-                            "enum": [
-                              "http"
-                            ]
+                            "enum": ["http"]
                           },
                           "connection_string": {
                             "type": "string",
@@ -44623,16 +42837,11 @@
                     "allOf": [
                       {
                         "type": "object",
-                        "required": [
-                          "name",
-                          "connection_type"
-                        ],
+                        "required": ["name", "connection_type"],
                         "allOf": [
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "const": "per_user_headers"
@@ -44640,9 +42849,7 @@
                               }
                             },
                             "then": {
-                              "required": [
-                                "per_user_header_keys"
-                              ],
+                              "required": ["per_user_header_keys"],
                               "properties": {
                                 "per_user_header_keys": {
                                   "type": "array",
@@ -44658,9 +42865,7 @@
                           },
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "const": "token_exchange"
@@ -44668,17 +42873,13 @@
                               }
                             },
                             "then": {
-                              "required": [
-                                "token_exchange"
-                              ],
+                              "required": ["token_exchange"],
                               "description": "When `auth_type` is `token_exchange`, `token_exchange` must declare\nat least `audience`, plus either `client_id` or\n`use_idp_credentials: true` — there is nothing to scope the\nexchange to, or exchange with, otherwise.\n"
                             }
                           },
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "not": {
@@ -44689,9 +42890,7 @@
                             },
                             "then": {
                               "not": {
-                                "required": [
-                                  "token_exchange"
-                                ]
+                                "required": ["token_exchange"]
                               },
                               "description": "A `token_exchange` block only applies to auth_type \"token_exchange\";\nreject it for every other auth_type instead of silently ignoring it.\n"
                             }
@@ -44738,12 +42937,7 @@
                           },
                           "connection_type": {
                             "type": "string",
-                            "enum": [
-                              "http",
-                              "stdio",
-                              "sse",
-                              "inprocess"
-                            ],
+                            "enum": ["http", "stdio", "sse", "inprocess"],
                             "description": "Connection type for MCP client"
                           },
                           "auth_type": {
@@ -44815,9 +43009,7 @@
                           },
                           "token_exchange": {
                             "type": "object",
-                            "required": [
-                              "audience"
-                            ],
+                            "required": ["audience"],
                             "properties": {
                               "audience": {
                                 "type": "string",
@@ -44858,15 +43050,11 @@
                                         "const": true
                                       }
                                     },
-                                    "required": [
-                                      "use_idp_credentials"
-                                    ]
+                                    "required": ["use_idp_credentials"]
                                   }
                                 },
                                 "then": {
-                                  "required": [
-                                    "client_id"
-                                  ],
+                                  "required": ["client_id"],
                                   "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                                 }
                               }
@@ -44885,15 +43073,11 @@
                       },
                       {
                         "type": "object",
-                        "required": [
-                          "connection_string"
-                        ],
+                        "required": ["connection_string"],
                         "properties": {
                           "connection_type": {
                             "type": "string",
-                            "enum": [
-                              "sse"
-                            ]
+                            "enum": ["sse"]
                           },
                           "connection_string": {
                             "type": "string",
@@ -44907,16 +43091,11 @@
                     "allOf": [
                       {
                         "type": "object",
-                        "required": [
-                          "name",
-                          "connection_type"
-                        ],
+                        "required": ["name", "connection_type"],
                         "allOf": [
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "const": "per_user_headers"
@@ -44924,9 +43103,7 @@
                               }
                             },
                             "then": {
-                              "required": [
-                                "per_user_header_keys"
-                              ],
+                              "required": ["per_user_header_keys"],
                               "properties": {
                                 "per_user_header_keys": {
                                   "type": "array",
@@ -44942,9 +43119,7 @@
                           },
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "const": "token_exchange"
@@ -44952,17 +43127,13 @@
                               }
                             },
                             "then": {
-                              "required": [
-                                "token_exchange"
-                              ],
+                              "required": ["token_exchange"],
                               "description": "When `auth_type` is `token_exchange`, `token_exchange` must declare\nat least `audience`, plus either `client_id` or\n`use_idp_credentials: true` — there is nothing to scope the\nexchange to, or exchange with, otherwise.\n"
                             }
                           },
                           {
                             "if": {
-                              "required": [
-                                "auth_type"
-                              ],
+                              "required": ["auth_type"],
                               "properties": {
                                 "auth_type": {
                                   "not": {
@@ -44973,9 +43144,7 @@
                             },
                             "then": {
                               "not": {
-                                "required": [
-                                  "token_exchange"
-                                ]
+                                "required": ["token_exchange"]
                               },
                               "description": "A `token_exchange` block only applies to auth_type \"token_exchange\";\nreject it for every other auth_type instead of silently ignoring it.\n"
                             }
@@ -45022,12 +43191,7 @@
                           },
                           "connection_type": {
                             "type": "string",
-                            "enum": [
-                              "http",
-                              "stdio",
-                              "sse",
-                              "inprocess"
-                            ],
+                            "enum": ["http", "stdio", "sse", "inprocess"],
                             "description": "Connection type for MCP client"
                           },
                           "auth_type": {
@@ -45099,9 +43263,7 @@
                           },
                           "token_exchange": {
                             "type": "object",
-                            "required": [
-                              "audience"
-                            ],
+                            "required": ["audience"],
                             "properties": {
                               "audience": {
                                 "type": "string",
@@ -45142,15 +43304,11 @@
                                         "const": true
                                       }
                                     },
-                                    "required": [
-                                      "use_idp_credentials"
-                                    ]
+                                    "required": ["use_idp_credentials"]
                                   }
                                 },
                                 "then": {
-                                  "required": [
-                                    "client_id"
-                                  ],
+                                  "required": ["client_id"],
                                   "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                                 }
                               }
@@ -45169,15 +43327,11 @@
                       },
                       {
                         "type": "object",
-                        "required": [
-                          "stdio_config"
-                        ],
+                        "required": ["stdio_config"],
                         "properties": {
                           "connection_type": {
                             "type": "string",
-                            "enum": [
-                              "stdio"
-                            ]
+                            "enum": ["stdio"]
                           },
                           "stdio_config": {
                             "type": "object",
@@ -45272,9 +43426,7 @@
         "operationId": "editMCPClient",
         "summary": "Edit MCP client",
         "description": "Updates an existing MCP client's configuration. All fields are optional\n(PATCH semantics); connection_type, auth_type, connection_string,\nstdio_config, and oauth_config_id are immutable after creation.\nUnlike client creation, tool_pricing can be included to set per-tool execution costs since tools are already fetched.\nFor OAuth-based clients, providing oauth_config rotates the stored OAuth\nconfiguration in place and flips every bound token to needs_reauth when\na field actually changes (see MCPClientUpdateRequest.oauth_config).\nOptionally provide vk_configs to manage which virtual keys have access to this MCP server and with which tools. When provided, this fully replaces all existing VK assignments in a single atomic transaction.\nSet disabled: true to shut down the client's connection and workers without removing it. Set disabled: false to reconnect a previously disabled client.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -45374,9 +43526,7 @@
                   },
                   "token_exchange": {
                     "type": "object",
-                    "required": [
-                      "audience"
-                    ],
+                    "required": ["audience"],
                     "properties": {
                       "audience": {
                         "type": "string",
@@ -45417,15 +43567,11 @@
                                 "const": true
                               }
                             },
-                            "required": [
-                              "use_idp_credentials"
-                            ]
+                            "required": ["use_idp_credentials"]
                           }
                         },
                         "then": {
-                          "required": [
-                            "client_id"
-                          ],
+                          "required": ["client_id"],
                           "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                         }
                       }
@@ -45457,10 +43603,7 @@
                     "items": {
                       "type": "object",
                       "description": "Per-virtual-key tool access configuration for an MCP client",
-                      "required": [
-                        "virtual_key_id",
-                        "tools_to_execute"
-                      ],
+                      "required": ["virtual_key_id", "tools_to_execute"],
                       "properties": {
                         "virtual_key_id": {
                           "type": "string",
@@ -45524,9 +43667,7 @@
         "operationId": "removeMCPClient",
         "summary": "Remove MCP client",
         "description": "Removes an MCP client from the configuration.",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -45582,9 +43723,7 @@
         "operationId": "reconnectMCPClient",
         "summary": "Reconnect MCP client",
         "description": "Reconnects an MCP client that is in an error or unstable state.\nNot applicable (400) to any per-call client — a shared client running\nper-call (needs_session_stickiness false/omitted) as well as any\nper-user auth type — since none of them hold a shared upstream\nconnection to re-establish. Also not applicable to clients in\npending_verification state — complete the admin verification instead.\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -45640,10 +43779,7 @@
         "operationId": "completeMCPClientOAuth",
         "summary": "Complete MCP client OAuth flow",
         "description": "Completes an OAuth flow for an MCP client after the admin has authorized\nthe request upstream. Call it once the flow's status_url reports\n\"authorized\". It serves every admin-side OAuth completion with one\nendpoint:\n\n- Create-time and config.json-bootstrap flows: retrieves the pending MCP\n  client configuration and establishes the connection with the\n  OAuth-provided credentials (per_user_oauth clients instead verify with\n  the admin token, discover tools, and retain the token as the admin\n  discovery credential).\n- Reauthorize flows (started via POST /api/mcp/client/{id}/reauthorize):\n  for shared \"oauth\" clients, reconnects the client with the fresh\n  credential; for per_user_oauth clients, verifies the fresh admin token\n  upstream, re-discovers tools, and promotes it to the retained admin\n  discovery credential.\n\nReplays are rejected with 409: hitting the endpoint again after the flow\nalready completed (no pending configuration and no freshly-written\ntoken) returns \"OAuth flow has already been completed\". A shared\n\"oauth\" reauthorize is also rejected with 409 if its flow never\nactually resolved via a real callback — e.g. the upstream authorization\nserver rejected the request outright before ever redirecting back —\nreturning \"Authorization has not completed yet\". This is detected via\nthe flow's own row rather than the client's overall OAuth status,\nwhich never regresses once a client has been authorized once and so\ncan't distinguish a stale prior authorization from a fresh one.\n",
-        "tags": [
-          "MCP",
-          "OAuth"
-        ],
+        "tags": ["MCP", "OAuth"],
         "parameters": [
           {
             "name": "id",
@@ -45719,10 +43855,7 @@
         "operationId": "initiateMCPClientVerification",
         "summary": "Initiate verification for a pending MCP client",
         "description": "Starts the one-time admin OAuth authorization for an MCP client sitting\nin pending_verification state (declared via config.json with auth_type\n\"oauth\" or \"per_user_oauth\"). Runs OAuth metadata discovery (RFC 8414)\nand dynamic client registration (RFC 7591) against the client's\nconnection_string when the declared oauth_config omits those fields,\ncreates a fresh OAuth flow, and returns the authorization URL.\n\nComplete the flow like a create-time OAuth flow: open authorize_url in a\nbrowser, poll status_url until \"authorized\", then POST complete_url.\nSafe to call again if a previous attempt expired or was abandoned — each\ncall starts a fresh flow.\n",
-        "tags": [
-          "MCP",
-          "OAuth"
-        ],
+        "tags": ["MCP", "OAuth"],
         "parameters": [
           {
             "name": "id",
@@ -45788,10 +43921,7 @@
         "operationId": "reauthorizeMCPClient",
         "summary": "Reauthorize an MCP client",
         "description": "Redoes the OAuth consent flow for an already-authorized OAuth-based MCP\nclient, without delete-and-recreate. The flow always runs against the\ncredentials currently stored on the client's OAuth config.\n\n- auth_type \"oauth\": serves both a standalone admin-triggered reauth\n  (e.g. the upstream provider revoked the credential and the client sits\n  in needs_reauth) and the follow-up to rotating oauth_config via\n  PUT /api/mcp/client/{id} (which cascades every bound token to\n  needs_reauth).\n- auth_type \"per_user_oauth\": repairs the retained admin discovery\n  credential used for periodic tool-list refresh. Only allowed while\n  that credential actually sits in needs_reauth (409 otherwise);\n  end-user credentials are untouched either way.\n\nComplete the returned flow like any other admin OAuth flow: open\nauthorize_url in a browser, poll status_url until \"authorized\", then\nPOST complete_url.\n",
-        "tags": [
-          "MCP",
-          "OAuth"
-        ],
+        "tags": ["MCP", "OAuth"],
         "parameters": [
           {
             "name": "id",
@@ -45877,9 +44007,7 @@
         "operationId": "verifyMCPClientHeaders",
         "summary": "Verify a pending per-user-headers MCP client",
         "description": "Completes the admin verification for an MCP client with auth_type\n\"per_user_headers\". The admin supplies sample values for every declared\nper_user_header_keys entry; Bifrost opens an upstream connection with\nthem, discovers the tool list, persists it, and transitions the client\nto connected. The sample values are retained as the admin discovery\ncredential the periodic tool syncer uses to refresh the tool list; each\nend-user still submits their own values at runtime. Synchronous; no\nbrowser flow.\n\nServes two situations: the one-time bootstrap verification for a client\nsitting in pending_verification (declared via config.json), and a\nvoluntary refresh of an already-verified client's retained admin\ndiscovery credential — resubmitting sample values always re-runs\nverification and upserts the credential back to active, whether or not\nit currently needs repair (mirrors POST /reauthorize for OAuth-based\nclients).\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -45897,9 +44025,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "user_headers"
-                ],
+                "required": ["user_headers"],
                 "properties": {
                   "user_headers": {
                     "type": "object",
@@ -45928,9 +44054,7 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "success"
-                      ]
+                      "enum": ["success"]
                     },
                     "message": {
                       "type": "string"
@@ -45992,9 +44116,7 @@
         "operationId": "verifyMCPClientExchange",
         "summary": "Verify a pending or repair a needs_reauth token_exchange MCP client",
         "description": "Completes admin verification for an MCP client with auth_type\n\"token_exchange\". No request body: the subject of the exchange is\nalways the signed-in admin's own identity-provider token (from an SSO\nsession or an identity-authenticated bearer request) — there is no\nmanual token input. Bifrost exchanges it exactly like a real caller's\ntoken would be exchanged, opens an upstream connection with the result,\ndiscovers the tool list, persists it, and transitions the client to\nconnected. The exchanged token (and any refresh token the identity\nprovider issued alongside it) is retained as the admin discovery\ncredential the periodic tool syncer uses to refresh the tool list;\nend-user tool calls always exchange the caller's own token instead.\nSynchronous; no browser flow.\n\nServes two situations: the one-time bootstrap verification for a client\nsitting in pending_verification, and a voluntary refresh of an\nalready-verified client's retained admin discovery credential —\nresubmitting always re-runs verification and retains a fresh\ncredential, whether or not it currently needs repair (mirrors POST\n/reauthorize for OAuth-based clients).\n",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -46021,9 +44143,7 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "success"
-                      ]
+                      "enum": ["success"]
                     },
                     "message": {
                       "type": "string"
@@ -46085,9 +44205,7 @@
         "summary": "List MCP sessions",
         "description": "Returns every per-user MCP authentication artifact visible to the caller:\nOAuth tokens, header credentials, and pending submission / consent flows.\n\nRow visibility is scoped to the caller's identity (Virtual Key, signed-in\nuser, or asserted session ID). Server-level `headers` / `oauth` clients\nare not surfaced here; their credentials live on the MCP client config.\nAdmin discovery credentials (the retained bootstrap credential Bifrost\nuses for periodic tool-list refresh on per-user clients) never appear\nhere either; only user-, vk-, and session-keyed rows are listed.\n\nWhen both a credential and a pending flow exist for the same\n`(identity, mcp_client)` binding, the credential is returned and the\nflow is suppressed to avoid duplicate entries.\n",
         "operationId": "listMcpSessions",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -46132,9 +44250,7 @@
         "summary": "Revoke an MCP session",
         "description": "Revokes a session by primary key. Accepts these row kinds:\n- OAuth token rows → hard-deletes the token plus any pending OAuth flow\n  for the same binding (so an in-flight callback can't undo the revoke)\n- Header credential rows → hard-deletes the credential plus any pending\n  header submission flow for the same binding\n- Pending per-user-headers flow rows → hard-deletes just the flow\n\nNote: pending per-user OAuth flow rows are **not** revocable by this\nendpoint — they expire naturally or are cleared when the bound token\nrow is revoked. To cancel a pending OAuth flow, revoke its parent token\n(if one exists) or wait for expiry.\n\nBifrost does **not** call the upstream provider's revoke endpoint —\nrevocation is local. Per-user-headers credentials never call upstream.\n",
         "operationId": "revokeMcpSession",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -46193,9 +44309,7 @@
         "summary": "Re-authenticate or edit an MCP session",
         "description": "Mints a fresh authentication flow against the same MCP client and identity\nas the existing row. Two branches based on row type:\n\n- **OAuth token** (any non-`orphaned` row, typically `needs_reauth` —\n  but `active` is also accepted) — opens a fresh upstream OAuth consent\n  flow. Caller is expected to follow `authorize_url` to the provider;\n  on callback the credential is replaced in place.\n- **Header credential** (`active` or `needs_update`) — opens a fresh\n  per-user-headers submission flow. Caller follows the same URL field\n  to the Bifrost submission form; on submit the credential is replaced\n  in place. `kind: \"headers\"` is set on the response.\n\nRefused with 403 if the row is `orphaned` — a fresh credential wouldn't\nhelp; the issue is the identity has lost access to the MCP, which the\nadmin must fix.\n",
         "operationId": "reauthMcpSession",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -46264,9 +44378,7 @@
         "summary": "Get per-user-headers submission flow",
         "description": "Returns the pending submission flow row plus the live MCP client's schema\n(required header names + optional admin header names). Used by the\n`/workspace/mcp-sessions/auth?flow=<id>&kind=headers` landing page to\nrender the values form.\n\nRequires management API authentication via `Authorization: Bearer <API key>`.\n",
         "operationId": "getPerUserHeadersFlow",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -46330,9 +44442,7 @@
         "summary": "Submit per-user-headers values",
         "description": "Consumes a pending submission flow row: verifies the caller's values\nagainst the upstream MCP server, upserts the credential keyed by the flow\nrow's (mode, identity), then deletes the flow row and the bound temp\ntoken. Mirrors the OAuth callback's \"complete the flow\" semantics.\n\nValues for any key not in the live `per_user_header_keys` schema are\ndropped server-side so a stale UI can't persist deprecated keys.\n",
         "operationId": "submitPerUserHeadersFlow",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -46424,9 +44534,7 @@
         "summary": "Revoke a per-user-headers credential",
         "description": "Hard-deletes a per-user-headers credential row by primary key. Authorization\nscoping is enforced server-side — callers may only delete credentials\nvisible to their identity.\n\nThe unified DELETE /api/mcp/sessions/{id} is the more convenient entry\npoint; this typed endpoint exists for callers that already know they're\nacting on a header credential row.\n",
         "operationId": "revokePerUserHeadersCredential",
-        "tags": [
-          "MCP"
-        ],
+        "tags": ["MCP"],
         "parameters": [
           {
             "name": "id",
@@ -46485,9 +44593,7 @@
         "operationId": "getPerUserOauthFlow",
         "summary": "Get per-user OAuth flow detail",
         "description": "Returns the pending OAuth flow row metadata: which MCP client is being\nauthorized, which identity (user / VK / session) the resulting token\nwill be bound to, and whether an active token already exists for that\nbinding (`has_active_token`).\n\nRequires management API authentication via `Authorization: Bearer <API key>`.\n",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "parameters": [
           {
             "name": "id",
@@ -46553,9 +44659,7 @@
         "operationId": "startPerUserOauthFlow",
         "summary": "Start the upstream OAuth authorization for a pending flow",
         "description": "Reconstructs the upstream provider's authorize URL for a pending OAuth\nflow. The auth-landing page redirects the browser to that URL; the user\ncompletes upstream auth; the upstream provider redirects back to\n`/api/oauth/callback`, which exchanges the code for tokens server-side\nand stores them against the flow's identity.\n\nReturns 410 if the flow is no longer pending (expired / completed /\nfailed). The caller should restart the original action to get a fresh\nflow.\n",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "parameters": [
           {
             "name": "id",
@@ -46579,9 +44683,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "authorize_url"
-                  ],
+                  "required": ["authorize_url"],
                   "properties": {
                     "authorize_url": {
                       "type": "string",
@@ -46650,9 +44752,7 @@
         "operationId": "handleOAuthCallback",
         "summary": "OAuth callback endpoint",
         "description": "Handles the OAuth provider callback after user authorization.\nThis endpoint processes the authorization code and exchanges it for an access token.\nOn success, displays an HTML page that closes the authorization window.\n",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "parameters": [
           {
             "name": "state",
@@ -46721,9 +44821,7 @@
         "operationId": "getOAuthConfigStatus",
         "summary": "Get OAuth config status",
         "description": "Retrieves the current status of an OAuth configuration.\nShows whether the OAuth flow is pending, authorized, or failed,\nand includes token expiration and scopes if authorized.\n",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "parameters": [
           {
             "name": "id",
@@ -46779,9 +44877,7 @@
         "operationId": "revokeOAuthConfig",
         "summary": "Revoke OAuth config",
         "description": "Revokes a server-level OAuth configuration and its associated access token.\nAfter revocation, the MCP client will no longer be able to use this OAuth token.\nRevocation is not terminal for the client: an admin can restore access by\nredoing consent via POST /api/mcp/client/{id}/reauthorize, which runs\nagainst the credentials currently stored on the client's OAuth config.\n",
-        "tags": [
-          "OAuth"
-        ],
+        "tags": ["OAuth"],
         "parameters": [
           {
             "name": "id",
@@ -46837,9 +44933,7 @@
         "operationId": "listVirtualKeys",
         "summary": "List virtual keys",
         "description": "Returns a list of all virtual keys with their configurations.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "from_memory",
@@ -46906,12 +45000,7 @@
             "description": "Field to sort by",
             "schema": {
               "type": "string",
-              "enum": [
-                "name",
-                "budget_spent",
-                "created_at",
-                "status"
-              ]
+              "enum": ["name", "budget_spent", "created_at", "status"]
             }
           },
           {
@@ -46920,10 +45009,7 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ]
+              "enum": ["asc", "desc"]
             }
           },
           {
@@ -46987,9 +45073,7 @@
         "operationId": "createVirtualKey",
         "summary": "Create virtual key",
         "description": "Creates a new virtual key with the specified configuration.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "requestBody": {
           "required": true,
           "content": {
@@ -47044,9 +45128,7 @@
         "operationId": "getVirtualKeyQuota",
         "summary": "Get virtual key quota",
         "description": "Returns the overall budget and rate limit quota for the authenticated virtual key,\nas well as per-provider and per-model budgets and rate limits (with current usage).\nEach budget also carries the actual per-model usage for its current cycle.\nThis is a self-service endpoint - no admin authentication required.\nThe virtual key value itself (provided via header) is the credential.\nDuring an active rotation grace window (client vk_rotation_cooldown), the\nprevious key value also authenticates until previous_value_expires_at.\nAn expired virtual key is rejected with 403; an inactive one still returns\nits quota with is_active false.\n",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "security": [
           {
             "VirtualKeyAuth": []
@@ -47117,9 +45199,7 @@
         "operationId": "getVirtualKey",
         "summary": "Get virtual key",
         "description": "Returns a specific virtual key by ID.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47152,9 +45232,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "virtual_key"
-                  ],
+                  "required": ["virtual_key"],
                   "properties": {
                     "virtual_key": {
                       "$ref": "#/components/schemas/VirtualKey"
@@ -47190,9 +45268,7 @@
         "operationId": "updateVirtualKey",
         "summary": "Update virtual key",
         "description": "Updates an existing virtual key's configuration.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47266,9 +45342,7 @@
         "operationId": "deleteVirtualKey",
         "summary": "Delete virtual key",
         "description": "Deletes a virtual key.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47324,9 +45398,7 @@
         "operationId": "updateVirtualKeyBudgetOverride",
         "summary": "Set virtual key budget override",
         "description": "Sets or replaces the spending override on one of a virtual key's budgets. The override is additive —\nwhile it is active the budget is enforced against `max_limit + override_amount` — and it leaves the\nbudget's base limit, current usage, and reset schedule untouched.\n\nUse `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows\n(the current window counts as the first), or `mode: forever` to keep the override until it is deleted.\nA finite grant is anchored to the budget's current reset window, so every node in a cluster derives the\nsame number of remaining cycles and a config reload cannot resurrect a spent one.\n",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47409,9 +45481,7 @@
         "operationId": "deleteVirtualKeyBudgetOverride",
         "summary": "Remove virtual key budget override",
         "description": "Removes any active override from the budget, so it is enforced against its base `max_limit` again.\nThe budget's current usage and reset schedule are unchanged, and the removal is permanent — a cleared\ngrant cannot be re-derived. Safe to call on a budget that has no override.\n",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47481,10 +45551,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List users attached to a virtual key",
-        "tags": [
-          "Virtual Keys",
-          "Users"
-        ],
+        "tags": ["Virtual Keys", "Users"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47507,10 +45574,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "users",
-                    "count"
-                  ],
+                  "required": ["users", "count"],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -47647,10 +45711,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach users to a virtual key",
-        "tags": [
-          "Virtual Keys",
-          "Users"
-        ],
+        "tags": ["Virtual Keys", "Users"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47667,9 +45728,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "user_ids"
-                ],
+                "required": ["user_ids"],
                 "properties": {
                   "user_ids": {
                     "type": "array",
@@ -47715,10 +45774,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a user from a virtual key",
-        "tags": [
-          "Virtual Keys",
-          "Users"
-        ],
+        "tags": ["Virtual Keys", "Users"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47761,9 +45817,7 @@
         "operationId": "bulkRotateVirtualKeys",
         "summary": "Rotate multiple virtual keys",
         "description": "Generates a new value for each listed virtual key. When the client vk_rotation_cooldown setting is non-zero, each retired value keeps authenticating until previous_value_expires_at; otherwise it stops working immediately.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -47775,9 +45829,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "ids"
-                ],
+                "required": ["ids"],
                 "properties": {
                   "ids": {
                     "type": "array",
@@ -47799,10 +45851,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "message",
-                    "virtual_keys"
-                  ],
+                  "required": ["message", "virtual_keys"],
                   "properties": {
                     "message": {
                       "type": "string"
@@ -47841,11 +45890,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "message",
-                    "virtual_keys",
-                    "errors"
-                  ],
+                  "required": ["message", "virtual_keys", "errors"],
                   "properties": {
                     "message": {
                       "type": "string"
@@ -47877,9 +45922,7 @@
         "operationId": "rotateVirtualKey",
         "summary": "Rotate virtual key",
         "description": "Generates a new value for the virtual key. When the client vk_rotation_cooldown setting is non-zero, the retired value keeps authenticating until previous_value_expires_at; otherwise it stops working immediately.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "vk_id",
@@ -47903,10 +45946,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "message",
-                    "virtual_key"
-                  ],
+                  "required": ["message", "virtual_key"],
                   "properties": {
                     "message": {
                       "type": "string"
@@ -47947,9 +45987,7 @@
         "operationId": "listTeams",
         "summary": "List teams",
         "description": "Returns a list of all teams.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "customer_id",
@@ -48001,9 +46039,7 @@
         "operationId": "createTeam",
         "summary": "Create team",
         "description": "Creates a new team.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "requestBody": {
           "required": true,
           "content": {
@@ -48058,9 +46094,7 @@
         "operationId": "getTeam",
         "summary": "Get team",
         "description": "Returns a specific team by ID.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "team_id",
@@ -48128,9 +46162,7 @@
         "operationId": "updateTeam",
         "summary": "Update team",
         "description": "Updates an existing team.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "team_id",
@@ -48204,9 +46236,7 @@
         "operationId": "deleteTeam",
         "summary": "Delete team",
         "description": "Deletes a team.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "team_id",
@@ -48267,10 +46297,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List customers attached to a team",
-        "tags": [
-          "Teams",
-          "Customers"
-        ],
+        "tags": ["Teams", "Customers"],
         "parameters": [
           {
             "name": "team_id",
@@ -48324,10 +46351,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach a customer to a team",
-        "tags": [
-          "Teams",
-          "Customers"
-        ],
+        "tags": ["Teams", "Customers"],
         "parameters": [
           {
             "name": "team_id",
@@ -48344,9 +46368,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "customer_id"
-                ],
+                "required": ["customer_id"],
                 "properties": {
                   "customer_id": {
                     "type": "string"
@@ -48385,10 +46407,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a customer from a team",
-        "tags": [
-          "Teams",
-          "Customers"
-        ],
+        "tags": ["Teams", "Customers"],
         "parameters": [
           {
             "name": "team_id",
@@ -48431,9 +46450,7 @@
         "operationId": "listCustomers",
         "summary": "List customers",
         "description": "Returns a list of all customers.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "from_memory",
@@ -48477,9 +46494,7 @@
         "operationId": "createCustomer",
         "summary": "Create customer",
         "description": "Creates a new customer.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "requestBody": {
           "required": true,
           "content": {
@@ -48534,9 +46549,7 @@
         "operationId": "getCustomer",
         "summary": "Get customer",
         "description": "Returns a specific customer by ID.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "customer_id",
@@ -48604,9 +46617,7 @@
         "operationId": "updateCustomer",
         "summary": "Update customer",
         "description": "Updates an existing customer.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "customer_id",
@@ -48680,9 +46691,7 @@
         "operationId": "deleteCustomer",
         "summary": "Delete customer",
         "description": "Deletes a customer.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "customer_id",
@@ -48743,10 +46752,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List teams attached to a customer",
-        "tags": [
-          "Customers",
-          "Teams"
-        ],
+        "tags": ["Customers", "Teams"],
         "parameters": [
           {
             "name": "customer_id",
@@ -48802,10 +46808,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List business units attached to a customer",
-        "tags": [
-          "Customers",
-          "Business Units"
-        ],
+        "tags": ["Customers", "Business Units"],
         "parameters": [
           {
             "name": "customer_id",
@@ -48862,9 +46865,7 @@
         },
         "summary": "List business units",
         "description": "Returns a paginated list of business units, each with its team count.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "offset",
@@ -48909,13 +46910,7 @@
                 "schema": {
                   "type": "object",
                   "description": "Paginated list of business units",
-                  "required": [
-                    "business_units",
-                    "count",
-                    "total_count",
-                    "limit",
-                    "offset"
-                  ],
+                  "required": ["business_units", "count", "total_count", "limit", "offset"],
                   "properties": {
                     "business_units": {
                       "type": "array",
@@ -48985,9 +46980,7 @@
         },
         "summary": "Create business unit",
         "description": "Creates a new business unit. Names must be unique.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "requestBody": {
           "required": true,
           "content": {
@@ -48995,9 +46988,7 @@
               "schema": {
                 "type": "object",
                 "description": "Create business unit request",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -49076,9 +47067,7 @@
         },
         "summary": "Get business unit",
         "description": "Returns a specific business unit by ID, including governance and team count.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -49164,9 +47153,7 @@
         },
         "summary": "Update business unit",
         "description": "Updates the business unit name.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -49185,9 +47172,7 @@
               "schema": {
                 "type": "object",
                 "description": "Create business unit request",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -49274,9 +47259,7 @@
         },
         "summary": "Delete business unit",
         "description": "Deletes a business unit. Any teams assigned to it are atomically unassigned\nas part of the deletion.\n",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -49338,9 +47321,7 @@
         },
         "summary": "List business unit teams",
         "description": "Returns a paginated list of teams assigned to the business unit.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -49394,13 +47375,7 @@
                 "schema": {
                   "type": "object",
                   "description": "Paginated list of teams assigned to a business unit",
-                  "required": [
-                    "teams",
-                    "count",
-                    "total_count",
-                    "limit",
-                    "offset"
-                  ],
+                  "required": ["teams", "count", "total_count", "limit", "offset"],
                   "properties": {
                     "teams": {
                       "type": "array",
@@ -49465,9 +47440,7 @@
         },
         "summary": "Assign team to business unit",
         "description": "Assigns an existing team to the business unit. Returns 409 if the team is\nalready assigned to a different business unit.\n",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -49486,9 +47459,7 @@
               "schema": {
                 "type": "object",
                 "description": "Request to assign a team to a business unit",
-                "required": [
-                  "team_id"
-                ],
+                "required": ["team_id"],
                 "properties": {
                   "team_id": {
                     "type": "string"
@@ -49568,9 +47539,7 @@
         },
         "summary": "Remove team from business unit",
         "description": "Unassigns a team from the business unit.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -49651,9 +47620,7 @@
         },
         "summary": "Create business unit governance",
         "description": "Configures budget and/or rate limit governance for a business unit. At least\none of `budget` or `rate_limit` is required. Returns 409 if the business unit\nalready has governance configured (use PUT to update).\n",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -49674,14 +47641,10 @@
                 "description": "Create business unit governance request. The business unit is identified by\nthe {id} path parameter. At least one of budget or rate_limit is required.\n",
                 "anyOf": [
                   {
-                    "required": [
-                      "budget"
-                    ]
+                    "required": ["budget"]
                   },
                   {
-                    "required": [
-                      "rate_limit"
-                    ]
+                    "required": ["rate_limit"]
                   }
                 ],
                 "properties": {
@@ -49827,9 +47790,7 @@
         },
         "summary": "Update business unit governance",
         "description": "Updates budget and/or rate limit governance for a business unit. Passing an\nempty `budget` or `rate_limit` object removes that governance component.\n",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -49981,9 +47942,7 @@
         },
         "summary": "Delete business unit governance",
         "description": "Removes all budget and rate limit governance from a business unit.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -50044,10 +48003,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List customers attached to a business unit",
-        "tags": [
-          "Business Units",
-          "Customers"
-        ],
+        "tags": ["Business Units", "Customers"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -50131,10 +48087,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach customers to a business unit",
-        "tags": [
-          "Business Units",
-          "Customers"
-        ],
+        "tags": ["Business Units", "Customers"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -50195,10 +48148,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a customer from a business unit",
-        "tags": [
-          "Business Units",
-          "Customers"
-        ],
+        "tags": ["Business Units", "Customers"],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -50241,9 +48191,7 @@
         "operationId": "listBudgets",
         "summary": "List budgets",
         "description": "Returns a list of all budgets. Use the `from_memory` query parameter to get data from in-memory cache.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "from_memory",
@@ -50289,9 +48237,7 @@
         "operationId": "listRateLimits",
         "summary": "List rate limits",
         "description": "Returns a list of all rate limits. Use the `from_memory` query parameter to get data from in-memory cache.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "from_memory",
@@ -50337,9 +48283,7 @@
         "operationId": "listModelConfigs",
         "summary": "List model limits",
         "description": "Returns a paginated list of model limits with their budget and rate limit settings.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -50378,11 +48322,7 @@
             "description": "Filter by scope (`global`, `virtual_key`, or `user`; `user` is Enterprise only)",
             "schema": {
               "type": "string",
-              "enum": [
-                "global",
-                "virtual_key",
-                "user"
-              ]
+              "enum": ["global", "virtual_key", "user"]
             }
           },
           {
@@ -50430,9 +48370,7 @@
         "operationId": "createModelConfig",
         "summary": "Create model config",
         "description": "Creates a new model configuration with budget and rate limit settings.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "requestBody": {
           "required": true,
           "content": {
@@ -50487,9 +48425,7 @@
         "operationId": "getModelConfig",
         "summary": "Get model config",
         "description": "Returns a specific model configuration by ID.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "mc_id",
@@ -50548,9 +48484,7 @@
         "operationId": "updateModelConfig",
         "summary": "Update model config",
         "description": "Updates an existing model configuration's budget and rate limit settings.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "mc_id",
@@ -50624,9 +48558,7 @@
         "operationId": "deleteModelConfig",
         "summary": "Delete model config",
         "description": "Deletes a model configuration.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "mc_id",
@@ -50682,9 +48614,7 @@
         "operationId": "listProviderGovernance",
         "summary": "List provider governance",
         "description": "Returns a list of all providers with their governance settings (budget and rate limits).",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -50719,9 +48649,7 @@
         "operationId": "updateProviderGovernance",
         "summary": "Update provider governance",
         "description": "Updates governance settings (budget and rate limits) for a specific provider.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "provider_name",
@@ -50795,9 +48723,7 @@
         "operationId": "deleteProviderGovernance",
         "summary": "Delete provider governance",
         "description": "Removes governance settings (budget and rate limits) for a specific provider.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "provider_name",
@@ -50853,9 +48779,7 @@
         "operationId": "listPricingOverrides",
         "summary": "List pricing overrides",
         "description": "Returns all pricing overrides, optionally filtered by scope.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "scope_kind",
@@ -50956,9 +48880,7 @@
         "operationId": "createPricingOverride",
         "summary": "Create pricing override",
         "description": "Creates a new pricing override. The most specific matching scope always wins during cost resolution.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "requestBody": {
           "required": true,
           "content": {
@@ -51013,9 +48935,7 @@
         "operationId": "updatePricingOverride",
         "summary": "Update pricing override",
         "description": "Updates an existing pricing override. Omitted fields are merged from the existing record. The `patch` field is always replaced in full when provided.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "id",
@@ -51089,9 +49009,7 @@
         "operationId": "deletePricingOverride",
         "summary": "Delete pricing override",
         "description": "Deletes a pricing override by ID.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "id",
@@ -51143,9 +49061,7 @@
         },
         "summary": "List roles",
         "description": "Returns all roles visible to the caller, scoped by data access control.",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -51182,11 +49098,7 @@
                           },
                           "dac": {
                             "type": "string",
-                            "enum": [
-                              "own-data",
-                              "team-data",
-                              "all-data"
-                            ],
+                            "enum": ["own-data", "team-data", "all-data"],
                             "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                           },
                           "created_by_user_id": {
@@ -51231,18 +49143,14 @@
         },
         "summary": "Create role",
         "description": "Creates a custom role with the specified data access control scope.\nIf `dac` is omitted, defaults to `all-data`.\n",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -51254,11 +49162,7 @@
                   },
                   "dac": {
                     "type": "string",
-                    "enum": [
-                      "own-data",
-                      "team-data",
-                      "all-data"
-                    ],
+                    "enum": ["own-data", "team-data", "all-data"],
                     "description": "Defaults to `all-data` when omitted."
                   }
                 }
@@ -51300,11 +49204,7 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": [
-                            "own-data",
-                            "team-data",
-                            "all-data"
-                          ],
+                          "enum": ["own-data", "team-data", "all-data"],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -51359,9 +49259,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get role by ID",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -51406,11 +49304,7 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": [
-                            "own-data",
-                            "team-data",
-                            "all-data"
-                          ],
+                          "enum": ["own-data", "team-data", "all-data"],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -51457,9 +49351,7 @@
         },
         "summary": "Update role",
         "description": "Partial update. Omitted fields preserve the current value.\nNotable: omitting `dac` preserves the current scope (does not default to `all-data`).\n",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -51489,11 +49381,7 @@
                   },
                   "dac": {
                     "type": "string",
-                    "enum": [
-                      "own-data",
-                      "team-data",
-                      "all-data"
-                    ],
+                    "enum": ["own-data", "team-data", "all-data"],
                     "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                   }
                 }
@@ -51535,11 +49423,7 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": [
-                            "own-data",
-                            "team-data",
-                            "all-data"
-                          ],
+                          "enum": ["own-data", "team-data", "all-data"],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -51596,9 +49480,7 @@
         },
         "summary": "Delete role",
         "description": "Deletes a custom role. Built-in system roles cannot be deleted and return 403.\n",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -51672,9 +49554,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List permissions assigned to a role",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -51746,9 +49626,7 @@
         },
         "summary": "Replace the permission set on a role",
         "description": "Replaces the permission set assigned to the role.\nSend the complete list of permission IDs that should be active for the role.\n",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -51765,9 +49643,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "permission_ids"
-                ],
+                "required": ["permission_ids"],
                 "properties": {
                   "permission_ids": {
                     "type": "array",
@@ -51839,9 +49715,7 @@
         },
         "summary": "List RBAC resources",
         "description": "Returns the set of resource names that permissions can target.",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -51899,9 +49773,7 @@
         },
         "summary": "List RBAC operations",
         "description": "Returns the set of operation names that permissions can grant.",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -51959,9 +49831,7 @@
         },
         "summary": "List all RBAC permissions",
         "description": "Returns every (resource, operation) pair that can be granted to a role.",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -52022,9 +49892,7 @@
         },
         "summary": "List access profiles",
         "description": "Returns access profiles visible to the caller.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "limit",
@@ -52108,9 +49976,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "provider_name"
-                              ],
+                              "required": ["provider_name"],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -52136,10 +50002,7 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": [
-                                      "max_limit",
-                                      "reset_duration"
-                                    ],
+                                    "required": ["max_limit", "reset_duration"],
                                     "properties": {
                                       "id": {
                                         "type": "string",
@@ -52151,14 +50014,7 @@
                                       },
                                       "reset_duration": {
                                         "type": "string",
-                                        "enum": [
-                                          "1h",
-                                          "1d",
-                                          "1w",
-                                          "1M",
-                                          "1Q",
-                                          "1Y"
-                                        ],
+                                        "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                         "description": "Reset duration for a budget."
                                       },
                                       "reset_config": {
@@ -52203,13 +50059,7 @@
                                     },
                                     "token_reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                       "description": "Reset duration for a rate limit."
                                     },
                                     "request_max_limit": {
@@ -52218,13 +50068,7 @@
                                     },
                                     "request_reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                       "description": "Reset duration for a rate limit."
                                     },
                                     "token_current_usage": {
@@ -52244,10 +50088,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "max_limit",
-                                "reset_duration"
-                              ],
+                              "required": ["max_limit", "reset_duration"],
                               "properties": {
                                 "id": {
                                   "type": "string",
@@ -52259,14 +50100,7 @@
                                 },
                                 "reset_duration": {
                                   "type": "string",
-                                  "enum": [
-                                    "1h",
-                                    "1d",
-                                    "1w",
-                                    "1M",
-                                    "1Q",
-                                    "1Y"
-                                  ],
+                                  "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                   "description": "Reset duration for a budget."
                                 },
                                 "reset_config": {
@@ -52311,13 +50145,7 @@
                               },
                               "token_reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                 "description": "Reset duration for a rate limit."
                               },
                               "request_max_limit": {
@@ -52326,13 +50154,7 @@
                               },
                               "request_reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                 "description": "Reset duration for a rate limit."
                               },
                               "token_current_usage": {
@@ -52352,9 +50174,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "tool_group_id"
-                              ],
+                              "required": ["tool_group_id"],
                               "properties": {
                                 "tool_group_id": {
                                   "type": "integer",
@@ -52367,9 +50187,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "mcp_server_id"
-                              ],
+                              "required": ["mcp_server_id"],
                               "properties": {
                                 "mcp_server_id": {
                                   "type": "string"
@@ -52381,11 +50199,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "mcp_client_id",
-                                "tool_name",
-                                "action"
-                              ],
+                              "required": ["mcp_client_id", "tool_name", "action"],
                               "properties": {
                                 "mcp_client_id": {
                                   "type": "string"
@@ -52395,10 +50209,7 @@
                                 },
                                 "action": {
                                   "type": "string",
-                                  "enum": [
-                                    "include",
-                                    "exclude"
-                                  ]
+                                  "enum": ["include", "exclude"]
                                 }
                               }
                             }
@@ -52453,18 +50264,14 @@
         },
         "summary": "Create access profile",
         "description": "Creates a new access profile template. The profile is inactive until attached to a role.\nNo size limits are enforced on create; the limits apply on update.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -52483,9 +50290,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "provider_name"
-                      ],
+                      "required": ["provider_name"],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -52511,10 +50316,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -52526,14 +50328,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -52578,13 +50373,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -52593,13 +50382,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -52619,10 +50402,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "max_limit",
-                        "reset_duration"
-                      ],
+                      "required": ["max_limit", "reset_duration"],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -52634,14 +50414,7 @@
                         },
                         "reset_duration": {
                           "type": "string",
-                          "enum": [
-                            "1h",
-                            "1d",
-                            "1w",
-                            "1M",
-                            "1Q",
-                            "1Y"
-                          ],
+                          "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                           "description": "Reset duration for a budget."
                         },
                         "reset_config": {
@@ -52686,13 +50459,7 @@
                       },
                       "token_reset_duration": {
                         "type": "string",
-                        "enum": [
-                          "1h",
-                          "1d",
-                          "1w",
-                          "1M",
-                          "1Y"
-                        ],
+                        "enum": ["1h", "1d", "1w", "1M", "1Y"],
                         "description": "Reset duration for a rate limit."
                       },
                       "request_max_limit": {
@@ -52701,13 +50468,7 @@
                       },
                       "request_reset_duration": {
                         "type": "string",
-                        "enum": [
-                          "1h",
-                          "1d",
-                          "1w",
-                          "1M",
-                          "1Y"
-                        ],
+                        "enum": ["1h", "1d", "1w", "1M", "1Y"],
                         "description": "Reset duration for a rate limit."
                       },
                       "token_current_usage": {
@@ -52727,9 +50488,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "tool_group_id"
-                      ],
+                      "required": ["tool_group_id"],
                       "properties": {
                         "tool_group_id": {
                           "type": "integer",
@@ -52742,9 +50501,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_server_id"
-                      ],
+                      "required": ["mcp_server_id"],
                       "properties": {
                         "mcp_server_id": {
                           "type": "string"
@@ -52756,11 +50513,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_client_id",
-                        "tool_name",
-                        "action"
-                      ],
+                      "required": ["mcp_client_id", "tool_name", "action"],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string"
@@ -52770,10 +50523,7 @@
                         },
                         "action": {
                           "type": "string",
-                          "enum": [
-                            "include",
-                            "exclude"
-                          ]
+                          "enum": ["include", "exclude"]
                         }
                       }
                     }
@@ -52826,9 +50576,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -52854,10 +50602,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -52869,14 +50614,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -52921,13 +50659,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -52936,13 +50668,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -52962,10 +50688,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -52977,14 +50700,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -53029,13 +50745,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -53044,13 +50754,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -53070,9 +50774,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -53085,9 +50787,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -53099,11 +50799,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -53113,10 +50809,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -53173,9 +50866,7 @@
         },
         "summary": "Get access profile by ID",
         "description": "Returns the profile plus its role attachments and the count of users holding a copy.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -53230,9 +50921,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -53258,10 +50947,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -53273,14 +50959,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -53325,13 +51004,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -53340,13 +51013,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -53366,10 +51033,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -53381,14 +51045,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -53433,13 +51090,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -53448,13 +51099,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -53474,9 +51119,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -53489,9 +51132,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -53503,11 +51144,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -53517,10 +51154,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -53594,9 +51228,7 @@
         },
         "summary": "Update access profile",
         "description": "Partial update. Omitted fields preserve the current value.\n`rate_limit: null` explicitly clears the existing rate limit.\nSize limits enforced: max 100 provider_configs, max 100 budgets, max 50 tags.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -53633,9 +51265,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "provider_name"
-                      ],
+                      "required": ["provider_name"],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -53661,10 +51291,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -53676,14 +51303,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -53728,13 +51348,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -53743,13 +51357,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -53769,10 +51377,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "max_limit",
-                        "reset_duration"
-                      ],
+                      "required": ["max_limit", "reset_duration"],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -53784,14 +51389,7 @@
                         },
                         "reset_duration": {
                           "type": "string",
-                          "enum": [
-                            "1h",
-                            "1d",
-                            "1w",
-                            "1M",
-                            "1Q",
-                            "1Y"
-                          ],
+                          "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                           "description": "Reset duration for a budget."
                         },
                         "reset_config": {
@@ -53840,13 +51438,7 @@
                           },
                           "token_reset_duration": {
                             "type": "string",
-                            "enum": [
-                              "1h",
-                              "1d",
-                              "1w",
-                              "1M",
-                              "1Y"
-                            ],
+                            "enum": ["1h", "1d", "1w", "1M", "1Y"],
                             "description": "Reset duration for a rate limit."
                           },
                           "request_max_limit": {
@@ -53855,13 +51447,7 @@
                           },
                           "request_reset_duration": {
                             "type": "string",
-                            "enum": [
-                              "1h",
-                              "1d",
-                              "1w",
-                              "1M",
-                              "1Y"
-                            ],
+                            "enum": ["1h", "1d", "1w", "1M", "1Y"],
                             "description": "Reset duration for a rate limit."
                           },
                           "token_current_usage": {
@@ -53884,9 +51470,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "tool_group_id"
-                      ],
+                      "required": ["tool_group_id"],
                       "properties": {
                         "tool_group_id": {
                           "type": "integer",
@@ -53899,9 +51483,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_server_id"
-                      ],
+                      "required": ["mcp_server_id"],
                       "properties": {
                         "mcp_server_id": {
                           "type": "string"
@@ -53913,11 +51495,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_client_id",
-                        "tool_name",
-                        "action"
-                      ],
+                      "required": ["mcp_client_id", "tool_name", "action"],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string"
@@ -53927,10 +51505,7 @@
                         },
                         "action": {
                           "type": "string",
-                          "enum": [
-                            "include",
-                            "exclude"
-                          ]
+                          "enum": ["include", "exclude"]
                         }
                       }
                     }
@@ -53983,9 +51558,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -54011,10 +51584,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -54026,14 +51596,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -54078,13 +51641,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -54093,13 +51650,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -54119,10 +51670,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -54134,14 +51682,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -54186,13 +51727,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -54201,13 +51736,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -54227,9 +51756,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -54242,9 +51769,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -54256,11 +51781,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -54270,10 +51791,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -54331,9 +51849,7 @@
         },
         "summary": "Delete access profile",
         "description": "Blocked with 409 if any users still hold copies. Detach role attachments or remove user assignments first.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -54395,9 +51911,7 @@
         },
         "summary": "Activate access profile",
         "description": "Sets the profile active. Idempotent.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -54451,9 +51965,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -54479,10 +51991,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -54494,14 +52003,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -54546,13 +52048,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -54561,13 +52057,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -54587,10 +52077,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -54602,14 +52089,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -54654,13 +52134,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -54669,13 +52143,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -54695,9 +52163,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -54710,9 +52176,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -54724,11 +52188,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -54738,10 +52198,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -54788,9 +52245,7 @@
         },
         "summary": "Deactivate access profile",
         "description": "Sets the profile inactive. Idempotent. User copies are preserved; the profile is hidden from selection menus.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -54844,9 +52299,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -54872,10 +52325,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -54887,14 +52337,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -54939,13 +52382,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -54954,13 +52391,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -54980,10 +52411,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -54995,14 +52423,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -55047,13 +52468,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -55062,13 +52477,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -55088,9 +52497,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -55103,9 +52510,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -55117,11 +52522,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -55131,10 +52532,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -55181,9 +52579,7 @@
         },
         "summary": "Clone an access profile",
         "description": "Creates a fresh copy of the profile under a new name. The clone has no role attachments or user copies.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -55200,9 +52596,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -55258,9 +52652,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -55286,10 +52678,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -55301,14 +52690,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -55353,13 +52735,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -55368,13 +52744,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -55394,10 +52764,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -55409,14 +52776,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -55461,13 +52821,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -55476,13 +52830,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -55502,9 +52850,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -55517,9 +52863,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -55531,11 +52875,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -55545,10 +52885,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -55608,9 +52945,7 @@
         },
         "summary": "Propagate template changes to user copies",
         "description": "Pushes selected fields from the template to every user that holds a copy.\nUse `dry_run: true` to preview the impact. By default, accumulated usage is preserved.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -55627,9 +52962,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "fields"
-                ],
+                "required": ["fields"],
                 "properties": {
                   "dry_run": {
                     "type": "boolean"
@@ -55758,9 +53091,7 @@
         },
         "summary": "Attach roles to access profile",
         "description": "Attaches one or more roles. Setting `is_default: true` makes the profile the role's default\nfor new users. `apply_to_existing: true` provisions the profile to users already in the role.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -55777,9 +53108,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "role_ids"
-                ],
+                "required": ["role_ids"],
                 "properties": {
                   "role_ids": {
                     "type": "array",
@@ -55860,9 +53189,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach role from access profile",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -55928,9 +53255,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List version snapshots for an access profile",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -56017,9 +53342,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get a single version snapshot",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -56114,9 +53437,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List audit log entries for a single profile",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -56241,9 +53562,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List workspace-wide audit log entries",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "limit",
@@ -56359,9 +53678,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List access profiles held by a user",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -56456,9 +53773,7 @@
         },
         "summary": "Detach a user's access profile",
         "description": "Removes the profile from the user and deletes every virtual key it produced. Fails closed if a virtual key cannot be deleted.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -56534,9 +53849,7 @@
         },
         "summary": "Set a user's access-profile budget override",
         "description": "Sets or replaces the spending override on one budget of a single user's copy of an access profile.\nThe override is additive — while it is active the budget is enforced against\n`max_limit + override_amount` — and it leaves the budget's base limit, current usage, and reset\nschedule untouched. Only this user is affected; the access profile template and every other user\nassigned to it keep their original limits.\n\nUse `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows\n(the current window counts as the first), or `mode: forever` to keep the override until it is deleted.\nA finite grant is anchored to the profile's reset window — calendar-aligned profiles anchor at the\ncalendar period start — so every node in a cluster derives the same number of remaining cycles.\nThe change is propagated cluster-wide and survives access-profile cloning and propagation.\n\nRequires the `AccessProfiles.Update` permission. `budget_id` must be a budget on the user's own copy\nof the profile, not on the shared template.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -56627,9 +53940,7 @@
         },
         "summary": "Remove a user's access-profile budget override",
         "description": "Removes any active override from the user's budget, so it is enforced against its base `max_limit`\nagain. The budget's current usage and reset schedule are unchanged, and the removal is permanent — a\ncleared grant cannot be re-derived. Safe to call on a budget that has no override.\n\nRequires the `AccessProfiles.Update` permission.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -56701,9 +54012,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Add an extra virtual key under a user's access profile",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -56799,9 +54108,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Delete a virtual key from a user's access profile",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -56867,10 +54174,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/virtual-keys/{vk_id}/users` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List users attached to a virtual key (deprecated path)",
-        "tags": [
-          "Virtual Keys",
-          "Users"
-        ],
+        "tags": ["Virtual Keys", "Users"],
         "parameters": [
           {
             "name": "vk_id",
@@ -56893,10 +54197,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "users",
-                    "count"
-                  ],
+                  "required": ["users", "count"],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -57036,10 +54337,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/virtual-keys/{vk_id}/users` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach users to a virtual key (deprecated path)",
-        "tags": [
-          "Virtual Keys",
-          "Users"
-        ],
+        "tags": ["Virtual Keys", "Users"],
         "parameters": [
           {
             "name": "vk_id",
@@ -57056,9 +54354,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "user_ids"
-                ],
+                "required": ["user_ids"],
                 "properties": {
                   "user_ids": {
                     "type": "array",
@@ -57107,10 +54403,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/virtual-keys/{vk_id}/users/{user_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a user from a virtual key (deprecated path)",
-        "tags": [
-          "Virtual Keys",
-          "Users"
-        ],
+        "tags": ["Virtual Keys", "Users"],
         "parameters": [
           {
             "name": "vk_id",
@@ -57161,10 +54454,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/teams/{team_id}/customers` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List customers attached to a team (deprecated path)",
-        "tags": [
-          "Teams",
-          "Customers"
-        ],
+        "tags": ["Teams", "Customers"],
         "parameters": [
           {
             "name": "team_id",
@@ -57221,10 +54511,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/teams/{team_id}/customers` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach a customer to a team (deprecated path)",
-        "tags": [
-          "Teams",
-          "Customers"
-        ],
+        "tags": ["Teams", "Customers"],
         "parameters": [
           {
             "name": "team_id",
@@ -57241,9 +54528,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "customer_id"
-                ],
+                "required": ["customer_id"],
                 "properties": {
                   "customer_id": {
                     "type": "string"
@@ -57285,10 +54570,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/teams/{team_id}/customers/{customer_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a customer from a team (deprecated path)",
-        "tags": [
-          "Teams",
-          "Customers"
-        ],
+        "tags": ["Teams", "Customers"],
         "parameters": [
           {
             "name": "team_id",
@@ -57339,10 +54621,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/customers/{customer_id}/teams` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List teams attached to a customer (deprecated path)",
-        "tags": [
-          "Customers",
-          "Teams"
-        ],
+        "tags": ["Customers", "Teams"],
         "parameters": [
           {
             "name": "customer_id",
@@ -57402,9 +54681,7 @@
         },
         "summary": "List roles (deprecated path)",
         "description": "Returns all roles visible to the caller, scoped by data access control.",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -57441,11 +54718,7 @@
                           },
                           "dac": {
                             "type": "string",
-                            "enum": [
-                              "own-data",
-                              "team-data",
-                              "all-data"
-                            ],
+                            "enum": ["own-data", "team-data", "all-data"],
                             "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                           },
                           "created_by_user_id": {
@@ -57493,18 +54766,14 @@
         },
         "summary": "Create role (deprecated path)",
         "description": "Creates a custom role with the specified data access control scope.\nIf `dac` is omitted, defaults to `all-data`.\n",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -57516,11 +54785,7 @@
                   },
                   "dac": {
                     "type": "string",
-                    "enum": [
-                      "own-data",
-                      "team-data",
-                      "all-data"
-                    ],
+                    "enum": ["own-data", "team-data", "all-data"],
                     "description": "Defaults to `all-data` when omitted."
                   }
                 }
@@ -57562,11 +54827,7 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": [
-                            "own-data",
-                            "team-data",
-                            "all-data"
-                          ],
+                          "enum": ["own-data", "team-data", "all-data"],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -57624,9 +54885,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/rbac/roles/{role_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get role by ID (deprecated path)",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -57671,11 +54930,7 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": [
-                            "own-data",
-                            "team-data",
-                            "all-data"
-                          ],
+                          "enum": ["own-data", "team-data", "all-data"],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -57725,9 +54980,7 @@
         },
         "summary": "Update role (deprecated path)",
         "description": "Partial update. Omitted fields preserve the current value.\nNotable: omitting `dac` preserves the current scope (does not default to `all-data`).\n",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -57757,11 +55010,7 @@
                   },
                   "dac": {
                     "type": "string",
-                    "enum": [
-                      "own-data",
-                      "team-data",
-                      "all-data"
-                    ],
+                    "enum": ["own-data", "team-data", "all-data"],
                     "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                   }
                 }
@@ -57803,11 +55052,7 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": [
-                            "own-data",
-                            "team-data",
-                            "all-data"
-                          ],
+                          "enum": ["own-data", "team-data", "all-data"],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -57867,9 +55112,7 @@
         },
         "summary": "Delete role (deprecated path)",
         "description": "Deletes a custom role. Built-in system roles cannot be deleted and return 403.\n",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -57946,9 +55189,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/rbac/roles/{role_id}/permissions` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List permissions assigned to a role (deprecated path)",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -58023,9 +55264,7 @@
         },
         "summary": "Replace the permission set on a role (deprecated path)",
         "description": "Replaces the permission set assigned to the role.\nSend the complete list of permission IDs that should be active for the role.\n",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "parameters": [
           {
             "name": "role_id",
@@ -58042,9 +55281,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "permission_ids"
-                ],
+                "required": ["permission_ids"],
                 "properties": {
                   "permission_ids": {
                     "type": "array",
@@ -58119,9 +55356,7 @@
         },
         "summary": "List RBAC resources (deprecated path)",
         "description": "Returns the set of resource names that permissions can target.",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -58182,9 +55417,7 @@
         },
         "summary": "List RBAC operations (deprecated path)",
         "description": "Returns the set of operation names that permissions can grant.",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -58245,9 +55478,7 @@
         },
         "summary": "List all RBAC permissions (deprecated path)",
         "description": "Returns every (resource, operation) pair that can be granted to a role.",
-        "tags": [
-          "RBAC"
-        ],
+        "tags": ["RBAC"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -58311,9 +55542,7 @@
         },
         "summary": "List users (deprecated path)",
         "description": "Returns a paginated list of users with optional search.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "page",
@@ -58373,14 +55602,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "users",
-                    "total",
-                    "page",
-                    "limit",
-                    "total_pages",
-                    "has_more"
-                  ],
+                  "required": ["users", "total", "page", "limit", "total_pages", "has_more"],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -58543,19 +55765,14 @@
         },
         "summary": "Create user (deprecated path)",
         "description": "Manually creates a new user in the organization.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name",
-                  "email"
-                ],
+                "required": ["name", "email"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -58754,9 +55971,7 @@
         },
         "summary": "Get user (deprecated path)",
         "description": "Returns a single Enterprise user.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -58929,9 +56144,7 @@
         },
         "summary": "Delete user (deprecated path)",
         "description": "Permanently removes a user from the organization. This cascades to delete the user's governance settings (budget/rate limits), team memberships, access profiles, and OIDC sessions. Cannot delete yourself.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -59006,9 +56219,7 @@
         },
         "summary": "Get current user permissions (deprecated path)",
         "description": "Returns the RBAC permissions for the authenticated user. When SCIM is not enabled, returns full permissions for all resources. Otherwise returns the permissions associated with the user's assigned role.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -59084,9 +56295,7 @@
         },
         "summary": "Assign role to user (deprecated path)",
         "description": "Assigns an RBAC role to a user. This also auto-assigns the default access profile for the new role and reloads the RBAC permission cache.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -59104,9 +56313,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "role_id"
-                ],
+                "required": ["role_id"],
                 "properties": {
                   "role_id": {
                     "type": "integer",
@@ -59180,9 +56387,7 @@
         },
         "summary": "Get user's teams (deprecated path)",
         "description": "Returns the list of teams a user belongs to, including the membership source.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -59277,9 +56482,7 @@
         },
         "summary": "Update user's team assignments (deprecated path)",
         "description": "Replaces the user's manual team assignments. Synced team memberships (from SCIM providers) are preserved and cannot be removed via this endpoint.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "user_id",
@@ -59297,9 +56500,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "team_ids"
-                ],
+                "required": ["team_ids"],
                 "properties": {
                   "team_ids": {
                     "type": "array",
@@ -59376,9 +56577,7 @@
         },
         "summary": "Get user's virtual keys by email (deprecated path)",
         "description": "**Enterprise only.**\nReturns all virtual keys associated with a user, looked up by email address. Returns an empty `virtual_keys` array when the user exists but has no virtual keys assigned. Intended for MDM and credential-helper integrations that need to resolve a user's keys without knowing their internal ID.\n",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "email",
@@ -59491,9 +56690,7 @@
         },
         "summary": "Get user by email (deprecated path)",
         "description": "Returns a single Enterprise user resolved by URL-encoded email address.",
-        "tags": [
-          "Users"
-        ],
+        "tags": ["Users"],
         "parameters": [
           {
             "name": "email",
@@ -59662,9 +56859,7 @@
         "operationId": "listTeamsLegacy",
         "summary": "List teams (deprecated path)",
         "description": "Returns a list of all teams.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "page",
@@ -59701,9 +56896,7 @@
             "description": "Set to `business_unit` to include business-unit associations",
             "schema": {
               "type": "string",
-              "enum": [
-                "business_unit"
-              ]
+              "enum": ["business_unit"]
             }
           }
         ],
@@ -59719,12 +56912,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": [
-                    "teams",
-                    "total",
-                    "page",
-                    "limit"
-                  ],
+                  "required": ["teams", "total", "page", "limit"],
                   "properties": {
                     "teams": {
                       "type": "array",
@@ -59771,9 +56959,7 @@
         "operationId": "createTeamLegacy",
         "summary": "Create team (deprecated path)",
         "description": "Creates a new team.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "requestBody": {
           "required": true,
           "content": {
@@ -59837,9 +57023,7 @@
         "operationId": "getTeamLegacy",
         "summary": "Get team (deprecated path)",
         "description": "Returns a specific team by ID.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "team_id",
@@ -59916,9 +57100,7 @@
         "operationId": "updateTeamLegacy",
         "summary": "Update team (deprecated path)",
         "description": "Updates an existing team.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "team_id",
@@ -60001,9 +57183,7 @@
         "operationId": "deleteTeamLegacy",
         "summary": "Delete team (deprecated path)",
         "description": "Deletes a team.",
-        "tags": [
-          "Governance"
-        ],
+        "tags": ["Governance"],
         "parameters": [
           {
             "name": "team_id",
@@ -60074,9 +57254,7 @@
         },
         "summary": "List team members (deprecated path)",
         "description": "Returns all members of a team with their user details and membership source.",
-        "tags": [
-          "Teams"
-        ],
+        "tags": ["Teams"],
         "parameters": [
           {
             "name": "team_id",
@@ -60172,9 +57350,7 @@
         },
         "summary": "Add team member (deprecated path)",
         "description": "Adds a user to a team. Both the team and user must exist.",
-        "tags": [
-          "Teams"
-        ],
+        "tags": ["Teams"],
         "parameters": [
           {
             "name": "team_id",
@@ -60192,9 +57368,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "user_id"
-                ],
+                "required": ["user_id"],
                 "properties": {
                   "user_id": {
                     "type": "string",
@@ -60268,9 +57442,7 @@
         },
         "summary": "Remove team member (deprecated path)",
         "description": "Removes a user from a team.",
-        "tags": [
-          "Teams"
-        ],
+        "tags": ["Teams"],
         "parameters": [
           {
             "name": "team_id",
@@ -60344,9 +57516,7 @@
         },
         "summary": "List access profiles (deprecated path)",
         "description": "Returns access profiles visible to the caller.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "limit",
@@ -60430,9 +57600,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "provider_name"
-                              ],
+                              "required": ["provider_name"],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -60458,10 +57626,7 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": [
-                                      "max_limit",
-                                      "reset_duration"
-                                    ],
+                                    "required": ["max_limit", "reset_duration"],
                                     "properties": {
                                       "id": {
                                         "type": "string",
@@ -60473,14 +57638,7 @@
                                       },
                                       "reset_duration": {
                                         "type": "string",
-                                        "enum": [
-                                          "1h",
-                                          "1d",
-                                          "1w",
-                                          "1M",
-                                          "1Q",
-                                          "1Y"
-                                        ],
+                                        "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                         "description": "Reset duration for a budget."
                                       },
                                       "reset_config": {
@@ -60525,13 +57683,7 @@
                                     },
                                     "token_reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                       "description": "Reset duration for a rate limit."
                                     },
                                     "request_max_limit": {
@@ -60540,13 +57692,7 @@
                                     },
                                     "request_reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                       "description": "Reset duration for a rate limit."
                                     },
                                     "token_current_usage": {
@@ -60566,10 +57712,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "max_limit",
-                                "reset_duration"
-                              ],
+                              "required": ["max_limit", "reset_duration"],
                               "properties": {
                                 "id": {
                                   "type": "string",
@@ -60581,14 +57724,7 @@
                                 },
                                 "reset_duration": {
                                   "type": "string",
-                                  "enum": [
-                                    "1h",
-                                    "1d",
-                                    "1w",
-                                    "1M",
-                                    "1Q",
-                                    "1Y"
-                                  ],
+                                  "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                   "description": "Reset duration for a budget."
                                 },
                                 "reset_config": {
@@ -60633,13 +57769,7 @@
                               },
                               "token_reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                 "description": "Reset duration for a rate limit."
                               },
                               "request_max_limit": {
@@ -60648,13 +57778,7 @@
                               },
                               "request_reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                 "description": "Reset duration for a rate limit."
                               },
                               "token_current_usage": {
@@ -60674,9 +57798,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "tool_group_id"
-                              ],
+                              "required": ["tool_group_id"],
                               "properties": {
                                 "tool_group_id": {
                                   "type": "integer",
@@ -60689,9 +57811,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "mcp_server_id"
-                              ],
+                              "required": ["mcp_server_id"],
                               "properties": {
                                 "mcp_server_id": {
                                   "type": "string"
@@ -60703,11 +57823,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "mcp_client_id",
-                                "tool_name",
-                                "action"
-                              ],
+                              "required": ["mcp_client_id", "tool_name", "action"],
                               "properties": {
                                 "mcp_client_id": {
                                   "type": "string"
@@ -60717,10 +57833,7 @@
                                 },
                                 "action": {
                                   "type": "string",
-                                  "enum": [
-                                    "include",
-                                    "exclude"
-                                  ]
+                                  "enum": ["include", "exclude"]
                                 }
                               }
                             }
@@ -60778,18 +57891,14 @@
         },
         "summary": "Create access profile (deprecated path)",
         "description": "Creates a new access profile template. The profile is inactive until attached to a role.\nNo size limits are enforced on create; the limits apply on update.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -60808,9 +57917,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "provider_name"
-                      ],
+                      "required": ["provider_name"],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -60836,10 +57943,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -60851,14 +57955,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -60903,13 +58000,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -60918,13 +58009,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -60944,10 +58029,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "max_limit",
-                        "reset_duration"
-                      ],
+                      "required": ["max_limit", "reset_duration"],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -60959,14 +58041,7 @@
                         },
                         "reset_duration": {
                           "type": "string",
-                          "enum": [
-                            "1h",
-                            "1d",
-                            "1w",
-                            "1M",
-                            "1Q",
-                            "1Y"
-                          ],
+                          "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                           "description": "Reset duration for a budget."
                         },
                         "reset_config": {
@@ -61011,13 +58086,7 @@
                       },
                       "token_reset_duration": {
                         "type": "string",
-                        "enum": [
-                          "1h",
-                          "1d",
-                          "1w",
-                          "1M",
-                          "1Y"
-                        ],
+                        "enum": ["1h", "1d", "1w", "1M", "1Y"],
                         "description": "Reset duration for a rate limit."
                       },
                       "request_max_limit": {
@@ -61026,13 +58095,7 @@
                       },
                       "request_reset_duration": {
                         "type": "string",
-                        "enum": [
-                          "1h",
-                          "1d",
-                          "1w",
-                          "1M",
-                          "1Y"
-                        ],
+                        "enum": ["1h", "1d", "1w", "1M", "1Y"],
                         "description": "Reset duration for a rate limit."
                       },
                       "token_current_usage": {
@@ -61052,9 +58115,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "tool_group_id"
-                      ],
+                      "required": ["tool_group_id"],
                       "properties": {
                         "tool_group_id": {
                           "type": "integer",
@@ -61067,9 +58128,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_server_id"
-                      ],
+                      "required": ["mcp_server_id"],
                       "properties": {
                         "mcp_server_id": {
                           "type": "string"
@@ -61081,11 +58140,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_client_id",
-                        "tool_name",
-                        "action"
-                      ],
+                      "required": ["mcp_client_id", "tool_name", "action"],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string"
@@ -61095,10 +58150,7 @@
                         },
                         "action": {
                           "type": "string",
-                          "enum": [
-                            "include",
-                            "exclude"
-                          ]
+                          "enum": ["include", "exclude"]
                         }
                       }
                     }
@@ -61151,9 +58203,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -61179,10 +58229,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -61194,14 +58241,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -61246,13 +58286,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -61261,13 +58295,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -61287,10 +58315,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -61302,14 +58327,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -61354,13 +58372,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -61369,13 +58381,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -61395,9 +58401,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -61410,9 +58414,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -61424,11 +58426,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -61438,10 +58436,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -61501,9 +58496,7 @@
         },
         "summary": "Get access profile by ID (deprecated path)",
         "description": "Returns the profile plus its role attachments and the count of users holding a copy.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -61558,9 +58551,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -61586,10 +58577,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -61601,14 +58589,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -61653,13 +58634,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -61668,13 +58643,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -61694,10 +58663,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -61709,14 +58675,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -61761,13 +58720,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -61776,13 +58729,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -61802,9 +58749,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -61817,9 +58762,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -61831,11 +58774,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -61845,10 +58784,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -61925,9 +58861,7 @@
         },
         "summary": "Update access profile (deprecated path)",
         "description": "Partial update. Omitted fields preserve the current value.\n`rate_limit: null` explicitly clears the existing rate limit.\nSize limits enforced: max 100 provider_configs, max 100 budgets, max 50 tags.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -61964,9 +58898,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "provider_name"
-                      ],
+                      "required": ["provider_name"],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -61992,10 +58924,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -62007,14 +58936,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -62059,13 +58981,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -62074,13 +58990,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -62100,10 +59010,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "max_limit",
-                        "reset_duration"
-                      ],
+                      "required": ["max_limit", "reset_duration"],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -62115,14 +59022,7 @@
                         },
                         "reset_duration": {
                           "type": "string",
-                          "enum": [
-                            "1h",
-                            "1d",
-                            "1w",
-                            "1M",
-                            "1Q",
-                            "1Y"
-                          ],
+                          "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                           "description": "Reset duration for a budget."
                         },
                         "reset_config": {
@@ -62171,13 +59071,7 @@
                           },
                           "token_reset_duration": {
                             "type": "string",
-                            "enum": [
-                              "1h",
-                              "1d",
-                              "1w",
-                              "1M",
-                              "1Y"
-                            ],
+                            "enum": ["1h", "1d", "1w", "1M", "1Y"],
                             "description": "Reset duration for a rate limit."
                           },
                           "request_max_limit": {
@@ -62186,13 +59080,7 @@
                           },
                           "request_reset_duration": {
                             "type": "string",
-                            "enum": [
-                              "1h",
-                              "1d",
-                              "1w",
-                              "1M",
-                              "1Y"
-                            ],
+                            "enum": ["1h", "1d", "1w", "1M", "1Y"],
                             "description": "Reset duration for a rate limit."
                           },
                           "token_current_usage": {
@@ -62215,9 +59103,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "tool_group_id"
-                      ],
+                      "required": ["tool_group_id"],
                       "properties": {
                         "tool_group_id": {
                           "type": "integer",
@@ -62230,9 +59116,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_server_id"
-                      ],
+                      "required": ["mcp_server_id"],
                       "properties": {
                         "mcp_server_id": {
                           "type": "string"
@@ -62244,11 +59128,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_client_id",
-                        "tool_name",
-                        "action"
-                      ],
+                      "required": ["mcp_client_id", "tool_name", "action"],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string"
@@ -62258,10 +59138,7 @@
                         },
                         "action": {
                           "type": "string",
-                          "enum": [
-                            "include",
-                            "exclude"
-                          ]
+                          "enum": ["include", "exclude"]
                         }
                       }
                     }
@@ -62314,9 +59191,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -62342,10 +59217,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -62357,14 +59229,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -62409,13 +59274,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -62424,13 +59283,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -62450,10 +59303,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -62465,14 +59315,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -62517,13 +59360,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -62532,13 +59369,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -62558,9 +59389,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -62573,9 +59402,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -62587,11 +59414,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -62601,10 +59424,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -62665,9 +59485,7 @@
         },
         "summary": "Delete access profile (deprecated path)",
         "description": "Blocked with 409 if any users still hold copies. Detach role attachments or remove user assignments first.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -62732,9 +59550,7 @@
         },
         "summary": "Activate access profile (deprecated path)",
         "description": "Sets the profile active. Idempotent.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -62788,9 +59604,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -62816,10 +59630,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -62831,14 +59642,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -62883,13 +59687,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -62898,13 +59696,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -62924,10 +59716,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -62939,14 +59728,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -62991,13 +59773,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -63006,13 +59782,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -63032,9 +59802,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -63047,9 +59815,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -63061,11 +59827,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -63075,10 +59837,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -63128,9 +59887,7 @@
         },
         "summary": "Deactivate access profile (deprecated path)",
         "description": "Sets the profile inactive. Idempotent. User copies are preserved; the profile is hidden from selection menus.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -63184,9 +59941,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -63212,10 +59967,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -63227,14 +59979,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -63279,13 +60024,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -63294,13 +60033,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -63320,10 +60053,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -63335,14 +60065,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -63387,13 +60110,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -63402,13 +60119,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -63428,9 +60139,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -63443,9 +60152,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -63457,11 +60164,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -63471,10 +60174,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -63524,9 +60224,7 @@
         },
         "summary": "Clone an access profile (deprecated path)",
         "description": "Creates a fresh copy of the profile under a new name. The clone has no role attachments or user copies.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -63543,9 +60241,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -63601,9 +60297,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "provider_name"
-                            ],
+                            "required": ["provider_name"],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -63629,10 +60323,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "max_limit",
-                                    "reset_duration"
-                                  ],
+                                  "required": ["max_limit", "reset_duration"],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -63644,14 +60335,7 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": [
-                                        "1h",
-                                        "1d",
-                                        "1w",
-                                        "1M",
-                                        "1Q",
-                                        "1Y"
-                                      ],
+                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -63696,13 +60380,7 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -63711,13 +60389,7 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": [
-                                      "1h",
-                                      "1d",
-                                      "1w",
-                                      "1M",
-                                      "1Y"
-                                    ],
+                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -63737,10 +60409,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "max_limit",
-                              "reset_duration"
-                            ],
+                            "required": ["max_limit", "reset_duration"],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -63752,14 +60421,7 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": [
-                                  "1h",
-                                  "1d",
-                                  "1w",
-                                  "1M",
-                                  "1Q",
-                                  "1Y"
-                                ],
+                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -63804,13 +60466,7 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -63819,13 +60475,7 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": [
-                                "1h",
-                                "1d",
-                                "1w",
-                                "1M",
-                                "1Y"
-                              ],
+                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -63845,9 +60495,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "tool_group_id"
-                            ],
+                            "required": ["tool_group_id"],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -63860,9 +60508,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_server_id"
-                            ],
+                            "required": ["mcp_server_id"],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -63874,11 +60520,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id",
-                              "tool_name",
-                              "action"
-                            ],
+                            "required": ["mcp_client_id", "tool_name", "action"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -63888,10 +60530,7 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": [
-                                  "include",
-                                  "exclude"
-                                ]
+                                "enum": ["include", "exclude"]
                               }
                             }
                           }
@@ -63954,9 +60593,7 @@
         },
         "summary": "Propagate template changes to user copies (deprecated path)",
         "description": "Pushes selected fields from the template to every user that holds a copy.\nUse `dry_run: true` to preview the impact. By default, accumulated usage is preserved.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -63973,9 +60610,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "fields"
-                ],
+                "required": ["fields"],
                 "properties": {
                   "dry_run": {
                     "type": "boolean"
@@ -64107,9 +60742,7 @@
         },
         "summary": "Attach roles to access profile (deprecated path)",
         "description": "Attaches one or more roles. Setting `is_default: true` makes the profile the role's default\nfor new users. `apply_to_existing: true` provisions the profile to users already in the role.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -64126,9 +60759,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "role_ids"
-                ],
+                "required": ["role_ids"],
                 "properties": {
                   "role_ids": {
                     "type": "array",
@@ -64212,9 +60843,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/{profile_id}/roles/{role_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach role from access profile (deprecated path)",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -64283,9 +60912,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/{profile_id}/versions` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List version snapshots for an access profile (deprecated path)",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -64375,9 +61002,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/{profile_id}/versions/{version}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get a single version snapshot (deprecated path)",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -64475,9 +61100,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/{profile_id}/audit-logs` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List audit log entries for a single profile (deprecated path)",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "profile_id",
@@ -64605,9 +61228,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/audit-logs` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List workspace-wide audit log entries (deprecated path)",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "limit",
@@ -64726,9 +61347,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/users/{user_id}/access-profiles` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List access profiles held by a user (deprecated path)",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -64825,10 +61444,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/users/{user_id}/virtual-keys` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List virtual keys available to a user (deprecated path)",
-        "tags": [
-          "Users",
-          "Virtual Keys"
-        ],
+        "tags": ["Users", "Virtual Keys"],
         "parameters": [
           {
             "name": "user_id",
@@ -64881,9 +61497,7 @@
         },
         "summary": "Set a user's access-profile budget override (deprecated path)",
         "description": "Sets or replaces the spending override on one budget of a single user's copy of an access profile.\nThe override is additive — while it is active the budget is enforced against\n`max_limit + override_amount` — and it leaves the budget's base limit, current usage, and reset\nschedule untouched. Only this user is affected; the access profile template and every other user\nassigned to it keep their original limits.\n\nUse `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows\n(the current window counts as the first), or `mode: forever` to keep the override until it is deleted.\nA finite grant is anchored to the profile's reset window — calendar-aligned profiles anchor at the\ncalendar period start — so every node in a cluster derives the same number of remaining cycles.\nThe change is propagated cluster-wide and survives access-profile cloning and propagation.\n\nRequires the `AccessProfiles.Update` permission. `budget_id` must be a budget on the user's own copy\nof the profile, not on the shared template.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -64977,9 +61591,7 @@
         },
         "summary": "Remove a user's access-profile budget override (deprecated path)",
         "description": "Removes any active override from the user's budget, so it is enforced against its base `max_limit`\nagain. The budget's current usage and reset schedule are unchanged, and the removal is permanent — a\ncleared grant cannot be re-derived. Safe to call on a budget that has no override.\n\nRequires the `AccessProfiles.Update` permission.\n",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -65055,9 +61667,7 @@
         },
         "summary": "Detach a user's access profile (deprecated path)",
         "description": "Removes the profile from the user and deletes every virtual key it produced. Fails closed if a virtual key cannot be deleted.",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -65135,9 +61745,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/users/{user_id}/access-profiles/{profile_id}/virtual-keys` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Add an extra virtual key under a user's access profile (deprecated path)",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -65236,9 +61844,7 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/users/{user_id}/access-profiles/virtual-keys/{vk_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Delete a virtual key from a user's access profile (deprecated path)",
-        "tags": [
-          "Access Profiles"
-        ],
+        "tags": ["Access Profiles"],
         "parameters": [
           {
             "name": "user_id",
@@ -65308,9 +61914,7 @@
         },
         "summary": "List audit logs",
         "description": "Retrieves CADF-compliant audit log events with filtering, search, and\npagination via query parameters. Most filter dimensions accept either a\nsingle value (singular parameter, e.g. `action`) or a JSON-encoded array\nof values (plural parameter, e.g. `actions`); when both are supplied the\nplural array takes precedence.\n",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "page",
@@ -65559,10 +62163,7 @@
             "description": "Sort direction.",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "desc"
             }
           }
@@ -65617,9 +62218,7 @@
         },
         "summary": "Get audit log filter data",
         "description": "Returns the distinct values available for each audit log filter dimension,\nused to populate filter dropdowns in the dashboard.\n",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "dimensions",
@@ -65679,9 +62278,7 @@
         },
         "summary": "Export audit logs",
         "description": "Streams audit log events matching the supplied filters as a downloadable\nfile. Accepts the same filter query parameters as `GET /api/audit-logs`.\nThe response is returned as an attachment with a generated filename.\n",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "format",
@@ -65689,11 +62286,7 @@
             "description": "Export format. Defaults to `json` when omitted or unrecognized.\n- `json`: a JSON array of events\n- `jsonl`: JSON Lines, one event per line\n- `syslog`: RFC 5424 syslog format\n",
             "schema": {
               "type": "string",
-              "enum": [
-                "json",
-                "jsonl",
-                "syslog"
-              ],
+              "enum": ["json", "jsonl", "syslog"],
               "default": "json"
             }
           },
@@ -65814,9 +62407,7 @@
         },
         "summary": "Get audit log by ID",
         "description": "Retrieves a single audit log event by its unique ID.",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "id",
@@ -65888,9 +62479,7 @@
         },
         "summary": "Verify audit log signature",
         "description": "Recomputes the HMAC-SHA256 signature for a single audit log event and\ncompares it (in constant time) against the stored signature to detect\ntampering.\n",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "id",
@@ -65962,9 +62551,7 @@
         },
         "summary": "List audit logs (deprecated path)",
         "description": "Retrieves CADF-compliant audit log events with filtering, search, and\npagination via query parameters. Most filter dimensions accept either a\nsingle value (singular parameter, e.g. `action`) or a JSON-encoded array\nof values (plural parameter, e.g. `actions`); when both are supplied the\nplural array takes precedence.\n",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "page",
@@ -66213,10 +62800,7 @@
             "description": "Sort direction.",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "desc"
             }
           }
@@ -66274,9 +62858,7 @@
         },
         "summary": "Get audit log filter data (deprecated path)",
         "description": "Returns the distinct values available for each audit log filter dimension,\nused to populate filter dropdowns in the dashboard.\n",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "dimensions",
@@ -66339,9 +62921,7 @@
         },
         "summary": "Export audit logs (deprecated path)",
         "description": "Streams audit log events matching the supplied filters as a downloadable\nfile. Accepts the same filter query parameters as `GET /api/audit-logs`.\nThe response is returned as an attachment with a generated filename.\n",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "format",
@@ -66349,11 +62929,7 @@
             "description": "Export format. Defaults to `json` when omitted or unrecognized.\n- `json`: a JSON array of events\n- `jsonl`: JSON Lines, one event per line\n- `syslog`: RFC 5424 syslog format\n",
             "schema": {
               "type": "string",
-              "enum": [
-                "json",
-                "jsonl",
-                "syslog"
-              ],
+              "enum": ["json", "jsonl", "syslog"],
               "default": "json"
             }
           },
@@ -66477,9 +63053,7 @@
         },
         "summary": "Get audit log by ID (deprecated path)",
         "description": "Retrieves a single audit log event by its unique ID.",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "id",
@@ -66554,9 +63128,7 @@
         },
         "summary": "Verify audit log signature (deprecated path)",
         "description": "Recomputes the HMAC-SHA256 signature for a single audit log event and\ncompares it (in constant time) against the stored signature to detect\ntampering.\n",
-        "tags": [
-          "Audit Logs"
-        ],
+        "tags": ["Audit Logs"],
         "parameters": [
           {
             "name": "id",
@@ -66631,9 +63203,7 @@
         },
         "summary": "List MCP Tool Groups",
         "description": "Returns tool groups visible to the caller. When all of `limit`, `offset`, and `search` are omitted, every group is returned in one response.\n",
-        "tags": [
-          "MCP Tool Groups"
-        ],
+        "tags": ["MCP Tool Groups"],
         "parameters": [
           {
             "name": "limit",
@@ -66695,9 +63265,7 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": [
-                                "mcp_client_id"
-                              ],
+                              "required": ["mcp_client_id"],
                               "properties": {
                                 "mcp_client_id": {
                                   "type": "string",
@@ -66800,19 +63368,14 @@
         },
         "summary": "Create MCP Tool Group",
         "description": "Creates a new tool group along with its attachments in a single transaction.\nValidates that every `mcp_client_id` points to a deployed MCP client and that every named\ntool exists on its server.\n",
-        "tags": [
-          "MCP Tool Groups"
-        ],
+        "tags": ["MCP Tool Groups"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name",
-                  "tools"
-                ],
+                "required": ["name", "tools"],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -66829,9 +63392,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_client_id"
-                      ],
+                      "required": ["mcp_client_id"],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string",
@@ -66924,9 +63485,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id"
-                            ],
+                            "required": ["mcp_client_id"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string",
@@ -67020,9 +63579,7 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get MCP Tool Group by ID",
-        "tags": [
-          "MCP Tool Groups"
-        ],
+        "tags": ["MCP Tool Groups"],
         "parameters": [
           {
             "name": "id",
@@ -67068,9 +63625,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id"
-                            ],
+                            "required": ["mcp_client_id"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string",
@@ -67163,9 +63718,7 @@
         },
         "summary": "Update MCP Tool Group",
         "description": "Partial update. Scalar fields preserve the current value when omitted.\nArray fields are replace-on-send: an empty array clears all attachments in that dimension.\n",
-        "tags": [
-          "MCP Tool Groups"
-        ],
+        "tags": ["MCP Tool Groups"],
         "parameters": [
           {
             "name": "id",
@@ -67200,9 +63753,7 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "mcp_client_id"
-                      ],
+                      "required": ["mcp_client_id"],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string",
@@ -67295,9 +63846,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "mcp_client_id"
-                            ],
+                            "required": ["mcp_client_id"],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string",
@@ -67393,9 +63942,7 @@
         },
         "summary": "Delete MCP Tool Group",
         "description": "Deletes the group; attachments are removed automatically.",
-        "tags": [
-          "MCP Tool Groups"
-        ],
+        "tags": ["MCP Tool Groups"],
         "parameters": [
           {
             "name": "id",
@@ -67454,9 +64001,7 @@
         },
         "summary": "List circuit breaker policies",
         "description": "Returns all circuit breaker policies defined in this workspace.",
-        "tags": [
-          "Circuit Breaker"
-        ],
+        "tags": ["Circuit Breaker"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -67517,16 +64062,11 @@
                           },
                           "condition": {
                             "type": "object",
-                            "required": [
-                              "signals"
-                            ],
+                            "required": ["signals"],
                             "properties": {
                               "operator": {
                                 "type": "string",
-                                "enum": [
-                                  "OR",
-                                  "AND"
-                                ],
+                                "enum": ["OR", "AND"],
                                 "default": "OR",
                                 "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                               },
@@ -67536,16 +64076,11 @@
                                 "description": "List of response signals to evaluate. At least one required.",
                                 "items": {
                                   "type": "object",
-                                  "required": [
-                                    "source",
-                                    "header_name"
-                                  ],
+                                  "required": ["source", "header_name"],
                                   "properties": {
                                     "source": {
                                       "type": "string",
-                                      "enum": [
-                                        "response_header"
-                                      ],
+                                      "enum": ["response_header"],
                                       "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                                     },
                                     "header_name": {
@@ -67618,9 +64153,7 @@
         },
         "summary": "Create circuit breaker policy",
         "description": "Creates a new circuit breaker policy and immediately activates it in the running gateway.\nReturns 409 if a policy with the same name already exists.\n",
-        "tags": [
-          "Circuit Breaker"
-        ],
+        "tags": ["Circuit Breaker"],
         "requestBody": {
           "required": true,
           "content": {
@@ -67670,16 +64203,11 @@
                   },
                   "condition": {
                     "type": "object",
-                    "required": [
-                      "signals"
-                    ],
+                    "required": ["signals"],
                     "properties": {
                       "operator": {
                         "type": "string",
-                        "enum": [
-                          "OR",
-                          "AND"
-                        ],
+                        "enum": ["OR", "AND"],
                         "default": "OR",
                         "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                       },
@@ -67689,16 +64217,11 @@
                         "description": "List of response signals to evaluate. At least one required.",
                         "items": {
                           "type": "object",
-                          "required": [
-                            "source",
-                            "header_name"
-                          ],
+                          "required": ["source", "header_name"],
                           "properties": {
                             "source": {
                               "type": "string",
-                              "enum": [
-                                "response_header"
-                              ],
+                              "enum": ["response_header"],
                               "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                             },
                             "header_name": {
@@ -67797,16 +64320,11 @@
                     },
                     "condition": {
                       "type": "object",
-                      "required": [
-                        "signals"
-                      ],
+                      "required": ["signals"],
                       "properties": {
                         "operator": {
                           "type": "string",
-                          "enum": [
-                            "OR",
-                            "AND"
-                          ],
+                          "enum": ["OR", "AND"],
                           "default": "OR",
                           "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                         },
@@ -67816,16 +64334,11 @@
                           "description": "List of response signals to evaluate. At least one required.",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "source",
-                              "header_name"
-                            ],
+                            "required": ["source", "header_name"],
                             "properties": {
                               "source": {
                                 "type": "string",
-                                "enum": [
-                                  "response_header"
-                                ],
+                                "enum": ["response_header"],
                                 "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                               },
                               "header_name": {
@@ -67906,9 +64419,7 @@
         },
         "summary": "Update circuit breaker policy",
         "description": "Replaces a circuit breaker policy by name. The `name` field in the request body must match the URL parameter or be omitted.\nChanges take effect immediately in the running gateway.\n",
-        "tags": [
-          "Circuit Breaker"
-        ],
+        "tags": ["Circuit Breaker"],
         "parameters": [
           {
             "name": "name",
@@ -67969,16 +64480,11 @@
                   },
                   "condition": {
                     "type": "object",
-                    "required": [
-                      "signals"
-                    ],
+                    "required": ["signals"],
                     "properties": {
                       "operator": {
                         "type": "string",
-                        "enum": [
-                          "OR",
-                          "AND"
-                        ],
+                        "enum": ["OR", "AND"],
                         "default": "OR",
                         "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                       },
@@ -67988,16 +64494,11 @@
                         "description": "List of response signals to evaluate. At least one required.",
                         "items": {
                           "type": "object",
-                          "required": [
-                            "source",
-                            "header_name"
-                          ],
+                          "required": ["source", "header_name"],
                           "properties": {
                             "source": {
                               "type": "string",
-                              "enum": [
-                                "response_header"
-                              ],
+                              "enum": ["response_header"],
                               "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                             },
                             "header_name": {
@@ -68096,16 +64597,11 @@
                     },
                     "condition": {
                       "type": "object",
-                      "required": [
-                        "signals"
-                      ],
+                      "required": ["signals"],
                       "properties": {
                         "operator": {
                           "type": "string",
-                          "enum": [
-                            "OR",
-                            "AND"
-                          ],
+                          "enum": ["OR", "AND"],
                           "default": "OR",
                           "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                         },
@@ -68115,16 +64611,11 @@
                           "description": "List of response signals to evaluate. At least one required.",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "source",
-                              "header_name"
-                            ],
+                            "required": ["source", "header_name"],
                             "properties": {
                               "source": {
                                 "type": "string",
-                                "enum": [
-                                  "response_header"
-                                ],
+                                "enum": ["response_header"],
                                 "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                               },
                               "header_name": {
@@ -68203,9 +64694,7 @@
         },
         "summary": "Delete circuit breaker policy",
         "description": "Deletes a circuit breaker policy by name and removes it from the running gateway.\nAny open circuits for this policy are discarded immediately.\n",
-        "tags": [
-          "Circuit Breaker"
-        ],
+        "tags": ["Circuit Breaker"],
         "parameters": [
           {
             "name": "name",
@@ -68265,9 +64754,7 @@
         },
         "summary": "Get circuit breaker state",
         "description": "Returns a snapshot of all currently-open circuits.\nMain circuits are keyed by policy name. Per-key sub-circuits are keyed by `\"<policy_name>\\x00<key_id>\"`.\nCircuits not present in the map are closed.\n",
-        "tags": [
-          "Circuit Breaker"
-        ],
+        "tags": ["Circuit Breaker"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -68333,9 +64820,7 @@
         "operationId": "listRoutingRules",
         "summary": "List routing rules",
         "description": "Returns a list of all routing rules configured for intelligent request routing across providers.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "parameters": [
           {
             "name": "scope",
@@ -68386,9 +64871,7 @@
         "operationId": "createRoutingRule",
         "summary": "Create routing rule",
         "description": "Creates a new CEL-based routing rule for intelligent request routing. Provider and model can be left empty to use the incoming request values.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "requestBody": {
           "required": true,
           "content": {
@@ -68443,9 +64926,7 @@
         "operationId": "getRoutingRule",
         "summary": "Get routing rule",
         "description": "Returns a specific routing rule by ID.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "parameters": [
           {
             "name": "rule_id",
@@ -68504,9 +64985,7 @@
         "operationId": "updateRoutingRule",
         "summary": "Update routing rule",
         "description": "Updates an existing routing rule's configuration.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "parameters": [
           {
             "name": "rule_id",
@@ -68580,9 +65059,7 @@
         "operationId": "deleteRoutingRule",
         "summary": "Delete routing rule",
         "description": "Deletes a routing rule.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "parameters": [
           {
             "name": "rule_id",
@@ -68638,9 +65115,7 @@
         "operationId": "getComplexityAnalyzerConfig",
         "summary": "Get complexity analyzer config",
         "description": "Returns the full complexity analyzer runtime config, including tier thresholds and editable keyword lists. Returns built-in defaults if none have been configured.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -68655,20 +65130,13 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": [
-                    "tier_boundaries",
-                    "keywords"
-                  ],
+                  "required": ["tier_boundaries", "keywords"],
                   "properties": {
                     "tier_boundaries": {
                       "type": "object",
                       "description": "Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
                       "additionalProperties": false,
-                      "required": [
-                        "simple_medium",
-                        "medium_complex",
-                        "complex_reasoning"
-                      ],
+                      "required": ["simple_medium", "medium_complex", "complex_reasoning"],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -68762,9 +65230,7 @@
         "operationId": "updateComplexityAnalyzerConfig",
         "summary": "Update complexity analyzer config",
         "description": "Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Tier thresholds must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "requestBody": {
           "required": true,
           "content": {
@@ -68773,20 +65239,13 @@
                 "type": "object",
                 "description": "Full runtime configuration for complexity routing analysis.",
                 "additionalProperties": false,
-                "required": [
-                  "tier_boundaries",
-                  "keywords"
-                ],
+                "required": ["tier_boundaries", "keywords"],
                 "properties": {
                   "tier_boundaries": {
                     "type": "object",
                     "description": "Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
                     "additionalProperties": false,
-                    "required": [
-                      "simple_medium",
-                      "medium_complex",
-                      "complex_reasoning"
-                    ],
+                    "required": ["simple_medium", "medium_complex", "complex_reasoning"],
                     "properties": {
                       "simple_medium": {
                         "type": "number",
@@ -68868,20 +65327,13 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": [
-                    "tier_boundaries",
-                    "keywords"
-                  ],
+                  "required": ["tier_boundaries", "keywords"],
                   "properties": {
                     "tier_boundaries": {
                       "type": "object",
                       "description": "Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
                       "additionalProperties": false,
-                      "required": [
-                        "simple_medium",
-                        "medium_complex",
-                        "complex_reasoning"
-                      ],
+                      "required": ["simple_medium", "medium_complex", "complex_reasoning"],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -68987,9 +65439,7 @@
         "operationId": "resetComplexityAnalyzerConfig",
         "summary": "Reset complexity analyzer config",
         "description": "Restores the built-in complexity analyzer runtime config defaults and hot-reloads the routing plugin.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -69004,20 +65454,13 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": [
-                    "tier_boundaries",
-                    "keywords"
-                  ],
+                  "required": ["tier_boundaries", "keywords"],
                   "properties": {
                     "tier_boundaries": {
                       "type": "object",
                       "description": "Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
                       "additionalProperties": false,
-                      "required": [
-                        "simple_medium",
-                        "medium_complex",
-                        "complex_reasoning"
-                      ],
+                      "required": ["simple_medium", "medium_complex", "complex_reasoning"],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -69114,9 +65557,7 @@
         "deprecated": true,
         "summary": "List routing rules (deprecated path)",
         "description": "Returns a list of all routing rules configured for intelligent request routing across providers. Deprecated, use /api/routing/rules instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "parameters": [
           {
             "name": "scope",
@@ -69168,9 +65609,7 @@
         "deprecated": true,
         "summary": "Create routing rule (deprecated path)",
         "description": "Creates a new CEL-based routing rule for intelligent request routing. Provider and model can be left empty to use the incoming request values. Deprecated, use /api/routing/rules instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "requestBody": {
           "required": true,
           "content": {
@@ -69226,9 +65665,7 @@
         "deprecated": true,
         "summary": "Get routing rule (deprecated path)",
         "description": "Returns a specific routing rule by ID. Deprecated, use /api/routing/rules/{rule_id} instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "parameters": [
           {
             "name": "rule_id",
@@ -69288,9 +65725,7 @@
         "deprecated": true,
         "summary": "Update routing rule (deprecated path)",
         "description": "Updates an existing routing rule's configuration. Deprecated, use /api/routing/rules/{rule_id} instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "parameters": [
           {
             "name": "rule_id",
@@ -69365,9 +65800,7 @@
         "deprecated": true,
         "summary": "Delete routing rule (deprecated path)",
         "description": "Deletes a routing rule. Deprecated, use /api/routing/rules/{rule_id} instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "parameters": [
           {
             "name": "rule_id",
@@ -69424,9 +65857,7 @@
         "deprecated": true,
         "summary": "Get complexity analyzer config (deprecated path)",
         "description": "Returns the full complexity analyzer runtime config, including tier thresholds and editable keyword lists. Returns built-in defaults if none have been configured. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -69441,20 +65872,13 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": [
-                    "tier_boundaries",
-                    "keywords"
-                  ],
+                  "required": ["tier_boundaries", "keywords"],
                   "properties": {
                     "tier_boundaries": {
                       "type": "object",
                       "description": "Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
                       "additionalProperties": false,
-                      "required": [
-                        "simple_medium",
-                        "medium_complex",
-                        "complex_reasoning"
-                      ],
+                      "required": ["simple_medium", "medium_complex", "complex_reasoning"],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -69549,9 +65973,7 @@
         "deprecated": true,
         "summary": "Update complexity analyzer config (deprecated path)",
         "description": "Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Tier thresholds must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "requestBody": {
           "required": true,
           "content": {
@@ -69560,20 +65982,13 @@
                 "type": "object",
                 "description": "Full runtime configuration for complexity routing analysis.",
                 "additionalProperties": false,
-                "required": [
-                  "tier_boundaries",
-                  "keywords"
-                ],
+                "required": ["tier_boundaries", "keywords"],
                 "properties": {
                   "tier_boundaries": {
                     "type": "object",
                     "description": "Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
                     "additionalProperties": false,
-                    "required": [
-                      "simple_medium",
-                      "medium_complex",
-                      "complex_reasoning"
-                    ],
+                    "required": ["simple_medium", "medium_complex", "complex_reasoning"],
                     "properties": {
                       "simple_medium": {
                         "type": "number",
@@ -69655,20 +66070,13 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": [
-                    "tier_boundaries",
-                    "keywords"
-                  ],
+                  "required": ["tier_boundaries", "keywords"],
                   "properties": {
                     "tier_boundaries": {
                       "type": "object",
                       "description": "Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
                       "additionalProperties": false,
-                      "required": [
-                        "simple_medium",
-                        "medium_complex",
-                        "complex_reasoning"
-                      ],
+                      "required": ["simple_medium", "medium_complex", "complex_reasoning"],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -69775,9 +66183,7 @@
         "deprecated": true,
         "summary": "Reset complexity analyzer config (deprecated path)",
         "description": "Restores the built-in complexity analyzer runtime config defaults and hot-reloads the routing plugin. Deprecated, use /api/routing/complexity-analyzer-config/reset instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": [
-          "Routing"
-        ],
+        "tags": ["Routing"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -69792,20 +66198,13 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": [
-                    "tier_boundaries",
-                    "keywords"
-                  ],
+                  "required": ["tier_boundaries", "keywords"],
                   "properties": {
                     "tier_boundaries": {
                       "type": "object",
                       "description": "Score thresholds for complexity tier classification. All values must satisfy 0 < simple_medium < medium_complex < complex_reasoning < 1.",
                       "additionalProperties": false,
-                      "required": [
-                        "simple_medium",
-                        "medium_complex",
-                        "complex_reasoning"
-                      ],
+                      "required": ["simple_medium", "medium_complex", "complex_reasoning"],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -69901,9 +66300,7 @@
         "operationId": "getLogs",
         "summary": "Get logs",
         "description": "Retrieves logs with filtering, search, and pagination via query parameters.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -70084,12 +66481,7 @@
             "description": "Field to sort by",
             "schema": {
               "type": "string",
-              "enum": [
-                "timestamp",
-                "latency",
-                "tokens",
-                "cost"
-              ],
+              "enum": ["timestamp", "latency", "tokens", "cost"],
               "default": "timestamp"
             }
           },
@@ -70099,10 +66491,7 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "desc"
             }
           }
@@ -70149,9 +66538,7 @@
         "operationId": "deleteLogs",
         "summary": "Delete logs",
         "description": "Deletes logs by their IDs.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "requestBody": {
           "required": true,
           "content": {
@@ -70206,9 +66593,7 @@
         "operationId": "getLogById",
         "summary": "Get a single log entry",
         "description": "Retrieves a single log entry by its ID.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "id",
@@ -70264,9 +66649,7 @@
         "operationId": "getLogSessionById",
         "summary": "Get logs for a session",
         "description": "Returns the paginated logs belonging to a single parent-request session\n(grouped by `parent_request_id`). Sorted ascending by timestamp by default.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "session_id",
@@ -70302,10 +66685,7 @@
             "description": "Sort order (default `asc`)",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "asc"
             }
           }
@@ -70345,10 +66725,7 @@
                         },
                         "order": {
                           "type": "string",
-                          "enum": [
-                            "asc",
-                            "desc"
-                          ]
+                          "enum": ["asc", "desc"]
                         },
                         "total_count": {
                           "type": "integer",
@@ -70402,9 +66779,7 @@
         "operationId": "getLogSessionSummaryById",
         "summary": "Get aggregate totals for a session",
         "description": "Returns aggregate request count, token usage, cost, and duration for a single session.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "session_id",
@@ -70489,9 +66864,7 @@
         "operationId": "getLogsStats",
         "summary": "Get log statistics",
         "description": "Returns statistics for logs matching the specified filters.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -70646,6 +67019,15 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "compare_to_previous",
+            "in": "query",
+            "description": "When true, also return the same statistics for the immediately preceding window of equal length, so callers can render change-vs-previous-period. Requires a bounded window of positive length (start_time and end_time, or period) and no `request_id`, since an id lookup matches one row regardless of the window. Where there is no preceding window to compare against, the response omits `previous` with `has_previous_period` false. A failure to compute the previous period degrades to `has_previous_period` false rather than failing the request.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "security": [
@@ -70659,7 +67041,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LogStats"
+                  "$ref": "#/components/schemas/LogStatsResponse"
                 }
               }
             }
@@ -70692,9 +67074,7 @@
         "operationId": "getLogsHistogram",
         "summary": "Get request count histogram",
         "description": "Returns time-bucketed request counts. Bucket size is auto-calculated from the time range.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -71007,9 +67387,7 @@
         "operationId": "getLogsTokenHistogram",
         "summary": "Get token usage histogram",
         "description": "Returns time-bucketed token usage (prompt, completion, total).",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -71242,9 +67620,7 @@
         "operationId": "getLogsCostHistogram",
         "summary": "Get cost histogram",
         "description": "Returns time-bucketed cost data with model breakdown.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -71482,9 +67858,7 @@
         "operationId": "getLogsModelHistogram",
         "summary": "Get model usage histogram",
         "description": "Returns time-bucketed model usage with success/error breakdown.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -71733,9 +68107,7 @@
         "operationId": "getLogsLatencyHistogram",
         "summary": "Get latency histogram",
         "description": "Returns time-bucketed latency percentiles (avg, p90, p95, p99).",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -71972,9 +68344,7 @@
         "operationId": "getLogsProviderCostHistogram",
         "summary": "Get cost histogram by provider",
         "description": "Returns time-bucketed cost data with provider breakdown.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -72211,9 +68581,7 @@
         "operationId": "getLogsProviderTokenHistogram",
         "summary": "Get token histogram by provider",
         "description": "Returns time-bucketed token usage with provider breakdown.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -72462,9 +68830,7 @@
         "operationId": "getLogsProviderLatencyHistogram",
         "summary": "Get latency histogram by provider",
         "description": "Returns time-bucketed latency percentiles with provider breakdown.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -72717,9 +69083,7 @@
         "operationId": "getLogsDimensionCostHistogram",
         "summary": "Get cost histogram by dimension",
         "description": "Returns time-bucketed cost data grouped by an arbitrary dimension\n(`provider`, `team_id`, `customer_id`, `user_id`, `business_unit_id`).\nThe dimension is supplied via the required `dimension` query parameter.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "dimension",
@@ -72729,13 +69093,7 @@
             "schema": {
               "type": "string",
               "description": "Grouping dimension for dimension-aware histograms. Used by the\n`/api/logs/histogram/{cost,tokens,latency}/by-dimension` endpoints.\n",
-              "enum": [
-                "provider",
-                "team_id",
-                "customer_id",
-                "user_id",
-                "business_unit_id"
-              ]
+              "enum": ["provider", "team_id", "customer_id", "user_id", "business_unit_id"]
             }
           },
           {
@@ -72937,13 +69295,7 @@
                     "dimension": {
                       "type": "string",
                       "description": "Grouping dimension for dimension-aware histograms. Used by the\n`/api/logs/histogram/{cost,tokens,latency}/by-dimension` endpoints.\n",
-                      "enum": [
-                        "provider",
-                        "team_id",
-                        "customer_id",
-                        "user_id",
-                        "business_unit_id"
-                      ]
+                      "enum": ["provider", "team_id", "customer_id", "user_id", "business_unit_id"]
                     },
                     "dimension_values": {
                       "type": "array",
@@ -72984,9 +69336,7 @@
         "operationId": "getLogsDimensionTokenHistogram",
         "summary": "Get token histogram by dimension",
         "description": "Returns time-bucketed token usage grouped by an arbitrary dimension.\nSee `getLogsDimensionCostHistogram` for the list of supported dimensions.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "dimension",
@@ -72996,13 +69346,7 @@
             "schema": {
               "type": "string",
               "description": "Grouping dimension for dimension-aware histograms. Used by the\n`/api/logs/histogram/{cost,tokens,latency}/by-dimension` endpoints.\n",
-              "enum": [
-                "provider",
-                "team_id",
-                "customer_id",
-                "user_id",
-                "business_unit_id"
-              ]
+              "enum": ["provider", "team_id", "customer_id", "user_id", "business_unit_id"]
             }
           },
           {
@@ -73215,13 +69559,7 @@
                     "dimension": {
                       "type": "string",
                       "description": "Grouping dimension for dimension-aware histograms. Used by the\n`/api/logs/histogram/{cost,tokens,latency}/by-dimension` endpoints.\n",
-                      "enum": [
-                        "provider",
-                        "team_id",
-                        "customer_id",
-                        "user_id",
-                        "business_unit_id"
-                      ]
+                      "enum": ["provider", "team_id", "customer_id", "user_id", "business_unit_id"]
                     },
                     "dimension_values": {
                       "type": "array",
@@ -73262,9 +69600,7 @@
         "operationId": "getLogsDimensionLatencyHistogram",
         "summary": "Get latency histogram by dimension",
         "description": "Returns time-bucketed latency percentiles (avg, p90, p95, p99) grouped by\nan arbitrary dimension.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "dimension",
@@ -73274,13 +69610,7 @@
             "schema": {
               "type": "string",
               "description": "Grouping dimension for dimension-aware histograms. Used by the\n`/api/logs/histogram/{cost,tokens,latency}/by-dimension` endpoints.\n",
-              "enum": [
-                "provider",
-                "team_id",
-                "customer_id",
-                "user_id",
-                "business_unit_id"
-              ]
+              "enum": ["provider", "team_id", "customer_id", "user_id", "business_unit_id"]
             }
           },
           {
@@ -73497,13 +69827,7 @@
                     "dimension": {
                       "type": "string",
                       "description": "Grouping dimension for dimension-aware histograms. Used by the\n`/api/logs/histogram/{cost,tokens,latency}/by-dimension` endpoints.\n",
-                      "enum": [
-                        "provider",
-                        "team_id",
-                        "customer_id",
-                        "user_id",
-                        "business_unit_id"
-                      ]
+                      "enum": ["provider", "team_id", "customer_id", "user_id", "business_unit_id"]
                     },
                     "dimension_values": {
                       "type": "array",
@@ -73544,9 +69868,7 @@
         "operationId": "getDroppedRequests",
         "summary": "Get dropped requests count",
         "description": "Returns the number of dropped requests.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -73578,9 +69900,7 @@
         "operationId": "getAvailableFilterData",
         "summary": "Get available filter data",
         "description": "Returns all unique filter data from logs (models, keys, virtual keys).",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -73650,9 +69970,7 @@
         "operationId": "getModelRankings",
         "summary": "Get model usage rankings",
         "description": "Returns models ranked by usage with trend percentages versus the previous\ncomparable period. Accepts the same filter parameters as the histogram\nendpoints.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -74021,9 +70339,7 @@
         "operationId": "getDashboard",
         "summary": "Get consolidated dashboard data",
         "description": "Returns every metric shown on the workspace dashboard in a single\nresponse: overview totals and histograms, provider usage, model rankings,\ndimension rankings (team, user, virtual key, customer, business unit), and\nMCP usage. Intended for external integrations that want the full dashboard\nin one call rather than orchestrating the individual endpoints.\n\nAccepts the same LLM filter parameters as the histogram and rankings\nendpoints, plus the MCP filter parameters (`tool_names`, `server_labels`)\nwhich apply to the `mcp` section. Filters are applied once and every\nsection is computed against the same time window and bucket size. The\nrequest fails as a whole if any section cannot be computed, so the payload\nis always complete.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "providers",
@@ -74887,13 +71203,7 @@
                           "dimension": {
                             "type": "string",
                             "description": "Entity used to group dimension rankings",
-                            "enum": [
-                              "team",
-                              "customer",
-                              "business_unit",
-                              "user",
-                              "virtual_key"
-                            ]
+                            "enum": ["team", "customer", "business_unit", "user", "virtual_key"]
                           },
                           "total_actual_requests": {
                             "type": "integer",
@@ -75033,9 +71343,7 @@
         "operationId": "recalculateLogCosts",
         "summary": "Recalculate log costs",
         "description": "Starts an asynchronous background job that recalculates log costs in batches.\nThe returned payload is a job status object that can be polled via the status endpoint.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "requestBody": {
           "required": false,
           "content": {
@@ -75110,9 +71418,7 @@
         "operationId": "getRecalculateCostStatus",
         "summary": "Get log cost recalculation status",
         "description": "Returns the current status of a log cost recalculation job.\nWhen `id` is omitted, the current in-flight job is returned, or `idle` when no job is running.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "id",
@@ -75177,9 +71483,7 @@
         "operationId": "getMCPLogs",
         "summary": "Get MCP tool logs",
         "description": "Retrieves MCP tool execution logs with filtering, search, and pagination via query parameters.\n",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "tool_names",
@@ -75203,11 +71507,7 @@
             "description": "Comma-separated list of statuses to filter by (processing, success, error)",
             "schema": {
               "type": "string",
-              "enum": [
-                "processing",
-                "success",
-                "error"
-              ]
+              "enum": ["processing", "success", "error"]
             }
           },
           {
@@ -75293,11 +71593,7 @@
             "description": "Field to sort by",
             "schema": {
               "type": "string",
-              "enum": [
-                "timestamp",
-                "latency",
-                "cost"
-              ],
+              "enum": ["timestamp", "latency", "cost"],
               "default": "timestamp"
             }
           },
@@ -75307,10 +71603,7 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "desc"
             }
           }
@@ -75387,11 +71680,7 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": [
-                              "processing",
-                              "success",
-                              "error"
-                            ],
+                            "enum": ["processing", "success", "error"],
                             "description": "Execution status"
                           },
                           "metadata": {
@@ -75436,9 +71725,7 @@
                     },
                     "pagination": {
                       "type": "object",
-                      "required": [
-                        "total_count"
-                      ],
+                      "required": ["total_count"],
                       "properties": {
                         "limit": {
                           "type": "integer"
@@ -75494,9 +71781,7 @@
         "operationId": "deleteMCPLogs",
         "summary": "Delete MCP tool logs",
         "description": "Deletes MCP tool logs by their IDs.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "requestBody": {
           "required": true,
           "content": {
@@ -75504,9 +71789,7 @@
               "schema": {
                 "type": "object",
                 "description": "Delete MCP logs request",
-                "required": [
-                  "ids"
-                ],
+                "required": ["ids"],
                 "properties": {
                   "ids": {
                     "type": "array",
@@ -75564,9 +71847,7 @@
         "operationId": "getMCPLogById",
         "summary": "Get MCP tool log by ID",
         "description": "Retrieves a single MCP tool execution log by ID, including hydrated object-storage payloads when configured.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "id",
@@ -75644,11 +71925,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "processing",
-                        "success",
-                        "error"
-                      ],
+                      "enum": ["processing", "success", "error"],
                       "description": "Execution status"
                     },
                     "metadata": {
@@ -75731,9 +72008,7 @@
         "operationId": "getMCPLogsStats",
         "summary": "Get MCP tool log statistics",
         "description": "Returns statistics for MCP tool logs matching the specified filters.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "tool_names",
@@ -75757,11 +72032,7 @@
             "description": "Comma-separated list of statuses to filter by",
             "schema": {
               "type": "string",
-              "enum": [
-                "processing",
-                "success",
-                "error"
-              ]
+              "enum": ["processing", "success", "error"]
             }
           },
           {
@@ -75886,9 +72157,7 @@
         "operationId": "getMCPLogsFilterData",
         "summary": "Get available MCP log filter data",
         "description": "Returns all unique filter data from MCP tool logs (tool names, server labels).",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -75961,9 +72230,7 @@
         "operationId": "getMCPLogsHistogram",
         "summary": "Get MCP tool call volume histogram",
         "description": "Returns time-bucketed MCP tool call volume with success/error breakdown.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "tool_names",
@@ -76124,9 +72391,7 @@
         "operationId": "getMCPLogsCostHistogram",
         "summary": "Get MCP cost histogram",
         "description": "Returns time-bucketed MCP tool call cost data.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "tool_names",
@@ -76278,9 +72543,7 @@
         "operationId": "getMCPLogsTopTools",
         "summary": "Get top MCP tools by call count",
         "description": "Returns the top 10 MCP tools by call count, with cost totals.",
-        "tags": [
-          "Logging"
-        ],
+        "tags": ["Logging"],
         "parameters": [
           {
             "name": "tool_names",
@@ -76431,9 +72694,7 @@
         "operationId": "listFolders",
         "summary": "List folders",
         "description": "Returns all prompt folders.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -76500,18 +72761,14 @@
         "operationId": "createFolder",
         "summary": "Create folder",
         "description": "Creates a new prompt folder.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -76599,9 +72856,7 @@
         "operationId": "getFolder",
         "summary": "Get folder",
         "description": "Returns a folder by ID.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -76685,9 +72940,7 @@
         "operationId": "updateFolder",
         "summary": "Update folder",
         "description": "Updates a folder's name or description.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -76800,9 +73053,7 @@
         "operationId": "deleteFolder",
         "summary": "Delete folder",
         "description": "Deletes a folder and cascades to contained prompts.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -76857,9 +73108,7 @@
         "operationId": "listPrompts",
         "summary": "List prompts",
         "description": "Returns all prompts, optionally filtered by folder.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "folder_id",
@@ -77141,18 +73390,14 @@
         "operationId": "createPrompt",
         "summary": "Create prompt",
         "description": "Creates a new prompt.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -77445,9 +73690,7 @@
         "operationId": "getPrompt",
         "summary": "Get prompt",
         "description": "Returns a prompt by ID with its latest version.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -77736,9 +73979,7 @@
         "operationId": "updatePrompt",
         "summary": "Update prompt",
         "description": "Updates a prompt's name or folder.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78046,9 +74287,7 @@
         "operationId": "deletePrompt",
         "summary": "Delete prompt",
         "description": "Deletes a prompt and all its versions and sessions.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78103,9 +74342,7 @@
         "operationId": "listPromptVersions",
         "summary": "List prompt versions",
         "description": "Returns all versions for a prompt.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78211,9 +74448,7 @@
         "operationId": "createPromptVersion",
         "summary": "Create prompt version",
         "description": "Creates a new version for a prompt.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78231,13 +74466,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "commit_message",
-                  "messages",
-                  "model_params",
-                  "provider",
-                  "model"
-                ],
+                "required": ["commit_message", "messages", "model_params", "provider", "model"],
                 "properties": {
                   "commit_message": {
                     "type": "string"
@@ -78368,9 +74597,7 @@
         "operationId": "getPromptVersion",
         "summary": "Get prompt version",
         "description": "Returns a specific version by ID.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78483,9 +74710,7 @@
         "operationId": "deletePromptVersion",
         "summary": "Delete prompt version",
         "description": "Deletes a specific version.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78541,9 +74766,7 @@
         "operationId": "listPromptSessions",
         "summary": "List prompt sessions",
         "description": "Returns all sessions for a prompt.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78652,9 +74875,7 @@
         "operationId": "createPromptSession",
         "summary": "Create prompt session",
         "description": "Creates a new playground session for a prompt.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78672,12 +74893,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name",
-                  "model_params",
-                  "provider",
-                  "model"
-                ],
+                "required": ["name", "model_params", "provider", "model"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -78814,9 +75030,7 @@
         "operationId": "getPromptSession",
         "summary": "Get prompt session",
         "description": "Returns a specific session by ID.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78932,9 +75146,7 @@
         "operationId": "updatePromptSession",
         "summary": "Update prompt session",
         "description": "Updates a session's messages, model params, etc.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -78952,13 +75164,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name",
-                  "messages",
-                  "model_params",
-                  "provider",
-                  "model"
-                ],
+                "required": ["name", "messages", "model_params", "provider", "model"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -79089,9 +75295,7 @@
         "operationId": "deletePromptSession",
         "summary": "Delete prompt session",
         "description": "Deletes a specific session.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -79147,9 +75351,7 @@
         "operationId": "renamePromptSession",
         "summary": "Rename prompt session",
         "description": "Renames a session.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -79167,9 +75369,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "name"
-                ],
+                "required": ["name"],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -79285,9 +75485,7 @@
         "operationId": "commitPromptSession",
         "summary": "Commit session as version",
         "description": "Commits the current session state as a new prompt version.",
-        "tags": [
-          "Prompt Repository"
-        ],
+        "tags": ["Prompt Repository"],
         "parameters": [
           {
             "name": "id",
@@ -79305,9 +75503,7 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": [
-                  "commit_message"
-                ],
+                "required": ["commit_message"],
                 "properties": {
                   "commit_message": {
                     "type": "string"
@@ -79420,9 +75616,7 @@
         "operationId": "uploadSkillFile",
         "summary": "Upload skill file",
         "description": "Uploads one file for later attachment to a skill version. The response contains either an object-storage key or a database blob ID.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "requestBody": {
           "required": true,
           "content": {
@@ -79477,9 +75671,7 @@
         "operationId": "cleanupOrphanSkillFiles",
         "summary": "Clean up orphan skill files",
         "description": "Deletes uploaded files that are not attached to any skill version. This is mostly a maintenance escape hatch: Bifrost also runs orphan cleanup on server startup. Non-forced cleanup preserves uploads newer than 24 hours so files are not deleted while a skill is still being edited.\n",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "parameters": [
           {
             "name": "force",
@@ -79525,9 +75717,7 @@
         "operationId": "getAllSkillsVersion",
         "summary": "Get all-skills version",
         "description": "Returns the current version of the synthetic `bifrost-all-skills` marketplace plugin.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -79560,9 +75750,7 @@
         "operationId": "bumpAllSkillsVersion",
         "summary": "Bump all-skills version",
         "description": "Manually bumps the synthetic `bifrost-all-skills` plugin version as an escape hatch for marketplace refreshes.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "requestBody": {
           "required": true,
           "content": {
@@ -79617,9 +75805,7 @@
         "operationId": "listSkills",
         "summary": "List skills",
         "description": "Returns a paginated list of skills from the Skills Repository.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "parameters": [
           {
             "name": "search",
@@ -79635,11 +75821,7 @@
             "description": "Field to sort by.",
             "schema": {
               "type": "string",
-              "enum": [
-                "name",
-                "updated_at",
-                "created_at"
-              ],
+              "enum": ["name", "updated_at", "created_at"],
               "default": "created_at"
             }
           },
@@ -79649,10 +75831,7 @@
             "description": "Sort order.",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "desc"
             }
           },
@@ -79710,9 +75889,7 @@
         "operationId": "createSkill",
         "summary": "Create skill",
         "description": "Creates a new skill and immediately serves its first immutable version.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "requestBody": {
           "required": true,
           "content": {
@@ -79767,9 +75944,7 @@
         "operationId": "getSkill",
         "summary": "Get skill",
         "description": "Returns a skill by ID. Pass `version` to inspect a historical version snapshot.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "parameters": [
           {
             "name": "id",
@@ -79842,9 +76017,7 @@
         "operationId": "updateSkill",
         "summary": "Update skill",
         "description": "Creates a new immutable skill version. Set `serve` to false to save the version without switching the served version.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "parameters": [
           {
             "name": "id",
@@ -79918,9 +76091,7 @@
         "operationId": "deleteSkill",
         "summary": "Delete skill",
         "description": "Deletes a skill and all of its versions.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "parameters": [
           {
             "name": "id",
@@ -79976,9 +76147,7 @@
         "operationId": "listSkillVersions",
         "summary": "List skill versions",
         "description": "Returns immutable version snapshots for a skill.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "parameters": [
           {
             "name": "id",
@@ -80003,10 +76172,7 @@
             "description": "Field to sort by.",
             "schema": {
               "type": "string",
-              "enum": [
-                "version",
-                "created_at"
-              ],
+              "enum": ["version", "created_at"],
               "default": "created_at"
             }
           },
@@ -80016,10 +76182,7 @@
             "description": "Sort order.",
             "schema": {
               "type": "string",
-              "enum": [
-                "asc",
-                "desc"
-              ],
+              "enum": ["asc", "desc"],
               "default": "desc"
             }
           },
@@ -80089,9 +76252,7 @@
         "operationId": "shiftSkillVersion",
         "summary": "Shift served skill version",
         "description": "Changes the served version for a skill without deleting newer versions.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "parameters": [
           {
             "name": "id",
@@ -80167,9 +76328,7 @@
         "operationId": "getClaudeCodeSkillsMarketplace",
         "summary": "Get Claude Code skills marketplace",
         "description": "Public marketplace JSON consumed by Claude Code. Available only when the Bifrost server can access the `git` binary.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "security": [],
         "responses": {
           "200": {
@@ -80210,9 +76369,7 @@
         "operationId": "getCodexSkillsMarketplace",
         "summary": "Get Codex skills marketplace JSON",
         "description": "Public Codex marketplace JSON for inspecting the skills and plugin sources exposed by Bifrost.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "security": [],
         "responses": {
           "200": {
@@ -80253,9 +76410,7 @@
         "operationId": "downloadAllSkills",
         "summary": "Download all skills as ZIP",
         "description": "Public ZIP download containing every currently served skill.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "security": [],
         "responses": {
           "200": {
@@ -80287,9 +76442,7 @@
         "operationId": "downloadSkill",
         "summary": "Download skill as ZIP",
         "description": "Public ZIP download containing a single currently served skill.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "security": [],
         "parameters": [
           {
@@ -80342,9 +76495,7 @@
         "operationId": "downloadSkillFile",
         "summary": "Download skill file",
         "description": "Public raw file download from the currently served version of a skill.",
-        "tags": [
-          "Skills"
-        ],
+        "tags": ["Skills"],
         "security": [],
         "parameters": [
           {
@@ -80406,9 +76557,7 @@
         "operationId": "clearCacheByCacheId",
         "summary": "Clear cache entry by cache ID",
         "description": "Deletes a single cache entry by its storage ID. Read the cache ID from\n`extra_fields.cache_debug.cache_id` on a prior response — it is populated\non both cache hits and cache misses.\n",
-        "tags": [
-          "Cache"
-        ],
+        "tags": ["Cache"],
         "parameters": [
           {
             "name": "cacheId",
@@ -80464,9 +76613,7 @@
         "operationId": "clearCacheByCacheKey",
         "summary": "Clear cache by cache key",
         "description": "Clears a cache entry by its direct cache key.",
-        "tags": [
-          "Cache"
-        ],
+        "tags": ["Cache"],
         "parameters": [
           {
             "name": "cacheKey",
@@ -80528,9 +76675,7 @@
         },
         "summary": "Flush vault secret cache",
         "description": "Clears the in-memory vault secret cache so the next resolution of every\n`vault.<path>` reference re-fetches from the configured backend (AWS Secrets\nManager, GCP Secret Manager, or HashiCorp Vault).\n\nUse this after rotating a secret when you cannot wait for the hourly\nbackground refresh. In a clustered deployment the flush is broadcast to all\npeer nodes automatically — you only need to call this on one node.\n\nReturns `400` if vault integration is not enabled.\n",
-        "tags": [
-          "Vault"
-        ],
+        "tags": ["Vault"],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -80587,9 +76732,7 @@
         "operationId": "websocketConnect",
         "summary": "WebSocket connection",
         "description": "Upgrades to a WebSocket connection for real-time updates.\nServer pushes log events, MCP log events, and store update notifications.\nHeartbeat pings are sent every 30 seconds.\n",
-        "tags": [
-          "Infrastructure"
-        ],
+        "tags": ["Infrastructure"],
         "responses": {
           "101": {
             "description": "WebSocket upgrade successful"
@@ -80602,9 +76745,7 @@
         "operationId": "mcpServerMessage",
         "summary": "MCP protocol message",
         "description": "Receives a JSON-RPC 2.0 message for the MCP protocol server.\nReturns a JSON-RPC 2.0 response, or null for notifications.\n",
-        "tags": [
-          "Infrastructure"
-        ],
+        "tags": ["Infrastructure"],
         "requestBody": {
           "required": true,
           "content": {
@@ -80615,9 +76756,7 @@
                 "properties": {
                   "jsonrpc": {
                     "type": "string",
-                    "enum": [
-                      "2.0"
-                    ]
+                    "enum": ["2.0"]
                   },
                   "method": {
                     "type": "string"
@@ -80650,9 +76789,7 @@
                   "properties": {
                     "jsonrpc": {
                       "type": "string",
-                      "enum": [
-                        "2.0"
-                      ]
+                      "enum": ["2.0"]
                     },
                     "result": {
                       "type": "object"
@@ -80703,9 +76840,7 @@
         "operationId": "mcpServerSSE",
         "summary": "MCP protocol SSE stream",
         "description": "Opens a Server-Sent Events stream for the MCP protocol server.\nReturns `Content-Type: text/event-stream`.\n",
-        "tags": [
-          "Infrastructure"
-        ],
+        "tags": ["Infrastructure"],
         "responses": {
           "200": {
             "description": "SSE stream opened",
@@ -80739,9 +76874,7 @@
         "operationId": "getMetrics",
         "summary": "Prometheus metrics",
         "description": "Returns Prometheus-formatted metrics for monitoring.",
-        "tags": [
-          "Infrastructure"
-        ],
+        "tags": ["Infrastructure"],
         "responses": {
           "200": {
             "description": "Prometheus metrics",
@@ -80761,9 +76894,7 @@
         "operationId": "listWebhookEndpoints",
         "summary": "List webhook endpoints",
         "description": "Returns webhook endpoints, optionally filtered by search text, subscribed\nevent, and disabled status. Signing secrets are never included and custom\nheader values are redacted.\n",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "name": "search",
@@ -80841,9 +76972,7 @@
         "operationId": "createWebhookEndpoint",
         "summary": "Create a webhook endpoint",
         "description": "Creates a webhook endpoint. The signing secret is generated by the server\nand returned once in the response — it cannot be supplied and cannot be\nretrieved again afterwards.\n",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "requestBody": {
           "required": true,
           "content": {
@@ -80897,9 +77026,7 @@
       "get": {
         "operationId": "getWebhookEndpoint",
         "summary": "Get a webhook endpoint",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -80947,9 +77074,7 @@
         "operationId": "updateWebhookEndpoint",
         "summary": "Update a webhook endpoint",
         "description": "Updates a webhook endpoint. The signing secret is immutable here — use the\nrotate-secret endpoint to change it.\n",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -81016,9 +77141,7 @@
       "delete": {
         "operationId": "deleteWebhookEndpoint",
         "summary": "Delete a webhook endpoint",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -81068,9 +77191,7 @@
         "operationId": "rotateWebhookEndpointSecret",
         "summary": "Rotate a webhook signing secret",
         "description": "Generates a new signing secret for the endpoint and returns it once. The\nprevious secret stops verifying immediately — there is no grace window, so\nupdate your receiver in the same change.\n",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -81120,9 +77241,7 @@
         "operationId": "testWebhookEndpoint",
         "summary": "Send a test delivery",
         "description": "Sends a sample signed delivery for the chosen event through the production\nsigning path.\n",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -81182,9 +77301,7 @@
         "operationId": "listWebhookDeliveries",
         "summary": "List delivery history",
         "description": "Returns one page of delivery-attempt history for an endpoint, newest first.",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -81250,9 +77367,7 @@
         "operationId": "searchWebhookDeliveries",
         "summary": "Search delivery history",
         "description": "Returns one page of delivery-attempt history across every endpoint the\nfilters select, newest first. Unlike the per-endpoint\n`/api/webhooks/{id}/deliveries` route, every filter is optional, so an\nunfiltered call returns history for all endpoints.\n\nPagination is by delivery group (`webhook_id`), not by individual attempt:\na page holds every attempt of the deliveries it covers, so `deliveries`\ncan hold more entries than `limit`, and `total_count` counts deliveries\nrather than attempts.\n\nFilters select delivery groups, not attempts — a delivery is on the page\nif any of its attempts matches — and the matched delivery is then returned\nwith its full attempt sequence intact.\n",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "name": "endpoint_ids",
@@ -81398,9 +77513,7 @@
         "operationId": "redeliverWebhook",
         "summary": "Re-queue a delivery",
         "description": "Re-queues the delivery a history record belongs to, under its original\nwebhook-id so receivers can deduplicate the replay.\n",
-        "tags": [
-          "Webhooks"
-        ],
+        "tags": ["Webhooks"],
         "parameters": [
           {
             "name": "id",
@@ -81466,9 +77579,7 @@
         "operationId": "listNotifications",
         "summary": "List dashboard notifications",
         "description": "Returns notifications the caller is entitled to see, newest first.\nNotifications addressed to `all` are visible to everyone; those addressed\nto `roles` are only returned when the caller holds one of the listed\nroles. A local admin sees every notification.\n\nRead and dismissed state is not stored server-side, so every caller sees\nthe full page regardless of what they have already opened.\n",
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "parameters": [
           {
             "name": "limit",
@@ -81544,9 +77655,7 @@
         "operationId": "createNotification",
         "summary": "Publish a dashboard notification",
         "description": "Persists a notification and pushes it over the dashboard WebSocket to\nevery connected client the audience covers.\n\nAdministrators only. Reading is open to any authenticated user because a\ncaller only ever receives rows their role already entitles them to, but a\nsingle publish reaches every dashboard user on the deployment, so it is\nrestricted to the local admin. On a deployment with dashboard auth\ndisabled every request is treated as local admin.\n\nNotifications expire 30 days after creation and are pruned hourly.\n",
-        "tags": [
-          "Notifications"
-        ],
+        "tags": ["Notifications"],
         "requestBody": {
           "required": true,
           "content": {
@@ -81788,10 +77897,7 @@
       "Fallback": {
         "type": "object",
         "description": "Fallback model configuration",
-        "required": [
-          "provider",
-          "model"
-        ],
+        "required": ["provider", "model"],
         "properties": {
           "provider": {
             "$ref": "#/components/schemas/ModelProvider"
@@ -81942,9 +78048,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "ephemeral"
-            ]
+            "enum": ["ephemeral"]
           },
           "ttl": {
             "type": "string",
@@ -81955,21 +78059,12 @@
       "AsyncJobStatus": {
         "type": "string",
         "description": "The status of an async job",
-        "enum": [
-          "pending",
-          "processing",
-          "completed",
-          "failed"
-        ]
+        "enum": ["pending", "processing", "completed", "failed"]
       },
       "AsyncJobResponse": {
         "type": "object",
         "description": "Response returned when creating or polling an async job",
-        "required": [
-          "id",
-          "status",
-          "created_at"
-        ],
+        "required": ["id", "status", "created_at"],
         "properties": {
           "id": {
             "type": "string",
@@ -82302,10 +78397,7 @@
       },
       "ChatCompletionRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "messages"
-        ],
+        "required": ["model", "messages"],
         "properties": {
           "model": {
             "type": "string",
@@ -82374,14 +78466,7 @@
               "effort": {
                 "type": "string",
                 "description": "Reasoning effort level",
-                "enum": [
-                  "none",
-                  "minimal",
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh"
-                ]
+                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
               },
               "max_tokens": {
                 "type": "integer"
@@ -82421,34 +78506,19 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "auto",
-                  "required"
-                ]
+                "enum": ["none", "auto", "required"]
               },
               {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "none",
-                      "any",
-                      "required",
-                      "function",
-                      "allowed_tools",
-                      "custom"
-                    ]
+                    "enum": ["none", "any", "required", "function", "allowed_tools", "custom"]
                   },
                   "function": {
                     "type": "object",
-                    "required": [
-                      "name"
-                    ],
+                    "required": ["name"],
                     "properties": {
                       "name": {
                         "type": "string"
@@ -82460,27 +78530,20 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "auto",
-                          "required"
-                        ]
+                        "enum": ["auto", "required"]
                       },
                       "tools": {
                         "type": "array",
                         "items": {
                           "type": "object",
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "properties": {
                             "type": {
                               "type": "string"
                             },
                             "function": {
                               "type": "object",
-                              "required": [
-                                "name"
-                              ],
+                              "required": ["name"],
                               "properties": {
                                 "name": {
                                   "type": "string"
@@ -82500,22 +78563,15 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "function",
-                    "custom"
-                  ]
+                  "enum": ["function", "custom"]
                 },
                 "function": {
                   "type": "object",
-                  "required": [
-                    "name"
-                  ],
+                  "required": ["name"],
                   "properties": {
                     "name": {
                       "type": "string"
@@ -82563,29 +78619,21 @@
                   "properties": {
                     "format": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string"
                         },
                         "grammar": {
                           "type": "object",
-                          "required": [
-                            "definition",
-                            "syntax"
-                          ],
+                          "required": ["definition", "syntax"],
                           "properties": {
                             "definition": {
                               "type": "string"
                             },
                             "syntax": {
                               "type": "string",
-                              "enum": [
-                                "lark",
-                                "regex"
-                              ]
+                              "enum": ["lark", "regex"]
                             }
                           }
                         }
@@ -82656,10 +78704,7 @@
           },
           "prompt_cache_retention": {
             "type": "string",
-            "enum": [
-              "in_memory",
-              "24h"
-            ],
+            "enum": ["in_memory", "24h"],
             "description": "Prompt cache retention policy"
           },
           "web_search_options": {
@@ -82668,11 +78713,7 @@
             "properties": {
               "search_context_size": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high"
-                ],
+                "enum": ["low", "medium", "high"],
                 "description": "Amount of search context to include"
               },
               "user_location": {
@@ -82714,11 +78755,7 @@
           },
           "verbosity": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "enum": ["low", "medium", "high"]
           }
         }
       },
@@ -82884,11 +78921,7 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "reasoning.summary",
-                              "reasoning.encrypted",
-                              "reasoning.text"
-                            ]
+                            "enum": ["reasoning.summary", "reasoning.encrypted", "reasoning.text"]
                           },
                           "summary": {
                             "type": "string"
@@ -82909,9 +78942,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "function"
-                        ],
+                        "required": ["function"],
                         "properties": {
                           "index": {
                             "type": "integer"
@@ -82985,19 +79016,11 @@
       },
       "ChatMessage": {
         "type": "object",
-        "required": [
-          "role"
-        ],
+        "required": ["role"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "assistant",
-              "user",
-              "system",
-              "tool",
-              "developer"
-            ]
+            "enum": ["assistant", "user", "system", "tool", "developer"]
           },
           "name": {
             "type": "string"
@@ -83011,19 +79034,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": [
-                    "type"
-                  ],
+                  "required": ["type"],
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "text",
-                        "image_url",
-                        "input_audio",
-                        "file",
-                        "refusal"
-                      ]
+                      "enum": ["text", "image_url", "input_audio", "file", "refusal"]
                     },
                     "text": {
                       "type": "string"
@@ -83033,28 +79048,20 @@
                     },
                     "image_url": {
                       "type": "object",
-                      "required": [
-                        "url"
-                      ],
+                      "required": ["url"],
                       "properties": {
                         "url": {
                           "type": "string"
                         },
                         "detail": {
                           "type": "string",
-                          "enum": [
-                            "low",
-                            "high",
-                            "auto"
-                          ]
+                          "enum": ["low", "high", "auto"]
                         }
                       }
                     },
                     "input_audio": {
                       "type": "object",
-                      "required": [
-                        "data"
-                      ],
+                      "required": ["data"],
                       "properties": {
                         "data": {
                           "type": "string"
@@ -83130,11 +79137,7 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "reasoning.summary",
-                    "reasoning.encrypted",
-                    "reasoning.text"
-                  ]
+                  "enum": ["reasoning.summary", "reasoning.encrypted", "reasoning.text"]
                 },
                 "summary": {
                   "type": "string"
@@ -83189,9 +79192,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "function"
-              ],
+              "required": ["function"],
               "properties": {
                 "index": {
                   "type": "integer"
@@ -83264,10 +79265,7 @@
       },
       "TextCompletionRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "prompt"
-        ],
+        "required": ["model", "prompt"],
         "properties": {
           "model": {
             "type": "string",
@@ -83508,11 +79506,7 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "reasoning.summary",
-                              "reasoning.encrypted",
-                              "reasoning.text"
-                            ]
+                            "enum": ["reasoning.summary", "reasoning.encrypted", "reasoning.text"]
                           },
                           "summary": {
                             "type": "string"
@@ -83533,9 +79527,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "function"
-                        ],
+                        "required": ["function"],
                         "properties": {
                           "index": {
                             "type": "integer"
@@ -83622,10 +79614,7 @@
       },
       "ResponsesRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "input"
-        ],
+        "required": ["model", "input"],
         "properties": {
           "model": {
             "type": "string",
@@ -83672,22 +79661,11 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "in_progress",
-                        "completed",
-                        "incomplete",
-                        "interpreting",
-                        "failed"
-                      ]
+                      "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
                     },
                     "role": {
                       "type": "string",
-                      "enum": [
-                        "assistant",
-                        "user",
-                        "system",
-                        "developer"
-                      ]
+                      "enum": ["assistant", "user", "system", "developer"]
                     },
                     "content": {
                       "oneOf": [
@@ -83698,9 +79676,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "properties": {
                               "type": {
                                 "type": "string",
@@ -83743,17 +79719,11 @@
                               },
                               "input_audio": {
                                 "type": "object",
-                                "required": [
-                                  "format",
-                                  "data"
-                                ],
+                                "required": ["format", "data"],
                                 "properties": {
                                   "format": {
                                     "type": "string",
-                                    "enum": [
-                                      "mp3",
-                                      "wav"
-                                    ]
+                                    "enum": ["mp3", "wav"]
                                   },
                                   "data": {
                                     "type": "string"
@@ -83874,9 +79844,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "properties": {
                               "type": {
                                 "type": "string",
@@ -83919,17 +79887,11 @@
                               },
                               "input_audio": {
                                 "type": "object",
-                                "required": [
-                                  "format",
-                                  "data"
-                                ],
+                                "required": ["format", "data"],
                                 "properties": {
                                   "format": {
                                     "type": "string",
-                                    "enum": [
-                                      "mp3",
-                                      "wav"
-                                    ]
+                                    "enum": ["mp3", "wav"]
                                   },
                                   "data": {
                                     "type": "string"
@@ -84035,9 +79997,7 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "computer_screenshot"
-                              ]
+                              "enum": ["computer_screenshot"]
                             },
                             "file_id": {
                               "type": "string"
@@ -84071,16 +80031,11 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type",
-                          "text"
-                        ],
+                        "required": ["type", "text"],
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "summary_text"
-                            ]
+                            "enum": ["summary_text"]
                           },
                           "text": {
                             "type": "string"
@@ -84148,14 +80103,7 @@
             "properties": {
               "effort": {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "minimal",
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh"
-                ]
+                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
               },
               "generate_summary": {
                 "type": "string",
@@ -84163,11 +80111,7 @@
               },
               "summary": {
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
+                "enum": ["auto", "concise", "detailed"]
               },
               "max_tokens": {
                 "type": "integer"
@@ -84199,17 +80143,11 @@
             "properties": {
               "format": {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "text",
-                      "json_schema",
-                      "json_object"
-                    ]
+                    "enum": ["text", "json_schema", "json_object"]
                   },
                   "name": {
                     "type": "string"
@@ -84224,11 +80162,7 @@
               },
               "verbosity": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high"
-                ]
+                "enum": ["low", "medium", "high"]
               }
             }
           },
@@ -84242,17 +80176,11 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "auto",
-                  "required"
-                ]
+                "enum": ["none", "auto", "required"]
               },
               {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
                   "type": {
                     "type": "string",
@@ -84285,17 +80213,11 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "function",
-                            "mcp",
-                            "image_generation"
-                          ]
+                          "enum": ["function", "mcp", "image_generation"]
                         },
                         "name": {
                           "type": "string"
@@ -84314,9 +80236,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "type": {
                   "type": "string",
@@ -84496,10 +80416,7 @@
           },
           "error": {
             "type": "object",
-            "required": [
-              "code",
-              "message"
-            ],
+            "required": ["code", "message"],
             "properties": {
               "code": {
                 "type": "string"
@@ -84517,9 +80434,7 @@
           },
           "incomplete_details": {
             "type": "object",
-            "required": [
-              "reason"
-            ],
+            "required": ["reason"],
             "properties": {
               "reason": {
                 "type": "string"
@@ -84577,22 +80492,11 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "in_progress",
-                    "completed",
-                    "incomplete",
-                    "interpreting",
-                    "failed"
-                  ]
+                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
                 },
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "assistant",
-                    "user",
-                    "system",
-                    "developer"
-                  ]
+                  "enum": ["assistant", "user", "system", "developer"]
                 },
                 "content": {
                   "oneOf": [
@@ -84603,9 +80507,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -84648,17 +80550,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -84779,9 +80675,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -84824,17 +80718,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -84940,9 +80828,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "computer_screenshot"
-                          ]
+                          "enum": ["computer_screenshot"]
                         },
                         "file_id": {
                           "type": "string"
@@ -84976,16 +80862,11 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": [
-                      "type",
-                      "text"
-                    ],
+                    "required": ["type", "text"],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "summary_text"
-                        ]
+                        "enum": ["summary_text"]
                       },
                       "text": {
                         "type": "string"
@@ -85016,14 +80897,7 @@
             "properties": {
               "effort": {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "minimal",
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh"
-                ]
+                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
               },
               "generate_summary": {
                 "type": "string",
@@ -85031,11 +80905,7 @@
               },
               "summary": {
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
+                "enum": ["auto", "concise", "detailed"]
               },
               "max_tokens": {
                 "type": "integer"
@@ -85050,14 +80920,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "completed",
-              "failed",
-              "in_progress",
-              "canceled",
-              "queued",
-              "incomplete"
-            ]
+            "enum": ["completed", "failed", "in_progress", "canceled", "queued", "incomplete"]
           },
           "stop_reason": {
             "type": "string"
@@ -85073,17 +80936,11 @@
             "properties": {
               "format": {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "text",
-                      "json_schema",
-                      "json_object"
-                    ]
+                    "enum": ["text", "json_schema", "json_object"]
                   },
                   "name": {
                     "type": "string"
@@ -85098,11 +80955,7 @@
               },
               "verbosity": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high"
-                ]
+                "enum": ["low", "medium", "high"]
               }
             }
           },
@@ -85116,17 +80969,11 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "auto",
-                  "required"
-                ]
+                "enum": ["none", "auto", "required"]
               },
               {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
                   "type": {
                     "type": "string",
@@ -85159,17 +81006,11 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "function",
-                            "mcp",
-                            "image_generation"
-                          ]
+                          "enum": ["function", "mcp", "image_generation"]
                         },
                         "name": {
                           "type": "string"
@@ -85188,9 +81029,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "type": {
                   "type": "string",
@@ -85500,22 +81339,11 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "in_progress",
-                    "completed",
-                    "incomplete",
-                    "interpreting",
-                    "failed"
-                  ]
+                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
                 },
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "assistant",
-                    "user",
-                    "system",
-                    "developer"
-                  ]
+                  "enum": ["assistant", "user", "system", "developer"]
                 },
                 "content": {
                   "oneOf": [
@@ -85526,9 +81354,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -85571,17 +81397,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -85702,9 +81522,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -85747,17 +81565,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -85863,9 +81675,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "computer_screenshot"
-                          ]
+                          "enum": ["computer_screenshot"]
                         },
                         "file_id": {
                           "type": "string"
@@ -85899,16 +81709,11 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": [
-                      "type",
-                      "text"
-                    ],
+                    "required": ["type", "text"],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "summary_text"
-                        ]
+                        "enum": ["summary_text"]
                       },
                       "text": {
                         "type": "string"
@@ -85938,11 +81743,7 @@
       },
       "RerankRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "query",
-          "documents"
-        ],
+        "required": ["model", "query", "documents"],
         "properties": {
           "model": {
             "type": "string",
@@ -85991,10 +81792,7 @@
       },
       "RerankResponse": {
         "type": "object",
-        "required": [
-          "results",
-          "model"
-        ],
+        "required": ["results", "model"],
         "properties": {
           "id": {
             "type": "string",
@@ -86021,9 +81819,7 @@
       },
       "RerankDocument": {
         "type": "object",
-        "required": [
-          "text"
-        ],
+        "required": ["text"],
         "properties": {
           "text": {
             "type": "string",
@@ -86044,10 +81840,7 @@
       },
       "RerankResult": {
         "type": "object",
-        "required": [
-          "index",
-          "relevance_score"
-        ],
+        "required": ["index", "relevance_score"],
         "properties": {
           "index": {
             "type": "integer",
@@ -86065,10 +81858,7 @@
       },
       "EmbeddingRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "input"
-        ],
+        "required": ["model", "input"],
         "properties": {
           "model": {
             "type": "string",
@@ -86111,10 +81901,7 @@
           },
           "encoding_format": {
             "type": "string",
-            "enum": [
-              "float",
-              "base64"
-            ]
+            "enum": ["float", "base64"]
           },
           "dimensions": {
             "type": "integer"
@@ -86176,11 +81963,7 @@
       },
       "SpeechRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "input",
-          "voice"
-        ],
+        "required": ["model", "input", "voice"],
         "properties": {
           "model": {
             "type": "string",
@@ -86198,9 +81981,7 @@
           },
           "stream_format": {
             "type": "string",
-            "enum": [
-              "sse"
-            ],
+            "enum": ["sse"],
             "description": "Set to \"sse\" to enable streaming"
           },
           "voice": {
@@ -86212,10 +81993,7 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": [
-                    "speaker",
-                    "voice"
-                  ],
+                  "required": ["speaker", "voice"],
                   "properties": {
                     "speaker": {
                       "type": "string"
@@ -86233,14 +82011,7 @@
           },
           "response_format": {
             "type": "string",
-            "enum": [
-              "mp3",
-              "opus",
-              "aac",
-              "flac",
-              "wav",
-              "pcm"
-            ]
+            "enum": ["mp3", "opus", "aac", "flac", "wav", "pcm"]
           },
           "speed": {
             "type": "number",
@@ -86254,9 +82025,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "pronunciation_dictionary_id"
-              ],
+              "required": ["pronunciation_dictionary_id"],
               "properties": {
                 "pronunciation_dictionary_id": {
                   "type": "string"
@@ -86356,10 +82125,7 @@
       },
       "TranscriptionRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "file"
-        ],
+        "required": ["model", "file"],
         "properties": {
           "model": {
             "type": "string",
@@ -86387,13 +82153,7 @@
           },
           "response_format": {
             "type": "string",
-            "enum": [
-              "json",
-              "text",
-              "srt",
-              "verbose_json",
-              "vtt"
-            ]
+            "enum": ["json", "text", "srt", "verbose_json", "vtt"]
           },
           "file_format": {
             "type": "string"
@@ -86481,10 +82241,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "tokens",
-                  "duration"
-                ]
+                "enum": ["tokens", "duration"]
               },
               "input_tokens": {
                 "type": "integer"
@@ -86535,10 +82292,7 @@
       },
       "CountTokensRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "messages"
-        ],
+        "required": ["model", "messages"],
         "properties": {
           "model": {
             "type": "string",
@@ -86580,22 +82334,11 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "in_progress",
-                    "completed",
-                    "incomplete",
-                    "interpreting",
-                    "failed"
-                  ]
+                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
                 },
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "assistant",
-                    "user",
-                    "system",
-                    "developer"
-                  ]
+                  "enum": ["assistant", "user", "system", "developer"]
                 },
                 "content": {
                   "oneOf": [
@@ -86606,9 +82349,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -86651,17 +82392,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -86782,9 +82517,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -86827,17 +82560,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -86943,9 +82670,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "computer_screenshot"
-                          ]
+                          "enum": ["computer_screenshot"]
                         },
                         "file_id": {
                           "type": "string"
@@ -86979,16 +82704,11 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": [
-                      "type",
-                      "text"
-                    ],
+                    "required": ["type", "text"],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "summary_text"
-                        ]
+                        "enum": ["summary_text"]
                       },
                       "text": {
                         "type": "string"
@@ -87012,9 +82732,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "type": {
                   "type": "string",
@@ -87239,9 +82957,7 @@
       },
       "BatchCreateRequest": {
         "type": "object",
-        "required": [
-          "model"
-        ],
+        "required": ["model"],
         "properties": {
           "model": {
             "type": "string",
@@ -87255,9 +82971,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "custom_id"
-              ],
+              "required": ["custom_id"],
               "properties": {
                 "custom_id": {
                   "type": "string"
@@ -87581,10 +83295,7 @@
       },
       "FileUploadRequest": {
         "type": "object",
-        "required": [
-          "file",
-          "purpose"
-        ],
+        "required": ["file", "purpose"],
         "properties": {
           "file": {
             "type": "string",
@@ -87643,13 +83354,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "uploaded",
-              "processed",
-              "processing",
-              "error",
-              "deleted"
-            ]
+            "enum": ["uploaded", "processed", "processing", "error", "deleted"]
           },
           "status_details": {
             "type": "string"
@@ -87712,13 +83417,7 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "uploaded",
-                    "processed",
-                    "processing",
-                    "error",
-                    "deleted"
-                  ]
+                  "enum": ["uploaded", "processed", "processing", "error", "deleted"]
                 },
                 "status_details": {
                   "type": "string"
@@ -87743,10 +83442,7 @@
       },
       "OCRRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "document"
-        ],
+        "required": ["model", "document"],
         "properties": {
           "model": {
             "type": "string",
@@ -87803,28 +83499,17 @@
           },
           "confidence_scores_granularity": {
             "type": "string",
-            "enum": [
-              "page",
-              "block",
-              "word",
-              "document"
-            ],
+            "enum": ["page", "block", "word", "document"],
             "description": "Granularity of confidence scores to include in the response"
           },
           "bbox_annotation_format": {
             "type": "object",
             "description": "Format for bounding box annotations. Supports text, json_object, and json_schema modes.",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "text",
-                  "json_object",
-                  "json_schema"
-                ],
+                "enum": ["text", "json_object", "json_schema"],
                 "description": "The format type"
               },
               "json_schema": {
@@ -87850,23 +83535,15 @@
               {
                 "properties": {
                   "type": {
-                    "enum": [
-                      "text",
-                      "json_object"
-                    ]
+                    "enum": ["text", "json_object"]
                   }
                 }
               },
               {
-                "required": [
-                  "type",
-                  "json_schema"
-                ],
+                "required": ["type", "json_schema"],
                 "properties": {
                   "type": {
-                    "enum": [
-                      "json_schema"
-                    ]
+                    "enum": ["json_schema"]
                   }
                 }
               }
@@ -87875,17 +83552,11 @@
           "document_annotation_format": {
             "type": "object",
             "description": "Format for document-level annotations. Supports text, json_object, and json_schema modes.",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "text",
-                  "json_object",
-                  "json_schema"
-                ],
+                "enum": ["text", "json_object", "json_schema"],
                 "description": "The format type"
               },
               "json_schema": {
@@ -87911,23 +83582,15 @@
               {
                 "properties": {
                   "type": {
-                    "enum": [
-                      "text",
-                      "json_object"
-                    ]
+                    "enum": ["text", "json_object"]
                   }
                 }
               },
               {
-                "required": [
-                  "type",
-                  "json_schema"
-                ],
+                "required": ["type", "json_schema"],
                 "properties": {
                   "type": {
-                    "enum": [
-                      "json_schema"
-                    ]
+                    "enum": ["json_schema"]
                   }
                 }
               }
@@ -87944,10 +83607,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "document_url",
-              "image_url"
-            ],
+            "enum": ["document_url", "image_url"],
             "description": "Type of document input:\n- `document_url`: A PDF URL or base64 data URL\n- `image_url`: An image URL\n"
           },
           "document_url": {
@@ -87961,28 +83621,18 @@
         },
         "oneOf": [
           {
-            "required": [
-              "type",
-              "document_url"
-            ],
+            "required": ["type", "document_url"],
             "properties": {
               "type": {
-                "enum": [
-                  "document_url"
-                ]
+                "enum": ["document_url"]
               }
             }
           },
           {
-            "required": [
-              "type",
-              "image_url"
-            ],
+            "required": ["type", "image_url"],
             "properties": {
               "type": {
-                "enum": [
-                  "image_url"
-                ]
+                "enum": ["image_url"]
               }
             }
           }
@@ -87990,10 +83640,7 @@
       },
       "OCRResponse": {
         "type": "object",
-        "required": [
-          "model",
-          "pages"
-        ],
+        "required": ["model", "pages"],
         "properties": {
           "model": {
             "type": "string",
@@ -88020,10 +83667,7 @@
       },
       "OCRPage": {
         "type": "object",
-        "required": [
-          "index",
-          "markdown"
-        ],
+        "required": ["index", "markdown"],
         "properties": {
           "index": {
             "type": "integer",
@@ -88088,13 +83732,7 @@
       },
       "OCRPageImage": {
         "type": "object",
-        "required": [
-          "id",
-          "top_left_x",
-          "top_left_y",
-          "bottom_right_x",
-          "bottom_right_y"
-        ],
+        "required": ["id", "top_left_x", "top_left_y", "bottom_right_x", "bottom_right_y"],
         "properties": {
           "id": {
             "type": "string",
@@ -88124,11 +83762,7 @@
       },
       "OCRPageDimensions": {
         "type": "object",
-        "required": [
-          "dpi",
-          "height",
-          "width"
-        ],
+        "required": ["dpi", "height", "width"],
         "properties": {
           "dpi": {
             "type": "integer",
@@ -88146,10 +83780,7 @@
       },
       "OCRUsageInfo": {
         "type": "object",
-        "required": [
-          "pages_processed",
-          "doc_size_bytes"
-        ],
+        "required": ["pages_processed", "doc_size_bytes"],
         "properties": {
           "pages_processed": {
             "type": "integer",
@@ -88163,10 +83794,7 @@
       },
       "OpenAIChatRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "messages"
-        ],
+        "required": ["model", "messages"],
         "properties": {
           "model": {
             "type": "string",
@@ -88248,22 +83876,15 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "function",
-                    "custom"
-                  ]
+                  "enum": ["function", "custom"]
                 },
                 "function": {
                   "type": "object",
-                  "required": [
-                    "name"
-                  ],
+                  "required": ["name"],
                   "properties": {
                     "name": {
                       "type": "string"
@@ -88311,29 +83932,21 @@
                   "properties": {
                     "format": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string"
                         },
                         "grammar": {
                           "type": "object",
-                          "required": [
-                            "definition",
-                            "syntax"
-                          ],
+                          "required": ["definition", "syntax"],
                           "properties": {
                             "definition": {
                               "type": "string"
                             },
                             "syntax": {
                               "type": "string",
-                              "enum": [
-                                "lark",
-                                "regex"
-                              ]
+                              "enum": ["lark", "regex"]
                             }
                           }
                         }
@@ -88351,34 +83964,19 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "auto",
-                  "required"
-                ]
+                "enum": ["none", "auto", "required"]
               },
               {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "none",
-                      "any",
-                      "required",
-                      "function",
-                      "allowed_tools",
-                      "custom"
-                    ]
+                    "enum": ["none", "any", "required", "function", "allowed_tools", "custom"]
                   },
                   "function": {
                     "type": "object",
-                    "required": [
-                      "name"
-                    ],
+                    "required": ["name"],
                     "properties": {
                       "name": {
                         "type": "string"
@@ -88390,27 +83988,20 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "auto",
-                          "required"
-                        ]
+                        "enum": ["auto", "required"]
                       },
                       "tools": {
                         "type": "array",
                         "items": {
                           "type": "object",
-                          "required": [
-                            "type"
-                          ],
+                          "required": ["type"],
                           "properties": {
                             "type": {
                               "type": "string"
                             },
                             "function": {
                               "type": "object",
-                              "required": [
-                                "name"
-                              ],
+                              "required": ["name"],
                               "properties": {
                                 "name": {
                                   "type": "string"
@@ -88435,14 +84026,7 @@
           },
           "reasoning_effort": {
             "type": "string",
-            "enum": [
-              "none",
-              "minimal",
-              "low",
-              "medium",
-              "high",
-              "xhigh"
-            ],
+            "enum": ["none", "minimal", "low", "medium", "high", "xhigh"],
             "description": "OpenAI reasoning effort level"
           },
           "service_tier": {
@@ -88470,19 +84054,11 @@
       },
       "OpenAIMessage": {
         "type": "object",
-        "required": [
-          "role"
-        ],
+        "required": ["role"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "system",
-              "user",
-              "assistant",
-              "tool",
-              "developer"
-            ]
+            "enum": ["system", "user", "assistant", "tool", "developer"]
           },
           "name": {
             "type": "string"
@@ -88496,19 +84072,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": [
-                    "type"
-                  ],
+                  "required": ["type"],
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "text",
-                        "image_url",
-                        "input_audio",
-                        "file",
-                        "refusal"
-                      ]
+                      "enum": ["text", "image_url", "input_audio", "file", "refusal"]
                     },
                     "text": {
                       "type": "string"
@@ -88518,28 +84086,20 @@
                     },
                     "image_url": {
                       "type": "object",
-                      "required": [
-                        "url"
-                      ],
+                      "required": ["url"],
                       "properties": {
                         "url": {
                           "type": "string"
                         },
                         "detail": {
                           "type": "string",
-                          "enum": [
-                            "low",
-                            "high",
-                            "auto"
-                          ]
+                          "enum": ["low", "high", "auto"]
                         }
                       }
                     },
                     "input_audio": {
                       "type": "object",
-                      "required": [
-                        "data"
-                      ],
+                      "required": ["data"],
                       "properties": {
                         "data": {
                           "type": "string"
@@ -88623,9 +84183,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "function"
-              ],
+              "required": ["function"],
               "properties": {
                 "index": {
                   "type": "integer"
@@ -88654,10 +84212,7 @@
       },
       "OpenAITextCompletionRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "prompt"
-        ],
+        "required": ["model", "prompt"],
         "properties": {
           "model": {
             "type": "string",
@@ -88753,10 +84308,7 @@
       },
       "OpenAIResponsesRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "input"
-        ],
+        "required": ["model", "input"],
         "properties": {
           "model": {
             "type": "string",
@@ -88804,22 +84356,11 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "in_progress",
-                        "completed",
-                        "incomplete",
-                        "interpreting",
-                        "failed"
-                      ]
+                      "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
                     },
                     "role": {
                       "type": "string",
-                      "enum": [
-                        "assistant",
-                        "user",
-                        "system",
-                        "developer"
-                      ]
+                      "enum": ["assistant", "user", "system", "developer"]
                     },
                     "content": {
                       "oneOf": [
@@ -88830,9 +84371,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "properties": {
                               "type": {
                                 "type": "string",
@@ -88875,17 +84414,11 @@
                               },
                               "input_audio": {
                                 "type": "object",
-                                "required": [
-                                  "format",
-                                  "data"
-                                ],
+                                "required": ["format", "data"],
                                 "properties": {
                                   "format": {
                                     "type": "string",
-                                    "enum": [
-                                      "mp3",
-                                      "wav"
-                                    ]
+                                    "enum": ["mp3", "wav"]
                                   },
                                   "data": {
                                     "type": "string"
@@ -89006,9 +84539,7 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": [
-                              "type"
-                            ],
+                            "required": ["type"],
                             "properties": {
                               "type": {
                                 "type": "string",
@@ -89051,17 +84582,11 @@
                               },
                               "input_audio": {
                                 "type": "object",
-                                "required": [
-                                  "format",
-                                  "data"
-                                ],
+                                "required": ["format", "data"],
                                 "properties": {
                                   "format": {
                                     "type": "string",
-                                    "enum": [
-                                      "mp3",
-                                      "wav"
-                                    ]
+                                    "enum": ["mp3", "wav"]
                                   },
                                   "data": {
                                     "type": "string"
@@ -89167,9 +84692,7 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": [
-                                "computer_screenshot"
-                              ]
+                              "enum": ["computer_screenshot"]
                             },
                             "file_id": {
                               "type": "string"
@@ -89203,16 +84726,11 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type",
-                          "text"
-                        ],
+                        "required": ["type", "text"],
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": [
-                              "summary_text"
-                            ]
+                            "enum": ["summary_text"]
                           },
                           "text": {
                             "type": "string"
@@ -89257,30 +84775,15 @@
             "properties": {
               "effort": {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "minimal",
-                  "low",
-                  "medium",
-                  "high",
-                  "xhigh"
-                ]
+                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
               },
               "generate_summary": {
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
+                "enum": ["auto", "concise", "detailed"]
               },
               "summary": {
                 "type": "string",
-                "enum": [
-                  "auto",
-                  "concise",
-                  "detailed"
-                ]
+                "enum": ["auto", "concise", "detailed"]
               },
               "max_tokens": {
                 "type": "integer"
@@ -89303,11 +84806,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "text",
-                      "json_object",
-                      "json_schema"
-                    ]
+                    "enum": ["text", "json_object", "json_schema"]
                   },
                   "json_schema": {
                     "type": "object",
@@ -89331,17 +84830,11 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "auto",
-                  "required"
-                ]
+                "enum": ["none", "auto", "required"]
               },
               {
                 "type": "object",
-                "required": [
-                  "type"
-                ],
+                "required": ["type"],
                 "properties": {
                   "type": {
                     "type": "string",
@@ -89374,17 +84867,11 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "function",
-                            "mcp",
-                            "image_generation"
-                          ]
+                          "enum": ["function", "mcp", "image_generation"]
                         },
                         "name": {
                           "type": "string"
@@ -89403,9 +84890,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "type": {
                   "type": "string",
@@ -89568,10 +85053,7 @@
           },
           "truncation": {
             "type": "string",
-            "enum": [
-              "auto",
-              "disabled"
-            ]
+            "enum": ["auto", "disabled"]
           },
           "user": {
             "type": "string"
@@ -89586,10 +85068,7 @@
       },
       "OpenAIEmbeddingRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "input"
-        ],
+        "required": ["model", "input"],
         "properties": {
           "model": {
             "type": "string",
@@ -89612,10 +85091,7 @@
           },
           "encoding_format": {
             "type": "string",
-            "enum": [
-              "float",
-              "base64"
-            ]
+            "enum": ["float", "base64"]
           },
           "dimensions": {
             "type": "integer",
@@ -89634,10 +85110,7 @@
       },
       "OpenAISpeechRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "input"
-        ],
+        "required": ["model", "input"],
         "properties": {
           "model": {
             "type": "string",
@@ -89651,25 +85124,11 @@
           "voice": {
             "type": "string",
             "description": "Voice to use",
-            "enum": [
-              "alloy",
-              "echo",
-              "fable",
-              "onyx",
-              "nova",
-              "shimmer"
-            ]
+            "enum": ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
           },
           "response_format": {
             "type": "string",
-            "enum": [
-              "mp3",
-              "opus",
-              "aac",
-              "flac",
-              "wav",
-              "pcm"
-            ]
+            "enum": ["mp3", "opus", "aac", "flac", "wav", "pcm"]
           },
           "speed": {
             "type": "number",
@@ -89678,9 +85137,7 @@
           },
           "stream_format": {
             "type": "string",
-            "enum": [
-              "sse"
-            ],
+            "enum": ["sse"],
             "description": "Set to 'sse' for streaming"
           },
           "fallbacks": {
@@ -89693,10 +85150,7 @@
       },
       "OpenAITranscriptionRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "file"
-        ],
+        "required": ["model", "file"],
         "properties": {
           "model": {
             "type": "string",
@@ -89718,13 +85172,7 @@
           },
           "response_format": {
             "type": "string",
-            "enum": [
-              "json",
-              "text",
-              "srt",
-              "verbose_json",
-              "vtt"
-            ]
+            "enum": ["json", "text", "srt", "verbose_json", "vtt"]
           },
           "temperature": {
             "type": "number",
@@ -89735,10 +85183,7 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "word",
-                "segment"
-              ]
+              "enum": ["word", "segment"]
             }
           },
           "stream": {
@@ -89794,11 +85239,7 @@
       },
       "AnthropicMessageRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "max_tokens",
-          "messages"
-        ],
+        "required": ["model", "max_tokens", "messages"],
         "properties": {
           "model": {
             "type": "string",
@@ -89939,9 +85380,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "approximate"
-                      ]
+                      "enum": ["approximate"]
                     },
                     "city": {
                       "type": "string"
@@ -89964,12 +85403,7 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "auto",
-                      "any",
-                      "tool",
-                      "none"
-                    ]
+                    "enum": ["auto", "any", "tool", "none"]
                   },
                   "name": {
                     "type": "string",
@@ -90023,10 +85457,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "enabled",
-                  "disabled"
-                ]
+                "enum": ["enabled", "disabled"]
               },
               "budget_tokens": {
                 "type": "integer"
@@ -90047,17 +85478,11 @@
       },
       "AnthropicMessage": {
         "type": "object",
-        "required": [
-          "role",
-          "content"
-        ],
+        "required": ["role", "content"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "user",
-              "assistant"
-            ]
+            "enum": ["user", "assistant"]
           },
           "content": {
             "oneOf": [
@@ -90077,9 +85502,7 @@
       },
       "AnthropicContentBlock": {
         "type": "object",
-        "required": [
-          "type"
-        ],
+        "required": ["type"],
         "properties": {
           "type": {
             "type": "string",
@@ -90149,18 +85572,11 @@
           },
           "source": {
             "type": "object",
-            "required": [
-              "type"
-            ],
+            "required": ["type"],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "base64",
-                  "url",
-                  "text",
-                  "content_block"
-                ]
+                "enum": ["base64", "url", "text", "content_block"]
               },
               "media_type": {
                 "type": "string",
@@ -90271,11 +85687,7 @@
       },
       "AnthropicTextRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "prompt",
-          "max_tokens_to_sample"
-        ],
+        "required": ["model", "prompt", "max_tokens_to_sample"],
         "properties": {
           "model": {
             "type": "string",
@@ -90535,12 +85947,7 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": [
-                    "MODALITY_UNSPECIFIED",
-                    "TEXT",
-                    "IMAGE",
-                    "AUDIO"
-                  ]
+                  "enum": ["MODALITY_UNSPECIFIED", "TEXT", "IMAGE", "AUDIO"]
                 },
                 "description": "The modalities of the response"
               },
@@ -90611,11 +86018,7 @@
                   },
                   "thinkingLevel": {
                     "type": "string",
-                    "enum": [
-                      "THINKING_LEVEL_UNSPECIFIED",
-                      "LOW",
-                      "HIGH"
-                    ],
+                    "enum": ["THINKING_LEVEL_UNSPECIFIED", "LOW", "HIGH"],
                     "description": "Thinking level preset"
                   }
                 }
@@ -90741,11 +86144,7 @@
                       },
                       "behavior": {
                         "type": "string",
-                        "enum": [
-                          "UNSPECIFIED",
-                          "BLOCKING",
-                          "NON_BLOCKING"
-                        ],
+                        "enum": ["UNSPECIFIED", "BLOCKING", "NON_BLOCKING"],
                         "description": "Function behavior mode. BLOCKING waits for response, NON_BLOCKING continues conversation"
                       }
                     }
@@ -90811,11 +86210,7 @@
                         },
                         "apiSpec": {
                           "type": "string",
-                          "enum": [
-                            "API_SPEC_UNSPECIFIED",
-                            "SIMPLE_SEARCH",
-                            "ELASTIC_SEARCH"
-                          ]
+                          "enum": ["API_SPEC_UNSPECIFIED", "SIMPLE_SEARCH", "ELASTIC_SEARCH"]
                         },
                         "authConfig": {
                           "type": "object",
@@ -91131,10 +86526,7 @@
                   "properties": {
                     "environment": {
                       "type": "string",
-                      "enum": [
-                        "ENVIRONMENT_UNSPECIFIED",
-                        "ENVIRONMENT_BROWSER"
-                      ],
+                      "enum": ["ENVIRONMENT_UNSPECIFIED", "ENVIRONMENT_BROWSER"],
                       "description": "The environment being operated"
                     }
                   }
@@ -91150,13 +86542,7 @@
                 "properties": {
                   "mode": {
                     "type": "string",
-                    "enum": [
-                      "MODE_UNSPECIFIED",
-                      "AUTO",
-                      "ANY",
-                      "NONE",
-                      "VALIDATED"
-                    ],
+                    "enum": ["MODE_UNSPECIFIED", "AUTO", "ANY", "NONE", "VALIDATED"],
                     "description": "Function calling mode"
                   },
                   "allowedFunctionNames": {
@@ -91546,10 +86932,7 @@
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "user",
-              "model"
-            ],
+            "enum": ["user", "model"],
             "description": "The producer of the content. Must be either 'user' or 'model'"
           },
           "parts": {
@@ -91908,9 +87291,7 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "default"
-                      ]
+                      "enum": ["default"]
                     }
                   }
                 }
@@ -91970,9 +87351,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "default"
-                          ]
+                          "enum": ["default"]
                         }
                       }
                     }
@@ -92011,10 +87390,7 @@
               },
               "trace": {
                 "type": "string",
-                "enum": [
-                  "enabled",
-                  "disabled"
-                ]
+                "enum": ["enabled", "disabled"]
               }
             }
           },
@@ -92033,10 +87409,7 @@
             "properties": {
               "latency": {
                 "type": "string",
-                "enum": [
-                  "standard",
-                  "optimized"
-                ]
+                "enum": ["standard", "optimized"]
               }
             }
           },
@@ -92062,12 +87435,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "reserved",
-                  "priority",
-                  "default",
-                  "flex"
-                ]
+                "enum": ["reserved", "priority", "default", "flex"]
               }
             }
           },
@@ -92140,10 +87508,7 @@
             "properties": {
               "latency": {
                 "type": "string",
-                "enum": [
-                  "standard",
-                  "optimized"
-                ]
+                "enum": ["standard", "optimized"]
               }
             }
           },
@@ -92152,12 +87517,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "reserved",
-                  "priority",
-                  "default",
-                  "flex"
-                ]
+                "enum": ["reserved", "priority", "default", "flex"]
               }
             }
           }
@@ -92165,17 +87525,11 @@
       },
       "BedrockMessage": {
         "type": "object",
-        "required": [
-          "role",
-          "content"
-        ],
+        "required": ["role", "content"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "user",
-              "assistant"
-            ]
+            "enum": ["user", "assistant"]
           },
           "content": {
             "type": "array",
@@ -92196,12 +87550,7 @@
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "jpeg",
-                  "png",
-                  "gif",
-                  "webp"
-                ]
+                "enum": ["jpeg", "png", "gif", "webp"]
               },
               "source": {
                 "type": "object",
@@ -92219,17 +87568,7 @@
             "properties": {
               "format": {
                 "type": "string",
-                "enum": [
-                  "pdf",
-                  "csv",
-                  "doc",
-                  "docx",
-                  "xls",
-                  "xlsx",
-                  "html",
-                  "txt",
-                  "md"
-                ]
+                "enum": ["pdf", "csv", "doc", "docx", "xls", "xlsx", "html", "txt", "md"]
               },
               "name": {
                 "type": "string"
@@ -92277,10 +87616,7 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "success",
-                  "error"
-                ]
+                "enum": ["success", "error"]
               }
             }
           },
@@ -92328,9 +87664,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "default"
-                ]
+                "enum": ["default"]
               }
             }
           }
@@ -92406,11 +87740,7 @@
       },
       "BedrockBatchJobRequest": {
         "type": "object",
-        "required": [
-          "roleArn",
-          "inputDataConfig",
-          "outputDataConfig"
-        ],
+        "required": ["roleArn", "inputDataConfig", "outputDataConfig"],
         "properties": {
           "modelId": {
             "type": "string",
@@ -92565,10 +87895,7 @@
       },
       "CohereChatRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "messages"
-        ],
+        "required": ["model", "messages"],
         "properties": {
           "model": {
             "type": "string",
@@ -92589,9 +87916,7 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "function"
-                  ]
+                  "enum": ["function"]
                 },
                 "function": {
                   "type": "object",
@@ -92612,11 +87937,7 @@
           },
           "tool_choice": {
             "type": "string",
-            "enum": [
-              "AUTO",
-              "NONE",
-              "REQUIRED"
-            ],
+            "enum": ["AUTO", "NONE", "REQUIRED"],
             "description": "Tool choice mode - AUTO lets the model decide, NONE disables tools, REQUIRED forces tool use"
           },
           "temperature": {
@@ -92652,11 +87973,7 @@
           },
           "safety_mode": {
             "type": "string",
-            "enum": [
-              "CONTEXTUAL",
-              "STRICT",
-              "NONE"
-            ]
+            "enum": ["CONTEXTUAL", "STRICT", "NONE"]
           },
           "log_probs": {
             "type": "boolean"
@@ -92669,10 +87986,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "enabled",
-                  "disabled"
-                ]
+                "enum": ["enabled", "disabled"]
               },
               "token_budget": {
                 "type": "integer",
@@ -92685,10 +87999,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "text",
-                  "json_object"
-                ],
+                "enum": ["text", "json_object"],
                 "description": "Response format type"
               },
               "schema": {
@@ -92707,14 +88018,7 @@
           },
           "finish_reason": {
             "type": "string",
-            "enum": [
-              "COMPLETE",
-              "STOP_SEQUENCE",
-              "MAX_TOKENS",
-              "TOOL_CALL",
-              "ERROR",
-              "TIMEOUT"
-            ]
+            "enum": ["COMPLETE", "STOP_SEQUENCE", "MAX_TOKENS", "TOOL_CALL", "ERROR", "TIMEOUT"]
           },
           "message": {
             "type": "object",
@@ -92726,18 +88030,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": [
-                    "type"
-                  ],
+                  "required": ["type"],
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "text",
-                        "image_url",
-                        "thinking",
-                        "document"
-                      ]
+                      "enum": ["text", "image_url", "thinking", "document"]
                     },
                     "text": {
                       "type": "string"
@@ -92777,9 +88074,7 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "function"
-                      ]
+                      "enum": ["function"]
                     },
                     "function": {
                       "type": "object",
@@ -92874,18 +88169,11 @@
       },
       "CohereMessage": {
         "type": "object",
-        "required": [
-          "role"
-        ],
+        "required": ["role"],
         "properties": {
           "role": {
             "type": "string",
-            "enum": [
-              "system",
-              "user",
-              "assistant",
-              "tool"
-            ]
+            "enum": ["system", "user", "assistant", "tool"]
           },
           "content": {
             "oneOf": [
@@ -92896,18 +88184,11 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": [
-                    "type"
-                  ],
+                  "required": ["type"],
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": [
-                        "text",
-                        "image_url",
-                        "thinking",
-                        "document"
-                      ]
+                      "enum": ["text", "image_url", "thinking", "document"]
                     },
                     "text": {
                       "type": "string"
@@ -92950,9 +88231,7 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "function"
-                  ]
+                  "enum": ["function"]
                 },
                 "function": {
                   "type": "object",
@@ -92979,10 +88258,7 @@
       },
       "CohereEmbeddingRequest": {
         "type": "object",
-        "required": [
-          "model",
-          "input_type"
-        ],
+        "required": ["model", "input_type"],
         "properties": {
           "model": {
             "type": "string",
@@ -93018,18 +88294,11 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": [
-                      "type"
-                    ],
+                    "required": ["type"],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "text",
-                          "image_url",
-                          "thinking",
-                          "document"
-                        ]
+                        "enum": ["text", "image_url", "thinking", "document"]
                       },
                       "text": {
                         "type": "string"
@@ -93262,10 +88531,7 @@
       },
       "CohereCountTokensRequest": {
         "type": "object",
-        "required": [
-          "text",
-          "model"
-        ],
+        "required": ["text", "model"],
         "properties": {
           "model": {
             "type": "string",
@@ -93366,9 +88632,7 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ok"
-            ],
+            "enum": ["ok"],
             "example": "ok"
           },
           "components": {
@@ -93433,10 +88697,7 @@
                 "description": "Whether to enforce virtual key authentication on inference requests"
               },
               "vk_rotation_cooldown": {
-                "type": [
-                  "string",
-                  "integer"
-                ],
+                "type": ["string", "integer"],
                 "minimum": 0,
                 "maximum": 2592000000000000,
                 "default": 0,
@@ -93554,11 +88815,7 @@
               },
               "mcp_server_auth_mode": {
                 "type": "string",
-                "enum": [
-                  "headers",
-                  "both",
-                  "oauth"
-                ],
+                "enum": ["headers", "both", "oauth"],
                 "default": "headers",
                 "description": "How /mcp authenticates inbound MCP clients. 'headers' (default): VK/api-key/session headers only, discovery disabled. 'both': accepts header credentials and Bifrost-issued JWTs, discovery enabled. 'oauth': Bifrost JWTs only — disables VK/header MCP access.\n"
               },
@@ -93671,11 +88928,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "http",
-                  "socks5",
-                  "tcp"
-                ]
+                "enum": ["http", "socks5", "tcp"]
               },
               "url": {
                 "type": "string"
@@ -93774,10 +89027,7 @@
                 "description": "Whether to enforce virtual key authentication on inference requests"
               },
               "vk_rotation_cooldown": {
-                "type": [
-                  "string",
-                  "integer"
-                ],
+                "type": ["string", "integer"],
                 "minimum": 0,
                 "maximum": 2592000000000000,
                 "default": 0,
@@ -93895,11 +89145,7 @@
               },
               "mcp_server_auth_mode": {
                 "type": "string",
-                "enum": [
-                  "headers",
-                  "both",
-                  "oauth"
-                ],
+                "enum": ["headers", "both", "oauth"],
                 "default": "headers",
                 "description": "How /mcp authenticates inbound MCP clients. 'headers' (default): VK/api-key/session headers only, discovery disabled. 'both': accepts header credentials and Bifrost-issued JWTs, discovery enabled. 'oauth': Bifrost JWTs only — disables VK/header MCP access.\n"
               },
@@ -94025,10 +89271,7 @@
       "LoginRequest": {
         "type": "object",
         "description": "Login request",
-        "required": [
-          "username",
-          "password"
-        ],
+        "required": ["username", "password"],
         "properties": {
           "username": {
             "type": "string"
@@ -94083,12 +89326,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "http",
-                  "socks5",
-                  "environment"
-                ]
+                "enum": ["none", "http", "socks5", "environment"]
               },
               "url": {
                 "type": "string"
@@ -94214,11 +89452,7 @@
           },
           "provider_status": {
             "type": "string",
-            "enum": [
-              "active",
-              "error",
-              "deleted"
-            ],
+            "enum": ["active", "error", "deleted"],
             "description": "Status of the provider"
           },
           "status": {
@@ -94253,9 +89487,7 @@
       "AddProviderRequest": {
         "type": "object",
         "description": "Add provider request. Keys are managed separately via /api/providers/{provider}/keys.",
-        "required": [
-          "provider"
-        ],
+        "required": ["provider"],
         "properties": {
           "provider": {
             "$ref": "#/components/schemas/ModelProvider"
@@ -94272,12 +89504,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "http",
-                  "socks5",
-                  "environment"
-                ]
+                "enum": ["none", "http", "socks5", "environment"]
               },
               "url": {
                 "type": "string"
@@ -94419,12 +89646,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "http",
-                  "socks5",
-                  "environment"
-                ]
+                "enum": ["none", "http", "socks5", "environment"]
               },
               "url": {
                 "type": "string"
@@ -94576,11 +89798,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "plain_text",
-                  "env",
-                  "vault"
-                ],
+                "enum": ["plain_text", "env", "vault"],
                 "description": "Source type of the value"
               }
             }
@@ -94632,11 +89850,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94655,11 +89869,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94678,11 +89888,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94701,11 +89907,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94724,11 +89926,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94760,11 +89958,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94783,11 +89977,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94806,11 +89996,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94829,11 +90015,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94858,11 +90040,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94881,11 +90059,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94904,11 +90078,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94927,11 +90097,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -94950,11 +90116,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -95001,11 +90163,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -95014,9 +90172,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "url"
-            ]
+            "required": ["url"]
           },
           "ollama_key_config": {
             "type": "object",
@@ -95036,19 +90192,13 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
               }
             },
-            "required": [
-              "url"
-            ]
+            "required": ["url"]
           },
           "sgl_key_config": {
             "type": "object",
@@ -95068,19 +90218,13 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
               }
             },
-            "required": [
-              "url"
-            ]
+            "required": ["url"]
           },
           "replicate_key_config": {
             "type": "object",
@@ -95251,25 +90395,15 @@
                 "description": "Plugin types indicating which interfaces the plugin implements",
                 "items": {
                   "type": "string",
-                  "enum": [
-                    "llm",
-                    "mcp",
-                    "http",
-                    "observability"
-                  ]
+                  "enum": ["llm", "mcp", "http", "observability"]
                 }
               }
             },
             "example": {
               "name": "my_custom_plugin",
               "status": "active",
-              "logs": [
-                "plugin my_custom_plugin initialized successfully"
-              ],
-              "types": [
-                "llm",
-                "http"
-              ]
+              "logs": ["plugin my_custom_plugin initialized successfully"],
+              "types": ["llm", "http"]
             }
           },
           "created_at": {
@@ -95300,13 +90434,8 @@
           "status": {
             "name": "my_custom_plugin",
             "status": "active",
-            "logs": [
-              "plugin my_custom_plugin initialized successfully"
-            ],
-            "types": [
-              "llm",
-              "http"
-            ]
+            "logs": ["plugin my_custom_plugin initialized successfully"],
+            "types": ["llm", "http"]
           }
         }
       },
@@ -95328,9 +90457,7 @@
       "CreatePluginRequest": {
         "type": "object",
         "description": "Create plugin request",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -95450,12 +90577,7 @@
           },
           "connection_type": {
             "type": "string",
-            "enum": [
-              "http",
-              "stdio",
-              "sse",
-              "inprocess"
-            ],
+            "enum": ["http", "stdio", "sse", "inprocess"],
             "description": "Connection type for MCP client"
           },
           "connection_string": {
@@ -95559,9 +90681,7 @@
           },
           "token_exchange": {
             "type": "object",
-            "required": [
-              "audience"
-            ],
+            "required": ["audience"],
             "properties": {
               "audience": {
                 "type": "string",
@@ -95602,15 +90722,11 @@
                         "const": true
                       }
                     },
-                    "required": [
-                      "use_idp_credentials"
-                    ]
+                    "required": ["use_idp_credentials"]
                   }
                 },
                 "then": {
-                  "required": [
-                    "client_id"
-                  ],
+                  "required": ["client_id"],
                   "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                 }
               }
@@ -95629,9 +90745,7 @@
         "oneOf": [
           {
             "type": "object",
-            "required": [
-              "function"
-            ],
+            "required": ["function"],
             "properties": {
               "index": {
                 "type": "integer"
@@ -95660,9 +90774,7 @@
           {
             "type": "object",
             "description": "Responses format - uses ResponsesToolMessage schema",
-            "required": [
-              "name"
-            ],
+            "required": ["name"],
             "properties": {
               "call_id": {
                 "type": "string",
@@ -95728,11 +90840,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -95756,11 +90864,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -95799,9 +90903,7 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "pending_oauth"
-            ]
+            "enum": ["pending_oauth"]
           },
           "message": {
             "type": "string"
@@ -95850,11 +90952,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "authorized",
-              "failed"
-            ],
+            "enum": ["pending", "authorized", "failed"],
             "description": "Current status of the OAuth flow:\n- pending: User has not yet authorized\n- authorized: User authorized and token is stored\n- failed: Authorization failed\n"
           },
           "created_at": {
@@ -95938,20 +91036,11 @@
           },
           "flow_mode": {
             "type": "string",
-            "enum": [
-              "user",
-              "vk",
-              "session"
-            ]
+            "enum": ["user", "vk", "session"]
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "authorized",
-              "failed",
-              "expired"
-            ]
+            "enum": ["pending", "authorized", "failed", "expired"]
           },
           "mcp_client": {
             "$ref": "#/components/schemas/MCPClientSummary"
@@ -96028,15 +91117,7 @@
       "MCPSessionRow": {
         "type": "object",
         "description": "One row on the MCP Sessions list. Covers OAuth tokens, header credentials,\nand pending flows (of either kind). Always-set fields are at the top;\nper-kind-only fields use omitempty.\n",
-        "required": [
-          "id",
-          "kind",
-          "auth_kind",
-          "auth_mode",
-          "status",
-          "created_at",
-          "can_reauth"
-        ],
+        "required": ["id", "kind", "auth_kind", "auth_mode", "status", "created_at", "can_reauth"],
         "properties": {
           "id": {
             "type": "string",
@@ -96044,28 +91125,17 @@
           },
           "kind": {
             "type": "string",
-            "enum": [
-              "token",
-              "header",
-              "flow"
-            ],
+            "enum": ["token", "header", "flow"],
             "description": "Row type:\n- token: completed per-user OAuth credential\n- header: completed per-user-headers credential\n- flow: pending submission / consent flow (use auth_kind to disambiguate OAuth vs Headers)\n"
           },
           "auth_kind": {
             "type": "string",
-            "enum": [
-              "oauth",
-              "headers"
-            ],
+            "enum": ["oauth", "headers"],
             "description": "Disambiguates flow rows by which auth surface they belong to. For\n`kind=token` this is always `oauth`; for `kind=header` always `headers`.\n"
           },
           "auth_mode": {
             "type": "string",
-            "enum": [
-              "user",
-              "vk",
-              "session"
-            ],
+            "enum": ["user", "vk", "session"],
             "description": "Identity dimension this credential is keyed against"
           },
           "user_id": {
@@ -96093,13 +91163,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "active",
-              "orphaned",
-              "pending",
-              "needs_reauth",
-              "needs_update"
-            ],
+            "enum": ["active", "orphaned", "pending", "needs_reauth", "needs_update"],
             "description": "OAuth tokens use: active | orphaned | needs_reauth.\nHeader credentials use: active | orphaned | needs_update.\nFlow rows use: pending.\n"
           },
           "expires_at": {
@@ -96137,9 +91201,7 @@
       },
       "MCPSessionsListResponse": {
         "type": "object",
-        "required": [
-          "sessions"
-        ],
+        "required": ["sessions"],
         "properties": {
           "sessions": {
             "type": "array",
@@ -96152,10 +91214,7 @@
       "MCPSessionReauthResponse": {
         "type": "object",
         "description": "Response for POST /api/mcp/sessions/{id}/reauth. Returns the URL the caller\nmust visit to complete the fresh authentication / resubmission.\n",
-        "required": [
-          "authorize_url",
-          "session_id"
-        ],
+        "required": ["authorize_url", "session_id"],
         "properties": {
           "authorize_url": {
             "type": "string",
@@ -96171,10 +91230,7 @@
           },
           "kind": {
             "type": "string",
-            "enum": [
-              "oauth",
-              "headers"
-            ],
+            "enum": ["oauth", "headers"],
             "description": "Set only on header re-auth"
           }
         }
@@ -96197,19 +91253,11 @@
           },
           "flow_mode": {
             "type": "string",
-            "enum": [
-              "user",
-              "vk",
-              "session"
-            ]
+            "enum": ["user", "vk", "session"]
           },
           "status": {
             "type": "string",
-            "enum": [
-              "pending",
-              "completed",
-              "expired"
-            ]
+            "enum": ["pending", "completed", "expired"]
           },
           "mcp_client": {
             "$ref": "#/components/schemas/MCPClientSummary",
@@ -96269,9 +91317,7 @@
       "MCPHeadersSubmitRequest": {
         "type": "object",
         "description": "Request body for PUT /api/mcp/per-user-headers/flows/{id}. The flow row\nidentifies the (mode, identity, mcp_client) triple, so the caller carries\nonly the values. Extra keys not in the live `per_user_header_keys` schema\nare dropped server-side.\n",
-        "required": [
-          "headers"
-        ],
+        "required": ["headers"],
         "properties": {
           "headers": {
             "type": "object",
@@ -96283,17 +91329,11 @@
       },
       "MCPHeadersSubmitResponse": {
         "type": "object",
-        "required": [
-          "status",
-          "credential_id",
-          "updated_at"
-        ],
+        "required": ["status", "credential_id", "updated_at"],
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "success"
-            ]
+            "enum": ["success"]
           },
           "credential_id": {
             "type": "string"
@@ -96336,26 +91376,17 @@
             "type": "boolean"
           },
           "expires_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time",
             "description": "Expiry timestamp. Requests using this virtual key are rejected once it passes. Null or absent means the key never expires."
           },
           "previous_value_expires_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time",
             "description": "When set, the pre-rotation key value continues to authenticate until this timestamp (rotation grace period, configured via client vk_rotation_cooldown). Absent when no grace window is active."
           },
           "rotated_at": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "format": "date-time",
             "description": "Timestamp of the most recent value rotation. Absent if the key has never been rotated."
           },
@@ -96419,10 +91450,7 @@
       "VirtualKeyResponse": {
         "type": "object",
         "description": "Virtual key operation response",
-        "required": [
-          "message",
-          "virtual_key"
-        ],
+        "required": ["message", "virtual_key"],
         "properties": {
           "message": {
             "type": "string"
@@ -96456,10 +91484,7 @@
             "type": "string"
           },
           "weight": {
-            "type": [
-              "number",
-              "null"
-            ],
+            "type": ["number", "null"],
             "description": "Weight for provider load balancing. Null means excluded from weighted routing."
           },
           "allowed_models": {
@@ -96491,10 +91516,7 @@
             "$ref": "#/components/schemas/RateLimit"
           },
           "keys": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "description": "Associated API keys for this provider config. **Always null in the quota endpoint** — keys are intentionally not loaded here to keep the response lean and avoid exposing sensitive credentials. Use the admin virtual-key API to inspect actual key assignments.\n",
             "items": {
               "$ref": "#/components/schemas/TableKey"
@@ -96505,13 +91527,7 @@
       "VirtualKeyMCPConfig": {
         "type": "object",
         "description": "MCP configuration for a virtual key",
-        "required": [
-          "id",
-          "virtual_key_id",
-          "mcp_client_id",
-          "mcp_client",
-          "tools_to_execute"
-        ],
+        "required": ["id", "virtual_key_id", "mcp_client_id", "mcp_client", "tools_to_execute"],
         "properties": {
           "id": {
             "type": "integer"
@@ -96536,13 +91552,7 @@
       "ListVirtualKeysResponse": {
         "type": "object",
         "description": "List virtual keys response",
-        "required": [
-          "virtual_keys",
-          "count",
-          "total_count",
-          "limit",
-          "offset"
-        ],
+        "required": ["virtual_keys", "count", "total_count", "limit", "offset"],
         "properties": {
           "virtual_keys": {
             "type": "array",
@@ -96589,10 +91599,7 @@
             "description": "Whether the virtual key is active"
           },
           "budgets": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "description": "Overall budget quotas for this virtual key. Each budget also carries the actual per-model spend (from request logs) accumulated in its current cycle.\n",
             "items": {
               "description": "A virtual key budget with the actual per-model spend (from request logs) accumulated in its current cycle [last_reset, now]. The per-model totals reconcile with current_usage. The models list is empty when the logging plugin is not enabled.\n",
@@ -96602,9 +91609,7 @@
                 },
                 {
                   "type": "object",
-                  "required": [
-                    "per_model_usage"
-                  ],
+                  "required": ["per_model_usage"],
                   "properties": {
                     "per_model_usage": {
                       "type": "array",
@@ -96612,12 +91617,7 @@
                       "items": {
                         "type": "object",
                         "description": "One model's actual usage (from request logs) within a budget cycle",
-                        "required": [
-                          "model",
-                          "total_requests",
-                          "total_tokens",
-                          "total_cost"
-                        ],
+                        "required": ["model", "total_requests", "total_tokens", "total_cost"],
                         "properties": {
                           "model": {
                             "type": "string",
@@ -96660,10 +91660,7 @@
             ]
           },
           "provider_configs": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "description": "Per-provider budget quotas and rate limits (provider-level splits and limits)",
             "items": {
               "$ref": "#/components/schemas/VirtualKeyProviderConfig"
@@ -96675,9 +91672,7 @@
             "items": {
               "type": "object",
               "description": "Per-model budgets and rate limit (with current usage) for a model governed under a virtual key",
-              "required": [
-                "model_name"
-              ],
+              "required": ["model_name"],
               "properties": {
                 "model_name": {
                   "type": "string",
@@ -96688,10 +91683,7 @@
                   "description": "Provider this model config is scoped to; omitted when it applies to all providers"
                 },
                 "budgets": {
-                  "type": [
-                    "array",
-                    "null"
-                  ],
+                  "type": ["array", "null"],
                   "description": "Budget quotas for this model",
                   "items": {
                     "$ref": "#/components/schemas/Budget"
@@ -96715,9 +91707,7 @@
       "CreateVirtualKeyRequest": {
         "type": "object",
         "description": "Create virtual key request",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -96735,10 +91725,7 @@
                   "type": "string"
                 },
                 "weight": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
+                  "type": ["number", "null"],
                   "description": "Weight for load balancing. Null means excluded from weighted routing."
                 },
                 "allowed_models": {
@@ -96842,10 +91829,7 @@
                   "type": "string"
                 },
                 "weight": {
-                  "type": [
-                    "number",
-                    "null"
-                  ],
+                  "type": ["number", "null"],
                   "description": "Weight for load balancing. Null means excluded from weighted routing."
                 },
                 "allowed_models": {
@@ -96955,10 +91939,7 @@
             }
           },
           "virtual_keys": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "description": "Virtual keys assigned to this team. This field may be omitted or returned as null in some responses (for example, when a team is embedded inside a virtual-key response) to avoid nested `virtual_keys` recursion.\n",
             "items": {
               "$ref": "#/components/schemas/VirtualKey"
@@ -96977,10 +91958,7 @@
             "additionalProperties": true
           },
           "config_hash": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "created_at": {
             "type": "string",
@@ -97022,9 +92000,7 @@
       "CreateTeamRequest": {
         "type": "object",
         "description": "Create team request",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -97087,10 +92063,7 @@
             }
           },
           "virtual_keys": {
-            "type": [
-              "array",
-              "null"
-            ],
+            "type": ["array", "null"],
             "description": "Virtual keys owned by this customer. Omitted or returned as null by the paginated list endpoint (`GET /api/governance/customers` with `limit`/`offset`/`search`), which reports `virtual_key_count` instead; use the single-customer endpoint to retrieve the keys themselves.\n",
             "items": {
               "$ref": "#/components/schemas/VirtualKey"
@@ -97143,9 +92116,7 @@
       "CreateCustomerRequest": {
         "type": "object",
         "description": "Create customer request",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"
@@ -97228,10 +92199,7 @@
           "override_mode": {
             "type": "string",
             "description": "How long the override stays active. `cycles` keeps it active for a finite number of\nreset windows; `forever` keeps it active until it is removed. Omitted when no override is set.\n",
-            "enum": [
-              "cycles",
-              "forever"
-            ]
+            "enum": ["cycles", "forever"]
           },
           "override_cycles_remaining": {
             "type": "integer",
@@ -97259,10 +92227,7 @@
             "description": "Provider config that owns this budget, when the budget is provider-config-scoped"
           },
           "config_hash": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "created_at": {
             "type": "string",
@@ -97307,17 +92272,11 @@
             "format": "date-time"
           },
           "request_max_limit": {
-            "type": [
-              "integer",
-              "null"
-            ],
+            "type": ["integer", "null"],
             "format": "int64"
           },
           "request_reset_duration": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "request_current_usage": {
             "type": "integer",
@@ -97328,10 +92287,7 @@
             "format": "date-time"
           },
           "config_hash": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "created_at": {
             "type": "string",
@@ -97376,10 +92332,7 @@
       "CreateBudgetRequest": {
         "type": "object",
         "description": "Create budget request",
-        "required": [
-          "max_limit",
-          "reset_duration"
-        ],
+        "required": ["max_limit", "reset_duration"],
         "properties": {
           "max_limit": {
             "type": "number"
@@ -97431,10 +92384,7 @@
             "additionalProperties": false
           },
           "calendar_aligned": {
-            "type": [
-              "boolean",
-              "null"
-            ],
+            "type": ["boolean", "null"],
             "description": "Set to true or false to enable or disable calendar-aligned resets. Only valid with reset durations that use day, week, month, quarter, or year suffixes (`d`, `w`, `M`, `Q`, `Y`); sub-day durations (e.g. `1h`, `30m`) are invalid with calendar alignment and the API rejects that combination. When enabling on an existing budget, alignment takes effect from the next period: the current window keeps its start and its accumulated usage, and the first aligned reset happens at the next boundary. Changing quarter_start_month on a calendar-aligned quarterly budget does not move last_reset directly; the new definition shifts where the current window starts, so the budget converges onto the new fiscal boundary on the next reset tick.\n"
           }
         }
@@ -97442,10 +92392,7 @@
       "BudgetOverrideRequest": {
         "type": "object",
         "description": "Replaces the active override on one budget. The override is additive: it does not change the\nbudget's `max_limit`, `current_usage`, or reset schedule. Sending this request against a budget\nthat already has an override replaces that override entirely.\n",
-        "required": [
-          "amount",
-          "mode"
-        ],
+        "required": ["amount", "mode"],
         "properties": {
           "amount": {
             "type": "number",
@@ -97454,10 +92401,7 @@
           "mode": {
             "type": "string",
             "description": "`cycles` keeps the override active for `cycles` reset windows starting with the current one.\n`forever` keeps it active until it is removed with a DELETE.\n",
-            "enum": [
-              "cycles",
-              "forever"
-            ]
+            "enum": ["cycles", "forever"]
           },
           "cycles": {
             "type": "integer",
@@ -97469,10 +92413,7 @@
       "BudgetOverrideResponse": {
         "type": "object",
         "description": "The persisted budget and the additive limit now in force.",
-        "required": [
-          "budget",
-          "effective_max_limit"
-        ],
+        "required": ["budget", "effective_max_limit"],
         "properties": {
           "budget": {
             "$ref": "#/components/schemas/Budget"
@@ -97553,34 +92494,21 @@
             "items": {
               "type": "object",
               "description": "A single weighted routing target within a routing rule",
-              "required": [
-                "weight"
-              ],
+              "required": ["weight"],
               "dependentRequired": {
-                "key_id": [
-                  "provider"
-                ]
+                "key_id": ["provider"]
               },
               "properties": {
                 "provider": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "Target provider (omit or empty to use the incoming request provider)"
                 },
                 "model": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "Target model (omit or empty to use the incoming request model)"
                 },
                 "key_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "UUID of the API key to pin for this target (omit for load-balanced key selection)"
                 },
                 "weight": {
@@ -97602,19 +92530,11 @@
           },
           "scope": {
             "type": "string",
-            "enum": [
-              "global",
-              "team",
-              "customer",
-              "virtual_key"
-            ],
+            "enum": ["global", "team", "customer", "virtual_key"],
             "description": "Scope level for the rule"
           },
           "scope_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "ID for the scope (empty for global scope)"
           },
           "priority": {
@@ -97622,10 +92542,7 @@
             "description": "Priority for rule evaluation (lower number = higher priority)"
           },
           "query": {
-            "type": [
-              "object",
-              "null"
-            ],
+            "type": ["object", "null"],
             "description": "Visual rule tree structure from query builder"
           },
           "created_at": {
@@ -97643,14 +92560,10 @@
             "properties": {
               "scope": {
                 "type": "string",
-                "enum": [
-                  "global"
-                ]
+                "enum": ["global"]
               }
             },
-            "required": [
-              "scope"
-            ],
+            "required": ["scope"],
             "description": "Global scope routing rule"
           },
           {
@@ -97658,20 +92571,13 @@
             "properties": {
               "scope": {
                 "type": "string",
-                "enum": [
-                  "team",
-                  "customer",
-                  "virtual_key"
-                ]
+                "enum": ["team", "customer", "virtual_key"]
               },
               "scope_id": {
                 "type": "string"
               }
             },
-            "required": [
-              "scope",
-              "scope_id"
-            ],
+            "required": ["scope", "scope_id"],
             "description": "Scoped routing rule (requires scope_id)"
           }
         ]
@@ -97707,13 +92613,7 @@
       "CreateRoutingRuleRequest": {
         "type": "object",
         "description": "Request to create a routing rule",
-        "required": [
-          "name",
-          "cel_expression",
-          "scope",
-          "priority",
-          "targets"
-        ],
+        "required": ["name", "cel_expression", "scope", "priority", "targets"],
         "properties": {
           "name": {
             "type": "string",
@@ -97738,34 +92638,21 @@
             "items": {
               "type": "object",
               "description": "A single weighted routing target within a routing rule",
-              "required": [
-                "weight"
-              ],
+              "required": ["weight"],
               "dependentRequired": {
-                "key_id": [
-                  "provider"
-                ]
+                "key_id": ["provider"]
               },
               "properties": {
                 "provider": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "Target provider (omit or empty to use the incoming request provider)"
                 },
                 "model": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "Target model (omit or empty to use the incoming request model)"
                 },
                 "key_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "UUID of the API key to pin for this target (omit for load-balanced key selection)"
                 },
                 "weight": {
@@ -97787,19 +92674,11 @@
           },
           "scope": {
             "type": "string",
-            "enum": [
-              "global",
-              "team",
-              "customer",
-              "virtual_key"
-            ],
+            "enum": ["global", "team", "customer", "virtual_key"],
             "description": "Scope level for the rule"
           },
           "scope_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "ID for the scope (required if scope is not global)"
           },
           "priority": {
@@ -97807,10 +92686,7 @@
             "description": "Priority for rule evaluation (lower number = higher priority)"
           },
           "query": {
-            "type": [
-              "object",
-              "null"
-            ],
+            "type": ["object", "null"],
             "description": "Visual rule tree structure"
           }
         },
@@ -97820,14 +92696,10 @@
             "properties": {
               "scope": {
                 "type": "string",
-                "enum": [
-                  "global"
-                ]
+                "enum": ["global"]
               }
             },
-            "required": [
-              "scope"
-            ],
+            "required": ["scope"],
             "description": "Global scope routing rule"
           },
           {
@@ -97835,20 +92707,13 @@
             "properties": {
               "scope": {
                 "type": "string",
-                "enum": [
-                  "team",
-                  "customer",
-                  "virtual_key"
-                ]
+                "enum": ["team", "customer", "virtual_key"]
               },
               "scope_id": {
                 "type": "string"
               }
             },
-            "required": [
-              "scope",
-              "scope_id"
-            ],
+            "required": ["scope", "scope_id"],
             "description": "Scoped routing rule (requires scope_id)"
           }
         ]
@@ -97876,34 +92741,21 @@
             "items": {
               "type": "object",
               "description": "A single weighted routing target within a routing rule",
-              "required": [
-                "weight"
-              ],
+              "required": ["weight"],
               "dependentRequired": {
-                "key_id": [
-                  "provider"
-                ]
+                "key_id": ["provider"]
               },
               "properties": {
                 "provider": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "Target provider (omit or empty to use the incoming request provider)"
                 },
                 "model": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "Target model (omit or empty to use the incoming request model)"
                 },
                 "key_id": {
-                  "type": [
-                    "string",
-                    "null"
-                  ],
+                  "type": ["string", "null"],
                   "description": "UUID of the API key to pin for this target (omit for load-balanced key selection)"
                 },
                 "weight": {
@@ -97926,10 +92778,7 @@
             "type": "integer"
           },
           "query": {
-            "type": [
-              "object",
-              "null"
-            ]
+            "type": ["object", "null"]
           }
         }
       },
@@ -97966,11 +92815,7 @@
               },
               "type": {
                 "type": "string",
-                "enum": [
-                  "plain_text",
-                  "env",
-                  "vault"
-                ],
+                "enum": ["plain_text", "env", "vault"],
                 "description": "Source type of the value"
               }
             }
@@ -97982,23 +92827,14 @@
             }
           },
           "weight": {
-            "type": [
-              "number",
-              "null"
-            ]
+            "type": ["number", "null"]
           },
           "enabled": {
-            "type": [
-              "boolean",
-              "null"
-            ],
+            "type": ["boolean", "null"],
             "default": true
           },
           "use_for_batch_api": {
-            "type": [
-              "boolean",
-              "null"
-            ],
+            "type": ["boolean", "null"],
             "default": false
           },
           "created_at": {
@@ -98010,10 +92846,7 @@
             "format": "date-time"
           },
           "config_hash": {
-            "type": [
-              "string",
-              "null"
-            ]
+            "type": ["string", "null"]
           },
           "azure_endpoint": {
             "oneOf": [
@@ -98031,11 +92864,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98061,11 +92890,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98091,11 +92916,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98121,11 +92942,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98151,11 +92968,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98181,11 +92994,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98211,11 +93020,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98241,11 +93046,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98271,11 +93072,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98301,11 +93098,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98331,11 +93124,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98361,11 +93150,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98391,11 +93176,7 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": [
-                      "plain_text",
-                      "env",
-                      "vault"
-                    ],
+                    "enum": ["plain_text", "env", "vault"],
                     "description": "Source type of the value"
                   }
                 }
@@ -98426,11 +93207,7 @@
           "scope": {
             "type": "string",
             "description": "Scope where this limit applies. `global` covers all traffic; `virtual_key` scopes to a single virtual key; `user` scopes to a single user (Enterprise only).",
-            "enum": [
-              "global",
-              "virtual_key",
-              "user"
-            ],
+            "enum": ["global", "virtual_key", "user"],
             "default": "global"
           },
           "scope_id": {
@@ -98506,9 +93283,7 @@
       "CreateModelConfigRequest": {
         "type": "object",
         "description": "Request to create a new model config",
-        "required": [
-          "model_name"
-        ],
+        "required": ["model_name"],
         "properties": {
           "model_name": {
             "type": "string",
@@ -98521,11 +93296,7 @@
           "scope": {
             "type": "string",
             "description": "Scope where this limit applies. Defaults to `global`.",
-            "enum": [
-              "global",
-              "virtual_key",
-              "user"
-            ],
+            "enum": ["global", "virtual_key", "user"],
             "default": "global"
           },
           "scope_id": {
@@ -99120,39 +93891,24 @@
             "$ref": "#/components/schemas/PricingOverrideScopeKind"
           },
           "user_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "Required for user* scopes"
           },
           "virtual_key_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "Required for virtual_key* scopes"
           },
           "provider_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "Required for provider, virtual_key_provider, and user_provider scopes"
           },
           "provider_key_id": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "Required for provider_key, virtual_key_provider_key, and user_provider_key scopes"
           },
           "match_type": {
             "type": "string",
-            "enum": [
-              "exact",
-              "wildcard"
-            ],
+            "enum": ["exact", "wildcard"],
             "description": "How the pattern is matched against the model name"
           },
           "pattern": {
@@ -99176,10 +93932,7 @@
             "description": "Decoded pricing fields (present in API responses)"
           },
           "config_hash": {
-            "type": [
-              "string",
-              "null"
-            ],
+            "type": ["string", "null"],
             "description": "Auto-managed hash for config-file-sourced overrides. Do not set manually."
           },
           "created_at": {
@@ -99195,13 +93948,7 @@
       "CreatePricingOverrideRequest": {
         "type": "object",
         "description": "Request body for creating a pricing override.",
-        "required": [
-          "name",
-          "scope_kind",
-          "match_type",
-          "pattern",
-          "request_types"
-        ],
+        "required": ["name", "scope_kind", "match_type", "pattern", "request_types"],
         "properties": {
           "name": {
             "type": "string",
@@ -99228,10 +93975,7 @@
           },
           "match_type": {
             "type": "string",
-            "enum": [
-              "exact",
-              "wildcard"
-            ]
+            "enum": ["exact", "wildcard"]
           },
           "pattern": {
             "type": "string",
@@ -99279,10 +94023,7 @@
           },
           "match_type": {
             "type": "string",
-            "enum": [
-              "exact",
-              "wildcard"
-            ]
+            "enum": ["exact", "wildcard"]
           },
           "pattern": {
             "type": "string",
@@ -99343,21 +94084,12 @@
       "SkillSourceType": {
         "type": "string",
         "description": "Source backing for an attached skill file.",
-        "enum": [
-          "url",
-          "dataurl",
-          "text",
-          "upload"
-        ]
+        "enum": ["url", "dataurl", "text", "upload"]
       },
       "SkillFileEntry": {
         "type": "object",
         "description": "File entry used when creating or updating a skill version.",
-        "required": [
-          "path",
-          "source_type",
-          "mime_type"
-        ],
+        "required": ["path", "source_type", "mime_type"],
         "properties": {
           "path": {
             "type": "string",
@@ -99557,12 +94289,7 @@
       },
       "CreateSkillRequest": {
         "type": "object",
-        "required": [
-          "name",
-          "description",
-          "skill_md_body",
-          "version"
-        ],
+        "required": ["name", "description", "skill_md_body", "version"],
         "properties": {
           "name": {
             "type": "string",
@@ -99612,11 +94339,7 @@
       },
       "UpdateSkillRequest": {
         "type": "object",
-        "required": [
-          "description",
-          "skill_md_body",
-          "version"
-        ],
+        "required": ["description", "skill_md_body", "version"],
         "properties": {
           "description": {
             "type": "string",
@@ -99716,9 +94439,7 @@
       },
       "UploadSkillFileRequest": {
         "type": "object",
-        "required": [
-          "file"
-        ],
+        "required": ["file"],
         "properties": {
           "file": {
             "type": "string",
@@ -99790,25 +94511,17 @@
       },
       "BumpAllSkillsVersionRequest": {
         "type": "object",
-        "required": [
-          "bump"
-        ],
+        "required": ["bump"],
         "properties": {
           "bump": {
             "type": "string",
-            "enum": [
-              "patch",
-              "minor",
-              "major"
-            ]
+            "enum": ["patch", "minor", "major"]
           }
         }
       },
       "ShiftSkillVersionRequest": {
         "type": "object",
-        "required": [
-          "version"
-        ],
+        "required": ["version"],
         "properties": {
           "version": {
             "type": "string",
@@ -99873,11 +94586,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "processing",
-              "success",
-              "error"
-            ]
+            "enum": ["processing", "success", "error"]
           },
           "object": {
             "type": "string"
@@ -100006,22 +94715,11 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "in_progress",
-                    "completed",
-                    "incomplete",
-                    "interpreting",
-                    "failed"
-                  ]
+                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
                 },
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "assistant",
-                    "user",
-                    "system",
-                    "developer"
-                  ]
+                  "enum": ["assistant", "user", "system", "developer"]
                 },
                 "content": {
                   "oneOf": [
@@ -100032,9 +94730,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -100077,17 +94773,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -100208,9 +94898,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -100253,17 +94941,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -100369,9 +95051,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "computer_screenshot"
-                          ]
+                          "enum": ["computer_screenshot"]
                         },
                         "file_id": {
                           "type": "string"
@@ -100405,16 +95085,11 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": [
-                      "type",
-                      "text"
-                    ],
+                    "required": ["type", "text"],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "summary_text"
-                        ]
+                        "enum": ["summary_text"]
                       },
                       "text": {
                         "type": "string"
@@ -100467,22 +95142,11 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "in_progress",
-                    "completed",
-                    "incomplete",
-                    "interpreting",
-                    "failed"
-                  ]
+                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
                 },
                 "role": {
                   "type": "string",
-                  "enum": [
-                    "assistant",
-                    "user",
-                    "system",
-                    "developer"
-                  ]
+                  "enum": ["assistant", "user", "system", "developer"]
                 },
                 "content": {
                   "oneOf": [
@@ -100493,9 +95157,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -100538,17 +95200,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -100669,9 +95325,7 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": [
-                          "type"
-                        ],
+                        "required": ["type"],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -100714,17 +95368,11 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": [
-                              "format",
-                              "data"
-                            ],
+                            "required": ["format", "data"],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": [
-                                  "mp3",
-                                  "wav"
-                                ]
+                                "enum": ["mp3", "wav"]
                               },
                               "data": {
                                 "type": "string"
@@ -100830,9 +95478,7 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": [
-                            "computer_screenshot"
-                          ]
+                          "enum": ["computer_screenshot"]
                         },
                         "file_id": {
                           "type": "string"
@@ -100866,16 +95512,11 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": [
-                      "type",
-                      "text"
-                    ],
+                    "required": ["type", "text"],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": [
-                          "summary_text"
-                        ]
+                        "enum": ["summary_text"]
                       },
                       "text": {
                         "type": "string"
@@ -100906,22 +95547,15 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": [
-                    "function",
-                    "custom"
-                  ]
+                  "enum": ["function", "custom"]
                 },
                 "function": {
                   "type": "object",
-                  "required": [
-                    "name"
-                  ],
+                  "required": ["name"],
                   "properties": {
                     "name": {
                       "type": "string"
@@ -100969,29 +95603,21 @@
                   "properties": {
                     "format": {
                       "type": "object",
-                      "required": [
-                        "type"
-                      ],
+                      "required": ["type"],
                       "properties": {
                         "type": {
                           "type": "string"
                         },
                         "grammar": {
                           "type": "object",
-                          "required": [
-                            "definition",
-                            "syntax"
-                          ],
+                          "required": ["definition", "syntax"],
                           "properties": {
                             "definition": {
                               "type": "string"
                             },
                             "syntax": {
                               "type": "string",
-                              "enum": [
-                                "lark",
-                                "regex"
-                              ]
+                              "enum": ["lark", "regex"]
                             }
                           }
                         }
@@ -101009,9 +95635,7 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": [
-                "function"
-              ],
+              "required": ["function"],
               "properties": {
                 "index": {
                   "type": "integer"
@@ -101162,19 +95786,11 @@
               },
               "sort_by": {
                 "type": "string",
-                "enum": [
-                  "timestamp",
-                  "latency",
-                  "tokens",
-                  "cost"
-                ]
+                "enum": ["timestamp", "latency", "tokens", "cost"]
               },
               "order": {
                 "type": "string",
-                "enum": [
-                  "asc",
-                  "desc"
-                ]
+                "enum": ["asc", "desc"]
               },
               "total_count": {
                 "type": "integer",
@@ -101249,12 +95865,36 @@
           }
         }
       },
+      "LogStatsResponse": {
+        "description": "Log statistics for the requested window. The current period's fields are at the top level, so a request without `compare_to_previous` returns the LogStats fields unchanged, plus `has_previous_period` false. `has_previous_period` is always present; `previous` appears only when a comparison was requested and computed.",
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/LogStats"
+          },
+          {
+            "type": "object",
+            "required": ["has_previous_period"],
+            "properties": {
+              "has_previous_period": {
+                "type": "boolean",
+                "description": "Always present. True when `previous` is populated. False when the comparison was not requested, the window is unbounded, or the previous-period query failed."
+              },
+              "previous": {
+                "allOf": [
+                  {
+                    "$ref": "#/components/schemas/LogStats"
+                  }
+                ],
+                "description": "The same statistics for the preceding window of equal length, ending immediately before the requested window starts. Present only when `compare_to_previous` is true and `has_previous_period` is true."
+              }
+            }
+          }
+        ]
+      },
       "DeleteLogsRequest": {
         "type": "object",
         "description": "Delete logs request",
-        "required": [
-          "ids"
-        ],
+        "required": ["ids"],
         "properties": {
           "ids": {
             "type": "array",
@@ -101426,11 +96066,7 @@
       "AuditEventType": {
         "type": "string",
         "description": "Classifies the audit event.",
-        "enum": [
-          "activity",
-          "monitor",
-          "control"
-        ]
+        "enum": ["activity", "monitor", "control"]
       },
       "AuditAction": {
         "type": "string",
@@ -101456,11 +96092,7 @@
       "AuditOutcome": {
         "type": "string",
         "description": "The CADF outcome of the action.",
-        "enum": [
-          "success",
-          "failure",
-          "pending"
-        ]
+        "enum": ["success", "failure", "pending"]
       },
       "AuditResourceType": {
         "type": "string",
@@ -101505,10 +96137,7 @@
             "description": "Hostname or IP address associated with the resource."
           }
         },
-        "required": [
-          "id",
-          "typeURI"
-        ]
+        "required": ["id", "typeURI"]
       },
       "AuditReason": {
         "type": "object",
@@ -101545,11 +96174,7 @@
             "description": "Attachment data (typically a JSON string)."
           }
         },
-        "required": [
-          "name",
-          "contentType",
-          "content"
-        ]
+        "required": ["name", "contentType", "content"]
       },
       "AuditEvent": {
         "type": "object",
@@ -101684,14 +96309,7 @@
             "description": "Opaque cursor for the next page (cursor-based pagination)."
           }
         },
-        "required": [
-          "audit_logs",
-          "total",
-          "page",
-          "limit",
-          "total_pages",
-          "has_more"
-        ]
+        "required": ["audit_logs", "total", "page", "limit", "total_pages", "has_more"]
       },
       "AuditLogResponse": {
         "type": "object",
@@ -101701,9 +96319,7 @@
             "$ref": "#/components/schemas/AuditEvent"
           }
         },
-        "required": [
-          "audit_log"
-        ]
+        "required": ["audit_log"]
       },
       "AuditFilterKeyPair": {
         "type": "object",
@@ -101716,10 +96332,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "id",
-          "name"
-        ]
+        "required": ["id", "name"]
       },
       "AuditFilterDataResponse": {
         "type": "object",
@@ -101810,27 +96423,16 @@
             "description": "The signature persisted with the event."
           }
         },
-        "required": [
-          "valid",
-          "computed",
-          "stored"
-        ]
+        "required": ["valid", "computed", "stored"]
       },
       "WebhookEvent": {
         "type": "string",
-        "enum": [
-          "async_job.completed",
-          "async_job.failed"
-        ],
+        "enum": ["async_job.completed", "async_job.failed"],
         "description": "A terminal async-job event a webhook endpoint can subscribe to:\n- async_job.completed: an async job finished successfully\n- async_job.failed: an async job finished with an error\n"
       },
       "WebhookEndpointRequest": {
         "type": "object",
-        "required": [
-          "name",
-          "url",
-          "events"
-        ],
+        "required": ["name", "url", "events"],
         "description": "Create or update body for a webhook endpoint. The signing secret is never\naccepted here — it is generated by the server and returned once at creation,\nand can only be changed through the rotate-secret endpoint.\n",
         "properties": {
           "name": {
@@ -102053,9 +96655,7 @@
       },
       "TestWebhookRequest": {
         "type": "object",
-        "required": [
-          "event"
-        ],
+        "required": ["event"],
         "properties": {
           "event": {
             "$ref": "#/components/schemas/WebhookEvent",
@@ -102082,12 +96682,7 @@
       },
       "WebhookDeliveryOutcome": {
         "type": "string",
-        "enum": [
-          "delivered",
-          "retryable_failure",
-          "permanent_failure",
-          "exhausted"
-        ],
+        "enum": ["delivered", "retryable_failure", "permanent_failure", "exhausted"],
         "description": "Outcome of a single delivery attempt:\n- delivered: the receiver returned 2xx\n- retryable_failure: failed but will be retried\n- permanent_failure: failed in a way that is not retried\n- exhausted: retries were used up without success\n"
       },
       "WebhookDelivery": {
@@ -102187,30 +96782,17 @@
       "NotificationSeverity": {
         "type": "string",
         "description": "Visual weight the dashboard gives the notification.",
-        "enum": [
-          "info",
-          "success",
-          "warning",
-          "error"
-        ]
+        "enum": ["info", "success", "warning", "error"]
       },
       "NotificationAudience": {
         "type": "string",
         "description": "Who the notification reaches. `all` is every dashboard user; `roles` limits\nit to the listed RBAC roles, enforced on both the list endpoint and the\nWebSocket fan-out.\n",
-        "enum": [
-          "all",
-          "roles"
-        ]
+        "enum": ["all", "roles"]
       },
       "NotificationInput": {
         "type": "object",
         "description": "A notification to publish. IDs and both timestamps are assigned by the\nserver and cannot be supplied.\n",
-        "required": [
-          "audience",
-          "severity",
-          "title",
-          "message"
-        ],
+        "required": ["audience", "severity", "title", "message"],
         "properties": {
           "audience": {
             "$ref": "#/components/schemas/NotificationAudience"
@@ -102253,15 +96835,7 @@
       "Notification": {
         "type": "object",
         "description": "A persisted dashboard notification.",
-        "required": [
-          "id",
-          "audience",
-          "severity",
-          "title",
-          "message",
-          "created_at",
-          "expires_at"
-        ],
+        "required": ["id", "audience", "severity", "title", "message", "created_at", "expires_at"],
         "properties": {
           "id": {
             "type": "string",
@@ -102306,9 +96880,7 @@
       "NotificationList": {
         "type": "object",
         "description": "A page of notifications, newest first, already filtered to what the caller's\nrole may see.\n",
-        "required": [
-          "notifications"
-        ],
+        "required": ["notifications"],
         "properties": {
           "notifications": {
             "type": "array",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1841,6 +1841,8 @@ components:
       $ref: "./schemas/management/logging.yaml#/SearchLogsResponse"
     LogStats:
       $ref: "./schemas/management/logging.yaml#/LogStats"
+    LogStatsResponse:
+      $ref: "./schemas/management/logging.yaml#/LogStatsResponse"
     DeleteLogsRequest:
       $ref: "./schemas/management/logging.yaml#/DeleteLogsRequest"
     RecalculateCostRequest:

--- a/docs/openapi/paths/management/logging.yaml
+++ b/docs/openapi/paths/management/logging.yaml
@@ -101,7 +101,7 @@ logs:
           type: string
       - name: request_id
         in: query
-        description: 'Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.'
+        description: "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root."
         schema:
           type: string
       - name: limit
@@ -134,16 +134,16 @@ logs:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/SearchLogsResponse'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/SearchLogsResponse"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
   delete:
     operationId: deleteLogs
@@ -156,20 +156,20 @@ logs:
       content:
         application/json:
           schema:
-            $ref: '../../schemas/management/logging.yaml#/DeleteLogsRequest'
+            $ref: "../../schemas/management/logging.yaml#/DeleteLogsRequest"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Logs deleted successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/common.yaml#/MessageResponse'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/common.yaml#/MessageResponse"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-stats:
   get:
@@ -273,22 +273,35 @@ logs-stats:
           type: string
       - name: request_id
         in: query
-        description: 'Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.'
+        description: "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root."
         schema:
           type: string
+      - name: compare_to_previous
+        in: query
+        description: >-
+          When true, also return the same statistics for the immediately
+          preceding window of equal length, so callers can render
+          change-vs-previous-period. Requires a bounded window (start_time and
+          end_time, or period); an unbounded all-time filter has no preceding
+          window, and the response then omits `previous` with
+          `has_previous_period` false. A failure to compute the previous period
+          degrades to `has_previous_period` false rather than failing the request.
+        schema:
+          type: boolean
+          default: false
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/LogStats'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/LogStatsResponse"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-dropped:
   get:
@@ -300,12 +313,12 @@ logs-dropped:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/DroppedRequestsResponse'
+              $ref: "../../schemas/management/logging.yaml#/DroppedRequestsResponse"
 
 logs-filterdata:
   get:
@@ -317,14 +330,14 @@ logs-filterdata:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/FilterDataResponse'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/FilterDataResponse"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-by-id:
   get:
@@ -343,20 +356,20 @@ logs-by-id:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/LogEntry'
-      '404':
+              $ref: "../../schemas/management/logging.yaml#/LogEntry"
+      "404":
         description: Log not found
         content:
           application/json:
             schema:
-              $ref: '../../schemas/inference/common.yaml#/BifrostError'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/inference/common.yaml#/BifrostError"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram:
   get:
@@ -367,48 +380,48 @@ logs-histogram:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/aliases'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/team_ids'
-      - $ref: '#/_histogram-parameters/customer_ids'
-      - $ref: '#/_histogram-parameters/user_ids'
-      - $ref: '#/_histogram-parameters/business_unit_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/period'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/stop_reasons'
-      - $ref: '#/_histogram-parameters/cache_hit_types'
-      - $ref: '#/_histogram-parameters/parent_request_id'
-      - $ref: '#/_histogram-parameters/metadata_key'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/aliases"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/team_ids"
+      - $ref: "#/_histogram-parameters/customer_ids"
+      - $ref: "#/_histogram-parameters/user_ids"
+      - $ref: "#/_histogram-parameters/business_unit_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/period"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/stop_reasons"
+      - $ref: "#/_histogram-parameters/cache_hit_types"
+      - $ref: "#/_histogram-parameters/parent_request_id"
+      - $ref: "#/_histogram-parameters/metadata_key"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/HistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/HistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-tokens:
   get:
@@ -418,38 +431,38 @@ logs-histogram-tokens:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/TokenHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/TokenHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-cost:
   get:
@@ -459,38 +472,38 @@ logs-histogram-cost:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/CostHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/CostHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-models:
   get:
@@ -500,38 +513,38 @@ logs-histogram-models:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/ModelHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/ModelHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-latency:
   get:
@@ -541,38 +554,38 @@ logs-histogram-latency:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/LatencyHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/LatencyHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-cost-by-provider:
   get:
@@ -582,38 +595,38 @@ logs-histogram-cost-by-provider:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/ProviderCostHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/ProviderCostHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-tokens-by-provider:
   get:
@@ -623,38 +636,38 @@ logs-histogram-tokens-by-provider:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/ProviderTokenHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/ProviderTokenHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-latency-by-provider:
   get:
@@ -664,38 +677,38 @@ logs-histogram-latency-by-provider:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/ProviderLatencyHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/ProviderLatencyHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 # Shared histogram filter parameters
 _histogram-parameters:
@@ -872,7 +885,7 @@ _histogram-parameters:
   request_id:
     name: request_id
     in: query
-    description: 'Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.'
+    description: "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root."
     schema:
       type: string
 
@@ -911,32 +924,32 @@ logs-recalculate-cost:
       content:
         application/json:
           schema:
-            $ref: '../../schemas/management/logging.yaml#/RecalculateCostRequest'
+            $ref: "../../schemas/management/logging.yaml#/RecalculateCostRequest"
     security:
       - ManagementBearerAuth: []
     responses:
-      '202':
+      "202":
         description: Cost recalculation job accepted
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/RecalculateCostResponse'
-      '409':
+              $ref: "../../schemas/management/logging.yaml#/RecalculateCostResponse"
+      "409":
         description: A recalculation job is already running
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/RecalculateCostResponse'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '503':
+              $ref: "../../schemas/management/logging.yaml#/RecalculateCostResponse"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "503":
         description: Background job runner is not available
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/common.yaml#/ErrorResponse"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-recalculate-cost-status:
   get:
@@ -956,26 +969,26 @@ logs-recalculate-cost-status:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Recalculation job status
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/RecalculateCostResponse'
-      '404':
+              $ref: "../../schemas/management/logging.yaml#/RecalculateCostResponse"
+      "404":
         description: Recalculation job not found
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
-      '503':
+              $ref: "../../schemas/management/common.yaml#/ErrorResponse"
+      "503":
         description: Background job runner is not available
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/common.yaml#/ErrorResponse"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 mcp-logs:
   get:
@@ -1069,16 +1082,16 @@ mcp-logs:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/SearchMCPLogsResponse'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/SearchMCPLogsResponse"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
   delete:
     operationId: deleteMCPLogs
@@ -1091,20 +1104,20 @@ mcp-logs:
       content:
         application/json:
           schema:
-            $ref: '../../schemas/management/logging.yaml#/DeleteMCPLogsRequest'
+            $ref: "../../schemas/management/logging.yaml#/DeleteMCPLogsRequest"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: MCP tool logs deleted successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/common.yaml#/MessageResponse'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/common.yaml#/MessageResponse"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 mcp-logs-by-id:
   get:
@@ -1123,18 +1136,18 @@ mcp-logs-by-id:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: MCP tool log found
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/MCPToolLogEntry'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '404':
-        $ref: '../../openapi.yaml#/components/responses/NotFound'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/MCPToolLogEntry"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "404":
+        $ref: "../../openapi.yaml#/components/responses/NotFound"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 mcp-logs-stats:
   get:
@@ -1200,16 +1213,16 @@ mcp-logs-stats:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/MCPToolLogStats'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/MCPToolLogStats"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 mcp-logs-filterdata:
   get:
@@ -1221,14 +1234,14 @@ mcp-logs-filterdata:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Successful response
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/MCPLogsFilterDataResponse'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/MCPLogsFilterDataResponse"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-sessions-by-id:
   get:
@@ -1269,16 +1282,16 @@ logs-sessions-by-id:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Session logs retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/SessionDetailResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/SessionDetailResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-sessions-summary-by-id:
   get:
@@ -1297,16 +1310,16 @@ logs-sessions-summary-by-id:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Session summary retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/SessionSummaryResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/SessionSummaryResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-rankings:
   get:
@@ -1319,50 +1332,50 @@ logs-rankings:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/aliases'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/team_ids'
-      - $ref: '#/_histogram-parameters/customer_ids'
-      - $ref: '#/_histogram-parameters/user_ids'
-      - $ref: '#/_histogram-parameters/business_unit_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/period'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/stop_reasons'
-      - $ref: '#/_histogram-parameters/cache_hit_types'
-      - $ref: '#/_histogram-parameters/parent_request_id'
-      - $ref: '#/_histogram-parameters/metadata_key'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
-      - $ref: '#/_ranking-parameters/limit'
-      - $ref: '#/_ranking-parameters/all'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/aliases"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/team_ids"
+      - $ref: "#/_histogram-parameters/customer_ids"
+      - $ref: "#/_histogram-parameters/user_ids"
+      - $ref: "#/_histogram-parameters/business_unit_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/period"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/stop_reasons"
+      - $ref: "#/_histogram-parameters/cache_hit_types"
+      - $ref: "#/_histogram-parameters/parent_request_id"
+      - $ref: "#/_histogram-parameters/metadata_key"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
+      - $ref: "#/_ranking-parameters/limit"
+      - $ref: "#/_ranking-parameters/all"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Model rankings retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/ModelRankingResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/ModelRankingResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-dashboard:
   get:
@@ -1384,35 +1397,35 @@ logs-dashboard:
     tags:
       - Logging
     parameters:
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/aliases'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/team_ids'
-      - $ref: '#/_histogram-parameters/customer_ids'
-      - $ref: '#/_histogram-parameters/user_ids'
-      - $ref: '#/_histogram-parameters/business_unit_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/period'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/stop_reasons'
-      - $ref: '#/_histogram-parameters/cache_hit_types'
-      - $ref: '#/_histogram-parameters/parent_request_id'
-      - $ref: '#/_histogram-parameters/metadata_key'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/aliases"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/team_ids"
+      - $ref: "#/_histogram-parameters/customer_ids"
+      - $ref: "#/_histogram-parameters/user_ids"
+      - $ref: "#/_histogram-parameters/business_unit_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/period"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/stop_reasons"
+      - $ref: "#/_histogram-parameters/cache_hit_types"
+      - $ref: "#/_histogram-parameters/parent_request_id"
+      - $ref: "#/_histogram-parameters/metadata_key"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
       - name: tool_names
         in: query
         description: Comma-separated list of MCP tool names to filter the MCP section by
@@ -1423,21 +1436,21 @@ logs-dashboard:
         description: Comma-separated list of MCP server labels to filter the MCP section by
         schema:
           type: string
-      - $ref: '#/_ranking-parameters/limit'
-      - $ref: '#/_ranking-parameters/all'
+      - $ref: "#/_ranking-parameters/limit"
+      - $ref: "#/_ranking-parameters/all"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Dashboard data retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/DashboardResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/DashboardResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-cost-by-dimension:
   get:
@@ -1455,39 +1468,39 @@ logs-histogram-cost-by-dimension:
         required: true
         description: Grouping dimension
         schema:
-          $ref: '../../schemas/management/logging.yaml#/HistogramDimension'
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+          $ref: "../../schemas/management/logging.yaml#/HistogramDimension"
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Dimension cost histogram retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/DimensionCostHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/DimensionCostHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-tokens-by-dimension:
   get:
@@ -1504,39 +1517,39 @@ logs-histogram-tokens-by-dimension:
         required: true
         description: Grouping dimension
         schema:
-          $ref: '../../schemas/management/logging.yaml#/HistogramDimension'
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+          $ref: "../../schemas/management/logging.yaml#/HistogramDimension"
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Dimension token histogram retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/DimensionTokenHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/DimensionTokenHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 logs-histogram-latency-by-dimension:
   get:
@@ -1553,39 +1566,39 @@ logs-histogram-latency-by-dimension:
         required: true
         description: Grouping dimension
         schema:
-          $ref: '../../schemas/management/logging.yaml#/HistogramDimension'
-      - $ref: '#/_histogram-parameters/providers'
-      - $ref: '#/_histogram-parameters/models'
-      - $ref: '#/_histogram-parameters/status'
-      - $ref: '#/_histogram-parameters/objects'
-      - $ref: '#/_histogram-parameters/selected_key_ids'
-      - $ref: '#/_histogram-parameters/virtual_key_ids'
-      - $ref: '#/_histogram-parameters/routing_rule_ids'
-      - $ref: '#/_histogram-parameters/routing_engine_used'
-      - $ref: '#/_histogram-parameters/start_time'
-      - $ref: '#/_histogram-parameters/end_time'
-      - $ref: '#/_histogram-parameters/min_latency'
-      - $ref: '#/_histogram-parameters/max_latency'
-      - $ref: '#/_histogram-parameters/min_tokens'
-      - $ref: '#/_histogram-parameters/max_tokens'
-      - $ref: '#/_histogram-parameters/min_cost'
-      - $ref: '#/_histogram-parameters/max_cost'
-      - $ref: '#/_histogram-parameters/missing_cost_only'
-      - $ref: '#/_histogram-parameters/content_search'
-      - $ref: '#/_histogram-parameters/request_id'
+          $ref: "../../schemas/management/logging.yaml#/HistogramDimension"
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: Dimension latency histogram retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/DimensionLatencyHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/DimensionLatencyHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 mcp-logs-histogram:
   get:
@@ -1650,16 +1663,16 @@ mcp-logs-histogram:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: MCP histogram retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/MCPHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/MCPHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 mcp-logs-histogram-cost:
   get:
@@ -1724,16 +1737,16 @@ mcp-logs-histogram-cost:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: MCP cost histogram retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/MCPCostHistogramResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/MCPCostHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
 
 mcp-logs-histogram-top-tools:
   get:
@@ -1798,13 +1811,13 @@ mcp-logs-histogram-top-tools:
     security:
       - ManagementBearerAuth: []
     responses:
-      '200':
+      "200":
         description: MCP top tools retrieved successfully
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/logging.yaml#/MCPTopToolsResult'
-      '400':
-        $ref: '../../openapi.yaml#/components/responses/BadRequest'
-      '500':
-        $ref: '../../openapi.yaml#/components/responses/InternalError'
+              $ref: "../../schemas/management/logging.yaml#/MCPTopToolsResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"

--- a/docs/openapi/schemas/management/logging.yaml
+++ b/docs/openapi/schemas/management/logging.yaml
@@ -529,6 +529,28 @@ LogStats:
       format: int64
       description: Number of semantic local-cache hits
 
+LogStatsResponse:
+  description: >-
+    Log statistics for the requested window. The current period's fields are at
+    the top level, so a request without `compare_to_previous` returns exactly the
+    LogStats shape.
+  allOf:
+    - $ref: '#/LogStats'
+    - type: object
+      properties:
+        has_previous_period:
+          type: boolean
+          description: >-
+            True when `previous` is populated. False when the comparison was not
+            requested, the window is unbounded, or the previous-period query failed.
+        previous:
+          allOf:
+            - $ref: '#/LogStats'
+          description: >-
+            The same statistics for the preceding window of equal length, ending
+            immediately before the requested window starts. Present only when
+            `compare_to_previous` is true and `has_previous_period` is true.
+
 DroppedRequestsResponse:
   type: object
   description: Dropped requests response

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -994,8 +994,77 @@ func (h *LoggingHandler) getLogsStats(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Stats calculation failed: %v", err))
 		return
 	}
+	if stats == nil {
+		logger.Error("log stats returned no result")
+		SendError(ctx, fasthttp.StatusInternalServerError, "Stats calculation returned no result")
+		return
+	}
 
-	SendJSON(ctx, stats)
+	response := &LogStatsResponse{SearchStats: *stats}
+
+	// compare_to_previous adds the same stats for the immediately preceding window
+	// of equal length, so the UI can show change-vs-previous-period without having
+	// to derive that window itself (period= is resolved server side above).
+	if compare := string(ctx.QueryArgs().Peek("compare_to_previous")); compare != "" {
+		// Not every filter has a preceding window to compare against; where it does
+		// not, has_previous_period stays false and previous is omitted.
+		if enabled, parseErr := strconv.ParseBool(compare); parseErr == nil && enabled && hasComparableWindow(filters) {
+			previous, prevErr := h.logManager.GetStats(ctx, previousPeriodFilters(filters))
+			switch {
+			case prevErr != nil:
+				// The current period is still useful on its own, so degrade to no
+				// comparison rather than failing the whole request.
+				logger.Warn("failed to get previous period log stats: %v", prevErr)
+			case previous != nil:
+				response.Previous = previous
+				response.HasPreviousPeriod = true
+			}
+		}
+	}
+
+	SendJSON(ctx, response)
+}
+
+// LogStatsResponse is the GET /api/logs/stats payload. SearchStats is embedded so
+// the current period's fields stay at the top level: callers that do not pass
+// compare_to_previous see exactly the shape they saw before it existed.
+type LogStatsResponse struct {
+	logstore.SearchStats
+	Previous          *logstore.SearchStats `json:"previous,omitempty"`
+	HasPreviousPeriod bool                  `json:"has_previous_period"`
+}
+
+// hasComparableWindow reports whether a filter describes a window that actually
+// has a distinct preceding window to compare against.
+//
+// Three cases do not. An unbounded (all-time) filter has nothing before it. A
+// zero-length or reversed window has no positive duration to shift back by, so
+// previousPeriodFilters would build a range that ends before it starts. And an
+// explicit request_id is an exact primary-key lookup, for which the store drops
+// the time-range clauses entirely so an ID is never hidden by the selected window
+// (see the RequestID branch in framework/logstore/rdb.go) - shifting the window
+// back would read the very same row and report it as its own previous period.
+func hasComparableWindow(filters *logstore.SearchFilters) bool {
+	if filters.RequestID != "" || filters.StartTime == nil || filters.EndTime == nil {
+		return false
+	}
+	return filters.EndTime.After(*filters.StartTime)
+}
+
+// previousPeriodFilters shifts a bounded filter window back by its own duration,
+// ending one nanosecond before the current window starts so the two periods are
+// the same length and never overlap. This mirrors the trend windowing already used
+// by the ranking queries in framework/logstore/rdb.go. Callers must check that both
+// StartTime and EndTime are set.
+func previousPeriodFilters(filters *logstore.SearchFilters) *logstore.SearchFilters {
+	duration := filters.EndTime.Sub(*filters.StartTime)
+	prevStart := filters.StartTime.Add(-duration)
+	prevEnd := filters.StartTime.Add(-time.Nanosecond)
+
+	prev := *filters
+	prev.StartTime = &prevStart
+	prev.EndTime = &prevEnd
+	return &prev
 }
 
 // getLogsHistogram handles GET /api/logs/histogram - Get time-bucketed request counts

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -570,7 +570,14 @@ func (s *fakeSidekiqStore) FinalizeCancelledSidekiqJob(ctx context.Context, id, 
 }
 
 type dashboardLogManager struct {
-	failStats              bool
+	failStats bool
+	// statsCalls records every GetStats filter in call order, so tests that
+	// trigger more than one stats query (compare_to_previous) can assert on both
+	// windows rather than just the last one.
+	statsCalls []logstore.SearchFilters
+	// statsFunc, when set, supplies the SearchStats for each GetStats call so a
+	// test can tell the current and previous periods apart.
+	statsFunc              func(filters *logstore.SearchFilters) (*logstore.SearchStats, error)
 	mcpLog                 *logstore.MCPToolLog
 	lastLLMFilters         logstore.SearchFilters
 	lastMCPFilters         logstore.MCPToolLogSearchFilters
@@ -592,8 +599,12 @@ func (m *dashboardLogManager) GetSessionSummary(ctx context.Context, sessionID s
 }
 func (m *dashboardLogManager) GetStats(ctx context.Context, filters *logstore.SearchFilters) (*logstore.SearchStats, error) {
 	m.lastLLMFilters = *filters
+	m.statsCalls = append(m.statsCalls, *filters)
 	if m.failStats {
 		return nil, errors.New("stats failed")
+	}
+	if m.statsFunc != nil {
+		return m.statsFunc(filters)
 	}
 	return &logstore.SearchStats{}, nil
 }

--- a/transports/bifrost-http/handlers/logsstatscompareprevious_test.go
+++ b/transports/bifrost-http/handlers/logsstatscompareprevious_test.go
@@ -1,0 +1,251 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/valyala/fasthttp"
+)
+
+// callStats runs GET /api/logs/stats with the given query string against a mock
+// log manager and returns the manager, the decoded body and the status code.
+func callStats(t *testing.T, mgr *dashboardLogManager, query string) (map[string]json.RawMessage, int) {
+	t.Helper()
+	SetLogger(&mockLogger{})
+
+	h := &LoggingHandler{logManager: mgr}
+	var req fasthttp.Request
+	uri := "/api/logs/stats"
+	if query != "" {
+		uri += "?" + query
+	}
+	req.SetRequestURI(uri)
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Init(&req, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}, nil)
+
+	h.getLogsStats(ctx)
+
+	body := ctx.Response.Body()
+	payload := map[string]json.RawMessage{}
+	if json.Valid(body) {
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatalf("decode stats response: %v (body %s)", err, string(body))
+		}
+	}
+	return payload, ctx.Response.StatusCode()
+}
+
+// TestLogsStatsWithoutCompareIsUnchanged pins the backward-compatible shape: a
+// request that does not ask for a comparison must still return the current
+// period's fields at the top level and must issue exactly one stats query.
+func TestLogsStatsWithoutCompareIsUnchanged(t *testing.T) {
+	mgr := &dashboardLogManager{
+		statsFunc: func(filters *logstore.SearchFilters) (*logstore.SearchStats, error) {
+			return &logstore.SearchStats{TotalRequests: 42, SuccessRate: 68.27}, nil
+		},
+	}
+
+	payload, status := callStats(t, mgr, "period=24h")
+
+	if status != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if len(mgr.statsCalls) != 1 {
+		t.Fatalf("expected exactly one stats query, got %d", len(mgr.statsCalls))
+	}
+	if _, ok := payload["previous"]; ok {
+		t.Fatal("previous must be omitted when compare_to_previous is not requested")
+	}
+	// has_previous_period is the one comparison field that is always present, so
+	// callers can read it without probing for the key - the same shape the three
+	// ranking-trend structs in framework/logstore/tables.go publish. The schema
+	// marks it required; this is what stops it drifting to omitempty.
+	raw, ok := payload["has_previous_period"]
+	if !ok {
+		t.Fatal("has_previous_period must be present even without compare_to_previous")
+	}
+	var hasPreviousUnrequested bool
+	if err := json.Unmarshal(raw, &hasPreviousUnrequested); err != nil {
+		t.Fatalf("decode has_previous_period: %v", err)
+	}
+	if hasPreviousUnrequested {
+		t.Fatal("has_previous_period must be false when no comparison was requested")
+	}
+	var total int64
+	if err := json.Unmarshal(payload["total_requests"], &total); err != nil {
+		t.Fatalf("total_requests must stay at the top level: %v", err)
+	}
+	if total != 42 {
+		t.Fatalf("expected top-level total_requests 42, got %d", total)
+	}
+}
+
+// TestLogsStatsComparePreviousWindow is the core case: the previous window must
+// be the same length as the current one and must end just before it starts.
+func TestLogsStatsComparePreviousWindow(t *testing.T) {
+	mgr := &dashboardLogManager{}
+	// statsCalls has already been appended to when statsFunc runs, so call 1 is
+	// the current period (100) and call 2 is the previous one (200).
+	mgr.statsFunc = func(filters *logstore.SearchFilters) (*logstore.SearchStats, error) {
+		return &logstore.SearchStats{TotalRequests: int64(100 * len(mgr.statsCalls))}, nil
+	}
+
+	payload, status := callStats(t, mgr, "period=24h&compare_to_previous=true")
+
+	if status != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if len(mgr.statsCalls) != 2 {
+		t.Fatalf("expected current + previous stats queries, got %d", len(mgr.statsCalls))
+	}
+
+	current, previous := mgr.statsCalls[0], mgr.statsCalls[1]
+	if current.StartTime == nil || current.EndTime == nil || previous.StartTime == nil || previous.EndTime == nil {
+		t.Fatal("both windows must be bounded")
+	}
+
+	currentLen := current.EndTime.Sub(*current.StartTime)
+	previousLen := previous.EndTime.Sub(*previous.StartTime)
+	// The previous window is one nanosecond shorter by construction: it ends at
+	// currentStart-1ns so the two periods never overlap on the same row.
+	if got := currentLen - previousLen; got != time.Nanosecond {
+		t.Fatalf("previous window must match the current length (minus the 1ns gap), got a %v difference", got)
+	}
+	if !previous.EndTime.Equal(current.StartTime.Add(-time.Nanosecond)) {
+		t.Fatalf("previous window must end 1ns before the current one starts: prevEnd=%v currentStart=%v", previous.EndTime, current.StartTime)
+	}
+
+	var hasPrevious bool
+	if err := json.Unmarshal(payload["has_previous_period"], &hasPrevious); err != nil || !hasPrevious {
+		t.Fatalf("expected has_previous_period true, got %v (err %v)", hasPrevious, err)
+	}
+	if _, ok := payload["previous"]; !ok {
+		t.Fatal("expected previous stats in the payload")
+	}
+}
+
+// TestLogsStatsCompareSkippedWhenUnbounded covers the all-time filter: there is
+// no preceding window, so no second query is issued.
+func TestLogsStatsCompareSkippedWhenUnbounded(t *testing.T) {
+	mgr := &dashboardLogManager{}
+
+	payload, status := callStats(t, mgr, "compare_to_previous=true")
+
+	if status != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if len(mgr.statsCalls) != 1 {
+		t.Fatalf("an unbounded filter has no previous period, expected one query, got %d", len(mgr.statsCalls))
+	}
+	var hasPrevious bool
+	if err := json.Unmarshal(payload["has_previous_period"], &hasPrevious); err != nil {
+		t.Fatalf("decode has_previous_period: %v", err)
+	}
+	if hasPrevious {
+		t.Fatal("has_previous_period must be false for an unbounded window")
+	}
+}
+
+// TestLogsStatsCompareDegradesOnPreviousError asserts the comparison is
+// best-effort: a failing previous-period query must not fail the whole request,
+// because the current period is still useful on its own.
+func TestLogsStatsCompareDegradesOnPreviousError(t *testing.T) {
+	mgr := &dashboardLogManager{}
+	mgr.statsFunc = func(filters *logstore.SearchFilters) (*logstore.SearchStats, error) {
+		if len(mgr.statsCalls) > 1 {
+			return nil, errors.New("previous period query failed")
+		}
+		return &logstore.SearchStats{TotalRequests: 7}, nil
+	}
+
+	payload, status := callStats(t, mgr, "period=7d&compare_to_previous=true")
+
+	if status != fasthttp.StatusOK {
+		t.Fatalf("a failing comparison must not fail the request, got %d", status)
+	}
+	var total int64
+	if err := json.Unmarshal(payload["total_requests"], &total); err != nil || total != 7 {
+		t.Fatalf("expected the current period to survive, got %d (err %v)", total, err)
+	}
+	var hasPrevious bool
+	if err := json.Unmarshal(payload["has_previous_period"], &hasPrevious); err != nil {
+		t.Fatalf("decode has_previous_period: %v", err)
+	}
+	if hasPrevious {
+		t.Fatal("has_previous_period must be false when the previous query failed")
+	}
+	if _, ok := payload["previous"]; ok {
+		t.Fatal("previous must be omitted when the previous query failed")
+	}
+}
+
+// TestLogsStatsCompareSkippedForRequestIDLookup covers a window that is present
+// but not in effect. An explicit request_id is an exact primary-key lookup, and
+// the store deliberately drops the time-range clauses for it (see the RequestID
+// branch in framework/logstore/rdb.go), so shifting the window back changes
+// nothing about which row is read: without a guard the "previous period" is the
+// very same request, reported as a real comparison.
+func TestLogsStatsCompareSkippedForRequestIDLookup(t *testing.T) {
+	mgr := &dashboardLogManager{
+		statsFunc: func(filters *logstore.SearchFilters) (*logstore.SearchStats, error) {
+			return &logstore.SearchStats{TotalRequests: 1}, nil
+		},
+	}
+
+	payload, status := callStats(t, mgr, "request_id=req-abc&period=24h&compare_to_previous=true")
+
+	if status != fasthttp.StatusOK {
+		t.Fatalf("expected 200, got %d", status)
+	}
+	if len(mgr.statsCalls) != 1 {
+		t.Fatalf("an id lookup ignores the window, so there is no previous period to query: got %d queries", len(mgr.statsCalls))
+	}
+	if _, ok := payload["previous"]; ok {
+		t.Fatal("previous must be omitted for an id lookup: it would be the same request")
+	}
+	var hasPrevious bool
+	if err := json.Unmarshal(payload["has_previous_period"], &hasPrevious); err != nil {
+		t.Fatalf("decode has_previous_period: %v", err)
+	}
+	if hasPrevious {
+		t.Fatal("has_previous_period must be false for an id lookup")
+	}
+}
+
+// TestLogsStatsCompareSkippedForEmptyWindow covers start == end and a reversed
+// window. Neither has a positive duration to shift back by, so the preceding
+// range previousPeriodFilters would build ends before it starts.
+func TestLogsStatsCompareSkippedForEmptyWindow(t *testing.T) {
+	instant := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+	earlier := time.Date(2026, 9, 1, 11, 0, 0, 0, time.UTC).Format(time.RFC3339Nano)
+
+	for name, query := range map[string]string{
+		"zero length": "start_time=" + instant + "&end_time=" + instant + "&compare_to_previous=true",
+		"reversed":    "start_time=" + instant + "&end_time=" + earlier + "&compare_to_previous=true",
+	} {
+		t.Run(name, func(t *testing.T) {
+			mgr := &dashboardLogManager{}
+
+			payload, status := callStats(t, mgr, query)
+
+			if status != fasthttp.StatusOK {
+				t.Fatalf("expected 200, got %d", status)
+			}
+			if len(mgr.statsCalls) != 1 {
+				t.Fatalf("expected no previous-period query for a %s window, got %d queries", name, len(mgr.statsCalls))
+			}
+			var hasPrevious bool
+			if err := json.Unmarshal(payload["has_previous_period"], &hasPrevious); err != nil {
+				t.Fatalf("decode has_previous_period: %v", err)
+			}
+			if hasPrevious {
+				t.Fatalf("has_previous_period must be false for a %s window", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `compare_to_previous` query parameter to `GET /api/logs/stats` that returns statistics for the immediately preceding window of equal length alongside the current period. This allows callers to render change-vs-previous-period metrics without needing to derive or request the prior window themselves.

## Changes

- Added `compare_to_previous` boolean query parameter to the `GET /api/logs/stats` endpoint (defaults to `false`).
- Introduced a new `LogStatsResponse` schema that extends `LogStats` with `has_previous_period` and `previous` fields. The current period's fields remain at the top level, preserving backward compatibility for callers that do not pass `compare_to_previous`.
- Implemented `previousPeriodFilters` to shift a bounded filter window back by its own duration, ending one nanosecond before the current window starts so the two periods are the same length and never overlap.
- The comparison is best-effort: if the previous-period query fails, the response degrades to `has_previous_period: false` rather than failing the entire request.
- Unbounded (all-time) filters have no preceding window; in that case no second query is issued and `has_previous_period` is returned as `false`.
- Updated OpenAPI specs (JSON and YAML) to document the new parameter and response schema.
- Added a dedicated test file (`logsstatscompareprevious_test.go`) covering the backward-compatible shape, correct window calculation, unbounded filter handling, and graceful degradation on previous-period query failure.
- Extended the `dashboardLogManager` test mock with `statsCalls` and `statsFunc` to support multi-call assertions.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/... -run TestLogsStats
```

Expected: all four new tests pass — `TestLogsStatsWithoutCompareIsUnchanged`, `TestLogsStatsComparePreviousWindow`, `TestLogsStatsCompareSkippedWhenUnbounded`, and `TestLogsStatsCompareDegradesOnPreviousError`.

To exercise the endpoint manually:

```sh
# Current period only (backward-compatible)
curl "http://localhost:PORT/api/logs/stats?period=24h"

# With previous-period comparison
curl "http://localhost:PORT/api/logs/stats?period=24h&compare_to_previous=true"

# Unbounded — has_previous_period should be false, no second query issued
curl "http://localhost:PORT/api/logs/stats?compare_to_previous=true"
```

## Breaking changes

- [x] No

The response schema is additive. Callers that do not pass `compare_to_previous` receive the same top-level `LogStats` fields as before, with `has_previous_period: false` and no `previous` key.

## Security considerations

No new auth surfaces. The previous-period query reuses the same filters and security context as the current-period query, so no additional privilege is required or granted.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable