### PR TITLE
[fix]: marshal required nullable response fields

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,2 +1,3 @@
+- [fix]: marshal required nullable response fields as null [@PSR94](https://github.com/PSR94)
 - fix: strip the encrypted reasoning signature when the upstream reports the field as unsupported (e.g. Bedrock Converse replaying a Claude signature onto a non-Anthropic model after a mid-conversation model switch), extending the existing unverifiable-signature fail-soft
 - fix: clear Anthropic raw-body passthrough based on the resolved provider and model pair, so non-Claude models on multi-family providers (Vertex, Azure, Bedrock Mantle) convert the request instead of passing the Anthropic payload through

--- a/core/providers/anthropic/nullable_response_fields_test.go
+++ b/core/providers/anthropic/nullable_response_fields_test.go
@@ -1,0 +1,49 @@
+package anthropic
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAnthropicMessageResponseRequiredNullableFieldsMarshalAsNull(t *testing.T) {
+	response := AnthropicMessageResponse{
+		ID:      "msg_1",
+		Type:    "message",
+		Role:    "assistant",
+		Content: []AnthropicContentBlock{},
+		Model:   "claude-sonnet-4-20250514",
+	}
+
+	data, err := json.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if _, ok := got["stop_reason"]; !ok {
+		t.Fatalf("stop_reason key missing from response: %#v", got)
+	}
+	if got["stop_reason"] != nil {
+		t.Fatalf("stop_reason = %#v, want nil", got["stop_reason"])
+	}
+	if _, ok := got["stop_sequence"]; !ok {
+		t.Fatalf("stop_sequence key missing from response: %#v", got)
+	}
+	if got["stop_sequence"] != nil {
+		t.Fatalf("stop_sequence = %#v, want nil", got["stop_sequence"])
+	}
+}
+
+func TestAnthropicStopReasonMarshalPreservesNonEmptyValue(t *testing.T) {
+	data, err := json.Marshal(AnthropicStopReasonEndTurn)
+	if err != nil {
+		t.Fatalf("marshal stop reason: %v", err)
+	}
+	if string(data) != `"end_turn"` {
+		t.Fatalf("stop reason JSON = %s, want %q", data, `"end_turn"`)
+	}
+}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -1821,6 +1821,14 @@ const (
 	AnthropicStopReasonCompaction                 AnthropicStopReason = "compaction"
 )
 
+// MarshalJSON preserves Anthropic's required-null response contract for stop_reason.
+func (r AnthropicStopReason) MarshalJSON() ([]byte, error) {
+	if r == "" {
+		return []byte("null"), nil
+	}
+	return json.Marshal(string(r))
+}
+
 // AnthropicResponseContainer is the "container" object returned on responses
 // that used the code execution tool. The id can be passed back as the request
 // "container" to reuse the sandbox across turns.
@@ -1837,9 +1845,9 @@ type AnthropicMessageResponse struct {
 	Role         string                  `json:"role"`
 	Content      []AnthropicContentBlock `json:"content"`
 	Model        string                  `json:"model"`
-	StopReason   AnthropicStopReason     `json:"stop_reason,omitempty"`
+	StopReason   AnthropicStopReason     `json:"stop_reason"`
 	StopDetails  *AnthropicStopDetails   `json:"stop_details,omitempty"` // refusal detail; null for every stop_reason other than "refusal"
-	StopSequence *string                 `json:"stop_sequence,omitempty"`
+	StopSequence *string                 `json:"stop_sequence"`
 	Usage        *AnthropicUsage         `json:"usage,omitempty"`
 	// Container is the code-execution sandbox container, present on responses that
 	// used the code execution tool. Distinct from the request-side AnthropicContainer

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1068,7 +1068,7 @@ const (
 type ChatMessage struct {
 	Name    *string             `json:"name,omitempty"` // for chat completions
 	Role    ChatMessageRole     `json:"role,omitempty"`
-	Content *ChatMessageContent `json:"content,omitempty"`
+	Content *ChatMessageContent `json:"content"`
 
 	// Embedded pointer structs - when non-nil, their exported fields are flattened into the top-level JSON object
 	// IMPORTANT: Only one of the following can be non-nil at a time, otherwise the JSON marshalling will override the common fields
@@ -1098,7 +1098,7 @@ func (cm ChatMessage) MarshalJSON() ([]byte, error) {
 	base, err := Marshal(struct {
 		Name    *string             `json:"name,omitempty"`
 		Role    ChatMessageRole     `json:"role,omitempty"`
-		Content *ChatMessageContent `json:"content,omitempty"`
+		Content *ChatMessageContent `json:"content"`
 	}{Name: cm.Name, Role: cm.Role, Content: cm.Content})
 	if err != nil {
 		return nil, err
@@ -1532,7 +1532,7 @@ type ChatToolMessage struct {
 
 // ChatAssistantMessage represents a message in a chat conversation.
 type ChatAssistantMessage struct {
-	Refusal          *string                          `json:"refusal,omitempty"`
+	Refusal          *string                          `json:"refusal"`
 	Audio            *ChatAudioMessageAudio           `json:"audio,omitempty"`
 	Reasoning        *string                          `json:"reasoning,omitempty"`
 	ReasoningDetails []ChatReasoningDetails           `json:"reasoning_details,omitempty"`
@@ -1673,8 +1673,8 @@ type ChatAudioMessageAudio struct {
 // should be non-nil at a time.
 type BifrostResponseChoice struct {
 	Index        int              `json:"index"`
-	FinishReason *string          `json:"finish_reason,omitempty"`
-	LogProbs     *BifrostLogProbs `json:"logprobs,omitempty"`
+	FinishReason *string          `json:"finish_reason"`
+	LogProbs     *BifrostLogProbs `json:"logprobs"`
 
 	*TextCompletionResponseChoice
 	*ChatNonStreamResponseChoice

--- a/core/schemas/nullable_response_fields_test.go
+++ b/core/schemas/nullable_response_fields_test.go
@@ -1,0 +1,90 @@
+package schemas
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestBifrostChatResponseRequiredNullableFieldsMarshalAsNull(t *testing.T) {
+	response := BifrostChatResponse{
+		ID:      "chatcmpl-1",
+		Object:  "chat.completion",
+		Created: 1700000000,
+		Model:   "gpt-4o",
+		Choices: []BifrostResponseChoice{
+			{
+				Index: 0,
+				ChatNonStreamResponseChoice: &ChatNonStreamResponseChoice{
+					Message: &ChatMessage{
+						Role:                 ChatMessageRoleAssistant,
+						Content:              nil,
+						ChatAssistantMessage: &ChatAssistantMessage{},
+					},
+				},
+			},
+		},
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(mustMarshalJSON(t, response), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	choices := got["choices"].([]any)
+	choice := choices[0].(map[string]any)
+	if _, ok := choice["finish_reason"]; !ok {
+		t.Fatalf("finish_reason key missing from choice: %#v", choice)
+	}
+	if choice["finish_reason"] != nil {
+		t.Fatalf("finish_reason = %#v, want nil", choice["finish_reason"])
+	}
+	if _, ok := choice["logprobs"]; !ok {
+		t.Fatalf("logprobs key missing from choice: %#v", choice)
+	}
+	if choice["logprobs"] != nil {
+		t.Fatalf("logprobs = %#v, want nil", choice["logprobs"])
+	}
+
+	message := choice["message"].(map[string]any)
+	if _, ok := message["content"]; !ok {
+		t.Fatalf("content key missing from message: %#v", message)
+	}
+	if message["content"] != nil {
+		t.Fatalf("content = %#v, want nil", message["content"])
+	}
+	if _, ok := message["refusal"]; !ok {
+		t.Fatalf("refusal key missing from message: %#v", message)
+	}
+	if message["refusal"] != nil {
+		t.Fatalf("refusal = %#v, want nil", message["refusal"])
+	}
+}
+
+func TestBifrostResponsesResponseRequiredNullableMetadataMarshalsAsNull(t *testing.T) {
+	response := BifrostResponsesResponse{
+		Object:    "response",
+		CreatedAt: 1700000000,
+		Model:     "gpt-4o",
+		Output:    []ResponsesMessage{},
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(mustMarshalJSON(t, response), &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if _, ok := got["metadata"]; !ok {
+		t.Fatalf("metadata key missing from response: %#v", got)
+	}
+	if got["metadata"] != nil {
+		t.Fatalf("metadata = %#v, want nil", got["metadata"])
+	}
+}
+
+func mustMarshalJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	data, err := MarshalSorted(v)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	return data
+}

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -229,7 +229,7 @@ type BifrostResponsesResponse struct {
 	Instructions         *ResponsesResponseInstructions      `json:"instructions"`
 	MaxOutputTokens      *int                                `json:"max_output_tokens"`
 	MaxToolCalls         *int                                `json:"max_tool_calls"`
-	Metadata             *map[string]any                     `json:"metadata,omitempty"`
+	Metadata             *map[string]any                     `json:"metadata"`
 	Model                string                              `json:"model"`
 	Output               []ResponsesMessage                  `json:"output"`
 	ParallelToolCalls    *bool                               `json:"parallel_tool_calls,omitempty"`


### PR DESCRIPTION
Summary
- Marshals required nullable Chat Completions response fields as explicit null values when unset.
- Marshals Responses API metadata as explicit null when unset.
- Marshals Anthropic message stop_reason and stop_sequence as explicit null when unset.

Why this helps
This keeps Bifrost responses compatible with stricter OpenAI and Anthropic clients that require spec-required nullable fields to be present instead of omitted.

Changes made
- Removed omitempty from the affected required nullable response fields.
- Added AnthropicStopReason JSON serialization for the zero value.
- Added regression tests for Chat Completions, Responses API, and Anthropic message responses.
- Added a core changelog entry.

Testing
- go test ./schemas
- go test ./providers/anthropic
- make setup-mcp-tests
- go test ./...

Related issue
Closes #6689