### PR TITLE
refactor: move `gatherLimits` into `GovernanceStore.GatherLimits`, propagate settling errors as `DecisionAccessBlocked` after access checks, and split `modelConfigScopesFor` to one permit per call

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -642,7 +642,11 @@ func (p *GovernancePlugin) Evaluate(ctx *schemas.BifrostContext, evaluationReque
 	// streaming, realtime-turn and MCP pipelines run no request hook, and this is the funnel they
 	// all pass through. Everything downstream, the checks below and the co-payers named for the
 	// log, then reads one settled set instead of assembling its own.
-	limits := resolveLimits(ctx, p.store, evaluationRequest.Provider, evaluationRequest.Model)
+	//
+	// A settling error is held rather than refused on the spot: the ordering below puts identity
+	// refusals first, and a caller whose credential is dead must be told that before anything about
+	// how the request would have been funded.
+	limits, limitsErr := resolveLimits(ctx, p.store, evaluationRequest.Provider, evaluationRequest.Model)
 
 	// The order of everything below is load bearing:
 	//
@@ -725,6 +729,18 @@ func (p *GovernancePlugin) Evaluate(ctx *schemas.BifrostContext, evaluationReque
 
 	// Step 3: what the request may reach.
 	result := p.resolver.evaluateAccess(ctx, evaluationRequest, access)
+
+	// A request whose payers could not be settled is refused before any limit is consulted: there
+	// is no list to check, and serving it would spend money nothing agreed to spend. After the
+	// access step, so a request that was never allowed to reach the pair is told that instead.
+	// Skipped for a request that asked not to be checked against anything it answers to: it spends
+	// nothing, so an unsettled payer list is not something it depends on either.
+	if result.Decision == DecisionAllow && limitsErr != nil && !spendingChecksSkipped(ctx) {
+		result = &EvaluationResult{
+			Decision: DecisionAccessBlocked,
+			Reason:   limitsErr.Error(),
+		}
+	}
 
 	// Step 4: what the request can afford. One check over every limit covering this attempt, the
 	// deployment's provider limits, the model configs that apply, and whatever the permits are
@@ -969,57 +985,23 @@ func (p *GovernancePlugin) modelMatcher() grant.ModelMatcher {
 // A request carrying no access is still subject to the deployment's own limits, and they are
 // settled for it the same way. A context carrying no grant is a wiring fault evaluation has
 // already refused by the time this runs; it settles nothing.
-func resolveLimits(ctx *schemas.BifrostContext, store GovernanceStore, provider schemas.ModelProvider, model string) schemas.Limits {
+//
+// What the list holds is the store's to assemble (see GovernanceStore.GatherLimits): a store that
+// composes several possible payers settles there on who pays, and this only records the answer. An
+// error is a request whose payers cannot be settled at all; nothing is recorded for it, and the
+// funnel refuses it rather than serving it against half an answer.
+func resolveLimits(ctx *schemas.BifrostContext, store GovernanceStore, provider schemas.ModelProvider, model string) (schemas.Limits, error) {
 	g := ctx.Grant()
 	if g == nil {
-		return nil
+		return nil, nil
 	}
-	budgets, rateLimits := gatherLimits(ctx, store, g.Access(), provider, model)
+	budgets, rateLimits, err := store.GatherLimits(ctx, g.Access(), provider, model)
+	if err != nil {
+		return nil, err
+	}
 	limits := grant.NewLimits(budgets, rateLimits)
 	g.SetLimits(limits)
-	return limits
-}
-
-// gatherLimits assembles every limit an attempt answers to: the deployment's own for the pair; for
-// every permit the request carries, what funds the holder and the holder's own model limits; and
-// for every permit that pays for the pair, what funds its use of the provider.
-//
-// A holder's own limits bind whatever the request does, whichever permit admits the pair: a key
-// whose budget is spent is spent, however the request reached the provider. Only what is funded
-// per provider follows the pair, and which permits pay for it is the access's to say (see
-// PermitsForModel).
-//
-// The deployment's own come first, because that is the order refusals report in: what the
-// deployment imposes before what the holder is funded by.
-func gatherLimits(ctx *schemas.BifrostContext, store GovernanceStore, access schemas.Access, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
-	budgets, rateLimits = store.ProviderAndModelLimits(ctx, nil, provider, model)
-	if access == nil {
-		return budgets, rateLimits
-	}
-	carried := access.Bases()
-	if scoping := access.Scoping(); scoping != nil {
-		carried = append(carried, scoping)
-	}
-	for _, permit := range carried {
-		heldBudgets, heldRateLimits := store.HolderLimits(ctx, permit)
-		budgets = append(budgets, heldBudgets...)
-		rateLimits = append(rateLimits, heldRateLimits...)
-
-		// The holder's own model limits, gathered per permit because they are keyed by the permit's
-		// identity. The deployment's and the user's come back with them and are settled once, since
-		// one limit reached twice is still one limit.
-		modelBudgets, modelRateLimits := store.ProviderAndModelLimits(ctx, permit, provider, model)
-		budgets = append(budgets, modelBudgets...)
-		rateLimits = append(rateLimits, modelRateLimits...)
-	}
-	if provider != "" {
-		for _, permit := range access.PermitsForModel(string(provider), model) {
-			providerBudgets, providerRateLimits := store.ProviderLimits(ctx, permit, provider)
-			budgets = append(budgets, providerBudgets...)
-			rateLimits = append(rateLimits, providerRateLimits...)
-		}
-	}
-	return budgets, rateLimits
+	return limits, nil
 }
 
 // PreRequestHook is the per-request governance phase: it resolves the request's access, completes

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -2186,7 +2186,9 @@ func TestPostMCPHook_TracksVirtualKeyUsageWhenUserIDPresent(t *testing.T) {
 	// Evaluating the tool call settles the limits it answers to, and billing reads them from there.
 	// Tool execution names no provider and no model, so what it answers to is whatever funds the
 	// holder.
-	require.NotNil(t, resolveLimits(ctx, store, "", ""))
+	settled, settleErr := resolveLimits(ctx, store, "", "")
+	require.NoError(t, settleErr)
+	require.NotNil(t, settled)
 	resp := &schemas.BifrostMCPResponse{
 		ExtraFields: schemas.BifrostMCPResponseExtraFields{
 			MCPRequestType: schemas.MCPRequestTypeExecuteTool,
@@ -2224,7 +2226,9 @@ func TestPostMCPHook_SkipVirtualKeyUsageTrackingFlag(t *testing.T) {
 	ctx := resolverCtx(store, "sk-bf-test")
 	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
 	ctx.SetValue(schemas.BifrostContextKeySkipVirtualKeyUsageTracking, true)
-	require.NotNil(t, resolveLimits(ctx, store, "", ""))
+	settled, settleErr := resolveLimits(ctx, store, "", "")
+	require.NoError(t, settleErr)
+	require.NotNil(t, settled)
 	resp := &schemas.BifrostMCPResponse{
 		ExtraFields: schemas.BifrostMCPResponseExtraFields{
 			MCPRequestType: schemas.MCPRequestTypeExecuteTool,
@@ -2701,8 +2705,10 @@ func TestStore_ScopedAndGlobalModelBudgetsBothApply(t *testing.T) {
 	require.NoError(t, err)
 
 	// The holder has no model config of its own, so only the deployment's applies, and it refuses.
-	budgets, _ := store.ProviderAndModelLimits(context.Background(), grant.NewPermit(grant.PermitVirtualKey, vk.ID, "", true, false, nil, nil), schemas.OpenAI, "gpt-4")
-	require.Len(t, budgets, 1, "the deployment's model budget, and nothing of the holder's")
+	holderBudgets, _ := store.ProviderAndModelLimits(context.Background(), grant.NewPermit(grant.PermitVirtualKey, vk.ID, "", true, false, nil, nil), schemas.OpenAI, "gpt-4")
+	require.Empty(t, holderBudgets, "nothing of the holder's")
+	budgets, _ := store.ProviderAndModelLimits(context.Background(), nil, schemas.OpenAI, "gpt-4")
+	require.Len(t, budgets, 1, "the deployment's model budget")
 	assert.Equal(t, string(grant.LimitHolderModelConfig), budgets[0].HolderKind)
 
 	_, err = store.CheckBudgets(context.Background(), budgets, nil)

--- a/plugins/governance/permits_test.go
+++ b/plugins/governance/permits_test.go
@@ -2,6 +2,7 @@ package governance
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -1476,7 +1477,7 @@ func TestModelConfigScopesIncludeTheProjectScopingARequest(t *testing.T) {
 	t.Run("the project's permit", func(t *testing.T) {
 		project := permitWithProviders(grant.PermitProject, "proj-1", "Atlas", "openai")
 
-		scope, found := scopeNamed(modelConfigScopesFor(emptyCtx(), project), configstoreTables.ModelConfigScopeProject)
+		scope, found := scopeNamed(modelConfigScopesFor(project), configstoreTables.ModelConfigScopeProject)
 
 		require.True(t, found, "a request running inside a project answers to none of its per-model limits")
 		assert.Equal(t, "proj-1", scope.id)
@@ -1487,8 +1488,65 @@ func TestModelConfigScopesIncludeTheProjectScopingARequest(t *testing.T) {
 	t.Run("a permit that is not a project's", func(t *testing.T) {
 		key := permitWithProviders(grant.PermitVirtualKey, "vk-1", "Key", "openai")
 
-		_, found := scopeNamed(modelConfigScopesFor(emptyCtx(), key), configstoreTables.ModelConfigScopeProject)
+		_, found := scopeNamed(modelConfigScopesFor(key), configstoreTables.ModelConfigScopeProject)
 
 		assert.False(t, found, "a request outside every project was held to a project's per-model limits")
+	})
+}
+
+// settlingErrorStore wraps a real store so GatherLimits fails the way a store composing several
+// possible payers can: the payers could not be settled at all, not a limit being exhausted.
+type settlingErrorStore struct {
+	GovernanceStore
+	err error
+}
+
+func (s *settlingErrorStore) GatherLimits(ctx *schemas.BifrostContext, access schemas.Access, provider schemas.ModelProvider, model string) ([]schemas.Limit, []schemas.Limit, error) {
+	return nil, nil, s.err
+}
+
+// newSettlingErrorTestPlugin builds a plugin whose store fails to settle limits with err.
+func newSettlingErrorTestPlugin(t *testing.T, err error) *GovernancePlugin {
+	t.Helper()
+	vk := buildVKForMCPStamping(nil)
+	logger := NewMockLogger()
+	local, localErr := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil, &mockInMemoryStore{})
+	require.NoError(t, localErr)
+
+	plugin, initErr := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)},
+		logger, &settlingErrorStore{GovernanceStore: local, err: err}, nil, nil, nil, nil)
+	require.NoError(t, initErr)
+	t.Cleanup(func() { require.NoError(t, plugin.Cleanup()) })
+	return plugin
+}
+
+// TestEvaluateSkipsASettlingErrorWhenSpendingChecksAreSkipped covers the store.GatherLimits error
+// path for a request that asked not to be checked against anything it answers to (e.g. a read-only
+// list-models call). LocalGovernanceStore never returns one, but the interface allows a store
+// composing several possible payers to fail this way, and such a request spends nothing, so an
+// unsettled payer list is not something it depends on either.
+func TestEvaluateSkipsASettlingErrorWhenSpendingChecksAreSkipped(t *testing.T) {
+	request := &EvaluationRequest{Provider: schemas.OpenAI, Model: "gpt-4o"}
+
+	t.Run("a settling error still blocks a request that did not skip spending checks", func(t *testing.T) {
+		plugin := newSettlingErrorTestPlugin(t, errors.New("payers unavailable"))
+
+		result, bifrostErr := plugin.Evaluate(emptyCtx(), request)
+
+		require.NotNil(t, bifrostErr, "a request whose payers could not be settled was served anyway")
+		assert.Equal(t, DecisionAccessBlocked, result.Decision)
+	})
+
+	t.Run("a request that skipped spending checks is not blocked by it", func(t *testing.T) {
+		plugin := newSettlingErrorTestPlugin(t, errors.New("payers unavailable"))
+		ctx := emptyCtx()
+		ctx.SetValue(schemas.BifrostContextKeySkipBudgetAndRateLimits, true)
+
+		result, bifrostErr := plugin.Evaluate(ctx, request)
+
+		assert.Nil(t, bifrostErr, "a read-only request was blocked by a settling failure it does not depend on")
+		assert.Equal(t, DecisionAllow, result.Decision)
 	})
 }

--- a/plugins/governance/providerscopedlimits_test.go
+++ b/plugins/governance/providerscopedlimits_test.go
@@ -163,7 +163,7 @@ func TestProviderScopedLimitsFundOnlyTheirOwnProvider(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := resolverCtx(store, providerScopeTestVKValue)
 
-			settled := resolveLimits(ctx, store, tc.provider, tc.model)
+			settled := settleAttemptLimits(ctx, store, tc.provider, tc.model)
 			require.NotNil(t, settled, "the key resolves, so the request has a grant to settle limits on")
 
 			assert.ElementsMatch(t, tc.budgets, limitIDsOf(settled.Budgets()),

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -149,10 +149,22 @@ type GovernanceStore interface {
 	// that named a project and carries no scoping permit, exactly as it refuses one that presented a
 	// credential nothing granted.
 	ResolvePermits(ctx *schemas.BifrostContext) (bases []schemas.Permit, scoping schemas.Permit, mode grant.CompositionMode)
-	// ProviderAndModelLimits reports the deployment's own limits on a provider plus whichever model
-	// configs cover the pair, for the deployment and for the permit's holder. Resolved per attempt
-	// because a request can fail over to another provider or have its model rewritten, so they are
-	// not facts about the permit.
+	// GatherLimits assembles every limit an attempt answers to, once its provider and model are
+	// known: the deployment's own for the pair, what funds each holder the request carries, and what
+	// funds their use of the provider. Which holders pay is the store's to say: a store that composes
+	// several possible payers settles here on who pays, and everything downstream (the checks, the
+	// co-payers named on the log row, the charge) reads that one settled answer off the grant rather
+	// than assembling its own.
+	//
+	// An error is a request whose payers cannot be settled at all, which the funnel refuses as such;
+	// it is not a limit being exhausted, which the checks report.
+	GatherLimits(ctx *schemas.BifrostContext, access schemas.Access, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit, err error)
+	// ProviderAndModelLimits reports the model-config limits that cover the pair, resolved per
+	// attempt because a request can fail over to another provider or have its model rewritten, so
+	// they are not facts about the permit. A nil permit asks for the deployment's own: its provider
+	// limits plus its global model configs. A non-nil permit asks for that holder's, and only that
+	// holder's: the deployment's are not folded in, so a caller composing several holders can ask
+	// about each without gathering the same deployment rows once per holder.
 	ProviderAndModelLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit)
 	// HolderLimits reports what funds a permit's holder whichever provider serves the request: for a
 	// virtual key, its own limits plus its team's and customer's. Not on the permit because these
@@ -4310,8 +4322,49 @@ func (gs *LocalGovernanceStore) updateRateLimitReferences(ctx context.Context, r
 // GetBudgetAndRateLimitStatus implements GovernanceStore. It gathers what the request would answer to
 // for the pair, from the store and the access on its grant, and reports the fullest budget and rate
 // limit among them. A request with no access still answers to the deployment's own limits.
+// GatherLimits assembles every limit an attempt answers to: the deployment's own for the pair; for
+// every permit the request carries, what funds the holder and the holder's own model limits; and
+// for every permit that pays for the pair, what funds its use of the provider.
+//
+// A holder's own limits bind whatever the request does, whichever permit admits the pair: a key
+// whose budget is spent is spent, however the request reached the provider. Only what is funded
+// per provider follows the pair, and which permits pay for it is the access's to say (see
+// PermitsForModel).
+//
+// The deployment's own come first, because that is the order refusals report in: what the
+// deployment imposes before what the holder is funded by. Every carried permit is gathered: this
+// store resolves one permit per credential, so there is nothing to pick between, and one limit
+// reached twice is still one limit once the list is settled.
+func (gs *LocalGovernanceStore) GatherLimits(ctx *schemas.BifrostContext, access schemas.Access, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit, err error) {
+	budgets, rateLimits = gs.ProviderAndModelLimits(ctx, nil, provider, model)
+	if access == nil {
+		return budgets, rateLimits, nil
+	}
+	carried := access.Bases()
+	if scoping := access.Scoping(); scoping != nil {
+		carried = append(carried, scoping)
+	}
+	for _, permit := range carried {
+		heldBudgets, heldRateLimits := gs.HolderLimits(ctx, permit)
+		budgets = append(budgets, heldBudgets...)
+		rateLimits = append(rateLimits, heldRateLimits...)
+
+		// The holder's own model limits, gathered per permit because they are keyed by the
+		// permit's identity.
+		modelBudgets, modelRateLimits := gs.ProviderAndModelLimits(ctx, permit, provider, model)
+		budgets = append(budgets, modelBudgets...)
+		rateLimits = append(rateLimits, modelRateLimits...)
+	}
+	for _, permit := range access.PermitsForModel(string(provider), model) {
+		providerBudgets, providerRateLimits := gs.ProviderLimits(ctx, permit, provider)
+		budgets = append(budgets, providerBudgets...)
+		rateLimits = append(rateLimits, providerRateLimits...)
+	}
+	return budgets, rateLimits, nil
+}
+
 func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
-	budgets, rateLimits := gatherLimits(ctx, gs, ctx.Grant().Access(), provider, model)
+	budgets, rateLimits, _ := gs.GatherLimits(ctx, ctx.Grant().Access(), provider, model)
 	status := &BudgetAndRateLimitStatus{}
 
 	for _, limit := range budgets {
@@ -4393,11 +4446,17 @@ func (gs *LocalGovernanceStore) GlobalProviderLimits(ctx context.Context, provid
 // longer-lived, so one attempt's limits are never charged to the next.
 func (gs *LocalGovernanceStore) ProviderAndModelLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
 	providerName := string(provider)
-	budgets, rateLimits = gs.GlobalProviderLimits(ctx, provider)
+	// The deployment's own provider limits belong to the nil-permit answer alone: a caller asking
+	// about one holder is composing several answers and must not receive the deployment's rows once
+	// per holder it asks about.
+	if permit == nil {
+		budgets, rateLimits = gs.GlobalProviderLimits(ctx, provider)
+	}
 
-	// Model configs, most specific tier first, in every scope that applies: the deployment's own,
-	// then the grant holder's. collectModelConfigsFor walks the four tiers: exact pair, exact
-	// model on any provider, any model on this provider, any model anywhere.
+	// Model configs, most specific tier first, in the scope the permit selects: the deployment's
+	// own for a nil permit, the holder's own otherwise. collectModelConfigsFor walks the four
+	// tiers: exact pair, exact model on any provider, any model on this provider, any model
+	// anywhere.
 	//
 	// A request with no model still walks the scopes: only the wildcard tiers can match then,
 	// and an all-models budget covers a request whatever it runs. Batch creation is the case
@@ -4407,7 +4466,7 @@ func (gs *LocalGovernanceStore) ProviderAndModelLimits(ctx context.Context, perm
 	if providerName != "" {
 		providerArg = &providerName
 	}
-	for _, scope := range modelConfigScopesFor(ctx, permit) {
+	for _, scope := range modelConfigScopesFor(permit) {
 		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerArg) {
 			if mc == nil {
 				continue
@@ -4427,47 +4486,25 @@ type limitScope struct {
 	kind grant.LimitHolderKind
 }
 
-// modelConfigScopesFor lists the model-config scopes an attempt is subject to: the deployment's
-// global one, the user's when the request was made as one, and the permit holder's own when the
-// permit came from a holder that has one.
+// modelConfigScopesFor lists the model-config scopes one permit selects: the deployment's global
+// scope for a nil permit, and the permit holder's own scope otherwise.
 //
 // The holder's scope is keyed by the permit's identity rather than by a virtual key, so a permit
 // from any other kind of holder is looked up the same way without this needing to know what it is.
-func modelConfigScopesFor(ctx context.Context, permit schemas.Permit) []limitScope {
-	scopes := []limitScope{{
-		name: configstoreTables.ModelConfigScopeGlobal,
-		kind: grant.LimitHolderModelConfig,
-	}}
-	// The user the request was made as, when there is one. A user is not the permit holder, since a
-	// request can be made as a user through a key, so downstream-registered scopes keyed off it
-	// (e.g. enterprise's per-access-profile per-model budgets — see RegisterExtraScopedIDsResolver)
-	// are scopes of their own rather than derived from the permit.
-	userID, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string)
-	vkID := ""
-	if permit != nil && permit.Type() == string(grant.PermitVirtualKey) {
-		vkID = permit.ID()
-	}
-	for _, extra := range collectExtraScopedIDs(ctx, vkID, userID) {
-		// An empty Kind is a legitimate value for a batch-only caller (see ScopedID's
-		// doc comment), but this is the request-time path: a blank holder kind here
-		// would let a refusal name an empty holder. Skip rather than propagate it.
-		if extra.Kind == "" {
-			continue
-		}
-		scopes = append(scopes, limitScope{
-			name: extra.Scope,
-			id:   extra.ScopeID,
-			kind: extra.Kind,
-		})
-	}
+// One permit, one holder's scope: whoever gathers an attempt's limits asks once per permit it means
+// to charge, which is what lets it charge one holder among several without collecting the others.
+func modelConfigScopesFor(permit schemas.Permit) []limitScope {
 	if permit == nil || permit.ID() == "" {
-		return scopes
+		return []limitScope{{
+			name: configstoreTables.ModelConfigScopeGlobal,
+			kind: grant.LimitHolderModelConfig,
+		}}
 	}
-	return append(scopes, limitScope{
+	return []limitScope{{
 		name: modelConfigScopeFor(permit.Type()),
 		id:   permit.ID(),
 		kind: scopedModelConfigKind(permit.Type()),
-	})
+	}}
 }
 
 // modelConfigScopeFor is the scope a permit holder's own model configs are stored under.

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1451,7 +1451,7 @@ func TestCollectApplicableGovernanceIDs_VKWildcardBudget_NoModel(t *testing.T) {
 	// Settled the way the funnel settles it: the grant carries the attempt's limits, and the
 	// accounted set is read from there.
 	ctx := resolverCtx(store, vkValue)
-	limits := resolveLimits(ctx, store, schemas.ModelProvider("anthropic"), "")
+	limits := settleAttemptLimits(ctx, store, schemas.ModelProvider("anthropic"), "")
 	require.NotNil(t, limits)
 	budgetIDs := limitIDsOf(limits.Budgets())
 
@@ -1704,7 +1704,7 @@ func TestSettledLimitsAreWhatIsAccounted(t *testing.T) {
 	// afterwards reads them from there rather than working out a second answer.
 	settle := func(t *testing.T, provider schemas.ModelProvider, model string) schemas.Limits {
 		t.Helper()
-		limits := resolveLimits(resolverCtx(store, "sk-bf-collect"), store, provider, model)
+		limits := settleAttemptLimits(resolverCtx(store, "sk-bf-collect"), store, provider, model)
 		require.NotNil(t, limits)
 		return limits
 	}
@@ -1801,7 +1801,7 @@ func TestResolveLimits(t *testing.T) {
 	t.Run("after it runs, the grant carries exactly what this pair answers to", func(t *testing.T) {
 		ctx := resolverCtx(store, "sk-bf-resolve")
 
-		settled := resolveLimits(ctx, store, schemas.OpenAI, "gpt-4o")
+		settled := settleAttemptLimits(ctx, store, schemas.OpenAI, "gpt-4o")
 
 		require.NotNil(t, settled)
 		assert.ElementsMatch(t,
@@ -1814,7 +1814,7 @@ func TestResolveLimits(t *testing.T) {
 	t.Run("the settled limits are what everything downstream reads", func(t *testing.T) {
 		ctx := resolverCtx(store, "sk-bf-resolve")
 
-		settled := resolveLimits(ctx, store, schemas.OpenAI, "gpt-4o")
+		settled := settleAttemptLimits(ctx, store, schemas.OpenAI, "gpt-4o")
 
 		assert.Same(t, settled, ctx.Grant().Limits(),
 			"recorded, or the check and the charge would each resolve their own")
@@ -1826,8 +1826,8 @@ func TestResolveLimits(t *testing.T) {
 		ctx := resolverCtx(store, "sk-bf-resolve")
 		access := ctx.Grant().Access()
 
-		first := resolveLimits(ctx, store, schemas.OpenAI, "gpt-4o")
-		second := resolveLimits(ctx, store, schemas.Bedrock, "claude-sonnet-4")
+		first := settleAttemptLimits(ctx, store, schemas.OpenAI, "gpt-4o")
+		second := settleAttemptLimits(ctx, store, schemas.Bedrock, "claude-sonnet-4")
 
 		assert.Same(t, access, ctx.Grant().Access(), "what the request may reach is unchanged")
 		assert.NotSame(t, first, second)
@@ -1841,7 +1841,7 @@ func TestResolveLimits(t *testing.T) {
 		// all the same, and they are settled on its grant like anyone else's.
 		ctx := emptyCtx()
 
-		settled := resolveLimits(ctx, store, schemas.OpenAI, "gpt-4o")
+		settled := settleAttemptLimits(ctx, store, schemas.OpenAI, "gpt-4o")
 
 		require.NotNil(t, settled)
 		assert.ElementsMatch(t, []string{"b-provider", "b-model"}, limitIDsOf(settled.Budgets()))
@@ -1853,14 +1853,14 @@ func TestResolveLimits(t *testing.T) {
 		// and nothing here papers over it.
 		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
 
-		assert.Nil(t, resolveLimits(ctx, store, schemas.OpenAI, "gpt-4o"))
+		assert.Nil(t, settleAttemptLimits(ctx, store, schemas.OpenAI, "gpt-4o"))
 		assert.Nil(t, ctx.Grant())
 	})
 
 	t.Run("a modelless attempt still answers to its provider", func(t *testing.T) {
 		ctx := resolverCtx(store, "sk-bf-resolve")
 
-		settled := resolveLimits(ctx, store, schemas.OpenAI, "")
+		settled := settleAttemptLimits(ctx, store, schemas.OpenAI, "")
 
 		ids := limitIDsOf(settled.Budgets())
 		assert.Contains(t, ids, "b-provider")

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -250,7 +250,7 @@ func resolverCtx(store GovernanceStore, virtualKeyValue string) *schemas.Bifrost
 // request), so a test driving the tracker directly has to settle them or nothing is billed.
 func settleLimits(gs GovernanceStore, vkValue string, provider schemas.ModelProvider, model string, update *UsageUpdate) *UsageUpdate {
 	ctx := resolverCtx(gs, vkValue)
-	update.Budgets, update.RateLimits = gatherLimits(ctx, gs, ctx.Grant().Access(), provider, model)
+	update.Budgets, update.RateLimits, _ = gs.GatherLimits(ctx, ctx.Grant().Access(), provider, model)
 	return update
 }
 
@@ -389,7 +389,11 @@ func evaluateGrantedRequest(r *BudgetResolver, ctx *schemas.BifrostContext, acce
 	}
 	// Evaluate settles the limits on the grant before any check runs; a test reaching the resolver
 	// directly has to do the same, or it checks an attempt nothing has been settled for.
-	return r.evaluateLimits(ctx, evaluationRequest, resolveLimits(ctx, r.store, provider, model))
+	limits, err := resolveLimits(ctx, r.store, provider, model)
+	if err != nil {
+		return &EvaluationResult{Decision: DecisionAccessBlocked, Reason: err.Error()}
+	}
+	return r.evaluateLimits(ctx, evaluationRequest, limits)
 }
 
 // evaluateDeploymentLimits runs the limits that apply to every request regardless of what granted
@@ -398,13 +402,20 @@ func evaluateGrantedRequest(r *BudgetResolver, ctx *schemas.BifrostContext, acce
 // nobody granted anything reaches them: no access, with the deployment's limits settled on its grant.
 func evaluateDeploymentLimits(r *BudgetResolver, ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string) *EvaluationResult {
 	return r.evaluateLimits(ctx, &EvaluationRequest{Provider: provider, Model: model},
-		resolveLimits(ctx, r.store, provider, model))
+		resolveLimitsForTest(r, ctx, provider, model))
 }
 
 // resolveLimitsForTest settles the limits onto whatever access ctx carries, as Evaluate does, and
 // hands it back for a test that then calls the resolver itself.
 func resolveLimitsForTest(r *BudgetResolver, ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string) schemas.Limits {
-	return resolveLimits(ctx, r.store, provider, model)
+	return settleAttemptLimits(ctx, r.store, provider, model)
+}
+
+// settleAttemptLimits is resolveLimits for a test driving a store directly, dropping the settling
+// error: the store under test resolves one permit per credential and never fails to settle.
+func settleAttemptLimits(ctx *schemas.BifrostContext, store GovernanceStore, provider schemas.ModelProvider, model string) schemas.Limits {
+	limits, _ := resolveLimits(ctx, store, provider, model)
+	return limits
 }
 
 // evaluateHolderLimits runs the limits a grant carries, plus the deployment's, through that same


### PR DESCRIPTION
## Summary

Limit gathering is moved from a free function (`gatherLimits`) into the `GovernanceStore` interface as `GatherLimits`, which now returns an error. This allows stores that compose multiple possible payers to fail cleanly when payers cannot be settled, rather than silently serving a request against a partial or empty limit list. The error is held until after the identity/access checks run, so a caller with a dead credential is told that before anything about how the request would have been funded.

## Changes

- `gatherLimits` is removed as a package-level function and replaced by `GovernanceStore.GatherLimits`, which returns `(budgets, rateLimits, error)`. The `LocalGovernanceStore` implements it with the same assembly logic.
- `resolveLimits` now returns `(schemas.Limits, error)`. The error is held at the `Evaluate` funnel and converted to a `DecisionAccessBlocked` result only after the access check passes, preserving the ordering guarantee that identity refusals come before funding refusals.
- `ProviderAndModelLimits` is split by nil/non-nil permit: a nil permit returns the deployment's global provider limits plus its model configs; a non-nil permit returns only that holder's model configs. This prevents the deployment's rows from being gathered once per holder when a caller iterates over several permits.
- `modelConfigScopesFor` no longer takes a `context.Context` or resolves user/extra scopes. It returns exactly one scope: the deployment's global scope for a nil permit, or the holder's own scope for a non-nil permit. Callers that previously relied on the user and extra scopes being folded in here must now gather those separately.
- A test helper `settleAttemptLimits` is introduced to wrap `resolveLimits` for tests that drive a store directly and expect settling to always succeed, keeping test call sites clean without hiding the error in production paths.
- The `TestStore_ScopedAndGlobalModelBudgetsBothApply` assertion is corrected: `ProviderAndModelLimits` with a non-nil permit now returns only the holder's limits, so the deployment's budget is verified by a separate nil-permit call.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

Verify that a request whose payers cannot be settled receives `DecisionAccessBlocked` after any access denial would have been issued, and that a request denied by access policy still receives the access denial rather than the settling error.

## Breaking changes

- [x] Yes
- [ ] No

`GovernanceStore` gains a new required method `GatherLimits`. Any implementation outside this repository must add it. `ProviderAndModelLimits` behaviour changes for non-nil permits: the deployment's global provider limits are no longer included in the response; callers that previously relied on them being folded in must call with a nil permit separately.

## Related issues

## Security considerations

A request whose payers cannot be settled is now explicitly refused rather than evaluated against an empty limit list, which would have allowed it to proceed without any budget or rate-limit enforcement.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable