### PR TITLE
fix: video debug in logs and retry fix in polling

### DIFF
--- a/core/schemas/videos.go
+++ b/core/schemas/videos.go
@@ -322,3 +322,45 @@ type BifrostVideoDownloadResponse struct {
 type VideoLogParams struct {
 	VideoID string `json:"video_id"`
 }
+
+// BifrostVideoDebug is the video-kind detail carried on a log row. It mirrors
+// BifrostBatchDebug: video generation is billed at settlement, minutes after the
+// job was submitted, so the cost lands on its own aggregate row rather than on the
+// submission. Without this the aggregate row is indistinguishable from the
+// submission it settles — same object, same model, differing only by a cost.
+//
+// The row's Object stays the real request type (video_generation / video_remix /
+// video_edit) rather than a synthetic one, so a later repricing pass still finds
+// the right rates. Accounting being non-nil is what marks the aggregate row.
+type BifrostVideoDebug struct {
+	VideoID string `json:"video_id,omitempty"`
+	// Status is the provider's video lifecycle status as last known when this row
+	// was written. On the aggregate cost row it is the status settlement observed,
+	// which is always terminal.
+	Status VideoStatus `json:"status,omitempty"`
+	// Accounting is set only on the aggregate cost row, and is what distinguishes
+	// it from the submission row it settles.
+	Accounting *VideoAccountingDebug `json:"accounting,omitempty"`
+}
+
+func (d *BifrostVideoDebug) IsZero() bool {
+	if d == nil {
+		return true
+	}
+	return d.VideoID == "" && d.Status == "" && d.Accounting == nil
+}
+
+// VideoAccountingDebug records how a settled video was priced, so an operator can
+// see why a row cost what it did without re-deriving it from the provider.
+type VideoAccountingDebug struct {
+	// Seconds and Size are the dimensions the price was actually computed from,
+	// after merging the terminal response over the request captured at submission.
+	Seconds *int   `json:"seconds,omitempty"`
+	Size    string `json:"size,omitempty"`
+	// OutputCount is how many clips the job returned; the per-second rate is
+	// multiplied by it.
+	OutputCount int `json:"output_count,omitempty"`
+	// Incomplete marks a row whose cost is known to be short — priced with no rate,
+	// or from dimensions the provider never confirmed.
+	Incomplete bool `json:"incomplete,omitempty"`
+}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -479,7 +479,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_vk_rotation_cooldown_client_column"}, run: migrationAddVKRotationCooldownClientColumn},
 	{IDs: []string{"drop_legacy_oauth_user_fk_constraints"}, run: migrationDropLegacyOauthUserFKConstraints},
 	{IDs: []string{"add_video_resolution_pricing_columns"}, run: migrationAddVideoResolutionPricingColumns},
-	{IDs: []string{"add_provider_job_kind_columns"}, run: migrationAddProviderJobKindColumns},
+	{IDs: []string{"add_provider_job_kind_columns", "swap_provider_job_indexes"}, run: migrationAddProviderJobKindColumns},
 }
 
 // videoResolutionPricingColumns are the resolution-banded video output rate columns.
