### PR TITLE
feat(complexity): enforce 750-phrase combined semantic limit with split-config merge guard and local Chromem cleanup fixes

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -465,6 +465,16 @@ func PrepareContextForInternalRequest(ctx *schemas.BifrostContext) {
 	ClearContextForInternalRequest(ctx)
 }
 
+// PrepareContextForInternalEmbeddingRequest prepares a plugin-owned embedding request without capturing its raw payloads.
+func PrepareContextForInternalEmbeddingRequest(ctx *schemas.BifrostContext) {
+	PrepareContextForInternalRequest(ctx)
+	ctx.SetValue(schemas.BifrostContextKeyAllowPerRequestRawOverride, true)
+	ctx.SetValue(schemas.BifrostContextKeySendBackRawRequest, false)
+	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, false)
+	ctx.SetValue(schemas.BifrostContextKeyAllowPerRequestStorageOverride, true)
+	ctx.SetValue(schemas.BifrostContextKeyStoreRawRequestResponse, false)
+}
+
 var supportedBaseProvidersSet = func() map[schemas.ModelProvider]struct{} {
 	m := make(map[schemas.ModelProvider]struct{}, len(schemas.SupportedBaseProviders))
 	for _, p := range schemas.SupportedBaseProviders {

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -206,6 +206,28 @@ func TestValidateExternalURL(t *testing.T) {
 	}
 }
 
+// TestPrepareContextForInternalEmbeddingRequestDisablesRawCapture ensures plugin-owned embeddings never inherit provider raw capture.
+func TestPrepareContextForInternalEmbeddingRequestDisablesRawCapture(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	PrepareContextForInternalEmbeddingRequest(ctx)
+
+	applyRawCaptureSignals(ctx, &schemas.ProviderConfig{
+		SendBackRawRequest:      true,
+		SendBackRawResponse:     true,
+		StoreRawRequestResponse: true,
+	})
+
+	for key, name := range map[schemas.BifrostContextKey]string{
+		schemas.BifrostContextKeyCaptureRawRequest:    "capture raw request",
+		schemas.BifrostContextKeyCaptureRawResponse:   "capture raw response",
+		schemas.BifrostContextKeyShouldStoreRawInLogs: "store raw request/response",
+	} {
+		if enabled, _ := ctx.Value(key).(bool); enabled {
+			t.Errorf("%s = true, want false", name)
+		}
+	}
+}
+
 // TestValidateExternalURLBoundsDNSLookup guards against regressing to the package-level
 // net.LookupIP (which has no context/deadline of its own, and previously let a stalled
 // resolver block the caller indefinitely -- see externalURLDNSLookupTimeout's doc). A

--- a/docs/features/governance/complexity-router.mdx
+++ b/docs/features/governance/complexity-router.mdx
@@ -49,7 +49,9 @@ When writing your own phrases:
 - **Keep phrases short and prototypical.** A long, hyper-specific phrase mostly matches near-identical requests.
 - **Balance surface form across tiers.** If most Complex phrases are questions, every question routes to Complex. Mix questions, imperatives, terse and detailed phrasing in every tier.
 
-With semantic classification configured, every tier must contain at least one phrase and each phrase must be 2,000 characters or fewer. Bifrost also rejects the same normalized phrase in more than one tier when it saves or loads the configuration.
+With semantic classification configured, every tier must contain at least one phrase, each phrase must be 2,000 characters or fewer, and the three normalized lists may contain at most **750 phrases combined**. Trimming, lowercasing, and same-tier deduplication happen before that count. Bifrost also rejects the same normalized phrase in more than one tier when it saves or loads the configuration.
+
+In split configuration mode, phrases from `config.json` are merged additively with phrases already stored in the database before the 750-phrase limit is checked. If the merged result exceeds the limit, Bifrost logs a warning, keeps the existing database configuration active, and does not apply that `config.json` phrase edit. Reduce one of the lists before restarting. **Restore defaults** remains the recovery path for a stored semantic configuration this version cannot load: it replaces the unreadable configuration with the 150 built-in phrases. Re-enter the embedding provider, model, and storage settings afterward. For a valid readable configuration, restore defaults preserves those semantic settings and only resets the boundaries and phrase lists.
 
 ### Choosing how much conversation to embed
 
@@ -233,6 +235,10 @@ Reference-phrase lists are stored in the existing `keywords` fields (`simple_key
 | `keywords.simple_keywords` | string[] | 50 built-in phrases | Reference phrases for the Simple tier |
 | `keywords.medium_keywords` | string[] | 50 built-in phrases | Reference phrases for the Medium tier |
 | `keywords.complex_keywords` | string[] | 50 built-in phrases | Reference phrases for the Complex tier |
+
+<Warning>
+Chromem is a node-local embedded backend, including when its `path` option persists data to disk. In a multi-pod deployment, give every pod its own path or volume. Do not mount one writable Chromem directory into multiple pods; use Qdrant, Redis, Pinecone, or Weaviate when replicas need a shared vector store.
+</Warning>
 
 <Note>
 `min_similarity` is compared against the vector store backend's own similarity scale, which is not identical across backends: chromem, Qdrant, Pinecone, and Redis report raw cosine similarity, while Weaviate reports certainty ((cosine+1)/2). Retune the floor when switching backends.

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -68740,7 +68740,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, and the same phrase cannot appear in two\ntiers. The field names predate semantic classification and are kept for\nbackward compatibility.\n",
+                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
                       "required": [
                         "simple_keywords",
@@ -69030,7 +69030,7 @@
                   },
                   "keywords": {
                     "type": "object",
-                    "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, and the same phrase cannot appear in two\ntiers. The field names predate semantic classification and are kept for\nbackward compatibility.\n",
+                    "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                     "additionalProperties": false,
                     "required": [
                       "simple_keywords",
@@ -69297,7 +69297,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, and the same phrase cannot appear in two\ntiers. The field names predate semantic classification and are kept for\nbackward compatibility.\n",
+                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
                       "required": [
                         "simple_keywords",
@@ -69605,7 +69605,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, and the same phrase cannot appear in two\ntiers. The field names predate semantic classification and are kept for\nbackward compatibility.\n",
+                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
                       "required": [
                         "simple_keywords",
@@ -70303,7 +70303,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, and the same phrase cannot appear in two\ntiers. The field names predate semantic classification and are kept for\nbackward compatibility.\n",
+                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
                       "required": [
                         "simple_keywords",
@@ -70594,7 +70594,7 @@
                   },
                   "keywords": {
                     "type": "object",
-                    "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, and the same phrase cannot appear in two\ntiers. The field names predate semantic classification and are kept for\nbackward compatibility.\n",
+                    "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                     "additionalProperties": false,
                     "required": [
                       "simple_keywords",
@@ -70861,7 +70861,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, and the same phrase cannot appear in two\ntiers. The field names predate semantic classification and are kept for\nbackward compatibility.\n",
+                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
                       "required": [
                         "simple_keywords",
@@ -71170,7 +71170,7 @@
                     },
                     "keywords": {
                       "type": "object",
-                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, and the same phrase cannot appear in two\ntiers. The field names predate semantic classification and are kept for\nbackward compatibility.\n",
+                      "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
                       "required": [
                         "simple_keywords",

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -2237,9 +2237,9 @@ ComplexityKeywordConfig:
     Reference phrases for semantic complexity classification, one list per tier.
     Each request is embedded and takes the tier of its nearest phrase. Entries
     should be whole example prompts rather than individual keywords. Each phrase
-    is limited to 2000 characters, and the same phrase cannot appear in two
-    tiers. The field names predate semantic classification and are kept for
-    backward compatibility.
+    is limited to 2000 characters, the normalized lists may contain at most 750
+    phrases combined, and the same phrase cannot appear in two tiers. The field
+    names predate semantic classification and are kept for backward compatibility.
   additionalProperties: false
   required:
     - simple_keywords

--- a/framework/configstore/complexityconfig.go
+++ b/framework/configstore/complexityconfig.go
@@ -163,9 +163,13 @@ const (
 	ComplexitySemanticVectorStoreConfigured = "vector_store"
 )
 
-// MaxComplexitySemanticPhraseCharacters bounds one exemplar's input size.
-// The number of exemplars is intentionally unrestricted.
-const MaxComplexitySemanticPhraseCharacters = 2000
+const (
+	// MaxComplexitySemanticPhraseCharacters bounds one exemplar's input size.
+	MaxComplexitySemanticPhraseCharacters = 2000
+	// MaxComplexitySemanticPhrases bounds the total exemplar set embedded for
+	// one semantic classifier generation across all three tiers.
+	MaxComplexitySemanticPhrases = 750
+)
 
 // Semantic message-history bounds. The ceiling keeps one classification
 // embedding cheap and bounded. The dormant lexical analyzer happens to scan a
@@ -847,6 +851,21 @@ func validateComplexitySemanticPhrases(keywords ComplexityEditableKeywordConfig)
 		{name: "simple_keywords", values: keywords.SimpleKeywords},
 		{name: "medium_keywords", values: keywords.MediumKeywords},
 		{name: "complex_keywords", values: keywords.ComplexKeywords},
+	}
+	// Persistence and runtime entry points normalize before validation, so the
+	// slice lengths here already exclude blank and same-tier duplicate phrases.
+	// Do not introduce a second normalization rule in this validator: the
+	// stronger whitespace folding below exists only to catch cross-tier labels.
+	total := len(keywords.SimpleKeywords) + len(keywords.MediumKeywords) + len(keywords.ComplexKeywords)
+	if total > MaxComplexitySemanticPhrases {
+		return fmt.Errorf(
+			"semantic complexity configuration contains %d phrases (simple=%d, medium=%d, complex=%d); maximum is %d across all tiers",
+			total,
+			len(keywords.SimpleKeywords),
+			len(keywords.MediumKeywords),
+			len(keywords.ComplexKeywords),
+			MaxComplexitySemanticPhrases,
+		)
 	}
 	seen := make(map[string]string)
 	for _, tier := range tiers {

--- a/framework/configstore/complexityconfig_test.go
+++ b/framework/configstore/complexityconfig_test.go
@@ -249,9 +249,9 @@ func TestComplexityAnalyzerConfigRejectsSemanticCrossTierDuplicates(t *testing.T
 }
 
 func TestComplexityAnalyzerConfigSemanticPhraseValidation(t *testing.T) {
-	t.Run("allows more than 500 phrases", func(t *testing.T) {
+	t.Run("allows exactly the combined phrase limit", func(t *testing.T) {
 		cfg := testSemanticAnalyzerConfig()
-		cfg.Keywords.SimpleKeywords = make([]string, 501)
+		cfg.Keywords.SimpleKeywords = make([]string, MaxComplexitySemanticPhrases-2)
 		for index := range cfg.Keywords.SimpleKeywords {
 			cfg.Keywords.SimpleKeywords[index] = fmt.Sprintf("simple-%d", index)
 		}
@@ -259,6 +259,49 @@ func TestComplexityAnalyzerConfigSemanticPhraseValidation(t *testing.T) {
 		cfg.Keywords.ComplexKeywords = []string{"complex"}
 
 		normalized := cfg.Normalized()
+		require.NoError(t, normalized.Validate())
+	})
+
+	t.Run("rejects more than the combined phrase limit", func(t *testing.T) {
+		cfg := testSemanticAnalyzerConfig()
+		cfg.Keywords.SimpleKeywords = make([]string, MaxComplexitySemanticPhrases-1)
+		for index := range cfg.Keywords.SimpleKeywords {
+			cfg.Keywords.SimpleKeywords[index] = fmt.Sprintf("simple-%d", index)
+		}
+		cfg.Keywords.MediumKeywords = []string{"medium"}
+		cfg.Keywords.ComplexKeywords = []string{"complex"}
+
+		normalized := cfg.Normalized()
+		require.ErrorContains(t, normalized.Validate(), "contains 751 phrases (simple=749, medium=1, complex=1); maximum is 750")
+	})
+
+	t.Run("counts canonical phrases", func(t *testing.T) {
+		cfg := testSemanticAnalyzerConfig()
+		cfg.Keywords.SimpleKeywords = make([]string, MaxComplexitySemanticPhrases-2)
+		for index := range cfg.Keywords.SimpleKeywords {
+			cfg.Keywords.SimpleKeywords[index] = fmt.Sprintf("simple-%d", index)
+		}
+		cfg.Keywords.SimpleKeywords = append(cfg.Keywords.SimpleKeywords, " SIMPLE-0 ", "")
+		cfg.Keywords.MediumKeywords = []string{"medium"}
+		cfg.Keywords.ComplexKeywords = []string{"complex"}
+
+		normalized := cfg.Normalized()
+		require.Len(t, normalized.Keywords.SimpleKeywords, MaxComplexitySemanticPhrases-2)
+		require.NoError(t, normalized.Validate())
+	})
+
+	t.Run("does not cap lexical-only lists", func(t *testing.T) {
+		cfg := testSemanticAnalyzerConfig()
+		cfg.Semantic = nil
+		cfg.Keywords.SimpleKeywords = make([]string, MaxComplexitySemanticPhrases)
+		for index := range cfg.Keywords.SimpleKeywords {
+			cfg.Keywords.SimpleKeywords[index] = fmt.Sprintf("simple-%d", index)
+		}
+		cfg.Keywords.MediumKeywords = []string{"medium"}
+		cfg.Keywords.ComplexKeywords = []string{"complex"}
+
+		normalized := cfg.Normalized()
+		require.Greater(t, len(normalized.Keywords.SimpleKeywords)+len(normalized.Keywords.MediumKeywords)+len(normalized.Keywords.ComplexKeywords), MaxComplexitySemanticPhrases)
 		require.NoError(t, normalized.Validate())
 	})
 

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -196,6 +196,34 @@ func TestRDBConfigStore_GetComplexityAnalyzerConfigMarksUnreadableRows(t *testin
 		_, err := store.GetComplexityAnalyzerConfig(ctx)
 		require.ErrorIs(t, err, ErrConfigUnreadable)
 	})
+
+	t.Run("stored semantic config exceeds phrase limit", func(t *testing.T) {
+		store := setupRDBTestStore(t)
+		base := testComplexityAnalyzerConfig()
+		require.NoError(t, store.UpdateComplexityAnalyzerConfig(ctx, base))
+
+		oversized := *base
+		oversized.Semantic = &ComplexitySemanticConfig{
+			Provider:       "openai",
+			EmbeddingModel: "text-embedding-3-small",
+		}
+		oversized.Keywords.SimpleKeywords = make([]string, MaxComplexitySemanticPhrases-1)
+		for index := range oversized.Keywords.SimpleKeywords {
+			oversized.Keywords.SimpleKeywords[index] = fmt.Sprintf("simple-%d", index)
+		}
+		oversized.Keywords.MediumKeywords = []string{"medium"}
+		oversized.Keywords.ComplexKeywords = []string{"complex"}
+		semanticRaw, err := encodeComplexitySemanticConfigRow(oversized)
+		require.NoError(t, err)
+		require.NoError(t, store.UpdateConfig(ctx, &tables.TableGovernanceConfig{
+			Key:   tables.ConfigComplexitySemanticConfigKey,
+			Value: string(semanticRaw),
+		}))
+
+		_, err = store.GetComplexityAnalyzerConfig(ctx)
+		require.ErrorIs(t, err, ErrConfigUnreadable)
+		require.ErrorContains(t, err, "contains 751 phrases")
+	})
 }
 
 func TestRDBConfigStore_GetComplexityAnalyzerConfigMissingReturnsNil(t *testing.T) {

--- a/plugins/routing/complexity/semanticclassifier.go
+++ b/plugins/routing/complexity/semanticclassifier.go
@@ -17,6 +17,8 @@ import (
 	"github.com/maximhq/bifrost/framework/vectorstore"
 )
 
+var errSemanticVectorStoreUnavailable = errors.New("semantic vector store unavailable")
+
 // SemanticVectorStoreNamespace is the prefix for immutable, fingerprinted
 // complexity-routing generations. It isolates routing exemplars from every
 // other VectorStore consumer, including the semantic cache plugin.
@@ -47,14 +49,37 @@ const (
 	SemanticStatusFailed SemanticStatus = "failed"
 )
 
+// SemanticFailureReason is the safe, operator-actionable category for a failed
+// warmup. Provider and backend error bodies stay in server logs; status clients
+// only receive this bounded vocabulary and the corresponding safe message.
+type SemanticFailureReason string
+
+const (
+	SemanticFailureAuthentication         SemanticFailureReason = "authentication"
+	SemanticFailureModelUnavailable       SemanticFailureReason = "model_unavailable"
+	SemanticFailureRateLimited            SemanticFailureReason = "rate_limited"
+	SemanticFailureTimeout                SemanticFailureReason = "timeout"
+	SemanticFailureProviderUnavailable    SemanticFailureReason = "provider_unavailable"
+	SemanticFailureVectorStoreUnavailable SemanticFailureReason = "vector_store_unavailable"
+	SemanticFailureInvalidResponse        SemanticFailureReason = "invalid_response"
+	SemanticFailureUnknown                SemanticFailureReason = "unknown"
+)
+
+// semanticWarmupFailure is implemented by embedding adapters that can safely
+// classify an operational failure without exposing the provider's raw error.
+type semanticWarmupFailure interface {
+	SemanticFailureReason() SemanticFailureReason
+}
+
 // SemanticStatusInfo is the safe runtime state exposed to Governance handlers
 // and UI clients; it never contains prompts, embeddings, or provider secrets.
 type SemanticStatusInfo struct {
-	State           SemanticStatus `json:"state"`
-	Loaded          int            `json:"loaded"`
-	Total           int            `json:"total"`
-	ServingPrevious bool           `json:"serving_previous,omitempty"`
-	Error           string         `json:"error,omitempty"`
+	State           SemanticStatus        `json:"state"`
+	Loaded          int                   `json:"loaded"`
+	Total           int                   `json:"total"`
+	ServingPrevious bool                  `json:"serving_previous,omitempty"`
+	FailureReason   SemanticFailureReason `json:"failure_reason,omitempty"`
+	Error           string                `json:"error,omitempty"`
 	// CachedPhrases is how many phrase vectors are currently held in process for
 	// the configured provider/model. Reuse cannot be inferred from the persisted
 	// config alone: the cache lives only in memory (vectors cannot be read back
@@ -120,22 +145,22 @@ type SemanticClassifier struct {
 	ctx    context.Context
 	logger schemas.Logger
 
-	mu               sync.Mutex
-	configuredStore  vectorstore.VectorStore
-	ownedStore       vectorstore.VectorStore
-	embed            EmbeddingFunc
-	embedBatch       BatchEmbeddingFunc
-	config           *AnalyzerConfig
-	store            vectorstore.VectorStore
-	active           *semanticGeneration
-	status           SemanticStatusInfo
-	revision         uint64
-	warmCancel       context.CancelFunc
-	warming          bool
-	closed           bool
-	embeddedInFlight map[string]int
-	embeddingCache   *semanticEmbeddingCache
-	wg               sync.WaitGroup
+	mu              sync.Mutex
+	configuredStore vectorstore.VectorStore
+	ownedStore      vectorstore.VectorStore
+	embed           EmbeddingFunc
+	embedBatch      BatchEmbeddingFunc
+	config          *AnalyzerConfig
+	store           vectorstore.VectorStore
+	active          *semanticGeneration
+	status          SemanticStatusInfo
+	revision        uint64
+	warmCancel      context.CancelFunc
+	warming         bool
+	closed          bool
+	localInFlight   map[*semanticGeneration]int
+	embeddingCache  *semanticEmbeddingCache
+	wg              sync.WaitGroup
 }
 
 // NewSemanticClassifier creates a disabled classifier. Callers configure it
@@ -164,7 +189,7 @@ func (c *SemanticClassifier) Configure(config *AnalyzerConfig) {
 	c.mu.Unlock()
 }
 
-// SetConfiguredStore supplies Bifrost's configured shared VectorStore.
+// SetConfiguredStore supplies Bifrost's top-level configured VectorStore.
 // "embedded" mode ignores it; "vector_store" mode uses it when present and
 // falls back to the embedded store when it is nil.
 func (c *SemanticClassifier) SetConfiguredStore(store vectorstore.VectorStore) {
@@ -315,15 +340,15 @@ func (c *SemanticClassifier) Classify(ctx context.Context, input ComplexityInput
 	namespace := generation.namespace
 	embed := generation.embed
 	exemplars := generation.exemplars
-	embeddedGeneration := c.isOwnedStoreLocked(store)
-	if embeddedGeneration {
-		if c.embeddedInFlight == nil {
-			c.embeddedInFlight = make(map[string]int)
+	localGeneration := isLocalChromemStore(store)
+	if localGeneration {
+		if c.localInFlight == nil {
+			c.localInFlight = make(map[*semanticGeneration]int)
 		}
-		c.embeddedInFlight[namespace]++
+		c.localInFlight[generation]++
 	}
 	c.mu.Unlock()
-	if embeddedGeneration {
+	if localGeneration {
 		defer c.releaseGeneration(generation)
 	}
 
@@ -407,7 +432,7 @@ func (c *SemanticClassifier) resetForCurrentConfigLocked() {
 		c.active = nil
 		c.status = SemanticStatusInfo{State: SemanticStatusDisabled}
 		if previous != nil {
-			c.cleanupEmbeddedNamespaceLocked(previous.store, previous.namespace)
+			c.cleanupLocalGenerationLocked(previous)
 		}
 		return
 	}
@@ -428,7 +453,8 @@ func (c *SemanticClassifier) resetForCurrentConfigLocked() {
 	store, err := c.resolveStoreLocked(semantic)
 	if err != nil {
 		c.status.State = SemanticStatusFailed
-		c.status.Error = "semantic classifier is unavailable; check server logs"
+		c.status.FailureReason = SemanticFailureVectorStoreUnavailable
+		c.status.Error = semanticWarmupFailureMessage(c.status.FailureReason)
 		c.logWarmupError(err)
 		return
 	}
@@ -453,7 +479,10 @@ func (c *SemanticClassifier) requestWarmupLocked() {
 }
 
 // runWarmupWorker serializes namespace mutation so cancelled generations cannot
-// write vectors into the namespace selected by a newer configuration.
+// write vectors into the namespace selected by a newer configuration. Cleanup
+// on revision mismatch relies on this remaining a single worker: parallel
+// warmers could otherwise mistake a namespace another worker is building for
+// an abandoned generation.
 func (c *SemanticClassifier) runWarmupWorker() {
 	defer c.wg.Done()
 	for {
@@ -482,22 +511,24 @@ func (c *SemanticClassifier) runWarmupWorker() {
 
 		c.mu.Lock()
 		if c.revision != revision {
-			c.cleanupEmbeddedNamespaceLocked(store, namespace)
+			c.cleanupLocalNamespaceLocked(store, namespace)
 			c.mu.Unlock()
 			continue
 		}
 		c.warmCancel = nil
 		c.warming = false
 		if err != nil {
+			failureReason := semanticWarmupFailureReason(err)
 			c.status = SemanticStatusInfo{
 				State:           SemanticStatusFailed,
 				Loaded:          loaded,
 				Total:           len(semanticExemplars(config)),
 				ServingPrevious: c.active != nil,
-				Error:           "semantic warmup failed; check server logs",
+				FailureReason:   failureReason,
+				Error:           semanticWarmupFailureMessage(failureReason),
 			}
 			c.logWarmupError(err)
-			c.cleanupEmbeddedNamespaceLocked(store, namespace)
+			c.cleanupLocalNamespaceLocked(store, namespace)
 		} else {
 			previous := c.active
 			c.active = &semanticGeneration{
@@ -510,7 +541,7 @@ func (c *SemanticClassifier) runWarmupWorker() {
 			}
 			c.status = SemanticStatusInfo{State: SemanticStatusReady, Loaded: loaded, Total: len(semanticExemplars(config))}
 			if previous != nil {
-				c.cleanupEmbeddedNamespaceLocked(previous.store, previous.namespace)
+				c.cleanupLocalGenerationLocked(previous)
 			}
 		}
 		c.mu.Unlock()
@@ -518,46 +549,96 @@ func (c *SemanticClassifier) runWarmupWorker() {
 	}
 }
 
-// releaseGeneration drops the request's hold on an embedded generation. A
-// retired namespace is removed as soon as its final classification finishes.
+func semanticWarmupFailureReason(err error) SemanticFailureReason {
+	var failure semanticWarmupFailure
+	if errors.As(err, &failure) {
+		return failure.SemanticFailureReason()
+	}
+	if errors.Is(err, errSemanticVectorStoreUnavailable) {
+		return SemanticFailureVectorStoreUnavailable
+	}
+	return SemanticFailureUnknown
+}
+
+func semanticWarmupFailureMessage(reason SemanticFailureReason) string {
+	switch reason {
+	case SemanticFailureAuthentication:
+		return "Authentication failed for the selected embedding provider. Update its API key to restart warmup."
+	case SemanticFailureModelUnavailable:
+		return "The selected embedding model could not be used. Choose a supported embedding model and save the configuration again."
+	case SemanticFailureRateLimited:
+		return "The embedding provider's rate limit prevented warmup. Wait for capacity, then save the configuration again."
+	case SemanticFailureTimeout:
+		return "The embedding provider did not respond during warmup. Check provider availability, then save the configuration again."
+	case SemanticFailureProviderUnavailable:
+		return "The embedding provider is unavailable. Updating its configuration or API key restarts warmup."
+	case SemanticFailureVectorStoreUnavailable:
+		return "The vector store could not prepare the classifier index. Check its connectivity and configuration, then save again."
+	case SemanticFailureInvalidResponse:
+		return "The selected model returned an invalid embedding response. Choose a model that supports embeddings and save again."
+	default:
+		return "The classifier could not prepare the reference phrases. Review the embedding provider, model, and vector store settings, then save again."
+	}
+}
+
+// releaseGeneration drops the request's hold on a node-local Chromem
+// generation. A retired namespace is removed as soon as its final
+// classification finishes.
 func (c *SemanticClassifier) releaseGeneration(generation *semanticGeneration) {
 	if generation == nil {
 		return
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	if !c.isOwnedStoreLocked(generation.store) {
+	if !isLocalChromemStore(generation.store) {
 		return
 	}
-	if count := c.embeddedInFlight[generation.namespace]; count > 1 {
-		c.embeddedInFlight[generation.namespace] = count - 1
+	if count := c.localInFlight[generation]; count > 1 {
+		c.localInFlight[generation] = count - 1
 		return
 	}
-	delete(c.embeddedInFlight, generation.namespace)
-	c.cleanupEmbeddedNamespaceLocked(generation.store, generation.namespace)
+	delete(c.localInFlight, generation)
+	c.cleanupLocalGenerationLocked(generation)
 }
 
-// cleanupEmbeddedNamespaceLocked removes a private Chromem generation only
-// when no request can still query it. Shared stores are intentionally retained:
+// cleanupLocalGenerationLocked retires one serving snapshot. Tracking request
+// holds by generation identity keeps two stores with the same fingerprinted
+// namespace independent during a storage-mode switch.
+func (c *SemanticClassifier) cleanupLocalGenerationLocked(generation *semanticGeneration) {
+	if generation == nil || c.localInFlight[generation] > 0 {
+		return
+	}
+	c.cleanupLocalNamespaceLocked(generation.store, generation.namespace)
+}
+
+// cleanupLocalNamespaceLocked removes a node-local Chromem namespace only
+// when no active or in-flight generation can still query that exact store and
+// namespace pair. Shared external stores are intentionally retained because
 // another Bifrost replica may still serve the previous generation.
-func (c *SemanticClassifier) cleanupEmbeddedNamespaceLocked(store vectorstore.VectorStore, namespace string) {
-	if namespace == "" || !c.isOwnedStoreLocked(store) {
+func (c *SemanticClassifier) cleanupLocalNamespaceLocked(store vectorstore.VectorStore, namespace string) {
+	if namespace == "" || !isLocalChromemStore(store) {
 		return
 	}
-	if c.active != nil && c.isOwnedStoreLocked(c.active.store) && c.active.namespace == namespace {
+	if c.active != nil && c.active.store == store && c.active.namespace == namespace {
 		return
 	}
-	if c.embeddedInFlight[namespace] > 0 {
-		return
+	for generation, count := range c.localInFlight {
+		if count > 0 && generation.store == store && generation.namespace == namespace {
+			return
+		}
 	}
-	if err := c.ownedStore.DeleteNamespace(context.Background(), namespace); err != nil && c.logger != nil {
+	if err := store.DeleteNamespace(context.Background(), namespace); err != nil && c.logger != nil {
 		c.logger.Warn("[Governance] Failed to clean retired semantic complexity namespace %s: %v", namespace, err)
 	}
-	delete(c.embeddedInFlight, namespace)
 }
 
-func (c *SemanticClassifier) isOwnedStoreLocked(store vectorstore.VectorStore) bool {
-	return c.ownedStore != nil && store == c.ownedStore
+// isLocalChromemStore follows Chromem's supported deployment contract: the
+// embedded backend belongs to one Bifrost node, whether the classifier created
+// it or it came from the top-level vector_store configuration. A persistent
+// Chromem path must not be shared as one writable database across replicas.
+func isLocalChromemStore(store vectorstore.VectorStore) bool {
+	_, ok := store.(*vectorstore.ChromemStore)
+	return ok
 }
 
 // logWarmupError records provider and backend details without exposing them
@@ -569,7 +650,7 @@ func (c *SemanticClassifier) logWarmupError(err error) {
 }
 
 // resolveStoreLocked selects the backing store without ever taking ownership of
-// Bifrost's configured shared store. The caller must hold c.mu.
+// Bifrost's top-level configured store. The caller must hold c.mu.
 func (c *SemanticClassifier) resolveStoreLocked(semantic *SemanticConfig) (vectorstore.VectorStore, error) {
 	switch semantic.VectorStore {
 	case configstore.ComplexitySemanticVectorStoreEmbedded:
@@ -700,7 +781,7 @@ func warmSemanticExemplars(
 	// Creating first makes a brand-new generation work on Qdrant and Weaviate,
 	// whose reads return backend-specific errors for missing namespaces.
 	if err := store.CreateNamespace(ctx, namespace, dimension, semanticVectorStoreProperties); err != nil {
-		return 0, namespace, dimension, fmt.Errorf("create complexity generation namespace: %w", err)
+		return 0, namespace, dimension, fmt.Errorf("%w: create complexity generation namespace: %v", errSemanticVectorStoreUnavailable, err)
 	}
 	markers, err := store.GetChunks(ctx, namespace, []string{markerID})
 	if err == nil && len(markers) > 0 {
@@ -714,7 +795,7 @@ func warmSemanticExemplars(
 			return len(exemplars), namespace, dimension, nil
 		}
 	} else if err != nil && !errors.Is(err, vectorstore.ErrNotFound) {
-		return 0, namespace, dimension, fmt.Errorf("check complexity warmup marker: %w", err)
+		return 0, namespace, dimension, fmt.Errorf("%w: check complexity warmup marker: %v", errSemanticVectorStoreUnavailable, err)
 	}
 
 	for batchStart := 0; batchStart < len(pending); batchStart += semanticWarmupBatchSize {
@@ -788,7 +869,7 @@ func warmSemanticExemplars(
 			semanticMetadataKind:        semanticMetadataKindExample,
 			semanticMetadataFingerprint: fingerprint,
 		}); err != nil {
-			return index, namespace, dimension, fmt.Errorf("store %s exemplar %d: %w", strings.ToLower(exemplar.Tier), index+1, err)
+			return index, namespace, dimension, fmt.Errorf("%w: store %s exemplar %d: %v", errSemanticVectorStoreUnavailable, strings.ToLower(exemplar.Tier), index+1, err)
 		}
 		markerEmbedding = embedding
 	}
@@ -796,7 +877,7 @@ func warmSemanticExemplars(
 		semanticMetadataKind:        semanticMetadataKindMarker,
 		semanticMetadataFingerprint: fingerprint,
 	}); err != nil {
-		return len(exemplars), namespace, dimension, fmt.Errorf("store complexity warmup marker: %w", err)
+		return len(exemplars), namespace, dimension, fmt.Errorf("%w: store complexity warmup marker: %v", errSemanticVectorStoreUnavailable, err)
 	}
 	cache.retain(exemplars)
 	return len(exemplars), namespace, dimension, nil

--- a/plugins/routing/complexity/semanticclassifier_test.go
+++ b/plugins/routing/complexity/semanticclassifier_test.go
@@ -535,7 +535,7 @@ func TestSemanticClassifierDefersEmbeddedCleanupUntilInFlightRequestFinishes(t *
 	}, time.Second, 10*time.Millisecond, "F1 must be reclaimed after its last request releases it")
 }
 
-func TestSemanticClassifierRetainsPreviousExternalGeneration(t *testing.T) {
+func TestSemanticClassifierDeletesPreviousConfiguredChromemGeneration(t *testing.T) {
 	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
 	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
 		Enabled: true,
@@ -573,8 +573,130 @@ func TestSemanticClassifierRetainsPreviousExternalGeneration(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 
 	v1Markers, err := store.GetChunks(context.Background(), v1Namespace, []string{v1MarkerID})
+	require.ErrorIs(t, err, vectorstore.ErrNotFound)
+	assert.Empty(t, v1Markers, "configured Chromem is node-local and must reclaim retired generations")
+}
+
+func TestSemanticClassifierDefersConfiguredChromemCleanupUntilGenerationRelease(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, logger)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	const namespace = "configured-local-in-flight"
+	require.NoError(t, store.CreateNamespace(context.Background(), namespace, testSemanticDimension, semanticVectorStoreProperties))
+	require.NoError(t, store.Add(context.Background(), namespace, "marker", []float32{1, 0}, map[string]interface{}{
+		semanticMetadataKind: semanticMetadataKindMarker,
+	}))
+	generation := &semanticGeneration{store: store, namespace: namespace}
+	classifier := NewSemanticClassifier(context.Background(), logger)
+	classifier.localInFlight = map[*semanticGeneration]int{generation: 1}
+
+	classifier.cleanupLocalGenerationLocked(generation)
+	markers, err := store.GetChunks(context.Background(), namespace, []string{"marker"})
+	require.NoError(t, err)
+	require.Len(t, markers, 1, "a configured Chromem namespace must remain while a request holds its generation")
+
+	classifier.releaseGeneration(generation)
+	_, err = store.GetChunks(context.Background(), namespace, []string{"marker"})
+	require.ErrorIs(t, err, vectorstore.ErrNotFound)
+}
+
+func TestSemanticClassifierRetainsPreviousExternalGeneration(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	backingStore, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+		Enabled: true,
+		Type:    vectorstore.VectorStoreTypeChromem,
+		Config:  vectorstore.ChromemConfig{},
+	}, logger)
+	require.NoError(t, err)
+	store := &semanticExternalProbeStore{VectorStore: backingStore}
+	t.Cleanup(func() {
+		require.NoError(t, backingStore.Close(context.Background(), SemanticVectorStoreNamespace))
+	})
+
+	classifier := NewSemanticClassifier(context.Background(), logger)
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+	classifier.SetConfiguredStore(store)
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+
+	v1 := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
+	v1.Semantic.EmbeddingModel = "model-v1"
+	classifier.Configure(&v1)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+	v1Fingerprint := semanticFingerprint(&v1, semanticExemplars(&v1), testSemanticDimension)
+	v1Namespace := semanticGenerationNamespace(v1Fingerprint)
+	v1MarkerID := semanticMarkerID(v1Fingerprint)
+
+	v2 := v1
+	v2.Semantic = cloneSemanticConfig(v1.Semantic)
+	v2.Semantic.EmbeddingModel = "model-v2"
+	classifier.Configure(&v2)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	v1Markers, err := store.GetChunks(context.Background(), v1Namespace, []string{v1MarkerID})
 	require.NoError(t, err)
 	require.Len(t, v1Markers, 1, "shared stores retain F1 because another replica may still serve it")
+	assert.False(t, store.deleted)
+}
+
+func TestSemanticClassifierStoreSwitchKeepsActiveSameFingerprintNamespace(t *testing.T) {
+	logger := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	newStore := func(t *testing.T) vectorstore.VectorStore {
+		t.Helper()
+		store, err := vectorstore.NewVectorStore(context.Background(), &vectorstore.Config{
+			Enabled: true,
+			Type:    vectorstore.VectorStoreTypeChromem,
+			Config:  vectorstore.ChromemConfig{},
+		}, logger)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, store.Close(context.Background(), SemanticVectorStoreNamespace))
+		})
+		return store
+	}
+	firstStore := newStore(t)
+	secondStore := newStore(t)
+
+	classifier := NewSemanticClassifier(context.Background(), logger)
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+	classifier.SetEmbeddingFunc(testSemanticEmbedding)
+	classifier.SetConfiguredStore(firstStore)
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreConfigured)
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	fingerprint := semanticFingerprint(&config, semanticExemplars(&config), testSemanticDimension)
+	namespace := semanticGenerationNamespace(fingerprint)
+	markerID := semanticMarkerID(fingerprint)
+	classifier.SetConfiguredStore(secondStore)
+	require.Eventually(t, func() bool {
+		classifier.mu.Lock()
+		defer classifier.mu.Unlock()
+		return classifier.status.State == SemanticStatusReady && classifier.active != nil && classifier.active.store == secondStore
+	}, time.Second, 10*time.Millisecond)
+
+	_, err := firstStore.GetChunks(context.Background(), namespace, []string{markerID})
+	require.ErrorIs(t, err, vectorstore.ErrNotFound, "retired namespace must be deleted from its own local store")
+	markers, err := secondStore.GetChunks(context.Background(), namespace, []string{markerID})
+	require.NoError(t, err)
+	require.Len(t, markers, 1, "same-fingerprint activation must not delete the namespace in the new store")
 }
 
 func TestSemanticClassifierReusesEmbeddedNamespaceForScalarOnlyChange(t *testing.T) {
@@ -735,6 +857,19 @@ type semanticLifecycleProbeStore struct {
 	markerIDs         []string
 }
 
+// semanticExternalProbeStore wraps a local test backend so the classifier sees
+// the same opaque interface shape as a shared external store, while reads still
+// reach the backing store and destructive calls remain observable.
+type semanticExternalProbeStore struct {
+	vectorstore.VectorStore
+	deleted bool
+}
+
+func (s *semanticExternalProbeStore) DeleteNamespace(ctx context.Context, namespace string) error {
+	s.deleted = true
+	return s.VectorStore.DeleteNamespace(ctx, namespace)
+}
+
 // GetChunks rejects read-before-create and otherwise returns a missing marker.
 func (s *semanticLifecycleProbeStore) GetChunks(_ context.Context, _ string, ids []string) ([]vectorstore.SearchResult, error) {
 	s.createdBeforeRead = s.created
@@ -801,6 +936,46 @@ func makeSemanticTestPhrases(prefix string, count int) []string {
 		phrases[index] = fmt.Sprintf("%s exemplar %d", prefix, index)
 	}
 	return phrases
+}
+
+type categorizedSemanticWarmupError struct {
+	reason SemanticFailureReason
+}
+
+func (e categorizedSemanticWarmupError) Error() string {
+	return "raw provider detail must stay in logs"
+}
+
+func (e categorizedSemanticWarmupError) SemanticFailureReason() SemanticFailureReason {
+	return e.reason
+}
+
+func TestSemanticWarmupFailureStatusIsSafeAndActionable(t *testing.T) {
+	tests := []struct {
+		reason SemanticFailureReason
+		want   string
+	}{
+		{reason: SemanticFailureAuthentication, want: "Update its API key"},
+		{reason: SemanticFailureModelUnavailable, want: "supported embedding model"},
+		{reason: SemanticFailureRateLimited, want: "Wait for capacity"},
+		{reason: SemanticFailureTimeout, want: "Check provider availability"},
+		{reason: SemanticFailureProviderUnavailable, want: "configuration or API key"},
+		{reason: SemanticFailureVectorStoreUnavailable, want: "connectivity and configuration"},
+		{reason: SemanticFailureInvalidResponse, want: "supports embeddings"},
+		{reason: SemanticFailureUnknown, want: "Review the embedding provider"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.reason), func(t *testing.T) {
+			err := fmt.Errorf("warmup wrapper: %w", categorizedSemanticWarmupError{reason: tt.reason})
+			reason := semanticWarmupFailureReason(err)
+			message := semanticWarmupFailureMessage(reason)
+			require.Equal(t, tt.reason, reason)
+			require.Contains(t, message, tt.want)
+			require.NotContains(t, message, "raw provider detail")
+			require.NotContains(t, message, "server logs")
+		})
+	}
 }
 
 // TestSemanticClassifierRearmsForProviderOnlyWhenFailed pins the recovery path

--- a/plugins/routing/complexityrouting.go
+++ b/plugins/routing/complexityrouting.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/maximhq/bifrost/core/schemas"
-	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/plugins/routing/complexity"
 )
 
@@ -26,7 +25,7 @@ type complexityProposal struct {
 func (p *RoutingPlugin) computeComplexity(
 	ctx *schemas.BifrostContext,
 	req *schemas.BifrostRequest,
-	virtualKey *configstoreTables.TableVirtualKey,
+	virtualKeyID string,
 ) *complexity.ComplexityResult {
 	input, disposition := complexity.BuildInputWithDisposition(ctx, req)
 	sessionID, hasSessionID := complexity.ResolveComplexitySessionID(ctx)
@@ -34,7 +33,7 @@ func (p *RoutingPlugin) computeComplexity(
 
 	if disposition != complexity.InputClassifiable {
 		if sessionActive && disposition == complexity.InputContinuation {
-			key := buildComplexitySessionKey(ctx, virtualKey, sessionID)
+			key := buildComplexitySessionKey(ctx, virtualKeyID, sessionID)
 			tier, found, err := p.sessionStore.load(key, true)
 			if err != nil {
 				p.logComplexitySessionStoreError("refresh continuation", err)
@@ -65,7 +64,7 @@ func (p *RoutingPlugin) computeComplexity(
 		return proposal.Result
 	}
 
-	key := buildComplexitySessionKey(ctx, virtualKey, sessionID)
+	key := buildComplexitySessionKey(ctx, virtualKeyID, sessionID)
 	priorTier, priorFound, loadErr := p.sessionStore.load(key, false)
 	if loadErr != nil {
 		p.logComplexitySessionStoreError("inspect", loadErr)

--- a/plugins/routing/complexitysession.go
+++ b/plugins/routing/complexitysession.go
@@ -10,7 +10,6 @@ import (
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
-	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/plugins/routing/complexity"
 )
@@ -149,13 +148,9 @@ func decodeStoredComplexityTier(value any) (string, error) {
 // key has bounded size and reveals no caller-provided identifier.
 func buildComplexitySessionKey(
 	ctx *schemas.BifrostContext,
-	virtualKey *configstoreTables.TableVirtualKey,
+	virtualKeyID string,
 	sessionID string,
 ) string {
-	virtualKeyID := ""
-	if virtualKey != nil {
-		virtualKeyID = virtualKey.ID
-	}
 	userID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyUserID)
 	scopeKind := "deployment"
 	switch {

--- a/plugins/routing/complexitysession_test.go
+++ b/plugins/routing/complexitysession_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
-	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/plugins/routing/complexity"
 	"github.com/maximhq/bifrost/plugins/routing/rules"
@@ -177,17 +176,17 @@ func TestBuildComplexitySessionKeyScopesAndHidesIdentity(t *testing.T) {
 	ctx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
 	sessionID := "caller-session-secret"
 
-	base := buildComplexitySessionKey(ctx, &configstoreTables.TableVirtualKey{ID: "vk-1"}, sessionID)
+	base := buildComplexitySessionKey(ctx, "vk-1", sessionID)
 	require.True(t, strings.HasPrefix(base, complexitySessionKeyPrefix))
 	require.NotContains(t, base, sessionID)
 	require.NotContains(t, base, "user-1")
 	require.NotContains(t, base, "vk-1")
-	require.Equal(t, base, buildComplexitySessionKey(ctx, &configstoreTables.TableVirtualKey{ID: "vk-1"}, sessionID))
+	require.Equal(t, base, buildComplexitySessionKey(ctx, "vk-1", sessionID))
 
-	require.NotEqual(t, base, buildComplexitySessionKey(ctx, &configstoreTables.TableVirtualKey{ID: "vk-2"}, sessionID))
+	require.NotEqual(t, base, buildComplexitySessionKey(ctx, "vk-2", sessionID))
 	ctx.SetValue(schemas.BifrostContextKeyUserID, "user-2")
-	require.NotEqual(t, base, buildComplexitySessionKey(ctx, &configstoreTables.TableVirtualKey{ID: "vk-1"}, sessionID))
-	require.NotEqual(t, base, buildComplexitySessionKey(ctx, &configstoreTables.TableVirtualKey{ID: "vk-1"}, "another-session"))
+	require.NotEqual(t, base, buildComplexitySessionKey(ctx, "vk-1", sessionID))
+	require.NotEqual(t, base, buildComplexitySessionKey(ctx, "vk-1", "another-session"))
 }
 
 func TestPublishLocalSessionFallbackPreservesProposalEvidence(t *testing.T) {

--- a/plugins/routing/embedding.go
+++ b/plugins/routing/embedding.go
@@ -27,6 +27,48 @@ var ErrEmbeddingRequestExecutorNotConfigured = errors.New("embedding request exe
 // budget it was given, while every other failure says it is not working at all.
 var ErrEmbeddingTimeout = errors.New("embedding request timed out")
 
+// semanticEmbeddingFailure preserves the detailed internal error for logs while
+// exposing only a bounded failure category to the semantic status endpoint.
+type semanticEmbeddingFailure struct {
+	reason complexity.SemanticFailureReason
+	detail string
+	cause  error
+}
+
+func (e *semanticEmbeddingFailure) Error() string {
+	return e.detail
+}
+
+func (e *semanticEmbeddingFailure) Unwrap() error {
+	return e.cause
+}
+
+func (e *semanticEmbeddingFailure) SemanticFailureReason() complexity.SemanticFailureReason {
+	return e.reason
+}
+
+func newSemanticEmbeddingFailure(reason complexity.SemanticFailureReason, detail string, cause error) error {
+	return &semanticEmbeddingFailure{reason: reason, detail: detail, cause: cause}
+}
+
+func embeddingProviderFailureReason(bifrostErr *schemas.BifrostError) complexity.SemanticFailureReason {
+	if bifrostErr == nil || bifrostErr.StatusCode == nil {
+		return complexity.SemanticFailureProviderUnavailable
+	}
+	switch statusCode := *bifrostErr.StatusCode; {
+	case statusCode == 401 || statusCode == 403:
+		return complexity.SemanticFailureAuthentication
+	case statusCode == 400 || statusCode == 404 || statusCode == 405 || statusCode == 422:
+		return complexity.SemanticFailureModelUnavailable
+	case statusCode == 408 || statusCode == 504:
+		return complexity.SemanticFailureTimeout
+	case statusCode == 429:
+		return complexity.SemanticFailureRateLimited
+	default:
+		return complexity.SemanticFailureProviderUnavailable
+	}
+}
+
 // EmbeddingRequestExecutor invokes the embedding endpoint on the bifrost
 // client. The plugin calls it to embed request text for semantic complexity
 // classification. It mirrors the signature of bifrost.Client.EmbeddingRequest.
@@ -373,12 +415,10 @@ func (p *RoutingPlugin) generateEmbeddings(ctx *schemas.BifrostContext, semantic
 	// and may dereference fields on a parent context that has already been
 	// released back to its sync.Pool — see core/schemas.ReleasePluginScope.
 	defer embeddingCtx.Cancel()
-	// The embedding request targets the configured embedding provider/model,
-	// not the caller's. Mark it as an internal sub-request: it skips the
-	// plugin pipeline (so it cannot recurse back through governance) and
-	// sheds the caller's key-routing and body-transport state so it behaves
-	// like a fresh external /v1/embeddings call.
-	bifrost.PrepareContextForInternalRequest(embeddingCtx)
+	// The embedding request is an internal sub-request and must not capture its
+	// raw vector payloads, even when the configured provider captures external
+	// request/response bodies.
+	bifrost.PrepareContextForInternalEmbeddingRequest(embeddingCtx)
 
 	response, bifrostErr := executor(embeddingCtx, embeddingReq)
 	if bifrostErr != nil {
@@ -387,15 +427,27 @@ func (p *RoutingPlugin) generateEmbeddings(ctx *schemas.BifrostContext, semantic
 		// provider once the error is rendered into a string. Tag it here, at the
 		// only layer that knows which deadline was set and why.
 		if isEmbeddingTimeout(embeddingCtx, bifrostErr) {
-			return nil, 0, fmt.Errorf("%w after %s", ErrEmbeddingTimeout, timeout)
+			return nil, 0, newSemanticEmbeddingFailure(
+				complexity.SemanticFailureTimeout,
+				fmt.Sprintf("%s after %s", ErrEmbeddingTimeout, timeout),
+				ErrEmbeddingTimeout,
+			)
 		}
-		return nil, 0, fmt.Errorf("failed to generate embedding: %v", bifrostErr)
+		return nil, 0, newSemanticEmbeddingFailure(
+			embeddingProviderFailureReason(bifrostErr),
+			fmt.Sprintf("failed to generate embedding: %v", bifrostErr),
+			nil,
+		)
 	}
 
 	// A nil response means nothing arrived to read usage from, so it keeps the
 	// zero-token contract every pre-response failure above shares.
 	if response == nil {
-		return nil, 0, fmt.Errorf("no embeddings returned from provider")
+		return nil, 0, newSemanticEmbeddingFailure(
+			complexity.SemanticFailureInvalidResponse,
+			"no embeddings returned from provider",
+			nil,
+		)
 	}
 	inputTokens := 0
 	// Provider-reported usage is untrusted input: a negative count would flow
@@ -411,7 +463,11 @@ func (p *RoutingPlugin) generateEmbeddings(ctx *schemas.BifrostContext, semantic
 	// left an empty-Data response as the one post-response failure whose tokens
 	// went unobserved and unbilled.
 	if len(response.Data) == 0 {
-		return nil, inputTokens, fmt.Errorf("no embeddings returned from provider")
+		return nil, inputTokens, newSemanticEmbeddingFailure(
+			complexity.SemanticFailureInvalidResponse,
+			"no embeddings returned from provider",
+			nil,
+		)
 	}
 
 	if len(response.Data) != len(texts) {
@@ -423,7 +479,11 @@ func (p *RoutingPlugin) generateEmbeddings(ctx *schemas.BifrostContext, semantic
 				len(texts),
 			)
 		}
-		return nil, inputTokens, fmt.Errorf("provider returned %d vectors for one input", len(response.Data))
+		return nil, inputTokens, newSemanticEmbeddingFailure(
+			complexity.SemanticFailureInvalidResponse,
+			fmt.Sprintf("provider returned %d vectors for one input", len(response.Data)),
+			nil,
+		)
 	}
 
 	embeddings := make([][]float32, len(texts))
@@ -445,7 +505,11 @@ func (p *RoutingPlugin) generateEmbeddings(ctx *schemas.BifrostContext, semantic
 
 		embedding, err := decodeEmbedding(data.Embedding)
 		if err != nil {
-			return nil, inputTokens, fmt.Errorf("decode embedding %d: %w", inputIndex, err)
+			return nil, inputTokens, newSemanticEmbeddingFailure(
+				complexity.SemanticFailureInvalidResponse,
+				fmt.Sprintf("decode embedding %d: %v", inputIndex, err),
+				err,
+			)
 		}
 		embeddings[inputIndex] = embedding
 		seen[inputIndex] = true

--- a/plugins/routing/embedding_test.go
+++ b/plugins/routing/embedding_test.go
@@ -20,6 +20,32 @@ func testEmbeddingSemanticConfig() *complexity.SemanticConfig {
 	}
 }
 
+func TestValidateComplexityAnalyzerConfigRequiresSemanticClassifier(t *testing.T) {
+	plugin := &RoutingPlugin{}
+	config := complexity.DefaultAnalyzerConfig()
+	config.Semantic = testEmbeddingSemanticConfig()
+
+	require.EqualError(t, plugin.ValidateComplexityAnalyzerConfig(&config), "semantic complexity classifier is unavailable")
+
+	config.Semantic = nil
+	require.NoError(t, plugin.ValidateComplexityAnalyzerConfig(&config))
+}
+
+func TestValidateComplexityAnalyzerConfigRequiresEmbeddingExecutor(t *testing.T) {
+	plugin := &RoutingPlugin{
+		semanticClassifier: complexity.NewSemanticClassifier(t.Context(), nil),
+	}
+	config := complexity.DefaultAnalyzerConfig()
+	config.Semantic = testEmbeddingSemanticConfig()
+
+	require.EqualError(t, plugin.ValidateComplexityAnalyzerConfig(&config), "semantic complexity embedding executor is unavailable")
+
+	plugin.SetEmbeddingRequestExecutor(func(_ *schemas.BifrostContext, _ *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+		return nil, nil
+	})
+	require.NoError(t, plugin.ValidateComplexityAnalyzerConfig(&config))
+}
+
 func embeddingResponse(data schemas.EmbeddingStruct, totalTokens int) *schemas.BifrostEmbeddingResponse {
 	return &schemas.BifrostEmbeddingResponse{
 		Data:  []schemas.EmbeddingData{{Embedding: data}},
@@ -214,6 +240,29 @@ func TestGenerateEmbeddingDistinguishesTimeoutFromOtherFailures(t *testing.T) {
 			assert.Equal(t, tt.wantTimeout, errors.Is(err, ErrEmbeddingTimeout))
 		})
 	}
+}
+
+func TestEmbeddingProviderFailureReasonUsesStatusCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       complexity.SemanticFailureReason
+	}{
+		{name: "unauthorized", statusCode: 401, want: complexity.SemanticFailureAuthentication},
+		{name: "forbidden", statusCode: 403, want: complexity.SemanticFailureAuthentication},
+		{name: "not found", statusCode: 404, want: complexity.SemanticFailureModelUnavailable},
+		{name: "rate limited", statusCode: 429, want: complexity.SemanticFailureRateLimited},
+		{name: "gateway timeout", statusCode: 504, want: complexity.SemanticFailureTimeout},
+		{name: "provider error", statusCode: 500, want: complexity.SemanticFailureProviderUnavailable},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bifrostErr := &schemas.BifrostError{StatusCode: schemas.Ptr(tt.statusCode)}
+			require.Equal(t, tt.want, embeddingProviderFailureReason(bifrostErr))
+		})
+	}
+	require.Equal(t, complexity.SemanticFailureProviderUnavailable, embeddingProviderFailureReason(&schemas.BifrostError{}))
 }
 
 // TestWarmupEmbedsDoNotInheritTheRequestTimeout is a regression guard: warmup

--- a/plugins/routing/go.mod
+++ b/plugins/routing/go.mod
@@ -5,6 +5,7 @@ go 1.27.0
 require (
 	github.com/blevesearch/go-porterstemmer v1.0.3
 	github.com/google/cel-go v0.30.0
+	github.com/google/uuid v1.6.0
 	github.com/maximhq/bifrost/core v1.8.3
 	github.com/maximhq/bifrost/framework v1.6.0
 	github.com/maximhq/bifrost/plugins/governance v1.7.0
@@ -94,7 +95,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/hashicorp/go-version v1.8.0 // indirect

--- a/plugins/routing/main.go
+++ b/plugins/routing/main.go
@@ -238,11 +238,16 @@ func (p *RoutingPlugin) RearmComplexitySemanticClassifier(provider schemas.Model
 // ValidateComplexityAnalyzerConfig runs the semantic classifier's own
 // validation before a handler persists a complexity configuration.
 //
-// This is schema validation only. It is routed through the classifier rather
-// than calling complexity.ValidateAndNormalize directly so that a future
-// setting whose validity depends on live process state has a seam to hook
-// into; no semantic setting needs one today.
+// Semantic configuration also requires the runtime classifier and embedding
+// executor that will apply it. Keyword-only configuration remains valid without
+// either dependency.
 func (p *RoutingPlugin) ValidateComplexityAnalyzerConfig(config *complexity.AnalyzerConfig) error {
+	if config != nil && config.Semantic != nil && p.semanticClassifier == nil {
+		return fmt.Errorf("semantic complexity classifier is unavailable")
+	}
+	if config != nil && config.Semantic != nil && p.embeddingExecutor() == nil {
+		return fmt.Errorf("semantic complexity embedding executor is unavailable")
+	}
 	if p.semanticClassifier != nil {
 		if err := p.semanticClassifier.ValidateConfig(config); err != nil {
 			return err
@@ -378,7 +383,7 @@ func (p *RoutingPlugin) applyRoutingRules(ctx *schemas.BifrostContext, req *sche
 	var computeComplexity func() *complexity.ComplexityResult
 	if p.complexityAnalyzer.Load() != nil {
 		computeComplexity = func() *complexity.ComplexityResult {
-			return p.computeComplexity(ctx, req, virtualKey)
+			return p.computeComplexity(ctx, req, scope.VirtualKeyID)
 		}
 	}
 

--- a/plugins/semanticcache/plugin_paths_test.go
+++ b/plugins/semanticcache/plugin_paths_test.go
@@ -645,6 +645,7 @@ func TestGenerateEmbedding_ClearsInheritedKeyRoutingState(t *testing.T) {
 	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, true)
 	ctx.SetValue(schemas.BifrostContextKeySendBackRawRequest, true)
 	ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+	ctx.SetValue(schemas.BifrostContextKeyStoreRawRequestResponse, true)
 	ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, true)
 	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMode, true)
 	ctx.SetValue(schemas.BifrostContextKeyLargeResponseMode, true)
@@ -674,8 +675,6 @@ func TestGenerateEmbedding_ClearsInheritedKeyRoutingState(t *testing.T) {
 		schemas.BifrostContextKeyDirectKey,
 		schemas.BifrostContextKeySkipKeySelection,
 		schemas.BifrostContextKeyUseRawRequestBody,
-		schemas.BifrostContextKeySendBackRawRequest,
-		schemas.BifrostContextKeySendBackRawResponse,
 		schemas.BifrostContextKeyPassthroughOverridesPresent,
 		schemas.BifrostContextKeyLargePayloadMode,
 		schemas.BifrostContextKeyLargeResponseMode,
@@ -684,6 +683,18 @@ func TestGenerateEmbedding_ClearsInheritedKeyRoutingState(t *testing.T) {
 	} {
 		if v := captured.Value(key); v != nil {
 			t.Fatalf("expected %q cleared on internal embedding context, got %v", key, v)
+		}
+	}
+
+	// Raw capture is deliberately false, rather than absent: these values
+	// override provider-level raw-capture configuration for internal embeddings.
+	for _, key := range []schemas.BifrostContextKey{
+		schemas.BifrostContextKeySendBackRawRequest,
+		schemas.BifrostContextKeySendBackRawResponse,
+		schemas.BifrostContextKeyStoreRawRequestResponse,
+	} {
+		if enabled, _ := captured.Value(key).(bool); enabled {
+			t.Fatalf("expected %q disabled on internal embedding context", key)
 		}
 	}
 

--- a/plugins/semanticcache/search.go
+++ b/plugins/semanticcache/search.go
@@ -152,13 +152,10 @@ func (plugin *Plugin) generateEmbedding(ctx *schemas.BifrostContext, text string
 	// and may dereference fields on a parent context that has already been
 	// released back to its sync.Pool — see core/schemas.ReleasePluginScope.
 	defer embeddingCtx.Cancel()
-	embeddingCtx.SetValue(schemas.BifrostContextKeySkipPluginPipeline, true)
 	// The embedding request targets the plugin's own configured embedding
-	// provider/model, not the caller's — and because it skips the plugin
-	// pipeline, routing state is never re-resolved for it. Shed the caller's
-	// key-routing and body-transport state so the request behaves like a
-	// fresh external /v1/embeddings call.
-	bifrost.ClearContextForInternalRequest(embeddingCtx)
+	// provider/model. It must skip the plugin pipeline and raw payload capture
+	// because the embedding response is an internal implementation detail.
+	bifrost.PrepareContextForInternalEmbeddingRequest(embeddingCtx)
 	if plugin.embeddingRequestExecutor == nil {
 		return nil, 0, fmt.Errorf("embedding request executor is not configured")
 	}

--- a/transports/bifrost-http/handlers/routing_test.go
+++ b/transports/bifrost-http/handlers/routing_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -198,6 +199,17 @@ func TestComplexityAnalyzerConfigPutRejectsInvalidPayloads(t *testing.T) {
 	invalidBoundaries.TierBoundaries.MediumComplex = invalidBoundaries.TierBoundaries.SimpleMedium
 	emptyKeywords := valid
 	emptyKeywords.Keywords.MediumKeywords = nil
+	tooManyPhrases := valid
+	tooManyPhrases.Semantic = &complexity.SemanticConfig{
+		Provider:       "openai",
+		EmbeddingModel: "text-embedding-3-small",
+	}
+	tooManyPhrases.Keywords.SimpleKeywords = make([]string, configstore.MaxComplexitySemanticPhrases-1)
+	for index := range tooManyPhrases.Keywords.SimpleKeywords {
+		tooManyPhrases.Keywords.SimpleKeywords[index] = fmt.Sprintf("simple-%d", index)
+	}
+	tooManyPhrases.Keywords.MediumKeywords = []string{"medium"}
+	tooManyPhrases.Keywords.ComplexKeywords = []string{"complex"}
 
 	tests := []struct {
 		name string
@@ -208,6 +220,7 @@ func TestComplexityAnalyzerConfigPutRejectsInvalidPayloads(t *testing.T) {
 		{name: "multiple json values", body: validBody + `{}`, want: "multiple JSON values"},
 		{name: "invalid boundaries", body: testComplexityAnalyzerPayload(t, invalidBoundaries), want: "tier boundaries"},
 		{name: "empty keywords", body: testComplexityAnalyzerPayload(t, emptyKeywords), want: "keyword lists must be non-empty"},
+		{name: "too many semantic phrases", body: testComplexityAnalyzerPayload(t, tooManyPhrases), want: "contains 751 phrases"},
 	}
 
 	for _, tt := range tests {

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -2190,6 +2190,49 @@ func TestMergeGovernanceConfig_MergesComplexityKeywordsWhenSectionHashesChange(t
 	require.Equal(t, fileHashes, stored.ConfigHashes)
 }
 
+func TestMergeGovernanceConfig_RejectsComplexityKeywordMergeOverSemanticLimit(t *testing.T) {
+	initTestLogger()
+
+	store := NewMockConfigStore()
+	dbConfig := testRuntimeComplexityAnalyzerConfig()
+	dbConfig.Semantic = &configstore.ComplexitySemanticConfig{
+		Provider:       "openai",
+		EmbeddingModel: "text-embedding-3-small",
+	}
+	dbConfig.Keywords.SimpleKeywords = make([]string, 400)
+	for index := range dbConfig.Keywords.SimpleKeywords {
+		dbConfig.Keywords.SimpleKeywords[index] = fmt.Sprintf("db-simple-%d", index)
+	}
+	dbGovernance := &configstore.GovernanceConfig{ComplexityAnalyzerConfig: dbConfig}
+	store.governanceConfig = dbGovernance
+	config := &Config{
+		ConfigStore:      store,
+		GovernanceConfig: dbGovernance,
+	}
+
+	fileConfig := testFileComplexityAnalyzerConfig()
+	fileConfig.Semantic = &configstore.ComplexitySemanticConfig{
+		Provider:       "openai",
+		EmbeddingModel: "text-embedding-3-small",
+	}
+	fileConfig.Keywords.SimpleKeywords = make([]string, 400)
+	for index := range fileConfig.Keywords.SimpleKeywords {
+		fileConfig.Keywords.SimpleKeywords[index] = fmt.Sprintf("file-simple-%d", index)
+	}
+	configData := &ConfigData{
+		Governance: &configstore.GovernanceConfig{
+			ComplexityAnalyzerConfig: fileConfig,
+		},
+	}
+
+	mergeGovernanceConfig(context.Background(), config, configData, dbGovernance)
+
+	stored, err := store.GetComplexityAnalyzerConfig(context.Background())
+	require.NoError(t, err)
+	require.Same(t, dbConfig, stored, "an over-limit additive merge must leave the stored runtime config unchanged")
+	require.Len(t, stored.Keywords.SimpleKeywords, 400)
+}
+
 func TestMergeGovernanceConfig_OnlyChangedComplexitySectionsApply(t *testing.T) {
 	initTestLogger()
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3875,7 +3875,7 @@
     },
     "complexity_analyzer_keywords": {
       "type": "object",
-      "description": "User-editable keyword scoring signals. The legacy four-list shape remains accepted for config.json compatibility.",
+      "description": "User-editable keyword scoring signals. The legacy four-list shape remains accepted for config.json compatibility. When the semantic block is present, the three normalized tier lists may contain at most 750 phrases combined; additive config.json merges are checked against that combined limit.",
       "oneOf": [
         {
           "title": "Three-tier complexity keywords",

--- a/ui/app/workspace/complexity-router/formSchema.test.ts
+++ b/ui/app/workspace/complexity-router/formSchema.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "vitest";
+import { analyzerConfigSchema, countCanonicalSemanticPhrases, DEFAULT_FORM_VALUES } from "./formSchema";
+
+function phraseList(prefix: string, count: number): string[] {
+	return Array.from({ length: count }, (_, index) => `${prefix}-${index}`);
+}
+
+function formValues(simpleCount: number, semantic: boolean) {
+	return {
+		...DEFAULT_FORM_VALUES,
+		keywords: {
+			simple_keywords: phraseList("simple", simpleCount),
+			medium_keywords: ["medium"],
+			complex_keywords: ["complex"],
+		},
+		semantic: semantic
+			? { ...DEFAULT_FORM_VALUES.semantic, provider: "openai", embedding_model: "text-embedding-3-small" }
+			: { ...DEFAULT_FORM_VALUES.semantic },
+	};
+}
+
+describe("semantic complexity phrase limit", () => {
+	test("accepts exactly 750 canonical phrases", () => {
+		expect(analyzerConfigSchema.safeParse(formValues(748, true)).success).toBe(true);
+	});
+
+	test("rejects 751 canonical phrases with tier counts", () => {
+		const result = analyzerConfigSchema.safeParse(formValues(749, true));
+		expect(result.success).toBe(false);
+		if (result.success) return;
+		expect(result.error.issues.some((issue) => issue.message.includes("751 phrases (Simple=749, Medium=1, Complex=1)"))).toBe(true);
+	});
+
+	test("does not count blanks and same-tier duplicates twice", () => {
+		const values = formValues(748, true);
+		values.keywords.simple_keywords.push(" SIMPLE-0 ", "");
+		expect(countCanonicalSemanticPhrases(values.keywords).total).toBe(750);
+		expect(analyzerConfigSchema.safeParse(values).success).toBe(true);
+	});
+
+	test("does not cap a form that will omit the semantic block", () => {
+		expect(analyzerConfigSchema.safeParse(formValues(750, false)).success).toBe(true);
+	});
+});

--- a/ui/app/workspace/complexity-router/formSchema.ts
+++ b/ui/app/workspace/complexity-router/formSchema.ts
@@ -7,6 +7,7 @@ import {
 	MAX_LLM_MESSAGE_HISTORY,
 	MAX_SEMANTIC_MESSAGE_HISTORY,
 	MAX_SEMANTIC_PHRASE_CHARACTERS,
+	MAX_SEMANTIC_PHRASES,
 	MAX_SEMANTIC_TIMEOUT_MS,
 	MIN_LLM_MESSAGE_HISTORY,
 	MIN_SEMANTIC_MESSAGE_HISTORY,
@@ -18,6 +19,14 @@ import { z } from "zod";
 // Form-owned duration values are always a single unit (the controls append
 // "ms"), so a plain positive-duration check is enough.
 const positiveDurationPattern = /^[0-9]*\.?[0-9]+(ns|us|µs|ms|s|m|h)$/;
+
+export function countCanonicalSemanticPhrases(keywords: Record<KeywordListKey, string[]>) {
+	const count = (phrases: string[]) => new Set(phrases.map((phrase) => phrase.trim().toLowerCase()).filter(Boolean)).size;
+	const simple = count(keywords.simple_keywords);
+	const medium = count(keywords.medium_keywords);
+	const complex = count(keywords.complex_keywords);
+	return { simple, medium, complex, total: simple + medium + complex };
+}
 
 export function isPositiveDurationString(value: string | undefined): boolean {
 	if (!value) return false;
@@ -165,6 +174,17 @@ export const analyzerConfigSchema = z
 				} else if (!firstTier) {
 					seen.set(normalized, label);
 				}
+			}
+		}
+
+		if (hasProvider && hasModel) {
+			const counts = countCanonicalSemanticPhrases(data.keywords);
+			if (counts.total > MAX_SEMANTIC_PHRASES) {
+				ctx.addIssue({
+					code: "custom",
+					message: `Semantic routing has ${counts.total} phrases (Simple=${counts.simple}, Medium=${counts.medium}, Complex=${counts.complex}); the maximum is ${MAX_SEMANTIC_PHRASES} across all tiers.`,
+					path: ["keywords"],
+				});
 			}
 		}
 	});

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -25,7 +25,12 @@ import {
 	useResetComplexityAnalyzerConfigMutation,
 	useUpdateComplexityAnalyzerConfigMutation,
 } from "@/lib/store/apis/governanceApi";
-import { KeywordListKey, MAX_LLM_PROMPT_CHARACTERS, TIER_PHRASE_LIST_DEFINITIONS } from "@/lib/types/complexityRouter";
+import {
+	KeywordListKey,
+	MAX_LLM_PROMPT_CHARACTERS,
+	MAX_SEMANTIC_PHRASES,
+	TIER_PHRASE_LIST_DEFINITIONS,
+} from "@/lib/types/complexityRouter";
 import { ModelProvider } from "@/lib/types/config";
 import { DBKey } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
@@ -35,7 +40,14 @@ import { ExternalLink, Info, LoaderCircle, RotateCcw, Save, Settings2, TriangleA
 import { useEffect, useMemo, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { AnalyzerFormValues, analyzerConfigSchema, DEFAULT_FORM_VALUES, toAnalyzerPayload, toFormValues } from "./formSchema";
+import {
+	AnalyzerFormValues,
+	analyzerConfigSchema,
+	countCanonicalSemanticPhrases,
+	DEFAULT_FORM_VALUES,
+	toAnalyzerPayload,
+	toFormValues,
+} from "./formSchema";
 import { ClassifierStatusBadge } from "./views/classifierStatusBadge";
 import EmbeddingConfigSheet from "./views/embeddingConfigSheet";
 import { FieldLabel, SectionHeading } from "./views/formPrimitives";
@@ -74,16 +86,16 @@ const supportsChat = (provider: ModelProvider): boolean => {
 	return true;
 };
 
-// The three tier lists sit side by side, so they collapse to a fixed height
-// rather than to a fixed number of phrases: phrases wrap to different numbers of
-// lines, and equal counts would leave the columns visibly uneven.
+// The three tier lists sit side by side, so each is a fixed-height scroll
+// container rather than a fixed number of phrases: phrases wrap to different
+// numbers of lines, and equal counts would leave the columns visibly uneven.
 //
 // This only evens out the lists themselves. The header above them varies too --
 // a tier description that wraps to two lines pushes its list down by a line
-// while its neighbours stay put -- so the card is a flex column whose
-// description grows to absorb the difference, bottom-aligning all three lists
-// at any column width.
-const PHRASE_LIST_COLLAPSED_HEIGHT = 260;
+// while its neighbours stay put -- so the cards stretch to the grid row and each
+// is a flex column whose description grows to absorb the difference,
+// bottom-aligning all three lists at any column width.
+const PHRASE_LIST_HEIGHT = 300;
 
 function testIdPart(value: string) {
 	return value.replace(/_/g, "-");
@@ -168,7 +180,13 @@ export default function ComplexityRouterPage() {
 	// save: the endpoint carries llm_default_prompt, which seeds the prompt field
 	// and powers "Reset to default" — gating on the saved config alone left a
 	// newly enabled fallback with no default prompt until after the first save.
-	const { data: semanticStatus, isLoading: statusLoading } = useGetComplexitySemanticStatusQuery(undefined, {
+	const {
+		data: semanticStatus,
+		isLoading: statusLoading,
+		isFetching: statusFetching,
+		isError: statusIsError,
+		refetch: refetchStatus,
+	} = useGetComplexitySemanticStatusQuery(undefined, {
 		skip: !data?.semantic && !data?.llm && !isLLMFallbackEnabled,
 		pollingInterval: statusPollInterval,
 	});
@@ -184,9 +202,11 @@ export default function ComplexityRouterPage() {
 
 	const totalPhrases = useMemo(
 		() =>
-			(liveKeywords?.simple_keywords?.length ?? 0) +
-			(liveKeywords?.medium_keywords?.length ?? 0) +
-			(liveKeywords?.complex_keywords?.length ?? 0),
+			countCanonicalSemanticPhrases({
+				simple_keywords: liveKeywords?.simple_keywords ?? [],
+				medium_keywords: liveKeywords?.medium_keywords ?? [],
+				complex_keywords: liveKeywords?.complex_keywords ?? [],
+			}).total,
 		[liveKeywords],
 	);
 
@@ -296,7 +316,7 @@ export default function ComplexityRouterPage() {
 				toast.success("Reset to defaults", { position: "top-right" });
 			})
 			.catch((err) => {
-				setSubmitError(getErrorMessage(err));
+				setSubmitError(`Couldn’t restore the default phrases. ${getErrorMessage(err)}`);
 			});
 	};
 
@@ -326,7 +346,7 @@ export default function ComplexityRouterPage() {
 				toast.success("Configuration saved", { position: "top-right" });
 			})
 			.catch((err) => {
-				setSubmitError(getErrorMessage(err));
+				setSubmitError(`Couldn’t save the Complexity Router configuration. ${getErrorMessage(err)}`);
 			});
 	};
 
@@ -350,7 +370,8 @@ export default function ComplexityRouterPage() {
 	if (error && !data) {
 		return (
 			<div className="mx-auto w-full max-w-7xl space-y-4 px-4 pt-6 sm:px-6 sm:pt-8 lg:px-14">
-				<p className="text-destructive font-mono text-sm">{getErrorMessage(error)}</p>
+				<p className="text-sm font-medium">Couldn’t load the Complexity Router configuration.</p>
+				<p className="text-muted-foreground text-sm">{getErrorMessage(error)}</p>
 				<Button data-testid="complexity-router-fetch-retry-button" type="button" variant="outline" size="sm" onClick={() => refetch()}>
 					Retry
 				</Button>
@@ -438,7 +459,11 @@ export default function ComplexityRouterPage() {
 									isNotSaved={isClassifierConfigured && !data.semantic}
 									hasUnsavedChanges={willReembed}
 									hasEmbeddingProviders={embeddingProviders.length > 0}
+									statusUnavailable={statusIsError && !semanticStatus}
+									statusRefreshFailed={statusIsError && Boolean(semanticStatus)}
+									isRetryingStatus={statusFetching}
 									onConfigure={() => setEmbeddingSheetOpen(true)}
+									onRetryStatus={() => void refetchStatus()}
 								/>
 								<Button
 									type="button"
@@ -478,7 +503,7 @@ export default function ComplexityRouterPage() {
 								description="A request takes the tier of its nearest phrase."
 								aside={
 									<span className="text-muted-foreground font-mono text-[11px] tabular-nums" data-testid="complexity-router-phrase-total">
-										{totalPhrases} phrases
+										{isClassifierConfigured ? `${totalPhrases} / ${MAX_SEMANTIC_PHRASES} phrases` : `${totalPhrases} phrases`}
 									</span>
 								}
 							/>
@@ -502,7 +527,7 @@ export default function ComplexityRouterPage() {
 							{/* One column per tier, side by side: the three lists are read against
 							    each other, and equal-width columns keep a phrase's tier obvious
 							    from its position. */}
-							<div className="grid gap-3 md:grid-cols-3">
+							<div className="grid items-stretch gap-3 md:grid-cols-3">
 								{TIER_PHRASE_LIST_DEFINITIONS.map(({ key, label, description }) => {
 									const fieldError = keywordErrors?.[key as KeywordListKey];
 									const errorId = `keywords-${key}-error`;
@@ -527,8 +552,8 @@ export default function ComplexityRouterPage() {
 															data-testid={`complexity-router-keywords-${testIdPart(key)}-input`}
 															value={field.value}
 															onValueChange={field.onChange}
-															collapsedMaxHeight={PHRASE_LIST_COLLAPSED_HEIGHT}
-															expandButtonTestId={`complexity-router-keywords-${testIdPart(key)}-expand-button`}
+															listHeight={PHRASE_LIST_HEIGHT}
+															submitOnComma={false}
 															placeholder="Type a reference phrase and press Enter"
 															aria-invalid={fieldError ? true : undefined}
 															aria-describedby={fieldError ? errorId : undefined}

--- a/ui/app/workspace/complexity-router/views/classifierStatusBadge.test.ts
+++ b/ui/app/workspace/complexity-router/views/classifierStatusBadge.test.ts
@@ -1,0 +1,29 @@
+import type { SemanticStatusInfo } from "@/lib/types/complexityRouter";
+import { describe, expect, it } from "vitest";
+import { semanticWarmupFailureMessage, semanticWarmupImpactMessage } from "./classifierStatusBadge.utils";
+
+const failedStatus = (overrides: Partial<SemanticStatusInfo> = {}): SemanticStatusInfo => ({
+	state: "failed",
+	loaded: 0,
+	total: 150,
+	...overrides,
+});
+
+describe("semantic warmup status copy", () => {
+	it("maps safe failure reasons to actionable guidance", () => {
+		expect(semanticWarmupFailureMessage(failedStatus({ failure_reason: "authentication" }))).toContain("Update its API key");
+		expect(semanticWarmupFailureMessage(failedStatus({ failure_reason: "rate_limited" }))).toContain("Wait for capacity");
+		expect(semanticWarmupFailureMessage(failedStatus({ failure_reason: "vector_store_unavailable" }))).toContain("vector store");
+	});
+
+	it("does not show the old check-server-logs message during a rolling upgrade", () => {
+		const message = semanticWarmupFailureMessage(failedStatus({ error: "semantic warmup failed; check server logs" }));
+		expect(message).toContain("Review the embedding provider");
+		expect(message).not.toContain("server logs");
+	});
+
+	it("distinguishes a failed replacement from having no serving classifier", () => {
+		expect(semanticWarmupImpactMessage(failedStatus({ serving_previous: true }))).toContain("previous classifier is still routing");
+		expect(semanticWarmupImpactMessage(failedStatus({ serving_previous: false }))).toContain("rules are paused");
+	});
+});

--- a/ui/app/workspace/complexity-router/views/classifierStatusBadge.tsx
+++ b/ui/app/workspace/complexity-router/views/classifierStatusBadge.tsx
@@ -5,12 +5,13 @@ import { SEMANTIC_STATUS_LABELS, SemanticStatusInfo } from "@/lib/types/complexi
 import { cn } from "@/lib/utils";
 import type { VariantProps } from "class-variance-authority";
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, CircleAlert, CircleCheck, CircleDashed, LoaderCircle } from "lucide-react";
+import { ArrowRight, CircleAlert, CircleCheck, CircleDashed, LoaderCircle, RefreshCw } from "lucide-react";
 import type { ReactNode } from "react";
+import { semanticWarmupFailureMessage, semanticWarmupImpactMessage } from "./classifierStatusBadge.utils";
 
 // The two states below are local to the form rather than reported by the
 // gateway: nothing is embedded yet, so /semantic-status has nothing to say.
-type ClassifierState = SemanticStatusInfo["state"] | "not-configured" | "not-saved" | "loading";
+type ClassifierState = SemanticStatusInfo["state"] | "not-configured" | "not-saved" | "loading" | "unavailable";
 
 // The badge names the subject as well as the state: on its own in the header,
 // a bare "Ready" would not say what is ready.
@@ -22,6 +23,7 @@ const LABELS: Record<ClassifierState, string> = {
 	"not-configured": "Classifier not configured",
 	"not-saved": "Classifier not saved",
 	loading: "Checking classifier…",
+	unavailable: "Classifier status unavailable",
 };
 
 // Every tone comes from the shared Badge variants rather than a hand-picked
@@ -36,6 +38,7 @@ const TONES: Record<ClassifierState, VariantProps<typeof badgeVariants>["variant
 	"not-configured": "default",
 	"not-saved": "default",
 	loading: "secondary",
+	unavailable: "warning",
 };
 
 function StateIcon({ state }: { state: ClassifierState }) {
@@ -43,6 +46,7 @@ function StateIcon({ state }: { state: ClassifierState }) {
 		case "ready":
 			return <CircleCheck />;
 		case "failed":
+		case "unavailable":
 			return <CircleAlert />;
 		case "warming":
 		case "loading":
@@ -64,7 +68,11 @@ export function ClassifierStatusBadge({
 	isNotSaved,
 	hasUnsavedChanges,
 	hasEmbeddingProviders,
+	statusUnavailable,
+	statusRefreshFailed,
+	isRetryingStatus,
 	onConfigure,
+	onRetryStatus,
 }: {
 	status: SemanticStatusInfo | undefined;
 	isLoading: boolean;
@@ -72,17 +80,23 @@ export function ClassifierStatusBadge({
 	isNotSaved: boolean;
 	hasUnsavedChanges: boolean;
 	hasEmbeddingProviders: boolean;
+	statusUnavailable: boolean;
+	statusRefreshFailed: boolean;
+	isRetryingStatus: boolean;
 	onConfigure: () => void;
+	onRetryStatus: () => void;
 }) {
 	const state: ClassifierState = isNotConfigured
 		? "not-configured"
 		: isNotSaved
 			? "not-saved"
-			: status
-				? status.state
-				: isLoading
-					? "loading"
-					: "disabled";
+			: statusUnavailable
+				? "unavailable"
+				: status
+					? status.state
+					: isLoading
+						? "loading"
+						: "disabled";
 
 	const summary: ReactNode = {
 		"not-configured": hasEmbeddingProviders
@@ -94,6 +108,7 @@ export function ClassifierStatusBadge({
 		ready: status ? `${status.total} reference phrase${status.total === 1 ? "" : "s"} embedded and serving.` : "Serving.",
 		failed: "Warmup failed.",
 		disabled: "Classification is off.",
+		unavailable: "Bifrost could not report whether the saved classifier is ready. Routing may still be working.",
 	}[state];
 
 	return (
@@ -115,7 +130,7 @@ export function ClassifierStatusBadge({
 			<PopoverContent align="end" className="w-80 space-y-2.5 p-3 text-xs leading-relaxed" data-testid="complexity-router-semantic-status">
 				<p className="text-muted-foreground">{summary}</p>
 
-				{status?.serving_previous && (
+				{status?.serving_previous && state === "warming" && (
 					<p className="text-amber-700 dark:text-amber-400">
 						The previous reference phrases are still serving requests while this generation prepares. Routing is unaffected.
 					</p>
@@ -127,18 +142,27 @@ export function ClassifierStatusBadge({
 					</p>
 				)}
 
-				{status?.error && (
+				{statusRefreshFailed && status && (
+					<p className="text-amber-700 dark:text-amber-400">The latest status check failed. Showing the last known classifier state.</p>
+				)}
+
+				{state === "failed" && status && (
 					<p className="text-destructive" data-testid="complexity-router-semantic-status-error">
-						{status.error}
+						{semanticWarmupFailureMessage(status)}
 					</p>
 				)}
 
-				{state === "failed" && (
-					<p className="text-destructive">
-						Until warmup succeeds, complexity tier based routing is skipped, so rules referencing{" "}
-						<code className="font-mono">complexity_tier</code> do not match. Warmup restarts on its own once the provider it uses is working
-						again.
+				{state === "failed" && status && (
+					<p className={status.serving_previous ? "text-amber-700 dark:text-amber-400" : "text-destructive"}>
+						{semanticWarmupImpactMessage(status)}
 					</p>
+				)}
+
+				{state === "unavailable" && (
+					<Button type="button" variant="outline" size="sm" className="w-full" onClick={onRetryStatus} disabled={isRetryingStatus}>
+						<RefreshCw className={cn("size-3.5", isRetryingStatus && "animate-spin")} />
+						Retry status
+					</Button>
 				)}
 
 				{/* Offering "Configure embedding" with no embedding-capable provider

--- a/ui/app/workspace/complexity-router/views/classifierStatusBadge.utils.ts
+++ b/ui/app/workspace/complexity-router/views/classifierStatusBadge.utils.ts
@@ -1,0 +1,28 @@
+import type { SemanticStatusInfo } from "@/lib/types/complexityRouter";
+
+const FAILURE_MESSAGES: Partial<Record<NonNullable<SemanticStatusInfo["failure_reason"]>, string>> = {
+	authentication: "Authentication failed for the selected embedding provider. Update its API key to restart warmup.",
+	model_unavailable: "The selected embedding model could not be used. Choose a supported embedding model and save the configuration again.",
+	rate_limited: "The embedding provider's rate limit prevented warmup. Wait for capacity, then save the configuration again.",
+	timeout: "The embedding provider did not respond during warmup. Check provider availability, then save the configuration again.",
+	provider_unavailable: "The embedding provider is unavailable. Updating its configuration or API key restarts warmup.",
+	vector_store_unavailable:
+		"The vector store could not prepare the classifier index. Check its connectivity and configuration, then save again.",
+	invalid_response: "The selected model returned an invalid embedding response. Choose a model that supports embeddings and save again.",
+	unknown:
+		"The classifier could not prepare the reference phrases. Review the embedding provider, model, and vector store settings, then save again.",
+};
+
+export function semanticWarmupFailureMessage(status: SemanticStatusInfo): string {
+	// Rolling deployments may briefly pair this UI with an older gateway that
+	// only returns the former non-actionable message. Do not regress to it.
+	if (status.error && !/check server logs/i.test(status.error)) return status.error;
+	if (status.failure_reason) return FAILURE_MESSAGES[status.failure_reason] ?? FAILURE_MESSAGES.unknown!;
+	return FAILURE_MESSAGES.unknown!;
+}
+
+export function semanticWarmupImpactMessage(status: SemanticStatusInfo): string {
+	return status.serving_previous
+		? "The previous classifier is still routing requests. Your latest phrase or embedding changes will become active after warmup succeeds."
+		: "Complexity-tier rules are paused until the classifier is ready. Other routing rules continue normally.";
+}

--- a/ui/components/ui/tagInput.tsx
+++ b/ui/components/ui/tagInput.tsx
@@ -9,12 +9,17 @@ type OmittedInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>, "valu
 interface TagInputProps extends OmittedInputProps {
 	value: string[];
 	onValueChange: (value: string[]) => void;
-	// Height in px the tag area is clamped to before a "show all" toggle appears.
-	// Clamping by height rather than by tag count is what keeps several of these
+	// Height in px the tag area is fixed to; tags past it scroll inside it.
+	// Fixing the height rather than a tag count is what keeps several of these
 	// side by side the same size: tags wrap to different numbers of lines, so a
 	// fixed count of tags is not a fixed amount of space.
-	collapsedMaxHeight?: number;
-	expandButtonTestId?: string;
+	listHeight?: number;
+	// Whether a comma commits the current entry alongside Enter. True for
+	// values that cannot contain a comma (scopes, keys), where typing one
+	// almost always means "next item". Set false where the tags are prose —
+	// reference phrases read like sentences, and eating their commas turns
+	// one phrase into two.
+	submitOnComma?: boolean;
 }
 
 // Badge renders a single clipped line by default, which drops the tail of a
@@ -23,36 +28,8 @@ interface TagInputProps extends OmittedInputProps {
 const TAG_CLASSES = "bg-accent dark:bg-card flex max-w-full shrink items-center gap-1 text-left break-words whitespace-normal";
 
 export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
-	({ className, value, onValueChange, collapsedMaxHeight, expandButtonTestId, ...props }, ref) => {
+	({ className, value, onValueChange, listHeight, submitOnComma = true, ...props }, ref) => {
 		const [inputValue, setInputValue] = React.useState("");
-		const [tagsExpanded, setTagsExpanded] = React.useState(false);
-		const [isOverflowing, setIsOverflowing] = React.useState(false);
-		const tagsRef = React.useRef<HTMLDivElement>(null);
-
-		const isCollapsed = isOverflowing && !tagsExpanded;
-
-		// The toggle has to appear from the rendered height, not from the tag count:
-		// how many tags fit depends on how long each one is and how wide the column
-		// is, neither of which is known here.
-		React.useLayoutEffect(() => {
-			if (collapsedMaxHeight === undefined) {
-				setIsOverflowing(false);
-				return;
-			}
-			const element = tagsRef.current;
-			if (!element) return;
-
-			const measure = () => setIsOverflowing(element.scrollHeight > collapsedMaxHeight + 1);
-			measure();
-
-			const observer = new ResizeObserver(measure);
-			observer.observe(element);
-			return () => observer.disconnect();
-		}, [collapsedMaxHeight, value]);
-
-		React.useEffect(() => {
-			if (!isOverflowing) setTagsExpanded(false);
-		}, [isOverflowing]);
 
 		const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 			setInputValue(e.target.value);
@@ -67,7 +44,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
 		};
 
 		const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-			if (e.key === "Enter" || e.key === ",") {
+			if (e.key === "Enter" || (submitOnComma && e.key === ",")) {
 				e.preventDefault();
 				addCurrentTag();
 			} else if (e.key === "Backspace" && inputValue === "" && value.length > 0) {
@@ -97,7 +74,7 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
 			</Badge>
 		));
 
-		if (collapsedMaxHeight === undefined) {
+		if (listHeight === undefined) {
 			return (
 				<div className={cn("border-input dark:bg-accent flex flex-wrap items-center gap-2 rounded-sm border p-1", className)}>
 					{tags}
@@ -116,44 +93,13 @@ export const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
 		}
 
 		return (
-			<div className={cn("group border-input dark:bg-accent rounded-sm border", className)}>
-				<div className="relative">
-					<div
-						ref={tagsRef}
-						className="flex flex-wrap content-start items-start gap-2 overflow-hidden p-2"
-						style={{ maxHeight: isCollapsed ? collapsedMaxHeight : undefined }}
-						// Every tag carries a remove button, so tabbing through a collapsed list
-						// moves focus onto buttons clipped by the height clamp — off-screen, with
-						// no visible focus ring. Expanding on focus keeps the keyboard path in
-						// view; onFocus bubbles from the descendant, which is what makes this work
-						// without a listener per tag.
-						onFocus={() => {
-							if (isCollapsed) setTagsExpanded(true);
-						}}
-					>
-						{tags}
-					</div>
-					{/* Fades the tag clipped by the height clamp, so the cut reads as
-					    "there is more below" rather than as a rendering fault. */}
-					{isCollapsed && (
-						<div
-							aria-hidden
-							className="to-card dark:to-accent pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-b from-transparent"
-						/>
-					)}
+			<div className={cn("border-input dark:bg-accent rounded-sm border", className)}>
+				{/* The tag area is its own scroll container, so tabbing onto a remove
+				    button below the fold scrolls it into view natively -- no expand
+				    state to keep the keyboard path visible. */}
+				<div className="custom-scrollbar flex flex-wrap content-start items-start gap-2 overflow-y-auto p-2" style={{ height: listHeight }}>
+					{tags}
 				</div>
-
-				{isOverflowing && (
-					<button
-						type="button"
-						data-testid={expandButtonTestId}
-						aria-expanded={!isCollapsed}
-						onClick={() => setTagsExpanded((expanded) => !expanded)}
-						className="text-muted-foreground/70 hover:text-foreground/90 hover:bg-muted/15 border-border/30 w-full cursor-pointer border-t py-2 text-xs font-medium transition-colors"
-					>
-						{isCollapsed ? `Show all ${value.length}` : "Show less"}
-					</button>
-				)}
 
 				{/* On a light card the default placeholder tint reads as disabled text,
 				    so the entry row gets its own surface and a full-strength

--- a/ui/lib/types/complexityRouter.ts
+++ b/ui/lib/types/complexityRouter.ts
@@ -62,6 +62,15 @@ export interface SemanticStatusInfo {
 	loaded: number;
 	total: number;
 	serving_previous?: boolean;
+	failure_reason?:
+		| "authentication"
+		| "model_unavailable"
+		| "rate_limited"
+		| "timeout"
+		| "provider_unavailable"
+		| "vector_store_unavailable"
+		| "invalid_response"
+		| "unknown";
 	error?: string;
 	// How many phrase vectors the gateway currently holds for the configured
 	// provider/model. The cache is in-process only — vectors cannot be read back
@@ -163,6 +172,7 @@ export const MAX_SEMANTIC_TIMEOUT_MS = 9223372036854;
 export const MIN_SEMANTIC_MESSAGE_HISTORY = 1;
 export const MAX_SEMANTIC_MESSAGE_HISTORY = 10;
 export const MAX_SEMANTIC_PHRASE_CHARACTERS = 2000;
+export const MAX_SEMANTIC_PHRASES = 750;
 
 // Seeded when a deployment has no semantic block saved yet. Provider and model
 // stay blank because only the operator knows them.


### PR DESCRIPTION
## Summary

Enforces a hard cap of 750 combined reference phrases across all three semantic complexity tiers, closes a namespace-tracking bug where a storage-mode switch from one Chromem store to another could incorrectly retain or delete namespaces, and tightens the `buildComplexitySessionKey` signature to accept a plain string instead of a full virtual-key struct.

## Changes

- **750-phrase limit for semantic classification.** `MaxComplexitySemanticPhrases = 750` is introduced in `complexityconfig.go`. `validateComplexitySemanticPhrases` counts the already-normalized slices and returns an error when the total exceeds the cap. The limit applies only when a semantic block is present; lexical-only configurations are uncapped. In split configuration mode, `config.json` phrases are merged additively with the database before the limit is checked; if the merged result exceeds 750, Bifrost logs a warning and keeps the existing database configuration active without applying the file edit.
- **OpenAPI and schema descriptions updated.** All `keywords` field descriptions in `openapi.json`, `governance.yaml`, and `config.schema.json` now mention the 750-phrase combined limit.
- **Documentation updated.** `complexity-router.mdx` documents the 750-phrase cap, the normalization order (trim → lowercase → same-tier dedup → count), the split-config merge behavior, and adds a `<Warning>` block explaining that Chromem is node-local and must not be shared across pods.
- **Namespace cleanup rewritten around generation identity.** `embeddedInFlight` (keyed by namespace string) is replaced by `localInFlight` (keyed by `*semanticGeneration` pointer). `isOwnedStoreLocked` is replaced by the package-level `isLocalChromemStore`, which checks whether a store is a `*ChromemStore` regardless of which component created it. `cleanupEmbeddedNamespaceLocked` is split into `cleanupLocalGenerationLocked` (safe retire by generation pointer) and `cleanupLocalNamespaceLocked` (low-level delete guarded by active and in-flight checks). This prevents a storage-mode switch between two Chromem stores from deleting a namespace in the wrong store or skipping cleanup of the retired one.
- **`buildComplexitySessionKey` accepts a plain string.** The `*configstoreTables.TableVirtualKey` parameter is replaced with a `virtualKeyID string`, removing the nil-guard inside the function and the `configstoreTables` import from `complexityrouting.go`, `complexitysession.go`, and their tests.
- **Structured warmup failure reasons.** `SemanticFailureReason` is introduced as a bounded vocabulary of categorized warmup failures. Embedding errors are mapped to this vocabulary by HTTP status code in `embeddingProviderFailureReason`, and vector store errors are wrapped with `errSemanticVectorStoreUnavailable`. The `SemanticStatusInfo` struct gains a `FailureReason` field. Both the gateway and the UI expose operator-actionable messages derived from this vocabulary rather than the former opaque "check server logs" string.
- **UI phrase counter and validation.** `MAX_SEMANTIC_PHRASES = 750` is exported from `complexityRouter.ts`. `countCanonicalSemanticPhrases` mirrors the backend normalization (trim, lowercase, deduplicate, filter blank) and is used in both the Zod schema superRefine and the live phrase counter. When semantic classification is configured, the counter displays `N / 750 phrases` instead of `N phrases`.
- **Classifier status badge improvements.** An `unavailable` state is added for when the status endpoint cannot be reached, with a retry button. The `serving_previous` banner is scoped to the `warming` state only. Failure messages are extracted into `classifierStatusBadge.utils.ts` and distinguish between a failed replacement (previous classifier still routing) and a total failure (complexity-tier rules paused).
- **Tests added.** New cases cover: accepting exactly 750 phrases, rejecting 751, counting only canonical phrases, not capping lexical-only lists, stored configs that exceed the limit returning `ErrConfigUnreadable`, the HTTP handler rejecting over-limit payloads, additive `config.json` merges that would exceed the limit being silently skipped, configured-Chromem generation cleanup deferred until in-flight requests finish, a storage-mode switch retiring the old store's namespace while preserving the new store's, structured failure reason mapping by HTTP status code, and the UI schema validating the same boundary conditions.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/routing/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm test
pnpm build
```

To exercise the phrase limit end-to-end, configure semantic classification and submit a payload with 751 phrases across the three tiers; the API must return a 400 containing `"contains 751 phrases"`. To exercise the split-config path, place a `config.json` whose phrase lists would push the merged total above 750 and restart; the server log must contain a warning and the stored configuration must remain unchanged.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No new auth surfaces, secrets, or PII handling introduced. The phrase-count cap limits the size of data embedded and stored in the vector backend, reducing the potential for resource exhaustion through large phrase lists.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable