### PR TITLE
[fix]: Translate Responses cache breakpoints for Anthropic

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -2,5 +2,6 @@
 - [fix]: marshal required nullable response fields as null [@PSR94](https://github.com/PSR94)
 - fix: accept top-level arrays from OpenAI-compatible model APIs [@dani29](https://github.com/dani29)
 - feat: add Baseten to Hugging Face inference provider discovery [@nicolastoulemont](https://github.com/nicolastoulemont)
+- fix: translate OpenAI Responses `prompt_cache_breakpoint` markers into Anthropic `cache_control` blocks so Claude prompt caching works through the Responses API
 - fix: strip the encrypted reasoning signature when the upstream reports the field as unsupported (e.g. Bedrock Converse replaying a Claude signature onto a non-Anthropic model after a mid-conversation model switch), extending the existing unverifiable-signature fail-soft
 - fix: clear Anthropic raw-body passthrough based on the resolved provider and model pair, so non-Claude models on multi-family providers (Vertex, Azure, Bedrock Mantle) convert the request instead of passing the Anthropic payload through

--- a/core/providers/anthropic/cachebreakpointclamp_test.go
+++ b/core/providers/anthropic/cachebreakpointclamp_test.go
@@ -1,10 +1,43 @@
 package anthropic
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+func TestToAnthropicResponsesRequest_TranslatedBreakpointsAreClamped(t *testing.T) {
+	explicit := "explicit"
+	texts := []string{"one", "two", "three", "four", "five"}
+	blocks := make([]schemas.ResponsesMessageContentBlock, 0, len(texts))
+	for i := range texts {
+		blocks = append(blocks, schemas.ResponsesMessageContentBlock{
+			Type:                  schemas.ResponsesInputMessageContentBlockTypeText,
+			Text:                  &texts[i],
+			PromptCacheBreakpoint: &schemas.PromptCacheBreakpoint{Mode: &explicit},
+		})
+	}
+
+	req := &schemas.BifrostResponsesRequest{
+		Provider: schemas.Anthropic,
+		Model:    "claude-haiku-4-5",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentBlocks: blocks},
+		}},
+	}
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	got, err := ToAnthropicResponsesRequest(ctx, req)
+	if err != nil {
+		t.Fatalf("ToAnthropicResponsesRequest() error = %v", err)
+	}
+
+	if gotMarkers, want := markerTexts(got), []string{"two", "three", "four", "five"}; !eq(gotMarkers, want) {
+		t.Fatalf("translated breakpoint markers = %v, want %v", gotMarkers, want)
+	}
+}
 
 // Anthropic, Bedrock, and Vertex all reject a request carrying more than 4 blocks with
 // cache_control ("A maximum of 4 blocks with cache_control may be provided. Found 5."), verified

--- a/core/providers/anthropic/requestbuilder_test.go
+++ b/core/providers/anthropic/requestbuilder_test.go
@@ -379,6 +379,119 @@ func TestBuildAnthropicResponsesRequestBody_CountTokensMode(t *testing.T) {
 }
 
 func TestBuildAnthropicResponsesRequestBody_TypedPath(t *testing.T) {
+	t.Run("typed_path_translates_responses_prompt_cache_breakpoint", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		explicit := "explicit"
+		ttl := "30m"
+		prefix := "stable prefix"
+		question := "question"
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-haiku-4-5",
+			Input: []schemas.ResponsesMessage{{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{
+					{
+						Type:                  schemas.ResponsesInputMessageContentBlockTypeText,
+						Text:                  &prefix,
+						PromptCacheBreakpoint: &schemas.PromptCacheBreakpoint{Mode: &explicit},
+					},
+					{
+						Type: schemas.ResponsesInputMessageContentBlockTypeText,
+						Text: &question,
+					},
+				}},
+			}},
+			Params: &schemas.ResponsesParameters{
+				PromptCacheOptions: &schemas.PromptCacheOptions{Mode: &explicit, TTL: &ttl},
+			},
+		}
+
+		result, bifrostErr := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if bifrostErr != nil {
+			t.Fatalf("unexpected error: %v", bifrostErr)
+		}
+
+		if got := providerUtils.GetJSONField(result, "messages.0.content.0.cache_control.type").String(); got != "ephemeral" {
+			t.Fatalf("translated cache_control.type = %q, want ephemeral; body=%s", got, result)
+		}
+		if providerUtils.JSONFieldExists(result, "messages.0.content.0.prompt_cache_breakpoint") {
+			t.Fatalf("OpenAI prompt_cache_breakpoint leaked to Anthropic wire body: %s", result)
+		}
+		if providerUtils.JSONFieldExists(result, "prompt_cache_options") {
+			t.Fatalf("OpenAI prompt_cache_options leaked to Anthropic wire body: %s", result)
+		}
+		if providerUtils.JSONFieldExists(result, "messages.0.content.1.cache_control") {
+			t.Fatalf("unmarked content block acquired cache_control: %s", result)
+		}
+		if request.Input[0].Content.ContentBlocks[0].CacheControl != nil {
+			t.Fatal("translation mutated the neutral request's content block")
+		}
+	})
+
+	t.Run("typed_path_preserves_existing_cache_control_over_breakpoint", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		explicit := "explicit"
+		ttl := "1h"
+		text := "stable prefix"
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-haiku-4-5",
+			Input: []schemas.ResponsesMessage{{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type:                  schemas.ResponsesInputMessageContentBlockTypeText,
+					Text:                  &text,
+					CacheControl:          &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral, TTL: &ttl},
+					PromptCacheBreakpoint: &schemas.PromptCacheBreakpoint{Mode: &explicit},
+				}}},
+			}},
+		}
+
+		result, bifrostErr := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if bifrostErr != nil {
+			t.Fatalf("unexpected error: %v", bifrostErr)
+		}
+		if got := providerUtils.GetJSONField(result, "messages.0.content.0.cache_control.ttl").String(); got != ttl {
+			t.Fatalf("existing cache_control TTL = %q, want %q; body=%s", got, ttl, result)
+		}
+	})
+
+	t.Run("typed_path_does_not_translate_unknown_breakpoint_mode", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+		unknown := "implicit"
+		text := "stable prefix"
+
+		request := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Anthropic,
+			Model:    "claude-haiku-4-5",
+			Input: []schemas.ResponsesMessage{{
+				Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+				Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type:                  schemas.ResponsesInputMessageContentBlockTypeText,
+					Text:                  &text,
+					PromptCacheBreakpoint: &schemas.PromptCacheBreakpoint{Mode: &unknown},
+				}}},
+			}},
+		}
+
+		result, bifrostErr := BuildAnthropicResponsesRequestBody(ctx, request, AnthropicRequestBuildConfig{
+			Provider: schemas.Anthropic,
+		})
+		if bifrostErr != nil {
+			t.Fatalf("unexpected error: %v", bifrostErr)
+		}
+		if providerUtils.JSONFieldExists(result, "messages.0.content.0.cache_control") {
+			t.Fatalf("unknown breakpoint mode synthesized cache_control: %s", result)
+		}
+	})
+
 	t.Run("typed_path_basic_request", func(t *testing.T) {
 		ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
 

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -8685,8 +8685,24 @@ func convertResponsesToolChoiceToAnthropic(toolChoice *schemas.ResponsesToolChoi
 	return anthropicChoice
 }
 
+// resolveResponsesCacheControl translates the OpenAI Responses explicit cache
+// breakpoint into Anthropic's per-block cache_control representation. An
+// explicitly supplied cache_control remains authoritative.
+func resolveResponsesCacheControl(block schemas.ResponsesMessageContentBlock) *schemas.CacheControl {
+	if block.CacheControl != nil {
+		return block.CacheControl
+	}
+	if block.PromptCacheBreakpoint != nil &&
+		block.PromptCacheBreakpoint.Mode != nil &&
+		*block.PromptCacheBreakpoint.Mode == "explicit" {
+		return &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral}
+	}
+	return nil
+}
+
 // Helper function to convert ContentBlock to AnthropicContentBlock
 func convertContentBlockToAnthropic(block schemas.ResponsesMessageContentBlock) *AnthropicContentBlock {
+	cacheControl := resolveResponsesCacheControl(block)
 	switch block.Type {
 	case schemas.ResponsesInputMessageContentBlockTypeText, schemas.ResponsesOutputMessageContentTypeText:
 		anthropicBlock := AnthropicContentBlock{}
@@ -8694,7 +8710,7 @@ func convertContentBlockToAnthropic(block schemas.ResponsesMessageContentBlock) 
 			anthropicBlock = AnthropicContentBlock{
 				Type:         AnthropicContentBlockTypeText,
 				Text:         block.Text,
-				CacheControl: block.CacheControl,
+				CacheControl: cacheControl,
 			}
 			if block.ResponsesOutputMessageContentText != nil && len(block.ResponsesOutputMessageContentText.Annotations) > 0 {
 				anthropicBlock.Citations = &AnthropicCitations{
@@ -8714,7 +8730,7 @@ func convertContentBlockToAnthropic(block schemas.ResponsesMessageContentBlock) 
 				ImageURLStruct: &schemas.ChatInputImage{
 					URL: *block.ResponsesInputMessageContentBlockImage.ImageURL,
 				},
-				CacheControl: block.CacheControl,
+				CacheControl: cacheControl,
 			}
 			anthropicBlock := ConvertToAnthropicImageBlock(chatBlock)
 			return &anthropicBlock
@@ -8726,7 +8742,7 @@ func convertContentBlockToAnthropic(block schemas.ResponsesMessageContentBlock) 
 				Content: &AnthropicContent{
 					ContentStr: &block.ResponsesOutputMessageContentCompaction.Summary,
 				},
-				CacheControl: block.CacheControl,
+				CacheControl: cacheControl,
 			}
 		}
 	case schemas.ResponsesOutputMessageContentTypeFallback:
@@ -8747,7 +8763,7 @@ func convertContentBlockToAnthropic(block schemas.ResponsesMessageContentBlock) 
 			anthropicBlock := ConvertResponsesFileBlockToAnthropic(
 				block.ResponsesInputMessageContentBlockFile,
 				block.FileID,
-				block.CacheControl,
+				cacheControl,
 				block.Citations,
 			)
 			return &anthropicBlock
@@ -8757,7 +8773,7 @@ func convertContentBlockToAnthropic(block schemas.ResponsesMessageContentBlock) 
 			return &AnthropicContentBlock{
 				Type:         AnthropicContentBlockTypeContainerUpload,
 				FileID:       block.FileID,
-				CacheControl: block.CacheControl,
+				CacheControl: cacheControl,
 			}
 		}
 	case schemas.ResponsesOutputMessageContentTypeReasoning:

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140135,7 +140135,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code < 400) {",
+                  "pm.test('Anthropic Responses breakpoint write: response is 2xx', function () { pm.expect(pm.response.code).to.be.within(200, 299); });",
+                  "if (pm.response.code >= 200 && pm.response.code < 300) {",
                   "  var usage = pm.response.json().usage;",
                   "  function details(u) { return (u && (u.input_tokens_details || u.prompt_tokens_details)) || {}; }",
                   "  function num(v) { return typeof v === 'number' ? v : 0; }",
@@ -140191,7 +140192,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code < 400) {",
+                  "pm.test('Anthropic Responses breakpoint read: response is 2xx', function () { pm.expect(pm.response.code).to.be.within(200, 299); });",
+                  "if (pm.response.code >= 200 && pm.response.code < 300) {",
                   "  var usage = pm.response.json().usage;",
                   "  function details(u) { return (u && (u.input_tokens_details || u.prompt_tokens_details)) || {}; }",
                   "  function num(v) { return typeof v === 'number' ? v : 0; }",
@@ -140242,7 +140244,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code < 400) {",
+                  "pm.test('Anthropic Responses breakpoint stream write: response is 2xx', function () { pm.expect(pm.response.code).to.be.within(200, 299); });",
+                  "if (pm.response.code >= 200 && pm.response.code < 300) {",
                   "  pm.test('Anthropic Responses breakpoint stream write: SSE content-type', function () { pm.expect(pm.response.headers.get('content-type') || '').to.include('text/event-stream'); });",
                   "  function streamedUsage(text) {",
                   "    var usage = null;",
@@ -140311,7 +140314,8 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "if (pm.response.code < 400) {",
+                  "pm.test('Anthropic Responses breakpoint stream read: response is 2xx', function () { pm.expect(pm.response.code).to.be.within(200, 299); });",
+                  "if (pm.response.code >= 200 && pm.response.code < 300) {",
                   "  pm.test('Anthropic Responses breakpoint stream read: SSE content-type', function () { pm.expect(pm.response.headers.get('content-type') || '').to.include('text/event-stream'); });",
                   "  function streamedUsage(text) {",
                   "    var usage = null;",

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140123,6 +140123,251 @@
           ]
         }
       ]