@@ -12469,6 +12469,10 @@ func migrationAddProviderJobKindColumns(ctx context.Context, db *gorm.DB, logger
 	migrationName := "add_provider_job_kind_columns"
 	logger.Info("[configstore] starting migration %s", migrationName)
 	defer logger.Info("[configstore] finished migration %s", migrationName)
+
+	// Step 1 (transactional): the columns. Both are metadata-only — kind's constant
+	// default is applied on read rather than by rewriting rows, so this is O(1) on
+	// postgres 11+ and sqlite regardless of how large batch_jobs has grown.
 	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
 		ID: migrationName,
 		Migrate: func(tx *gorm.DB) error {
@@ -12488,21 +12492,6 @@ func migrationAddProviderJobKindColumns(ctx context.Context, db *gorm.DB, logger
 					return fmt.Errorf("failed to add params column to batch_jobs: %w", err)
 				}
 			}
-
-			if err := tx.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_batch_jobs_identity_v2 ON batch_jobs (provider, kind, batch_id)`).Error; err != nil {
-				return fmt.Errorf("failed to create idx_batch_jobs_identity_v2: %w", err)
-			}
-			if err := tx.Exec(`DROP INDEX IF EXISTS idx_batch_jobs_identity`).Error; err != nil {
-				return fmt.Errorf("failed to drop idx_batch_jobs_identity: %w", err)
-			}
-
-			// The sweeper scans by kind first now that each kind has its own settler.
-			if err := tx.Exec(`CREATE INDEX IF NOT EXISTS idx_batch_jobs_sweeper_v2 ON batch_jobs (kind, provider, accounting_status, next_check_at)`).Error; err != nil {
-				return fmt.Errorf("failed to create idx_batch_jobs_sweeper_v2: %w", err)
-			}
-			if err := tx.Exec(`DROP INDEX IF EXISTS idx_batch_jobs_sweeper`).Error; err != nil {
-				return fmt.Errorf("failed to drop idx_batch_jobs_sweeper: %w", err)
-			}
 			return nil
 		},
 		Rollback: func(tx *gorm.DB) error {
@@ -12512,7 +12501,88 @@ func migrationAddProviderJobKindColumns(ctx context.Context, db *gorm.DB, logger
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error running %s migration: %s", migrationName, err.Error())
 	}
-	return nil
+
+	// Step 2 (non-transactional): swap the indexes onto the new column.
+	return migrationSwapProviderJobIndexes(ctx, db, logger)
+}
+
+// providerJobIndexSwap is the index rework batch_jobs needs once rows carry a kind:
+// identity widens to include it, and the sweeper scans by it first.
+var providerJobIndexSwap = []struct {
+	name     string
+	columns  string
+	unique   bool
+	replaces string
+}{
+	{
+		name:     "idx_batch_jobs_identity_v2",
+		columns:  "(provider, kind, batch_id)",
+		unique:   true,
+		replaces: "idx_batch_jobs_identity",
+	},
+	{
+		name:     "idx_batch_jobs_sweeper_v2",
+		columns:  "(kind, provider, accounting_status, next_check_at)",
+		replaces: "idx_batch_jobs_sweeper",
+	},
+}
+
+func migrationSwapProviderJobIndexes(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "swap_provider_job_indexes"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+
+	noTxOpts := *migrator.DefaultOptions
+	noTxOpts.UseTransaction = false
+	return RunSingleMigration(ctx, &noTxOpts, db, logger, &migrator.Migration{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			// SQLite has a single writer and no CONCURRENTLY; the plain form is both
+			// required and harmless there.
+			concurrent := tx.Dialector.Name() != "sqlite"
+
+			for _, idx := range providerJobIndexSwap {
+				unique := ""
+				if idx.unique {
+					unique = "UNIQUE "
+				}
+				if concurrent {
+					valid, err := postgresIndexIsValid(tx, "batch_jobs", idx.name)
+					if err != nil {
+						return fmt.Errorf("failed to check whether %s is valid: %w", idx.name, err)
+					}
+					if !valid {
+						if err := tx.Exec("DROP INDEX CONCURRENTLY IF EXISTS " + idx.name).Error; err != nil {
+							return fmt.Errorf("failed to clear a partial %s: %w", idx.name, err)
+						}
+					}
+					if err := tx.Exec(fmt.Sprintf("CREATE %sINDEX CONCURRENTLY IF NOT EXISTS %s ON batch_jobs %s", unique, idx.name, idx.columns)).Error; err != nil {
+						return fmt.Errorf("failed to create %s: %w", idx.name, err)
+					}
+				} else if err := tx.Exec(fmt.Sprintf("CREATE %sINDEX IF NOT EXISTS %s ON batch_jobs %s", unique, idx.name, idx.columns)).Error; err != nil {
+					return fmt.Errorf("failed to create %s: %w", idx.name, err)
+				}
+
+				// Only now drop what it replaces. The new index is strictly weaker than
+				// the old one, so it can never fail to build on data the old one already
+				// accepted — but dropping second still means uniqueness is never briefly
+				// unenforced.
+				drop := "DROP INDEX IF EXISTS " + idx.replaces
+				if concurrent {
+					drop = "DROP INDEX CONCURRENTLY IF EXISTS " + idx.replaces
+				}
+				if err := tx.Exec(drop).Error; err != nil {
+					return fmt.Errorf("failed to drop %s: %w", idx.replaces, err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			// Index-only; the column rollback restores these names itself.
+			return nil
+		},
+	})
 }
 
 // rollbackProviderJobKindColumns reverses migrationAddProviderJobKindColumns.
@@ -12581,4 +12651,20 @@ func rollbackProviderJobKindColumns(ctx context.Context, db *gorm.DB) error {
 		return fmt.Errorf("failed to restore idx_batch_jobs_sweeper: %w", err)
 	}
 	return nil
+}
+
+// postgresIndexIsValid reports whether an index exists on table and is usable.
+// A missing index and an INVALID one both report false: the caller wants to know
+// "can I rely on this", and an INVALID index — the residue of an interrupted
+// CREATE INDEX CONCURRENTLY — answers no while still occupying the name.
+func postgresIndexIsValid(tx *gorm.DB, table, index string) (bool, error) {
+	var valid bool
+	err := tx.Raw(`
+		SELECT COALESCE(bool_and(pi.indisvalid), false)
+		FROM pg_class pc
+		JOIN pg_index pi ON pi.indrelid = pc.oid
+		JOIN pg_class ic ON ic.oid = pi.indexrelid
+		WHERE pc.relname = ? AND ic.relname = ?
+	`, table, index).Scan(&valid).Error
+	return valid, err
 }

--- a/framework/jobaccounting/batch.go
+++ b/framework/jobaccounting/batch.go
@@ -28,7 +28,19 @@ const (
 // download.
 const defaultProviderPollTimeout = 5 * time.Minute
 
-const unpriceableReasonTerminalWithoutResults = "terminal_without_results"
+const (
+	unpriceableReasonTerminalWithoutResults = "terminal_without_results"
+	// unpriceableReasonBatchGone is a batch the provider no longer recognises.
+	// Output files have finite retention, so this is an ordinary end state.
+	unpriceableReasonBatchGone = "batch_gone"
+	// unpriceableReasonBatchAccessDenied is the creating key being refused. Kept
+	// apart from batch_gone because it means a key was revoked or rotated, and
+	// every in-flight batch behind it is failing the same way.
+	unpriceableReasonBatchAccessDenied = "batch_access_denied"
+	// unpriceableReasonBatchRequestRejected is the provider refusing the retrieve
+	// itself — nothing expired, the request is one it will not accept.
+	unpriceableReasonBatchRequestRejected = "batch_request_rejected"
+)
 
 type BatchResultFetcher interface {
 	RetrieveBatch(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchRetrieveResponse, error)
@@ -185,6 +197,9 @@ func (s *BatchSettler) Poll(ctx context.Context, job *cstables.TableProviderJob)
 	}
 	retrieved, err := s.retrieveBatch(ctx, job)
 	if err != nil {
+		if reason := batchUnreachableReason(err); reason != "" {
+			return &PollResult{Terminal: true, UnpriceableReason: reason}, nil
+		}
 		return nil, err
 	}
 	if retrieved == nil {
@@ -409,6 +424,21 @@ func batchJobFromRetrieve(existing *cstables.TableProviderJob, retrieved *schema
 		job.ResultsURL = retrieved.ResultsURL
 	}
 	return &job
+}
+
+// batchUnreachableReason names why a failed retrieve is final, or returns empty
+// when the call is worth retrying.
+func batchUnreachableReason(err error) string {
+	switch ClassifyProviderCall(err) {
+	case ProviderCallGone:
+		return unpriceableReasonBatchGone
+	case ProviderCallAccessDenied:
+		return unpriceableReasonBatchAccessDenied
+	case ProviderCallRejected:
+		return unpriceableReasonBatchRequestRejected
+	default:
+		return ""
+	}
 }
 
 func isTerminalStatus(status schemas.BatchStatus) bool {

--- a/framework/jobaccounting/batch_test.go
+++ b/framework/jobaccounting/batch_test.go
@@ -3,6 +3,7 @@ package jobaccounting
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -765,10 +766,16 @@ type fakeBatchResultFetcher struct {
 	resultsCalls  int
 	retrieveResp  *schemas.BifrostBatchRetrieveResponse
 	resultsResp   *schemas.BifrostBatchResultsResponse
+	// retrieveErr models a provider that refuses the retrieve outright, which is
+	// how a forgotten batch or a revoked key actually presents.
+	retrieveErr error
 }
 
 func (f *fakeBatchResultFetcher) RetrieveBatch(ctx context.Context, job *cstables.TableProviderJob) (*schemas.BifrostBatchRetrieveResponse, error) {
 	f.retrieveCalls++
+	if f.retrieveErr != nil {
+		return nil, f.retrieveErr
+	}
 	return f.retrieveResp, nil
 }
 
@@ -2198,4 +2205,117 @@ func TestAccountJob_RequiresARunnerID(t *testing.T) {
 	assert.Empty(t, store.jobs,
 		"the rejection must land before the coordination row is written, or an unclaimable job is left behind")
 	assert.Empty(t, store.logs)
+}
+
+// --- Provider call errors (shared by every job kind) ---
+
+// The status code is the only thing that distinguishes a job the provider has
+// forgotten from one it could not serve this minute. Flattening a BifrostError to
+// its message throws that away, and every failure then looks alike to the sweeper.
+func TestNewProviderCallError_PreservesStatusCode(t *testing.T) {
+	status := 404
+	err := NewProviderCallError(&schemas.BifrostError{
+		StatusCode: &status,
+		Error:      &schemas.ErrorField{Message: "Video with id 'vid_x' not found."},
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 404, ProviderCallStatus(err))
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// A settler that annotates a poll failure must not lose the code on the way up.
+func TestProviderCallStatus_UnwrapsThroughAnnotation(t *testing.T) {
+	status := 403
+	inner := NewProviderCallError(&schemas.BifrostError{
+		StatusCode: &status,
+		Error:      &schemas.ErrorField{Message: "PERMISSION_DENIED"},
+	})
+
+	wrapped := fmt.Errorf("polling job %s: %w", "video-job:gemini:abc", inner)
+	assert.Equal(t, 403, ProviderCallStatus(wrapped))
+}
+
+// A failure with no response at all — a timeout, a dial error — reports 0 rather
+// than a misleading code, so it keeps the ordinary reschedule path.
+func TestProviderCallStatus_ZeroWithoutAProviderResponse(t *testing.T) {
+	assert.Equal(t, 0, ProviderCallStatus(errors.New("context deadline exceeded")))
+	assert.Equal(t, 0, ProviderCallStatus(nil))
+
+	noStatus := NewProviderCallError(&schemas.BifrostError{
+		Error: &schemas.ErrorField{Message: "upstream unreachable"},
+	})
+	assert.Equal(t, 0, ProviderCallStatus(noStatus),
+		"a provider error carrying no status must not be mistaken for a client error")
+}
+
+// Nil in, nil out: call sites pass a provider error through unconditionally.
+func TestNewProviderCallError_NilIsNotAnError(t *testing.T) {
+	assert.NoError(t, NewProviderCallError(nil))
+}
+
+// Batch has the same gap as video: a provider that no longer recognises the batch
+// returned a bare error, so the sweeper rescheduled it to the attempt cap. Output
+// files have finite retention, so this is an ordinary end state, not a failure.
+func TestBatchSweeper_GoneBatchStopsPollingImmediately(t *testing.T) {
+	store := newFakeAccountingStore()
+	due := time.Now().UTC().Add(-time.Minute)
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_gone")
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
+		ID:               jobID,
+		Kind:             cstables.ProviderJobKindBatch,
+		Provider:         string(schemas.OpenAI),
+		JobID:            "batch_gone",
+		Model:            "gpt-4o-mini",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
+		NextCheckAt:      &due,
+	}))
+
+	status := 404
+	fetcher := &fakeBatchResultFetcher{retrieveErr: NewProviderCallError(&schemas.BifrostError{
+		StatusCode: &status,
+		Error:      &schemas.ErrorField{Message: "No such batch: batch_gone"},
+	})}
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+
+	sweeper.SweepOnce(context.Background())
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, fetcher.retrieveCalls, "a batch the provider has forgotten must not be polled again")
+	assert.Equal(t, 0, fetcher.resultsCalls, "and its results must not be fetched")
+	settled := store.jobs[jobID]
+	require.NotNil(t, settled)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, settled.AccountingStatus)
+	require.NotNil(t, settled.UnpriceableReason)
+	assert.Equal(t, unpriceableReasonBatchGone, *settled.UnpriceableReason)
+}
+
+// A transient failure keeps today's reschedule behaviour.
+func TestBatchSweeper_TransientRetrieveFailureStillRetries(t *testing.T) {
+	store := newFakeAccountingStore()
+	due := time.Now().UTC().Add(-time.Minute)
+	jobID := cstables.ProviderJobID(cstables.ProviderJobKindBatch, string(schemas.OpenAI), "batch_flaky")
+	require.NoError(t, store.UpsertProviderJob(context.Background(), &cstables.TableProviderJob{
+		ID:               jobID,
+		Kind:             cstables.ProviderJobKindBatch,
+		Provider:         string(schemas.OpenAI),
+		JobID:            "batch_flaky",
+		AccountingStatus: cstables.ProviderJobAccountingStatusPending,
+		NextCheckAt:      &due,
+	}))
+
+	status := 503
+	fetcher := &fakeBatchResultFetcher{retrieveErr: NewProviderCallError(&schemas.BifrostError{
+		StatusCode: &status,
+		Error:      &schemas.ErrorField{Message: "service unavailable"},
+	})}
+	sweeper := NewBatchSweeper(store, store, fakePricing{}, fetcher, nil, nil, SweeperConfig{Limit: 10})
+
+	sweeper.SweepOnce(context.Background())
+
+	settled := store.jobs[jobID]
+	require.NotNil(t, settled)
+	assert.NotEqual(t, cstables.ProviderJobAccountingStatusUnpriceable, settled.AccountingStatus,
+		"a 5xx must stay retryable, not park the batch")
+	assert.Positive(t, settled.PollAttempts, "the attempt must be recorded for backoff")
 }

--- a/framework/jobaccounting/types.go
+++ b/framework/jobaccounting/types.go
@@ -2,6 +2,7 @@ package jobaccounting
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -11,6 +12,92 @@ import (
 )
 
 const defaultClaimTTL = 5 * time.Minute
+
+// ProviderCallError carries the provider's HTTP status alongside the message, so a
+// settler can tell a job the provider has forgotten from one it merely could not
+// reach this time.
+//
+// Without it every provider failure looks alike: the poll returns a bare error, the
+// sweeper reschedules, and a job whose id the provider will never recognise again
+// still burns its whole attempt budget before parking under the wrong reason.
+type ProviderCallError struct {
+	// StatusCode is the provider's HTTP status, or 0 when the failure happened
+	// before a response was received (a timeout, a transport error).
+	StatusCode int
+	Message    string
+}
+
+func (e *ProviderCallError) Error() string { return e.Message }
+
+// NewProviderCallError converts a BifrostError into an error that keeps its status
+// code. Returns nil for a nil input so call sites can pass a provider error through
+// unconditionally.
+func NewProviderCallError(err *schemas.BifrostError) error {
+	if err == nil {
+		return nil
+	}
+	call := &ProviderCallError{Message: err.GetErrorString()}
+	if err.StatusCode != nil {
+		call.StatusCode = *err.StatusCode
+	}
+	return call
+}
+
+// ProviderCallStatus reports the provider HTTP status behind err, or 0 when err did
+// not come from a provider response. It unwraps, so a settler that annotates a poll
+// failure does not lose the code.
+func ProviderCallStatus(err error) int {
+	var call *ProviderCallError
+	if errors.As(err, &call) {
+		return call.StatusCode
+	}
+	return 0
+}
+
+// ProviderCallOutcome is how a settler should treat a failed provider call.
+type ProviderCallOutcome int
+
+const (
+	// ProviderCallRetry is a failure that may not recur: a 5xx, a rate limit, or no
+	// response at all. Poll again later.
+	ProviderCallRetry ProviderCallOutcome = iota
+	// ProviderCallGone is a job the provider no longer recognises. Expected — jobs
+	// and their assets age out.
+	ProviderCallGone
+	// ProviderCallAccessDenied is the pinned key being refused: revoked, rotated,
+	// or unpaid. Sound only because the sweeper polls key-pinned (see
+	// internalJobContext); an unpinned poll could get this merely by picking a key
+	// that did not create the job, where a different key would have worked.
+	ProviderCallAccessDenied
+	// ProviderCallRejected is the provider refusing the request itself. Nothing
+	// aged out — Bifrost built something the provider will not accept, and asking
+	// again with the same bytes cannot change that.
+	ProviderCallRejected
+)
+
+// retryableClientStatusCodes are the 4xx codes worth polling again. Every other 4xx
+// is the provider's final answer.
+var retryableClientStatusCodes = map[int]bool{
+	408: true, // Request Timeout — the server gave up waiting, not a refusal
+	429: true, // Too Many Requests — capacity, and the same key works later
+}
+
+// ClassifyProviderCall decides whether a failed provider call is worth retrying,
+// and if not, why it failed. A status of 0 (no response reached us) retries.
+func ClassifyProviderCall(err error) ProviderCallOutcome {
+	status := ProviderCallStatus(err)
+	if status < 400 || status > 499 || retryableClientStatusCodes[status] {
+		return ProviderCallRetry
+	}
+	switch status {
+	case 404, 410:
+		return ProviderCallGone
+	case 401, 402, 403:
+		return ProviderCallAccessDenied
+	default:
+		return ProviderCallRejected
+	}
+}
 
 // ProviderJobKind discriminates the job families sharing this engine. It is
 // deliberately not named "async job": logstore.AsyncJobExecutor and the /v1/async/*

--- a/framework/jobaccounting/video.go
+++ b/framework/jobaccounting/video.go
@@ -20,6 +20,14 @@ const (
 	// UnpriceableReasonVideoGone is a job the provider no longer knows about.
 	// Generated assets expire, so this is an ordinary end state, not an error.
 	UnpriceableReasonVideoGone = "video_gone"
+	// UnpriceableReasonVideoAccessDenied is the creating key being refused. Distinct
+	// from video_gone on purpose: one is an asset ageing out and needs no action, the
+	// other means a key was revoked or rotated and every in-flight job on that
+	// provider is quietly failing behind it.
+	UnpriceableReasonVideoAccessDenied = "video_access_denied"
+	// UnpriceableReasonVideoRequestRejected is the provider refusing the retrieve
+	// itself — nothing expired, Bifrost built a request it will not accept.
+	UnpriceableReasonVideoRequestRejected = "video_request_rejected"
 	// UnpriceableReasonContentFiltered is deliberately not a price. A safety-filtered
 	// job consumed real compute, but whether the provider bills for it is a
 	// per-provider policy none of them document consistently. Guessing free
@@ -104,6 +112,9 @@ func (s *VideoSettler) Poll(ctx context.Context, job *cstables.TableProviderJob)
 
 	resp, err := s.retriever.RetrieveVideo(callCtx, job)
 	if err != nil {
+		if reason := videoUnreachableReason(err); reason != "" {
+			return &PollResult{Terminal: true, UnpriceableReason: reason}, nil
+		}
 		return nil, err
 	}
 	if resp == nil {
@@ -147,6 +158,14 @@ func (s *VideoSettler) Settle(ctx context.Context, pricing PricingManager, jobRe
 		Object: videoObjectFor(dims.RequestType),
 	}
 
+	// Attached on every path below, including the unpriceable ones: a row with no
+	// cost is exactly the row an operator needs the detail on.
+	videoStatus := schemas.VideoStatus("")
+	if resp != nil {
+		videoStatus = resp.Status
+	}
+	settlement.ApplyDebug = videoDebugFor(jobReq.ProviderJobID, videoStatus, dims, false)
+
 	if resp != nil && resp.ContentFilter != nil && resp.ContentFilter.FilteredCount > 0 {
 		settlement.UnpriceableReason = UnpriceableReasonContentFiltered
 		return settlement, nil
@@ -169,18 +188,44 @@ func (s *VideoSettler) Settle(ctx context.Context, pricing PricingManager, jobRe
 		// once the rate lands, rather than dropping the job's cost entirely.
 		settlement.RecordUnpriced = true
 		settlement.UnpricedModel = dims.Model
+		settlement.ApplyDebug = videoDebugFor(jobReq.ProviderJobID, videoStatus, dims, true)
 		return settlement, nil
 	}
 
 	settlement.Priced = true
 	settlement.Complete = true
 	settlement.Cost = details.Cost
+	settlement.ApplyDebug = videoDebugFor(jobReq.ProviderJobID, videoStatus, dims, false)
 	return settlement, nil
 }
 
-// HydrateFromLog is a no-op: video carries no kind-specific detail on the aggregate
-// row yet, and the engine reads cost and usage off the row itself.
-func (s *VideoSettler) HydrateFromLog(entry *logstore.Log, out *Outcome) {}
+// videoDebugFor builds the closure that attaches video detail to the aggregate row.
+// Accounting being set is what marks this row as the settlement rather than the
+// submission it settles — the two are otherwise identical but for a cost.
+func videoDebugFor(videoID string, status schemas.VideoStatus, dims modelcatalog.VideoPricingDimensions, incomplete bool) func(*logstore.Log) {
+	return func(entry *logstore.Log) {
+		entry.VideoDebugParsed = &schemas.BifrostVideoDebug{
+			VideoID: videoID,
+			Status:  status,
+			Accounting: &schemas.VideoAccountingDebug{
+				Seconds:     dims.Seconds,
+				Size:        dims.Size,
+				OutputCount: dims.OutputCount,
+				Incomplete:  incomplete,
+			},
+		}
+	}
+}
+
+// HydrateFromLog reads this kind's detail back off an already-written aggregate row,
+// for a caller that lost the settlement claim and only wants to display a price.
+// The inverse of the closure videoDebugFor builds.
+func (s *VideoSettler) HydrateFromLog(entry *logstore.Log, out *Outcome) {
+	if entry.VideoDebugParsed == nil {
+		return
+	}
+	out.Status = string(entry.VideoDebugParsed.Status)
+}
 
 // VideoDimensionsFromJob reads the pricing dimensions captured on the job row at
 // submission. An unreadable blob yields empty dimensions rather than an error: the
@@ -264,6 +309,21 @@ func videoJobFromResponse(existing *cstables.TableProviderJob, resp *schemas.Bif
 		job.Model = resp.Model
 	}
 	return &job
+}
+
+// videoUnreachableReason names why a failed retrieve is final, or returns empty
+// when the call is worth retrying.
+func videoUnreachableReason(err error) string {
+	switch ClassifyProviderCall(err) {
+	case ProviderCallGone:
+		return UnpriceableReasonVideoGone
+	case ProviderCallAccessDenied:
+		return UnpriceableReasonVideoAccessDenied
+	case ProviderCallRejected:
+		return UnpriceableReasonVideoRequestRejected
+	default:
+		return ""
+	}
 }
 
 func isTerminalVideoStatus(status schemas.VideoStatus) bool {

--- a/framework/jobaccounting/video_test.go
+++ b/framework/jobaccounting/video_test.go
@@ -9,6 +9,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	cstables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -474,4 +475,170 @@ func TestAccountVideoJob_SharesTheSweepersAggregateRow(t *testing.T) {
 	assert.Len(t, store.logs, 1, "one video, one cost row, whichever path got there first")
 	assert.Len(t, reporter.reports, 1)
 	assert.Equal(t, 0, retriever.calls, "an accounted job is no longer due, so the sweeper skips it")
+}
+
+// --- Unreachable jobs (the retry-loop fix) ---
+
+func providerErr(status int, message string) error {
+	return NewProviderCallError(&schemas.BifrostError{
+		StatusCode: &status,
+		Error:      &schemas.ErrorField{Message: message},
+	})
+}
+
+// The three status families a provider actually returns for a job it will not
+// serve, taken from real responses: Runway and OpenAI 404, Gemini 403.
+func TestClassifyProviderCall(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		err  error
+		want ProviderCallOutcome
+	}{
+		{"runway 404", providerErr(404, "Could not find Task"), ProviderCallGone},
+		{"openai 404", providerErr(404, "Video with id 'video_x' not found."), ProviderCallGone},
+		{"gone", providerErr(410, "gone"), ProviderCallGone},
+		{"gemini 403", providerErr(403, "You do not have permission to access the Operation"), ProviderCallAccessDenied},
+		{"unauthorized", providerErr(401, "invalid api key"), ProviderCallAccessDenied},
+		{"billing", providerErr(402, "payment required"), ProviderCallAccessDenied},
+		{"bad request", providerErr(400, "malformed id"), ProviderCallRejected},
+		{"unprocessable", providerErr(422, "unprocessable"), ProviderCallRejected},
+		// The two 4xx that mean "ask again", not "no".
+		{"rate limited", providerErr(429, "slow down"), ProviderCallRetry},
+		{"request timeout", providerErr(408, "timeout"), ProviderCallRetry},
+		{"server error", providerErr(503, "unavailable"), ProviderCallRetry},
+		{"anthropic overloaded", providerErr(529, "overloaded"), ProviderCallRetry},
+		// No response at all must never be mistaken for a client error.
+		{"transport failure", errors.New("dial tcp: connection refused"), ProviderCallRetry},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, ClassifyProviderCall(tc.err))
+		})
+	}
+}
+
+// A provider that has forgotten the job must stop the polling on the first attempt.
+// Rescheduling instead spends the whole 120-attempt budget over hours and then parks
+// the job under max_poll_attempts, which names the wrong cause.
+func TestVideoPoll_UnreachableJobIsTerminalOnTheFirstAttempt(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		err    error
+		reason string
+	}{
+		{"gone", providerErr(404, "Could not find Task"), UnpriceableReasonVideoGone},
+		{"access denied", providerErr(403, "PERMISSION_DENIED"), UnpriceableReasonVideoAccessDenied},
+		{"rejected", providerErr(400, "malformed id"), UnpriceableReasonVideoRequestRejected},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			job := videoJob(t, "vid_unreachable", generationDims("sora-2-pro", "1920x1080", 8))
+			poll, err := NewVideoSettler(&fakeVideoRetriever{err: tc.err}).Poll(context.Background(), job)
+
+			require.NoError(t, err, "an unreachable job is an outcome, not a poll failure")
+			require.NotNil(t, poll)
+			assert.True(t, poll.Terminal)
+			assert.False(t, poll.Settleable)
+			assert.Equal(t, tc.reason, poll.UnpriceableReason)
+			assert.Nil(t, poll.Job, "a failed call learned nothing worth persisting")
+		})
+	}
+}
+
+// A transient failure keeps the existing reschedule path.
+func TestVideoPoll_TransientFailureStillRetries(t *testing.T) {
+	job := videoJob(t, "vid_transient", generationDims("sora-2-pro", "1920x1080", 8))
+	for _, err := range []error{providerErr(503, "unavailable"), providerErr(429, "slow down"), errors.New("timeout")} {
+		poll, pollErr := NewVideoSettler(&fakeVideoRetriever{err: err}).Poll(context.Background(), job)
+		require.Error(t, pollErr, "%v must stay a retryable poll failure", err)
+		assert.Nil(t, poll)
+	}
+}
+
+// End to end: the sweeper parks a gone video after exactly one provider call.
+func TestVideoSweeper_GoneJobStopsPollingImmediately(t *testing.T) {
+	store := newFakeAccountingStore()
+	due := time.Now().UTC().Add(-time.Minute)
+	job := videoJob(t, "vid_gone", generationDims("sora-2-pro", "1920x1080", 8))
+	job.NextCheckAt = &due
+	require.NoError(t, store.UpsertProviderJob(context.Background(), job))
+
+	retriever := &fakeVideoRetriever{err: providerErr(404, "Video with id 'vid_gone' not found.")}
+	sweeper := NewVideoSweeper(store, store, fakePricing{}, retriever, nil, nil, SweeperConfig{
+		Provider: schemas.OpenAI,
+		Limit:    10,
+	})
+
+	sweeper.SweepOnce(context.Background())
+	sweeper.SweepOnce(context.Background())
+
+	assert.Equal(t, 1, retriever.calls,
+		"a job the provider has forgotten must not be polled again")
+	settled := store.jobs[cstables.ProviderJobID(cstables.ProviderJobKindVideo, string(schemas.OpenAI), "vid_gone")]
+	require.NotNil(t, settled)
+	assert.Equal(t, cstables.ProviderJobAccountingStatusUnpriceable, settled.AccountingStatus)
+	require.NotNil(t, settled.UnpriceableReason)
+	assert.Equal(t, UnpriceableReasonVideoGone, *settled.UnpriceableReason)
+	assert.Empty(t, store.logs, "an unreachable job bills nothing")
+}
+
+// --- Aggregate row detail ---
+
+// A settled video writes its cost on its own row, minutes after the submission —
+// same object, same model, differing only by a cost. The accounting block is what
+// tells the two apart, so it must be present on the settlement and absent from the
+// submission.
+func TestVideoSettle_AggregateRowCarriesAccountingDetail(t *testing.T) {
+	job := videoJob(t, "vid_debug", generationDims("sora-2-pro", "1920x1080", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	})
+	require.NotNil(t, settlement.ApplyDebug)
+
+	entry := &logstore.Log{}
+	settlement.ApplyDebug(entry)
+	require.NotNil(t, entry.VideoDebugParsed)
+	assert.Equal(t, "vid_debug", entry.VideoDebugParsed.VideoID)
+	assert.Equal(t, schemas.VideoStatusCompleted, entry.VideoDebugParsed.Status)
+
+	acct := entry.VideoDebugParsed.Accounting
+	require.NotNil(t, acct, "the accounting block is what marks this as the settlement row")
+	require.NotNil(t, acct.Seconds)
+	assert.Equal(t, 8, *acct.Seconds)
+	assert.Equal(t, "1920x1080", acct.Size)
+	assert.Equal(t, 1, acct.OutputCount)
+	assert.False(t, acct.Incomplete)
+}
+
+// An unpriceable row is exactly the one an operator needs the detail on, so it must
+// carry the same block — marked incomplete.
+func TestVideoSettle_UnpriceableRowStillCarriesDetail(t *testing.T) {
+	job := videoJob(t, "vid_norate_debug", generationDims("some-unknown-model", "1920x1080", 8))
+	settlement := settleVideo(t, job, &schemas.BifrostVideoGenerationResponse{
+		Status: schemas.VideoStatusCompleted,
+		Videos: []schemas.VideoOutput{{Type: schemas.VideoOutputTypeURL}},
+	})
+
+	require.False(t, settlement.Priced)
+	require.NotNil(t, settlement.ApplyDebug)
+	entry := &logstore.Log{}
+	settlement.ApplyDebug(entry)
+	require.NotNil(t, entry.VideoDebugParsed.Accounting)
+	assert.True(t, entry.VideoDebugParsed.Accounting.Incomplete)
+}
+
+// HydrateFromLog is the inverse of the closure: a caller that lost the settlement
+// claim reads the status back off the already-written row.
+func TestVideoHydrateFromLog(t *testing.T) {
+	entry := &logstore.Log{VideoDebugParsed: &schemas.BifrostVideoDebug{
+		VideoID: "vid_x",
+		Status:  schemas.VideoStatusCompleted,
+	}}
+	out := &Outcome{}
+	NewVideoSettler(nil).HydrateFromLog(entry, out)
+	assert.Equal(t, string(schemas.VideoStatusCompleted), out.Status)
+
+	// A row written before video detail existed must not panic or invent a status.
+	bare := &Outcome{}
+	NewVideoSettler(nil).HydrateFromLog(&logstore.Log{}, bare)
+	assert.Empty(t, bare.Status)
 }

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -110,18 +110,18 @@ type parityLogSpec struct {
 	teamIDs, teamNames         *string
 	customerIDs, customerNames *string
 	buIDs, buNames             *string
-	cost         *float64
-	latency      *float64
-	tokens       [3]int // prompt, completion, total
-	stopReason   *string
-	routing      *string
-	metadata     *string
-	cacheDebug   string
-	content      string
-	parentID     *string
-	nodeID       *string
-	budgetIDs    *string
-	rateLimitIDs *string
+	cost                       *float64
+	latency                    *float64
+	tokens                     [3]int // prompt, completion, total
+	stopReason                 *string
+	routing                    *string
+	metadata                   *string
+	cacheDebug                 string
+	content                    string
+	parentID                   *string
+	nodeID                     *string
+	budgetIDs                  *string
+	rateLimitIDs               *string
 }
 
 func (s parityLogSpec) toLog(base time.Time) *Log {
@@ -1243,4 +1243,52 @@ func TestLogStoreParity(t *testing.T) {
 			return s.Close(ctx)
 		})
 	})
+}
+
+// video_debug must survive the serialize/deserialize round trip like batch_debug
+// does. It is operational detail, not request content, so it also has to outlive an
+// object-storage offload — a row whose payload was offloaded still needs to say
+// which video it settled.
+func TestLogVideoDebugRoundTrip(t *testing.T) {
+	seconds := 8
+	entry := &Log{
+		ID: "req-video-roundtrip",
+		VideoDebugParsed: &schemas.BifrostVideoDebug{
+			VideoID: "vid_rt",
+			Status:  schemas.VideoStatusCompleted,
+			Accounting: &schemas.VideoAccountingDebug{
+				Seconds:     &seconds,
+				Size:        "1920x1080",
+				OutputCount: 2,
+			},
+		},
+	}
+
+	require.NoError(t, entry.SerializeFields())
+	require.NotEmpty(t, entry.VideoDebug, "the parsed blob must reach the column")
+
+	decoded := &Log{ID: entry.ID, VideoDebug: entry.VideoDebug}
+	require.NoError(t, decoded.DeserializeFields())
+	require.NotNil(t, decoded.VideoDebugParsed)
+	assert.Equal(t, "vid_rt", decoded.VideoDebugParsed.VideoID)
+	assert.Equal(t, schemas.VideoStatusCompleted, decoded.VideoDebugParsed.Status)
+	require.NotNil(t, decoded.VideoDebugParsed.Accounting)
+	require.NotNil(t, decoded.VideoDebugParsed.Accounting.Seconds)
+	assert.Equal(t, 8, *decoded.VideoDebugParsed.Accounting.Seconds)
+	assert.Equal(t, 2, decoded.VideoDebugParsed.Accounting.OutputCount)
+}
+
+// A submission row carries the video id but no accounting block; that absence is
+// what the UI keys on to tell it from the settlement.
+func TestLogVideoDebugSubmissionRowHasNoAccounting(t *testing.T) {
+	entry := &Log{
+		ID:               "req-video-submission",
+		VideoDebugParsed: &schemas.BifrostVideoDebug{VideoID: "vid_sub", Status: schemas.VideoStatusQueued},
+	}
+	require.NoError(t, entry.SerializeFields())
+
+	decoded := &Log{VideoDebug: entry.VideoDebug}
+	require.NoError(t, decoded.DeserializeFields())
+	require.NotNil(t, decoded.VideoDebugParsed)
+	assert.Nil(t, decoded.VideoDebugParsed.Accounting)
 }

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -295,6 +295,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_recreate_matviews_with_cost_breakdown"}, run: migrationRecreateMatViewsWithCostBreakdown},
 	{IDs: []string{"logs_add_overhead_breakdown_column"}, run: migrationAddOverheadBreakdownColumn},
 	{IDs: []string{"webhook_deliveries_add_filter_indexes_v1"}, run: migrationAddWebhookDeliveryFilterIndexes},
+	{IDs: []string{"logs_add_video_debug_column"}, run: migrationAddVideoDebugColumn},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -4463,6 +4464,33 @@ func migrationAddVideoEditInputColumn(ctx context.Context, db *gorm.DB, logger s
 	err := m.Migrate()
 	if err != nil {
 		return fmt.Errorf("error while adding video edit input column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddVideoDebugColumn adds the video_debug column to the logs table. It
+// carries the video job id and lifecycle status on video rows, and on the aggregate
+// cost row the pricing detail that tells it apart from the submission it settles —
+// which is otherwise identical to it but for a cost. Nullable and unindexed, so this
+// is a metadata-only DDL change with no table rewrite and no backfill: rows written
+// before it simply have no video detail.
+func migrationAddVideoDebugColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_video_debug_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			return addColumnIfNotExists(tx.WithContext(ctx), logger, &Log{}, "video_debug")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return dropColumnIfExists(tx.WithContext(ctx), logger, &Log{}, "video_debug")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding video_debug column: %s", err.Error())
 	}
 	return nil
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -1269,6 +1269,11 @@ func (s *RDBLogStore) listSelectColumns() string {
 		fmt.Sprintf("substr(content_summary, 1, %d) AS content_summary", maxContentSummaryBytes),
 		"metadata", "cache_debug",
 		"batch_debug",
+		// video_debug tells a settled video's aggregate cost row apart from the
+		// submission it settles; without it the list shows the same video twice.
+		// Not added to billingScalarColumns: video reprices through the generic
+		// object_type path, so pricing never reads this.
+		"video_debug",
 		"is_large_payload_request", "is_large_payload_response",
 		"prompt_tokens", "completion_tokens", "total_tokens",
 		"cached_read_tokens",

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -329,6 +329,11 @@ type Log struct {
 	// operational records rather than request content, so they must survive
 	// object-storage offload and content-hidden rows.
 	BatchDebug string `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostBatchDebug
+	// VideoDebug carries the video job id and lifecycle status, and on the aggregate
+	// cost row the pricing detail that distinguishes it from the submission it
+	// settles. Operational, like BatchDebug — it must survive object-storage offload
+	// and content-hidden rows.
+	VideoDebug string `gorm:"type:text" json:"-"` // JSON serialized *schemas.BifrostVideoDebug
 
 	ServiceTier  *string `gorm:"type:varchar(32)" json:"service_tier,omitempty"`  // OpenAI served tier, e.g. "priority", "flex", "ultrafast", or "default"
 	Speed        *string `gorm:"type:varchar(32)" json:"speed,omitempty"`         // Anthropic served speed: "fast" / "standard"
@@ -361,6 +366,7 @@ type Log struct {
 	ImageGenerationOutputParsed *schemas.BifrostImageGenerationResponse `gorm:"-" json:"image_generation_output,omitempty"`
 	CacheDebugParsed            *schemas.BifrostCacheDebug              `gorm:"-" json:"cache_debug,omitempty"`
 	BatchDebugParsed            *schemas.BifrostBatchDebug              `gorm:"-" json:"batch_debug,omitempty"`
+	VideoDebugParsed            *schemas.BifrostVideoDebug              `gorm:"-" json:"video_debug,omitempty"`
 	GuardrailDebugParsed        *schemas.BifrostGuardrailDebug          `gorm:"-" json:"guardrail_debug,omitempty"`
 	ListModelsOutputParsed      []schemas.Model                         `gorm:"-" json:"list_models_output,omitempty"`
 	MetadataParsed              map[string]interface{}                  `gorm:"-" json:"metadata,omitempty"`
@@ -725,6 +731,14 @@ func (l *Log) SerializeFields() error {
 		}
 	}
 
+	if !l.VideoDebugParsed.IsZero() {
+		if data, err := sonic.Marshal(l.VideoDebugParsed); err != nil {
+			return err
+		} else {
+			l.VideoDebug = string(data)
+		}
+	}
+
 	if l.GuardrailDebugParsed != nil {
 		if data, err := sonic.Marshal(l.GuardrailDebugParsed); err != nil {
 			return err
@@ -1066,6 +1080,12 @@ func (l *Log) DeserializeFields() error {
 		if err := sonic.Unmarshal([]byte(l.BatchDebug), &l.BatchDebugParsed); err != nil {
 			// Log error but don't fail the operation - initialize as nil
 			l.BatchDebugParsed = nil
+		}
+	}
+
+	if l.VideoDebug != "" {
+		if err := sonic.Unmarshal([]byte(l.VideoDebug), &l.VideoDebugParsed); err != nil {
+			l.VideoDebugParsed = nil
 		}
 	}
 

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -637,6 +637,13 @@ func (p *LoggerPlugin) recordVideoJobLifecycle(entry *logstore.Log, result *sche
 		RateLimitIDs:     stringSlicePtr(entry.RateLimitIDsParsed),
 	}
 	job.ID = tables.ProviderJobID(tables.ProviderJobKindVideo, job.Provider, job.JobID)
+
+	// Mark the request row with the job it addressed. No Accounting block here —
+	// that is what distinguishes the settlement's aggregate cost row from this one.
+	entry.VideoDebugParsed = &schemas.BifrostVideoDebug{
+		VideoID: resp.ID,
+		Status:  resp.Status,
+	}
 	if entry.ID != "" {
 		sourceLogID := entry.ID
 		job.SourceLogID = &sourceLogID

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -3273,3 +3273,38 @@ func TestAccountVideoResults_SkipsAJobWithNoCoordinationRow(t *testing.T) {
 		t.Fatal("inline settlement must not create a job row for a video we never saw submitted")
 	}
 }
+
+// The submission row must name the video it started, so the settlement that lands
+// minutes later is traceable back to it. No accounting block here — that is what
+// distinguishes the settlement's own cost row from this one.
+func TestRecordVideoJobLifecycle_MarksTheRequestRowWithTheVideo(t *testing.T) {
+	plugin, _ := newVideoLifecyclePlugin(t)
+
+	eightSeconds := "8"
+	entry := &logstore.Log{
+		ID:           "req-video-debug",
+		Provider:     string(schemas.OpenAI),
+		Model:        "sora-2-pro",
+		ParamsParsed: &schemas.VideoGenerationParameters{Seconds: &eightSeconds, Size: "1280x720"},
+	}
+	result := &schemas.BifrostResponse{
+		VideoGenerationResponse: &schemas.BifrostVideoGenerationResponse{
+			ID:     "vid_marked",
+			Status: schemas.VideoStatusQueued,
+		},
+	}
+	plugin.recordVideoJobLifecycle(entry, result, schemas.VideoGenerationRequest)
+
+	if entry.VideoDebugParsed == nil {
+		t.Fatal("the submission row must name the video it started")
+	}
+	if entry.VideoDebugParsed.VideoID != "vid_marked" {
+		t.Fatalf("video id = %q, want vid_marked", entry.VideoDebugParsed.VideoID)
+	}
+	if entry.VideoDebugParsed.Status != schemas.VideoStatusQueued {
+		t.Fatalf("status = %q, want queued", entry.VideoDebugParsed.Status)
+	}
+	if entry.VideoDebugParsed.Accounting != nil {
+		t.Fatal("only the settlement's aggregate cost row carries an accounting block")
+	}
+}

--- a/transports/bifrost-http/server/batch_accounting.go
+++ b/transports/bifrost-http/server/batch_accounting.go
@@ -34,7 +34,7 @@ func (f *bifrostBatchResultFetcher) RetrieveBatch(ctx context.Context, job *csta
 	}
 	resp, bifrostErr := f.client.BatchRetrieveRequest(internalJobContext(ctx, job.SelectedKeyID), req)
 	if bifrostErr != nil {
-		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
+		return nil, jobaccounting.NewProviderCallError(bifrostErr)
 	}
 	return resp, nil
 }
@@ -53,7 +53,7 @@ func (f *bifrostBatchResultFetcher) FetchBatchResults(ctx context.Context, job *
 	}
 	resp, bifrostErr := f.client.BatchResultsRequest(internalJobContext(ctx, job.SelectedKeyID), req)
 	if bifrostErr != nil {
-		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
+		return nil, jobaccounting.NewProviderCallError(bifrostErr)
 	}
 	return resp, nil
 }
@@ -136,7 +136,7 @@ func (f *bifrostVideoRetriever) RetrieveVideo(ctx context.Context, job *cstables
 		ID:       job.JobID,
 	})
 	if bifrostErr != nil {
-		return nil, fmt.Errorf("%s", bifrostErr.GetErrorString())
+		return nil, jobaccounting.NewProviderCallError(bifrostErr)
 	}
 	return resp, nil
 }

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -368,6 +368,7 @@ export const createColumns = (
 			header: "Type",
 			size: 150,
 			cell: ({ row }) => {
+				const isVideoSettlement = Boolean(row.original.video_debug?.accounting);
 				return (
 					<Badge
 						variant="outline"
@@ -376,7 +377,9 @@ export const createColumns = (
 							RequestTypeColors[row.original.object as keyof typeof RequestTypeColors],
 						)}
 					>
-						{RequestTypeLabels[row.original.object as keyof typeof RequestTypeLabels]}
+						{isVideoSettlement
+							? "Video Settlement"
+							: RequestTypeLabels[row.original.object as keyof typeof RequestTypeLabels]}
 					</Badge>
 				);
 			},

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -510,6 +510,22 @@ export interface BatchAccountingDebug {
 
 // Batch detail for batch rows. `accounting` is present only on the aggregate
 // cost row written when a settled batch is priced.
+/** Video-kind detail on a log row. `accounting` is set only on the aggregate cost
+ * row a settled video writes, which is what tells it apart from the submission it
+ * settles — the two are otherwise identical but for a cost. */
+export interface VideoDebug {
+	video_id?: string;
+	status?: string; // Provider video lifecycle status, e.g. "queued" / "completed"
+	accounting?: VideoAccountingDebug;
+}
+
+export interface VideoAccountingDebug {
+	seconds?: number;
+	size?: string;
+	output_count?: number;
+	incomplete?: boolean;
+}
+
 export interface BatchDebug {
 	batch_id?: string;
 	status?: string; // Provider batch lifecycle status, e.g. "in_progress" / "completed"
@@ -688,6 +704,7 @@ export interface LogEntry {
 	token_usage?: LLMUsage;
 	cache_debug?: CacheDebug;
 	batch_debug?: BatchDebug;
+	video_debug?: VideoDebug;
 	guardrail_debug?: GuardrailDebug;
 	cost?: number; // Cost in dollars (total cost of the request - includes cache lookup cost and also guardrail judge calls)
 	cost_breakdown?: CostBreakdown; // Per-category split (input/output/additional); present whenever cost is


### PR DESCRIPTION
## Summary

Video and batch job settlers were converting provider errors to plain strings before returning them, discarding the HTTP status code. Without the status code, every provider failure looked identical to the sweeper: a transient error to reschedule. A job the provider had forgotten (404) or whose key was revoked (403) would burn its entire 120-attempt poll budget before parking under `max_poll_attempts`, which names the wrong cause. This PR preserves the status code through a typed `ProviderCallError`, classifies failures into terminal outcomes (gone, access denied, rejected) vs. retryable ones, and stops polling immediately when the outcome is terminal.

It also introduces `BifrostVideoDebug` — a structured block attached to video log rows that distinguishes the aggregate cost row a settlement writes from the submission it settles. Previously the two rows were identical except for a cost, making them indistinguishable in the logs UI.

## Changes

- **`ProviderCallError` / `ClassifyProviderCall`** (`types.go`): New typed error that carries the provider HTTP status alongside the message. `ClassifyProviderCall` maps status codes to `ProviderCallGone` (404/410), `ProviderCallAccessDenied` (401–403), `ProviderCallRejected` (other 4xx), or `ProviderCallRetry` (5xx, 408, 429, no response). 408 and 429 are explicitly retryable 4xx codes.

- **Video settler** (`video.go`): `Poll` now calls `videoUnreachableReason` on retrieve errors and returns a terminal `PollResult` with the appropriate unpriceable reason (`video_gone`, `video_access_denied`, `video_request_rejected`) instead of propagating the error for rescheduling. Two new unpriceable reason constants are exported. `HydrateFromLog` is now implemented rather than a no-op, reading status back off an already-written aggregate row.

- **Batch settler** (`batch.go`): Same pattern applied — `batchUnreachableReason` classifies retrieve errors and three new internal unpriceable reason constants (`batch_gone`, `batch_access_denied`, `batch_request_rejected`) cover the terminal cases.

- **`BifrostVideoDebug` / `VideoAccountingDebug`** (`schemas/videos.go`): New structs mirroring `BifrostBatchDebug`. `Accounting` being non-nil marks a row as the settlement rather than the submission. The `Object` field stays the real request type so repricing still finds the right rates.

- **`videoDebugFor` closure** (`video.go`): Attaches video detail to the aggregate log row on every settlement path, including unpriceable ones. The `Incomplete` flag is set when no rate was found.

- **Log row** (`logstore/tables.go`): `VideoDebug` column (text, nullable) and `VideoDebugParsed` transient field added. `SerializeFields` / `DeserializeFields` handle the JSON round-trip.

- **DB migration** (`logstore/migrations.go`): `migrationAddVideoDebugColumn` adds the nullable, unindexed `video_debug` column with no table rewrite and no backfill.

- **List query** (`logstore/rdb.go`): `video_debug` added to `listSelectColumns` so the UI receives it.

- **Submission row** (`plugins/logging/main.go`): `recordVideoJobLifecycle` now stamps `VideoDebugParsed` with the video ID and initial status on the request row. No `Accounting` block — that absence is what the UI keys on to distinguish submission from settlement.

- **HTTP transport** (`batch_accounting.go`): All three `fmt.Errorf("%s", bifrostErr.GetErrorString())` calls replaced with `jobaccounting.NewProviderCallError(bifrostErr)` so the status code is no longer discarded at the call site.

- **UI** (`columns.tsx`, `logs.ts`): `VideoDebug` and `VideoAccountingDebug` types added. The Type column badge reads "Video Settlement" when `video_debug.accounting` is present, so the two rows are visually distinct.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Plugins
- [x] UI (React)

## How to test

```sh
go test ./framework/jobaccounting/... ./framework/logstore/...
```

Key scenarios covered by new tests:

- `TestVideoPoll_UnreachableJobIsTerminalOnTheFirstAttempt` — 404/403/400 each produce a terminal poll result with the correct unpriceable reason and no rescheduling.
- `TestVideoPoll_TransientFailureStillRetries` — 503/429/timeout still propagate as errors for rescheduling.
- `TestVideoSweeper_GoneJobStopsPollingImmediately` — end-to-end: sweeper calls the retriever exactly once for a 404 job across two sweep passes.
- `TestBatchSweeper_GoneBatchStopsPollingImmediately` — same for batch.
- `TestBatchSweeper_TransientRetrieveFailureStillRetries` — 503 keeps the job retryable.
- `TestVideoSettle_AggregateRowCarriesAccountingDetail` — settlement row carries seconds, size, output count, and `incomplete: false`.
- `TestVideoSettle_UnpriceableRowStillCarriesDetail` — unpriceable row carries the block with `incomplete: true`.
- `TestLogVideoDebugRoundTrip` — serialize/deserialize round-trip through the `video_debug` column.
- `TestRecordVideoJobLifecycle_MarksTheRequestRowWithTheVideo` — submission row has video ID and status but no accounting block.

## Breaking changes

- [x] No

The `video_debug` column is nullable with no backfill. Rows written before the migration have no video detail; nothing reads the column as required.

## Security considerations

No auth, secrets, or PII changes. The `video_debug` column stores operational metadata (job IDs, durations, sizes) already present elsewhere in the row.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable