### PR TITLE
refactor: split `ProviderAndModelLimits` into `GlobalProviderLimits`, `GlobalModelLimits`, `PermitProviderLimits`, and `PermitModelLimits`, adding `ProviderScopedModelLimits` for load-balancing candidate exclusion

### DIFF
--- a/plugins/governance/loadbalance_test.go
+++ b/plugins/governance/loadbalance_test.go
@@ -364,3 +364,32 @@ func TestCandidateExclusionReason(t *testing.T) {
 	assert.Equal(t, "budget 'team-daily' is exhausted",
 		candidateExclusionReason(DecisionAllow, errors.New("budget 'team-daily' is exhausted")))
 }
+
+// A model budget scoped to one provider can tell candidates apart, so exclusion consults it and
+// routes around exactly that provider. A model budget covering every provider cannot: it excludes
+// nobody here, and running out of it is the funnel's refusal to state with a reason.
+func TestCandidateExclusionConsultsProviderScopedModelConfigs(t *testing.T) {
+	openai := "openai"
+	spentOnOpenAI := buildBudgetWithUsage("mc-openai-b", 100.0, 150.0, "1h")
+	spentEverywhere := buildBudgetWithUsage("mc-any-b", 100.0, 150.0, "1h")
+	pairConfig := buildModelConfig("mc-openai", "gpt-5", &openai, spentOnOpenAI, nil)
+	modelWideConfig := buildModelConfig("mc-any", "gpt-5", nil, spentEverywhere, nil)
+
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{*pairConfig, *modelWideConfig},
+		Budgets:      []configstoreTables.TableBudget{*spentOnOpenAI, *spentEverywhere},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	permit := permitWithProviders(grant.PermitVirtualKey, "vk-1", "Key", "openai", "azure")
+	access := grant.NewAccess([]schemas.Permit{permit}, nil, "", nil)
+
+	decision, exclusionErr := store.CheckProviderCandidateExclusion(emptyCtx(), access, schemas.ProviderCandidate{Provider: "openai"}, "gpt-5")
+	require.Error(t, exclusionErr, "the exact-pair budget is spent, so openai cannot serve the model")
+	assert.NotEqual(t, DecisionAllow, decision)
+
+	decision, exclusionErr = store.CheckProviderCandidateExclusion(emptyCtx(), access, schemas.ProviderCandidate{Provider: "azure"}, "gpt-5")
+	require.NoError(t, exclusionErr)
+	assert.Equal(t, DecisionAllow, decision,
+		"the spent budget covering every provider excludes no candidate; that refusal is the funnel's to state")
+}

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -1876,7 +1876,7 @@ func TestPreLLMHook_ModelProviderPass_VirtualKeyModelBlocked(t *testing.T) {
 	assert.Contains(t, shortCircuit.Error.Error.Message, "not allowed")
 }
 