+    },
+    {
+      "name": "68. Anthropic Responses prompt_cache_breakpoint translation",
+      "item": [
+        {
+          "name": "Anthropic Responses breakpoint translation non-streaming [write]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) {",
+                  "  var usage = pm.response.json().usage;",
+                  "  function details(u) { return (u && (u.input_tokens_details || u.prompt_tokens_details)) || {}; }",
+                  "  function num(v) { return typeof v === 'number' ? v : 0; }",
+                  "  function writes(d) { return num(d.cached_write_tokens) || num(d.cache_write_tokens); }",
+                  "  function reads(d) { return num(d.cached_tokens) || num(d.cached_read_tokens); }",
+                  "  var d = details(usage);",
+                  "  pm.test('Anthropic Responses breakpoint write: usage present', function () { pm.expect(usage).to.be.an('object'); });",
+                  "  pm.test('Anthropic Responses breakpoint write: cache-write tokens > 0', function () { pm.expect(writes(d), JSON.stringify(d)).to.be.above(0); });",
+                  "  pm.collectionVariables.set('anthropicResponsesBreakpointNonstreamWrite', 'sent-' + pm.collectionVariables.get('pcNonce'));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-haiku-4-5\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [anthropic responses breakpoint nonstream {{pcNonce}}]\",\n          \"prompt_cache_breakpoint\": {\n            \"mode\": \"explicit\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anthropic Responses breakpoint translation non-streaming [read]",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var __started = Date.now(); while (Date.now() - __started < 1500) { /* cache propagation */ }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) {",
+                  "  var usage = pm.response.json().usage;",
+                  "  function details(u) { return (u && (u.input_tokens_details || u.prompt_tokens_details)) || {}; }",
+                  "  function num(v) { return typeof v === 'number' ? v : 0; }",
+                  "  function writes(d) { return num(d.cached_write_tokens) || num(d.cache_write_tokens); }",
+                  "  function reads(d) { return num(d.cached_tokens) || num(d.cached_read_tokens); }",
+                  "  var d = details(usage);",
+                  "  pm.test('Anthropic Responses breakpoint read: cached tokens > 0', function () { pm.expect(reads(d), JSON.stringify(d)).to.be.above(0); });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-haiku-4-5\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [anthropic responses breakpoint nonstream {{pcNonce}}]\",\n          \"prompt_cache_breakpoint\": {\n            \"mode\": \"explicit\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses?_chain={{anthropicResponsesBreakpointNonstreamWrite}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ],
+              "query": [
+                {
+                  "key": "_chain",
+                  "value": "{{anthropicResponsesBreakpointNonstreamWrite}}"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anthropic Responses breakpoint translation streaming [write]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) {",
+                  "  pm.test('Anthropic Responses breakpoint stream write: SSE content-type', function () { pm.expect(pm.response.headers.get('content-type') || '').to.include('text/event-stream'); });",
+                  "  function streamedUsage(text) {",
+                  "    var usage = null;",
+                  "    (text || '').split('\\n').forEach(function (line) {",
+                  "      line = line.trim();",
+                  "      if (line.indexOf('data:') !== 0) return;",
+                  "      var data = line.slice(5).trim();",
+                  "      if (!data || data === '[DONE]') return;",
+                  "      var event; try { event = JSON.parse(data); } catch (e) { return; }",
+                  "      if (event.usage) usage = event.usage;",
+                  "      if (event.response && event.response.usage) usage = event.response.usage;",
+                  "    });",
+                  "    return usage;",
+                  "  }",
+                  "  function details(u) { return (u && (u.input_tokens_details || u.prompt_tokens_details)) || {}; }",
+                  "  function num(v) { return typeof v === 'number' ? v : 0; }",
+                  "  function writes(d) { return num(d.cached_write_tokens) || num(d.cache_write_tokens); }",
+                  "  function reads(d) { return num(d.cached_tokens) || num(d.cached_read_tokens); }",
+                  "  var usage = streamedUsage(pm.response.text()); var d = details(usage);",
+                  "  pm.test('Anthropic Responses breakpoint stream write: usage present', function () { pm.expect(usage).to.be.an('object'); });",
+                  "  pm.test('Anthropic Responses breakpoint stream write: cache-write tokens > 0', function () { pm.expect(writes(d), JSON.stringify(d)).to.be.above(0); });",
+                  "  pm.collectionVariables.set('anthropicResponsesBreakpointStreamWrite', 'sent-' + pm.collectionVariables.get('pcNonce'));",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-haiku-4-5\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [anthropic responses breakpoint stream {{pcNonce}}]\",\n          \"prompt_cache_breakpoint\": {\n            \"mode\": \"explicit\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Anthropic Responses breakpoint translation streaming [read]",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var __started = Date.now(); while (Date.now() - __started < 1500) { /* cache propagation */ }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.response.code < 400) {",
+                  "  pm.test('Anthropic Responses breakpoint stream read: SSE content-type', function () { pm.expect(pm.response.headers.get('content-type') || '').to.include('text/event-stream'); });",
+                  "  function streamedUsage(text) {",
+                  "    var usage = null;",
+                  "    (text || '').split('\\n').forEach(function (line) {",
+                  "      line = line.trim();",
+                  "      if (line.indexOf('data:') !== 0) return;",
+                  "      var data = line.slice(5).trim();",
+                  "      if (!data || data === '[DONE]') return;",
+                  "      var event; try { event = JSON.parse(data); } catch (e) { return; }",
+                  "      if (event.usage) usage = event.usage;",
+                  "      if (event.response && event.response.usage) usage = event.response.usage;",
+                  "    });",
+                  "    return usage;",
+                  "  }",
+                  "  function details(u) { return (u && (u.input_tokens_details || u.prompt_tokens_details)) || {}; }",
+                  "  function num(v) { return typeof v === 'number' ? v : 0; }",
+                  "  function writes(d) { return num(d.cached_write_tokens) || num(d.cache_write_tokens); }",
+                  "  function reads(d) { return num(d.cached_tokens) || num(d.cached_read_tokens); }",
+                  "  var usage = streamedUsage(pm.response.text()); var d = details(usage);",
+                  "  pm.test('Anthropic Responses breakpoint stream read: cached tokens > 0', function () { pm.expect(reads(d), JSON.stringify(d)).to.be.above(0); });",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-haiku-4-5\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [anthropic responses breakpoint stream {{pcNonce}}]\",\n          \"prompt_cache_breakpoint\": {\n            \"mode\": \"explicit\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses?_chain={{anthropicResponsesBreakpointStreamWrite}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ],
+              "query": [
+                {
+                  "key": "_chain",
+                  "value": "{{anthropicResponsesBreakpointStreamWrite}}"
+                }
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fix Anthropic prompt caching for OpenAI-compatible Responses requests. An explicit per-content-block `prompt_cache_breakpoint` was parsed into the neutral schema but dropped during Anthropic request conversion, so Claude received no `cache_control` marker and produced no cache hits.

## Changes

- Translate `prompt_cache_breakpoint.mode: "explicit"` to Anthropic `cache_control: {"type":"ephemeral"}` on cacheable Responses content blocks.
- Preserve an explicitly supplied `cache_control` as authoritative, including its TTL.
- Leave unknown breakpoint modes unmapped and avoid mutating the neutral request.
- Feed translated markers through the existing Anthropic four-breakpoint clamp.
- Add wire-level regression tests plus live non-streaming and streaming cold-write/warm-read provider harness cases.
- Leave request-wide `prompt_cache_options` unmapped because Anthropic has no faithful request-wide equivalent.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/anthropic ./schemas -count=1
go test ./providers/... -count=1

make test-harness-runner-lib
node tests/e2e/api/collections/collection-scripts.test.mjs

USE_INFISICAL=0 CI=1 \
  make run-provider-harness-test \
  PROVIDER=anthropic \
  FEATURE="breakpoint translation" 
```

Live provider result: all four Anthropic Responses cache cases pass:

- non-streaming cold write
- non-streaming warm read
- streaming cold write
- streaming warm read

The complete provider regression tree, schema suite, harness-runner library tests, and collection-script tests also pass.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

No issue linked.

## Security considerations

No security-sensitive behavior or credential handling changes.

## Checklist

- [x] I read the contribution guidelines and followed them
- [x] I added/updated tests where appropriate
- [x] I updated the core changelog
- [ ] I verified the complete Go and UI builds locally
- [ ] I verified the complete CI pipeline locally

Validation note: the full `core ./...` sweep reaches unrelated MCP integration tests that require generated MCP fixture binaries, and the current UI typecheck has a pre-existing missing `VKCreationPolicyResponse` export. The packages and live provider paths affected by this PR pass.
