### PR TITLE
feat: add `ReadOnlyNotice` component to model limit scope registry for customizable read-only alert messaging

### DIFF
--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -313,7 +313,13 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 					<div className="grow space-y-4 px-4 md:px-8">
 						<Alert variant="info">
 							<Lock className="h-4 w-4" />
-							<AlertDescription>This limit is read-only here — it's managed elsewhere and must be changed there.</AlertDescription>
+							<AlertDescription>
+								{scopeEntry?.ReadOnlyNotice ? (
+									<scopeEntry.ReadOnlyNotice modelConfig={modelConfig} />
+								) : (
+									<p>This limit is read-only here - it's managed elsewhere.</p>
+								)}
+							</AlertDescription>
 						</Alert>
 
 						<div className="space-y-1">

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -64,6 +64,11 @@ export interface ModelLimitScopeEntry {
 	// the row's own ModelConfig; renders nothing (returns null) itself when there
 	// is nothing to show.
 	ManagedByComponent?: ComponentType<{ modelConfig: ModelConfig }>;
+	// Optional. Replaces the generic read-only alert body in the Model Limit
+	// sheet for a readOnly scope, letting the owner name itself — e.g.
+	// enterprise's "managed by access profile X". Passed the row's own
+	// ModelConfig; falls back to the generic message when omitted.
+	ReadOnlyNotice?: ComponentType<{ modelConfig: ModelConfig }>;
 }
 
 const registry = new Map<string, ModelLimitScopeEntry>();


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