-func TestPreLLMHook_ModelProviderPass_VirtualKeyBudgetExceeded_WithModelProviderLimits(t *testing.T) {
+func TestPreLLMHook_ModelProviderPass_VirtualKeyBudgetExceeded_WithModelPermitProviderLimits(t *testing.T) {
 	logger := NewMockLogger()
 	// Model/provider checks pass (within limits)
 	providerBudget := buildBudget("provider-budget1", 200.0, "1h")
@@ -2705,9 +2705,9 @@ func TestStore_ScopedAndGlobalModelBudgetsBothApply(t *testing.T) {
 	require.NoError(t, err)
 
 	// The holder has no model config of its own, so only the deployment's applies, and it refuses.
-	holderBudgets, _ := store.ProviderAndModelLimits(context.Background(), grant.NewPermit(grant.PermitVirtualKey, vk.ID, "", true, false, nil, nil), schemas.OpenAI, "gpt-4")
+	holderBudgets, _ := store.PermitModelLimits(context.Background(), grant.NewPermit(grant.PermitVirtualKey, vk.ID, "", true, false, nil, nil), schemas.OpenAI, "gpt-4")
 	require.Empty(t, holderBudgets, "nothing of the holder's")
-	budgets, _ := store.ProviderAndModelLimits(context.Background(), nil, schemas.OpenAI, "gpt-4")
+	budgets, _ := store.GlobalModelLimits(context.Background(), schemas.OpenAI, "gpt-4")
 	require.Len(t, budgets, 1, "the deployment's model budget")
 	assert.Equal(t, string(grant.LimitHolderModelConfig), budgets[0].HolderKind)
 

--- a/plugins/governance/permits_test.go
+++ b/plugins/governance/permits_test.go
@@ -264,7 +264,7 @@ func TestPermitForVirtualKey_Limits(t *testing.T) {
 
 	// Each config's limits are answered for that provider, so which provider they answer for is
 	// what was asked rather than something to filter on.
-	openaiBudgets, openaiRateLimits := gs.ProviderLimits(ctx, permit, schemas.OpenAI)
+	openaiBudgets, openaiRateLimits := gs.PermitProviderLimits(ctx, permit, schemas.OpenAI)
 	require.Len(t, openaiBudgets, 1, "the openai config's own")
 	assert.Equal(t, schemas.Limit{
 		ID: "budget-openai", HolderKind: string(grant.LimitHolderVirtualKeyProviderConfig),
@@ -272,11 +272,11 @@ func TestPermitForVirtualKey_Limits(t *testing.T) {
 	}, openaiBudgets[0])
 	assert.Equal(t, []string{"rl-openai"}, limitIDsOf(openaiRateLimits))
 
-	anthropicBudgets, anthropicRateLimits := gs.ProviderLimits(ctx, permit, schemas.Anthropic)
+	anthropicBudgets, anthropicRateLimits := gs.PermitProviderLimits(ctx, permit, schemas.Anthropic)
 	assert.Empty(t, anthropicBudgets, "a config governed by nothing of its own")
 	assert.Empty(t, anthropicRateLimits)
 
-	noProviderBudgets, _ := gs.ProviderLimits(ctx, permit, "")
+	noProviderBudgets, _ := gs.PermitProviderLimits(ctx, permit, "")
 	assert.Empty(t, noProviderBudgets, "and there is no unscoped bucket to find the key's own in")
 
 	// The key's own limits are HolderLimits' to answer.
@@ -317,7 +317,7 @@ func TestPermitForVirtualKey_LimitsOfTwoConfigsForOneProvider(t *testing.T) {
 	ctx := emptyCtx()
 	permit := gs.permitForVirtualKey(ctx, vk)
 
-	budgets, rateLimits := gs.ProviderLimits(ctx, permit, schemas.OpenAI)
+	budgets, rateLimits := gs.PermitProviderLimits(ctx, permit, schemas.OpenAI)
 	require.Len(t, budgets, 2, "both configs govern openai traffic")
 	assert.Equal(t, []string{"budget-first", "budget-second"}, []string{budgets[0].ID, budgets[1].ID})
 	assert.Equal(t, []string{"1", "2"}, []string{budgets[0].HolderID, budgets[1].HolderID},
@@ -1325,7 +1325,7 @@ func TestPermitFindsItsOwnScopedModelConfigs(t *testing.T) {
 	require.Len(t, bases, 1)
 	require.Equal(t, string(grant.PermitVirtualKey), bases[0].Type(), "the type production stamps, not a scope name")
 
-	budgets, _ := store.ProviderAndModelLimits(ctx, bases[0], schemas.OpenAI, "gpt-4o")
+	budgets, _ := store.PermitModelLimits(ctx, bases[0], schemas.OpenAI, "gpt-4o")
 
 	assert.Contains(t, limitIDsOf(budgets), "b-vk-model",
 		"a key's own model budget must be found through the permit production builds for it")

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -161,7 +161,10 @@ func (r *BudgetResolver) evaluateLimits(ctx *schemas.BifrostContext, evaluationR
 	if limits != nil {
 		budgets, rateLimits = limits.Budgets(), limits.RateLimits()
 	} else {
-		budgets, rateLimits = r.store.ProviderAndModelLimits(ctx, nil, evaluationRequest.Provider, evaluationRequest.Model)
+		budgets, rateLimits = r.store.GlobalProviderLimits(ctx, evaluationRequest.Provider)
+		modelBudgets, modelRateLimits := r.store.GlobalModelLimits(ctx, evaluationRequest.Provider, evaluationRequest.Model)
+		budgets = append(budgets, modelBudgets...)
+		rateLimits = append(rateLimits, modelRateLimits...)
 	}
 
 	// Rate limits before budgets, as they always have been: a rate limit refuses a request that

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -159,13 +159,19 @@ type GovernanceStore interface {
 	// An error is a request whose payers cannot be settled at all, which the funnel refuses as such;
 	// it is not a limit being exhausted, which the checks report.
 	GatherLimits(ctx *schemas.BifrostContext, access schemas.Access, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit, err error)
-	// ProviderAndModelLimits reports the model-config limits that cover the pair, resolved per
-	// attempt because a request can fail over to another provider or have its model rewritten, so
-	// they are not facts about the permit. A nil permit asks for the deployment's own: its provider
-	// limits plus its global model configs. A non-nil permit asks for that holder's, and only that
-	// holder's: the deployment's are not folded in, so a caller composing several holders can ask
-	// about each without gathering the same deployment rows once per holder.
-	ProviderAndModelLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit)
+	// The gather primitives below are one vocabulary: who holds the money (the deployment, or a
+	// permit's holder) crossed with what scopes it (a provider, or a model on a provider), plus
+	// HolderLimits for what funds the holder whichever provider serves. GatherLimits composes them;
+	// nothing else decides who is charged. All are resolved per attempt because a request can fail
+	// over to another provider or have its model rewritten, so none of them are facts about the
+	// permit.
+
+	// GlobalProviderLimits reports the deployment's own limits on a provider, spent by every
+	// request that provider serves whatever granted it.
+	GlobalProviderLimits(ctx context.Context, provider schemas.ModelProvider) (budgets []schemas.Limit, rateLimits []schemas.Limit)
+	// GlobalModelLimits reports the deployment's own model-config limits covering the pair,
+	// wildcard tiers included.
+	GlobalModelLimits(ctx context.Context, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit)
 	// HolderLimits reports what funds a permit's holder whichever provider serves the request: for a
 	// virtual key, its own limits plus its team's and customer's. Not on the permit because these
 	// cannot tell one provider from another, so load balancing has no use for them and asking once
@@ -174,12 +180,17 @@ type GovernanceStore interface {
 	// This is the seam a deployment reimplements to fund requests from something other than a key.
 	// Nothing downstream asks what kind of holder answered.
 	HolderLimits(ctx context.Context, permit schemas.Permit) (budgets []schemas.Limit, rateLimits []schemas.Limit)
-	// ProviderLimits reports what funds a permit's use of one provider: the limits configured against
-	// that provider on the holder, and no other. These are the limits that can tell one provider
-	// from another, which is what load balancing asks about, and they are gathered again with the
-	// rest once the attempt's provider is settled. A permit describes what may be reached; what that
-	// costs is the store's to know, keyed by the permit's identity.
-	ProviderLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider) (budgets []schemas.Limit, rateLimits []schemas.Limit)
+	// PermitProviderLimits reports what funds a permit's use of one provider: the limits configured
+	// against that provider on the holder, and no other. These are the limits that can tell one
+	// provider from another, which is what load balancing asks about, and they are gathered again
+	// with the rest once the attempt's provider is settled. A permit describes what may be reached;
+	// what that costs is the store's to know, keyed by the permit's identity.
+	PermitProviderLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider) (budgets []schemas.Limit, rateLimits []schemas.Limit)
+	// PermitModelLimits reports the permit holder's own model-config limits covering the pair,
+	// keyed by the permit's identity the way PermitProviderLimits is. The deployment's are not
+	// folded in, so a caller composing several holders can ask about each without gathering the
+	// same deployment rows once per holder.
+	PermitModelLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit)
 	// CheckBudgets reports whether any of the given budgets is exhausted, and CheckRateLimits the
 	// same for rate limits. What to check is the caller's to assemble; these only evaluate, so
 	// neither knows what kind of holder is paying.
@@ -272,10 +283,11 @@ type GovernanceStore interface {
 	// limits are settled, one pair at a time, so it gathers rather than reads the settled set.
 	GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus
 	// CollectModelScopedGovernanceIDs returns the budget and rate-limit IDs owned by
-	// model configs matching (provider, model) across the global, user and virtual-key
-	// scopes. It takes the virtual key's ID rather than its value, so a caller settling
-	// long after the request — batch accounting, which has only a stored row — can
-	// still reach the same configs.
+	// model configs matching (provider, model) across the global and virtual-key scopes,
+	// plus whatever scopes a registered resolver derives from the IDs (see
+	// RegisterExtraScopedIDsResolver). It takes the virtual key's ID rather than its
+	// value, so a caller settling long after the request — batch accounting, which has
+	// only a stored row — can still reach the same configs.
 	CollectModelScopedGovernanceIDs(ctx context.Context, virtualKeyID string, userID string, provider schemas.ModelProvider, model string) (budgetIDs []string, rateLimitIDs []string)
 }
 
@@ -1336,18 +1348,19 @@ func recordVirtualKeyIdentity(ctx *schemas.BifrostContext, virtualKey *configsto
 // Only spending decides here: what a candidate may reach was already settled by the grant it came from.
 //
 // It asks about the limits that can tell one candidate from another, and only those: the deployment's
-// own limits on that provider, and what the grant's configs for it are funded by. A limit that covers
+// own limits on that provider, its model configs scoped to the provider, and what the grant's configs
+// for it are funded by, the holder's provider-scoped model configs included. A limit that covers
 // every provider answers the same for all of them, so it cannot make one candidate better than
 // another: it can only exclude every candidate at once, which is a refusal, and the funnel states it
-// with a reason rather than load balancing quietly running out of options.
+// with a reason rather than load balancing quietly running out of options. That is why the
+// provider-less model-config tiers stay out (see ProviderScopedModelLimits).
 //
 // So load balancing routes around a provider that is out of room, and being out of money overall is
 // left to the funnel, which is the only place that can say so.
 //
-// The model is what says which permits pay for the candidate: every permit that permits the model on
-// the candidate's provider is funded on it, and a candidate is affordable only when all of them have
-// room. A limit scoped to the model itself applies to every candidate serving it and is not asked
-// about here, since it cannot discriminate.
+// The model says two things here: which permits pay for the candidate (every permit that permits the
+// model on the candidate's provider is funded on it, and a candidate is affordable only when all of
+// them have room), and which per-model configs cover the pair on this provider and no other.
 func (gs *LocalGovernanceStore) CheckProviderCandidateExclusion(ctx *schemas.BifrostContext, access schemas.Access, candidate schemas.ProviderCandidate, model string) (Decision, error) {
 	if spendingChecksSkipped(ctx) {
 		return DecisionAllow, nil
@@ -1355,11 +1368,17 @@ func (gs *LocalGovernanceStore) CheckProviderCandidateExclusion(ctx *schemas.Bif
 
 	provider := schemas.ModelProvider(candidate.Provider)
 	budgets, rateLimits := gs.GlobalProviderLimits(ctx, provider)
+	modelBudgets, modelRateLimits := gs.ProviderScopedModelLimits(ctx, nil, provider, model)
+	budgets = append(budgets, modelBudgets...)
+	rateLimits = append(rateLimits, modelRateLimits...)
 	if access != nil {
 		for _, permit := range access.PermitsForModel(candidate.Provider, model) {
-			permitBudgets, permitRateLimits := gs.ProviderLimits(ctx, permit, provider)
+			permitBudgets, permitRateLimits := gs.PermitProviderLimits(ctx, permit, provider)
 			budgets = append(budgets, permitBudgets...)
 			rateLimits = append(rateLimits, permitRateLimits...)
+			permitModelBudgets, permitModelRateLimits := gs.ProviderScopedModelLimits(ctx, permit, provider, model)
+			budgets = append(budgets, permitModelBudgets...)
+			rateLimits = append(rateLimits, permitModelRateLimits...)
 		}
 	}
 
@@ -1383,7 +1402,7 @@ func (gs *LocalGovernanceStore) CheckProviderCandidateExclusion(ctx *schemas.Bif
 // The result is a snapshot for one attempt. Provider permits carry a copy of the config they came
 // from, so a key reloaded mid-attempt cannot change what that attempt has already resolved. A later
 // attempt builds its own and picks the reload up. What funds the key is not here: see HolderLimits
-// and ProviderLimits, which read it by the permit's identity when an attempt's provider is known.
+// and PermitProviderLimits, which read it by the permit's identity when an attempt's provider is known.
 func (gs *LocalGovernanceStore) permitForVirtualKey(ctx context.Context, vk *configstoreTables.TableVirtualKey) *grant.Permit {
 	if vk == nil {
 		return nil
@@ -1467,11 +1486,11 @@ func (gs *LocalGovernanceStore) virtualKeyOf(ctx context.Context, permit schemas
 	return vk
 }
 
-// ProviderLimits reports what funds a key's use of one provider: the limits of every provider config
+// PermitProviderLimits reports what funds a key's use of one provider: the limits of every provider config
 // the key holds for it. Every config, not the first: two configs for one provider are funded
 // separately, and a request served by that provider draws on both. A config keeps its own row
 // identity as holder, because nothing makes a provider unique within a key.
-func (gs *LocalGovernanceStore) ProviderLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
+func (gs *LocalGovernanceStore) PermitProviderLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
 	vk := gs.virtualKeyOf(ctx, permit)
 	if vk == nil || provider == "" {
 		return nil, nil
@@ -1495,7 +1514,7 @@ func (gs *LocalGovernanceStore) ProviderLimits(ctx context.Context, permit schem
 // when its permit is built, because these limits cannot tell one provider from another. Load
 // balancing asks which provider still has room; a limit that answers the same for every provider
 // cannot help it choose, and asking it once per candidate is how the same question gets answered N
-// times. ProviderLimits answers what discriminates, and this answers the rest.
+// times. PermitProviderLimits answers what discriminates, and this answers the rest.
 //
 // This is the seam a deployment reimplements to fund requests from something other than a key.
 // Nothing downstream asks what kind of holder came back, so answering with a project's limits, or a
@@ -3193,7 +3212,8 @@ func limitIDsOf(lists ...[]schemas.Limit) []string {
 }
 
 // CollectModelScopedGovernanceIDs returns only the model-config-owned IDs for a
-// (provider, model) pair, across the global, user and virtual-key scopes.
+// (provider, model) pair, across the global and virtual-key scopes plus whatever
+// scopes a registered resolver derives from the IDs (see RegisterExtraScopedIDsResolver).
 //
 // It exists for delayed settlement. A request's limits are settled while it is in
 // flight, and a batch create carries no top-level model (each input-file row names
@@ -4336,7 +4356,10 @@ func (gs *LocalGovernanceStore) updateRateLimitReferences(ctx context.Context, r
 // store resolves one permit per credential, so there is nothing to pick between, and one limit
 // reached twice is still one limit once the list is settled.
 func (gs *LocalGovernanceStore) GatherLimits(ctx *schemas.BifrostContext, access schemas.Access, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit, err error) {
-	budgets, rateLimits = gs.ProviderAndModelLimits(ctx, nil, provider, model)
+	budgets, rateLimits = gs.GlobalProviderLimits(ctx, provider)
+	globalModelBudgets, globalModelRateLimits := gs.GlobalModelLimits(ctx, provider, model)
+	budgets = append(budgets, globalModelBudgets...)
+	rateLimits = append(rateLimits, globalModelRateLimits...)
 	if access == nil {
 		return budgets, rateLimits, nil
 	}
@@ -4351,12 +4374,12 @@ func (gs *LocalGovernanceStore) GatherLimits(ctx *schemas.BifrostContext, access
 
 		// The holder's own model limits, gathered per permit because they are keyed by the
 		// permit's identity.
-		modelBudgets, modelRateLimits := gs.ProviderAndModelLimits(ctx, permit, provider, model)
+		modelBudgets, modelRateLimits := gs.PermitModelLimits(ctx, permit, provider, model)
 		budgets = append(budgets, modelBudgets...)
 		rateLimits = append(rateLimits, modelRateLimits...)
 	}
 	for _, permit := range access.PermitsForModel(string(provider), model) {
-		providerBudgets, providerRateLimits := gs.ProviderLimits(ctx, permit, provider)
+		providerBudgets, providerRateLimits := gs.PermitProviderLimits(ctx, permit, provider)
 		budgets = append(budgets, providerBudgets...)
 		rateLimits = append(rateLimits, providerRateLimits...)
 	}
@@ -4409,12 +4432,11 @@ func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx *schemas.Bifrost
 // provider configs that can tell one provider apart from another, which is what makes them the pair
 // load balancing asks about.
 //
-// Exported so a store that answers ResolvePermits from something other than a key can ask the same
-// narrow question over its own baseline-aware checks, which this package's cannot answer for it. It
-// exists so load balancing can ask that narrower question without naming a model. Asking
-// ProviderAndModelLimits with an empty one would answer the same, but it would say the model is
-// unknown where in fact it is known and deliberately not consulted, and the obvious repair to that
-// is to pass the model, which quietly puts model limits back into load balancing.
+// Exported alongside the other gather primitives so a store that answers ResolvePermits from
+// something other than a key can ask the same narrow question over its own baseline-aware checks,
+// which this package's cannot answer for it. GlobalModelLimits answers with every model-config
+// tier, including the ones that cover every provider, and those cannot tell one candidate from
+// another; the model-config limits that can are ProviderScopedModelLimits's to report.
 func (gs *LocalGovernanceStore) GlobalProviderLimits(ctx context.Context, provider schemas.ModelProvider) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
 	providerName := string(provider)
 	if providerName == "" {
@@ -4432,41 +4454,48 @@ func (gs *LocalGovernanceStore) GlobalProviderLimits(ctx context.Context, provid
 		grant.LimitsHeldBy(grant.LimitHolderProvider, providerName, providerName, providerName, "", idOrEmpty(providerTable.RateLimitID)...)
 }
 
-// ProviderAndModelLimits returns the limits that apply only once a request's provider and model are known:
-// the deployment's own provider limits, its global model-config limits, and the grant holder's
-// per-model ones.
+// ProviderScopedModelLimits reports the model-config limits that can tell one
+// load-balancing candidate from another for this model: the configs scoped to the candidate's
+// provider, exact pair and all-models-on-the-provider, in the scope the permit selects (the
+// deployment's own for nil, the holder's otherwise).
 //
-// These are resolved per attempt rather than carried on the grant. A grant is built before a
-// provider is chosen, and an attempt can fail over to a different provider or have its model
-// rewritten, so which of them apply is not a fact about the holder; it is a fact about the attempt.
-// Resolving them here costs four keyed lookups per scope instead of a scan over every model config
-// the deployment has.
+// The provider-less tiers are deliberately absent, and this method rather than
+// ProviderAndModelLimits is what routing asks so they stay absent: a limit covering every provider
+// answers the same for every candidate, so it can only exclude all of them at once, which is a
+// refusal for the funnel to state with a reason rather than load balancing quietly running out of
+// options.
 //
-// The caller gathers these into the attempt's settled limits rather than storing them anywhere
-// longer-lived, so one attempt's limits are never charged to the next.
-func (gs *LocalGovernanceStore) ProviderAndModelLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
+// The walk is collectModelConfigsFor's, filtered rather than reimplemented, so which configs cover
+// a pair has exactly one answer and routing's subset of it cannot drift from the funnel's.
+func (gs *LocalGovernanceStore) ProviderScopedModelLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
 	providerName := string(provider)
-	// The deployment's own provider limits belong to the nil-permit answer alone: a caller asking
-	// about one holder is composing several answers and must not receive the deployment's rows once
-	// per holder it asks about.
-	if permit == nil {
-		budgets, rateLimits = gs.GlobalProviderLimits(ctx, provider)
+	for _, scope := range modelConfigScopesFor(permit) {
+		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, &providerName) {
+			if mc == nil || mc.Provider == nil {
+				continue
+			}
+			budgets = append(budgets, grant.LimitsHeldBy(scope.kind, mc.ID, modelConfigDisplayName(mc), providerName, model, budgetIDsOf(mc.Budgets)...)...)
+			rateLimits = append(rateLimits, grant.LimitsHeldBy(scope.kind, mc.ID, modelConfigDisplayName(mc), providerName, model, idOrEmpty(mc.RateLimitID)...)...)
+		}
 	}
+	return budgets, rateLimits
+}
 
-	// Model configs, most specific tier first, in the scope the permit selects: the deployment's
-	// own for a nil permit, the holder's own otherwise. collectModelConfigsFor walks the four
-	// tiers: exact pair, exact model on any provider, any model on this provider, any model
-	// anywhere.
-	//
-	// A request with no model still walks the scopes: only the wildcard tiers can match then,
-	// and an all-models budget covers a request whatever it runs. Batch creation is the case
-	// that carries no top-level model, and skipping the walk there left the unscoped budget a
-	// key was created with unchecked and never bumped.
+// modelLimitsInScopes names the model-config limits covering the pair in the given scopes.
+// collectModelConfigsFor walks the four tiers, most specific first: exact pair, exact model on any
+// provider, any model on this provider, any model anywhere.
+//
+// A request with no model still walks the scopes: only the wildcard tiers can match then, and an
+// all-models budget covers a request whatever it runs. Batch creation is the case that carries no
+// top-level model, and skipping the walk there left the unscoped budget a key was created with
+// unchecked and never bumped.
+func (gs *LocalGovernanceStore) modelLimitsInScopes(ctx context.Context, scopes []limitScope, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
+	providerName := string(provider)
 	var providerArg *string
 	if providerName != "" {
 		providerArg = &providerName
 	}
-	for _, scope := range modelConfigScopesFor(permit) {
+	for _, scope := range scopes {
 		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, providerArg) {
 			if mc == nil {
 				continue
@@ -4476,6 +4505,31 @@ func (gs *LocalGovernanceStore) ProviderAndModelLimits(ctx context.Context, perm
 		}
 	}
 	return budgets, rateLimits
+}
+
+// GlobalModelLimits reports the deployment's own model-config limits covering the pair.
+//
+// Resolved per attempt rather than carried on the grant. A grant is built before a provider is
+// chosen, and an attempt can fail over to a different provider or have its model rewritten, so
+// which configs apply is a fact about the attempt. Resolving them here costs four keyed lookups
+// per scope instead of a scan over every model config the deployment has. The caller gathers these
+// into the attempt's settled limits rather than storing them anywhere longer-lived, so one
+// attempt's limits are never charged to the next.
+func (gs *LocalGovernanceStore) GlobalModelLimits(ctx context.Context, provider schemas.ModelProvider, model string) ([]schemas.Limit, []schemas.Limit) {
+	return gs.modelLimitsInScopes(ctx, modelConfigScopesFor(nil), provider, model)
+}
+
+// PermitModelLimits reports the permit holder's own model-config limits covering the pair, in the
+// scope the permit's identity selects and no other: the deployment's rows are GlobalModelLimits's
+// to report, so a caller composing several holders never gathers them once per holder. Per attempt
+// for the reasons on GlobalModelLimits.
+func (gs *LocalGovernanceStore) PermitModelLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider, model string) ([]schemas.Limit, []schemas.Limit) {
+	if permit == nil || permit.ID() == "" {
+		// A permit selects the scope, so no permit selects nothing: falling through would answer
+		// with the deployment's rows under a method that promised one holder's.
+		return nil, nil
+	}
+	return gs.modelLimitsInScopes(ctx, modelConfigScopesFor(permit), provider, model)
 }
 
 // limitScope is one model-config scope to resolve limits from, with the holder kind its limits are

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -1791,8 +1791,8 @@ func TestResolveLimits(t *testing.T) {
 		require.NotNil(t, access)
 		require.Len(t, access.Bases(), 1)
 
-		openaiBudgets, _ := store.ProviderLimits(ctx, access.Bases()[0], schemas.OpenAI)
-		bedrockBudgets, _ := store.ProviderLimits(ctx, access.Bases()[0], schemas.Bedrock)
+		openaiBudgets, _ := store.PermitProviderLimits(ctx, access.Bases()[0], schemas.OpenAI)
+		bedrockBudgets, _ := store.PermitProviderLimits(ctx, access.Bases()[0], schemas.Bedrock)
 		assert.Equal(t, []string{"b-key-openai"}, limitIDsOf(openaiBudgets))
 		assert.Equal(t, []string{"b-key-bedrock"}, limitIDsOf(bedrockBudgets))
 		assert.Nil(t, ctx.Grant().Limits(), "nothing is settled yet, which is not the same as nothing applying")

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -499,26 +499,28 @@ func settleTestIdentity(ctx *schemas.BifrostContext) {
 // checkDeploymentBudgets checks the limits that apply to every request regardless of what granted
 // it: the provider's own and the global model configs that cover the pair.
 func checkDeploymentBudgets(gs *LocalGovernanceStore, ctx context.Context, provider schemas.ModelProvider, model string, baselines map[string]float64) (Decision, error) {
-	budgets, _ := gs.ProviderAndModelLimits(ctx, nil, provider, model)
-	return gs.CheckBudgets(ctx, budgets, baselines)
+	budgets, _ := gs.GlobalProviderLimits(ctx, provider)
+	modelBudgets, _ := gs.GlobalModelLimits(ctx, provider, model)
+	return gs.CheckBudgets(ctx, append(budgets, modelBudgets...), baselines)
 }
 
 // checkDeploymentRateLimits is checkDeploymentBudgets for rate limits.
 func checkDeploymentRateLimits(gs *LocalGovernanceStore, ctx context.Context, provider schemas.ModelProvider, model string, tokens, requests map[string]int64) (Decision, error) {
-	_, rateLimits := gs.ProviderAndModelLimits(ctx, nil, provider, model)
-	return gs.CheckRateLimits(ctx, rateLimits, tokens, requests)
+	_, rateLimits := gs.GlobalProviderLimits(ctx, provider)
+	_, modelRateLimits := gs.GlobalModelLimits(ctx, provider, model)
+	return gs.CheckRateLimits(ctx, append(rateLimits, modelRateLimits...), tokens, requests)
 }
 
 // checkScopedBudgets checks the model configs a named holder set for its own traffic, which is what
 // a grant of that identity resolves to.
 func checkScopedBudgets(gs *LocalGovernanceStore, ctx context.Context, permitType grant.PermitType, scopeID string, provider schemas.ModelProvider, model string, baselines map[string]float64) (Decision, error) {
-	budgets, _ := gs.ProviderAndModelLimits(ctx, grant.NewPermit(permitType, scopeID, "", true, false, nil, nil), provider, model)
+	budgets, _ := gs.PermitModelLimits(ctx, grant.NewPermit(permitType, scopeID, "", true, false, nil, nil), provider, model)
 	return gs.CheckBudgets(ctx, budgets, baselines)
 }
 
 // checkScopedRateLimits is checkScopedBudgets for rate limits.
 func checkScopedRateLimits(gs *LocalGovernanceStore, ctx context.Context, permitType grant.PermitType, scopeID string, provider schemas.ModelProvider, model string, tokens, requests map[string]int64) (Decision, error) {
-	_, rateLimits := gs.ProviderAndModelLimits(ctx, grant.NewPermit(permitType, scopeID, "", true, false, nil, nil), provider, model)
+	_, rateLimits := gs.PermitModelLimits(ctx, grant.NewPermit(permitType, scopeID, "", true, false, nil, nil), provider, model)
 	return gs.CheckRateLimits(ctx, rateLimits, tokens, requests)
 }
 
@@ -529,13 +531,15 @@ func checkScopedRateLimits(gs *LocalGovernanceStore, ctx context.Context, permit
 // chargeDeploymentBudgets bills a cost to the limits every request to this provider and model
 // answers to regardless of what granted it, and chargeDeploymentRateLimits counts one against them.
 func chargeDeploymentBudgets(gs *LocalGovernanceStore, ctx context.Context, model string, provider schemas.ModelProvider, cost float64) error {
-	budgets, _ := gs.ProviderAndModelLimits(ctx, nil, provider, model)
-	return gs.ChargeBudgets(ctx, budgets, cost)
+	budgets, _ := gs.GlobalProviderLimits(ctx, provider)
+	modelBudgets, _ := gs.GlobalModelLimits(ctx, provider, model)
+	return gs.ChargeBudgets(ctx, append(budgets, modelBudgets...), cost)
 }
 
 func chargeDeploymentRateLimits(gs *LocalGovernanceStore, ctx context.Context, model string, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens, shouldUpdateRequests bool) error {
-	_, rateLimits := gs.ProviderAndModelLimits(ctx, nil, provider, model)
-	return gs.ChargeRateLimits(ctx, rateLimits, tokensUsed, shouldUpdateTokens, shouldUpdateRequests)
+	_, rateLimits := gs.GlobalProviderLimits(ctx, provider)
+	_, modelRateLimits := gs.GlobalModelLimits(ctx, provider, model)
+	return gs.ChargeRateLimits(ctx, append(rateLimits, modelRateLimits...), tokensUsed, shouldUpdateTokens, shouldUpdateRequests)
 }
 
 // scopedModelLimits is what one named scope's model configs impose on a request to this provider
@@ -574,14 +578,14 @@ func chargeScopedRateLimits(gs *LocalGovernanceStore, ctx context.Context, scope
 func chargeGrantBudgets(gs *LocalGovernanceStore, ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, cost float64) error {
 	permit := gs.permitForVirtualKey(ctx, vk)
 	heldBudgets, _ := gs.HolderLimits(ctx, permit)
-	providerBudgets, _ := gs.ProviderLimits(ctx, permit, provider)
+	providerBudgets, _ := gs.PermitProviderLimits(ctx, permit, provider)
 	return gs.ChargeBudgets(ctx, append(heldBudgets, providerBudgets...), cost)
 }
 
 func chargeGrantRateLimits(gs *LocalGovernanceStore, ctx context.Context, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, tokensUsed int64, shouldUpdateTokens, shouldUpdateRequests bool) error {
 	permit := gs.permitForVirtualKey(ctx, vk)
 	_, heldRateLimits := gs.HolderLimits(ctx, permit)
-	_, providerRateLimits := gs.ProviderLimits(ctx, permit, provider)
+	_, providerRateLimits := gs.PermitProviderLimits(ctx, permit, provider)
 	return gs.ChargeRateLimits(ctx, append(heldRateLimits, providerRateLimits...), tokensUsed, shouldUpdateTokens, shouldUpdateRequests)
 }
 
@@ -591,6 +595,6 @@ func chargeGrantRateLimits(gs *LocalGovernanceStore, ctx context.Context, vk *co
 func checkGrantBudgets(gs *LocalGovernanceStore, bifrostCtx *schemas.BifrostContext, vk *configstoreTables.TableVirtualKey, provider schemas.ModelProvider, model string, baselines map[string]float64) (Decision, error) {
 	permit := gs.permitForVirtualKey(bifrostCtx, vk)
 	heldBudgets, _ := gs.HolderLimits(bifrostCtx, permit)
-	providerBudgets, _ := gs.ProviderLimits(bifrostCtx, permit, provider)
+	providerBudgets, _ := gs.PermitProviderLimits(bifrostCtx, permit, provider)
 	return gs.CheckBudgets(bifrostCtx, append(heldBudgets, providerBudgets...), baselines)
 }


### PR DESCRIPTION
## Summary

The single `ProviderAndModelLimits` method was doing too much: it handled both the deployment's global limits and a permit holder's scoped limits through a nil-permit convention, and it mixed provider-level and model-config limits into one call. This made it impossible for load balancing to ask only about limits that can distinguish one provider candidate from another, because provider-less model-config tiers (which cover every provider equally) were always included. This PR splits that one method into a focused vocabulary of primitives and wires them correctly through load balancing, the funnel, and the budget resolver.

## Changes

- `ProviderAndModelLimits` is replaced by four named primitives:
  - `GlobalProviderLimits` — deployment's own limits on a provider
  - `GlobalModelLimits` — deployment's own model-config limits covering a (provider, model) pair, all tiers including provider-less ones
  - `PermitProviderLimits` — a permit holder's limits scoped to one provider (renamed from `ProviderLimits`)
  - `PermitModelLimits` — a permit holder's own model-config limits for the pair, excluding the deployment's rows so callers composing multiple holders don't gather them once per holder
- A new `ProviderScopedModelLimits` method reports only the model-config limits whose configs are pinned to a specific provider. This is what `CheckProviderCandidateExclusion` (load balancing) now consults, so provider-less tiers — which answer identically for every candidate and can only exclude all of them at once — are deliberately absent from routing decisions.
- `CheckProviderCandidateExclusion` now includes provider-scoped model-config limits for both the deployment and each permit, so a budget tied to a specific (provider, model) pair correctly routes around that provider while a budget covering every provider remains the funnel's refusal to state.
- `GatherLimits` and `evaluateLimits` in the budget resolver are updated to call the new primitives explicitly rather than relying on the nil-permit shorthand.
- A new test `TestCandidateExclusionConsultsProviderScopedModelConfigs` verifies that a spent budget scoped to one provider excludes that provider's candidate while leaving others available, and that a spent budget covering every provider excludes nobody at the load-balancing layer.
- All call sites in tests and test utilities are updated to the new method names.

## Type of change

- [ ] Bug fix
- [x] Refactor
- [ ] Feature
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

The new `TestCandidateExclusionConsultsProviderScopedModelConfigs` test covers the key behavioral distinction: a provider-scoped model budget routes around exactly that provider, while a provider-less model budget does not exclude any individual candidate.

## Breaking changes

- [x] Yes
- [ ] No

`ProviderAndModelLimits` and `ProviderLimits` are removed from the `GovernanceStore` interface and replaced by the four new primitives. Any deployment that embeds or reimplements `GovernanceStore` must implement `GlobalProviderLimits`, `GlobalModelLimits`, `PermitProviderLimits`, and `PermitModelLimits` in place of the old methods.

## Related issues

N/A

## Security considerations

None beyond the correctness fix: load balancing previously could have consulted provider-less model budgets when deciding whether to route around a provider, which could cause it to silently exhaust options rather than surfacing a clear refusal. The new structure ensures that path is taken only by the funnel.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable