### PR TITLE
fix(core): resolve env.-indirected network_config.base_url

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -566,7 +566,7 @@ func TestExecuteRequestWithRetries_LoggingAndCounting(t *testing.T) {
 func TestHandleProviderRequest_OCROperationNotAllowed(t *testing.T) {
 	providerConfig := &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        "http://127.0.0.1:1",
+			BaseURL:                        schemas.NewSecretVar("http://127.0.0.1:1"),
 			DefaultRequestTimeoutInSeconds: 1,
 		},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
@@ -865,7 +865,7 @@ func (ma *MockAccount) AddProviderWithBaseURL(provider schemas.ModelProvider, co
 	defer ma.mu.Unlock()
 	ma.configs[provider] = &schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        baseURL,
+			BaseURL:                        schemas.NewSecretVar(baseURL),
 			DefaultRequestTimeoutInSeconds: 300,
 			MaxRetries:                     3,
 			RetryBackoffInitial:            500 * time.Millisecond,

--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -684,7 +684,7 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 	case ProviderOpenAICustom:
 		return &schemas.ProviderConfig{
 			NetworkConfig: schemas.NetworkConfig{
-				BaseURL:                        "https://api.openai.com",
+				BaseURL:                        schemas.NewSecretVar("https://api.openai.com"),
 				DefaultRequestTimeoutInSeconds: 120,
 				MaxRetries:                     10, // Higher retries for Groq (can be flaky)
 				RetryBackoffInitial:            1 * time.Second,
@@ -793,7 +793,7 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 				MaxRetries:                     8, // Local service, fewer retries needed
 				RetryBackoffInitial:            250 * time.Millisecond,
 				RetryBackoffMax:                4 * time.Second,
-				BaseURL:                        os.Getenv("OLLAMA_BASE_URL"),
+				BaseURL:                        schemas.NewSecretVar(os.Getenv("OLLAMA_BASE_URL")),
 			},
 			ConcurrencyAndBufferSize: schemas.ConcurrencyAndBufferSize{
 				Concurrency: Concurrency,
@@ -829,7 +829,7 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 	case schemas.SGL:
 		return &schemas.ProviderConfig{
 			NetworkConfig: schemas.NetworkConfig{
-				BaseURL:                        os.Getenv("SGL_BASE_URL"),
+				BaseURL:                        schemas.NewSecretVar(os.Getenv("SGL_BASE_URL")),
 				DefaultRequestTimeoutInSeconds: 120,
 				MaxRetries:                     10, // SGL (self-hosted) can be variable
 				RetryBackoffInitial:            1 * time.Second,
@@ -947,7 +947,7 @@ func (account *ComprehensiveTestAccount) GetConfigForProvider(providerKey schema
 	case schemas.VLLM:
 		return &schemas.ProviderConfig{
 			NetworkConfig: schemas.NetworkConfig{
-				BaseURL:                        os.Getenv("VLLM_BASE_URL"),
+				BaseURL:                        schemas.NewSecretVar(os.Getenv("VLLM_BASE_URL")),
 				DefaultRequestTimeoutInSeconds: 120,
 				MaxRetries:                     10, // vllm is stable
 				RetryBackoffInitial:            5 * time.Second,

--- a/core/providers/anthropic/anthropic.go
+++ b/core/providers/anthropic/anthropic.go
@@ -105,10 +105,7 @@ func NewAnthropicProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.anthropic.com"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.anthropic.com")
 
 	return &AnthropicProvider{
 		logger:               logger,
@@ -133,7 +130,7 @@ func (provider *AnthropicProvider) buildRequestURL(ctx *schemas.BifrostContext, 
 	if isCompleteURL {
 		return path
 	}
-	return provider.networkConfig.BaseURL + path
+	return provider.networkConfig.BaseURL.GetValue() + path
 }
 
 func setAnthropicRequestBody(ctx *schemas.BifrostContext, req *fasthttp.Request, body []byte) bool {
@@ -2135,7 +2132,7 @@ func (provider *AnthropicProvider) BatchCancel(ctx *schemas.BifrostContext, keys
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/messages/batches/" + request.BatchID + "/cancel")
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/messages/batches/" + request.BatchID + "/cancel")
 		req.Header.SetMethod(http.MethodPost)
 		req.Header.SetContentType("application/json")
 
@@ -2248,7 +2245,7 @@ func (provider *AnthropicProvider) BatchResults(ctx *schemas.BifrostContext, key
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/messages/batches/" + request.BatchID + "/results")
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/messages/batches/" + request.BatchID + "/results")
 		req.Header.SetMethod(http.MethodGet)
 
 		if key.Value.GetValue() != "" {
@@ -2735,7 +2732,7 @@ func (provider *AnthropicProvider) FileDelete(ctx *schemas.BifrostContext, keys 
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + request.FileID)
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files/" + request.FileID)
 		req.Header.SetMethod(http.MethodDelete)
 		req.Header.SetContentType("application/json")
 
@@ -2847,7 +2844,7 @@ func (provider *AnthropicProvider) FileContent(ctx *schemas.BifrostContext, keys
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + request.FileID + "/content")
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files/" + request.FileID + "/content")
 		req.Header.SetMethod(http.MethodGet)
 
 		if key.Value.GetValue() != "" {
@@ -3089,7 +3086,7 @@ func (provider *AnthropicProvider) Passthrough(
 		return nil, err
 	}
 
-	url := provider.networkConfig.BaseURL + req.Path
+	url := provider.networkConfig.BaseURL.GetValue() + req.Path
 	if req.RawQuery != "" {
 		url += "?" + req.RawQuery
 	}
@@ -3160,7 +3157,7 @@ func (provider *AnthropicProvider) PassthroughStream(
 		return nil, err
 	}
 
-	url := provider.networkConfig.BaseURL + req.Path
+	url := provider.networkConfig.BaseURL.GetValue() + req.Path
 	if req.RawQuery != "" {
 		url += "?" + req.RawQuery
 	}

--- a/core/providers/anthropic/streamtruncation_test.go
+++ b/core/providers/anthropic/streamtruncation_test.go
@@ -60,7 +60,7 @@ func anthropicSSEServer(t *testing.T, prelude string, truncate bool) *httptest.S
 
 func newTruncationTestProvider(baseURL string) *AnthropicProvider {
 	return NewAnthropicProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: baseURL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(baseURL)},
 	}, truncationTestLogger{})
 }
 

--- a/core/providers/cerebras/cerebras.go
+++ b/core/providers/cerebras/cerebras.go
@@ -3,7 +3,6 @@ package cerebras
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/openai"
@@ -45,10 +44,7 @@ func NewCerebrasProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.cerebras.ai"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.cerebras.ai")
 
 	return &CerebrasProvider{
 		logger:              logger,
@@ -71,7 +67,7 @@ func (provider *CerebrasProvider) ListModels(ctx *schemas.BifrostContext, keys [
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
@@ -87,7 +83,7 @@ func (provider *CerebrasProvider) TextCompletion(ctx *schemas.BifrostContext, ke
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -107,7 +103,7 @@ func (provider *CerebrasProvider) TextCompletionStream(ctx *schemas.BifrostConte
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/completions",
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -129,7 +125,7 @@ func (provider *CerebrasProvider) ChatCompletion(ctx *schemas.BifrostContext, ke
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -151,7 +147,7 @@ func (provider *CerebrasProvider) ChatCompletionStream(ctx *schemas.BifrostConte
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/chat/completions",
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/cohere/cohere.go
+++ b/core/providers/cohere/cohere.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -126,10 +125,7 @@ func NewCohereProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	streamingClient := providerUtils.BuildStreamingClient(client)
 
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.cohere.ai"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.cohere.ai")
 
 	return &CohereProvider{
 		logger:               logger,
@@ -153,7 +149,7 @@ func (provider *CohereProvider) buildRequestURL(ctx *schemas.BifrostContext, def
 	if isCompleteURL {
 		return path
 	}
-	return provider.networkConfig.BaseURL + path
+	return provider.networkConfig.BaseURL.GetValue() + path
 }
 
 // completeRequest sends a request to Cohere's API and handles the response.

--- a/core/providers/databricks/databricks.go
+++ b/core/providers/databricks/databricks.go
@@ -98,7 +98,7 @@ func NewDatabricksProvider(config *schemas.ProviderConfig, logger schemas.Logger
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "")
 
 	return &DatabricksProvider{
 		logger:              logger,
@@ -124,8 +124,8 @@ func (provider *DatabricksProvider) resolveWorkspaceHost(key schemas.Key) (strin
 			return host, nil
 		}
 	}
-	if provider.networkConfig.BaseURL != "" {
-		if host := normalizeHost(provider.networkConfig.BaseURL); host != "" {
+	if provider.networkConfig.BaseURL.GetValue() != "" {
+		if host := normalizeHost(provider.networkConfig.BaseURL.GetValue()); host != "" {
 			return host, nil
 		}
 	}

--- a/core/providers/deepseek/anthropic_test.go
+++ b/core/providers/deepseek/anthropic_test.go
@@ -31,7 +31,7 @@ func (l testLogger) LogHTTPRequest(schemas.LogLevel, string) schemas.LogEventBui
 func newTestDeepSeekProvider(baseURL string) (*deepseek.DeepSeekProvider, error) {
 	return deepseek.NewDeepSeekProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        baseURL,
+			BaseURL:                        schemas.NewSecretVar(baseURL),
 			DefaultRequestTimeoutInSeconds: 5,
 			StreamIdleTimeoutInSeconds:     5,
 			MaxConnsPerHost:                1,

--- a/core/providers/deepseek/deepseek.go
+++ b/core/providers/deepseek/deepseek.go
@@ -4,7 +4,6 @@ package deepseek
 import (
 	"context"
 	"maps"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
@@ -47,10 +46,7 @@ func NewDeepSeekProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.deepseek.com"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.deepseek.com")
 
 	return &DeepSeekProvider{
 		logger:              logger,
@@ -167,7 +163,7 @@ func (provider *DeepSeekProvider) ListModels(ctx *schemas.BifrostContext, keys [
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
@@ -184,7 +180,7 @@ func (provider *DeepSeekProvider) TextCompletion(ctx *schemas.BifrostContext, ke
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/beta/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/beta/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -205,7 +201,7 @@ func (provider *DeepSeekProvider) TextCompletionStream(ctx *schemas.BifrostConte
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/beta/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/beta/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -228,7 +224,7 @@ func (provider *DeepSeekProvider) ChatCompletion(ctx *schemas.BifrostContext, ke
 		return anthropic.HandleAnthropicChatCompletionRequest(
 			ctx,
 			provider.client,
-			provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages"),
+			provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages"),
 			request,
 			anthropic.AnthropicRequestBuildConfig{
 				Provider:                  schemas.DeepSeek,
@@ -247,7 +243,7 @@ func (provider *DeepSeekProvider) ChatCompletion(ctx *schemas.BifrostContext, ke
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -279,7 +275,7 @@ func (provider *DeepSeekProvider) ChatCompletionStream(ctx *schemas.BifrostConte
 		return anthropic.HandleAnthropicChatCompletionStreaming(
 			ctx,
 			provider.streamingClient,
-			provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages"),
+			provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages"),
 			jsonData,
 			provider.anthropicHeaders(key),
 			provider.networkConfig.ExtraHeaders,
@@ -301,7 +297,7 @@ func (provider *DeepSeekProvider) ChatCompletionStream(ctx *schemas.BifrostConte
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -327,7 +323,7 @@ func (provider *DeepSeekProvider) Responses(ctx *schemas.BifrostContext, key sch
 		return anthropic.HandleAnthropicResponsesRequest(
 			ctx,
 			provider.client,
-			provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages"),
+			provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages"),
 			request,
 			anthropic.AnthropicRequestBuildConfig{
 				Provider:                  schemas.DeepSeek,
@@ -367,7 +363,7 @@ func (provider *DeepSeekProvider) ResponsesStream(ctx *schemas.BifrostContext, p
 		return anthropic.HandleAnthropicResponsesStream(
 			ctx,
 			provider.streamingClient,
-			provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages"),
+			provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages"),
 			jsonData,
 			provider.anthropicHeaders(key),
 			provider.networkConfig.ExtraHeaders,
@@ -549,7 +545,7 @@ func (provider *DeepSeekProvider) CountTokens(ctx *schemas.BifrostContext, key s
 	return anthropic.HandleAnthropicCountTokensRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages/count_tokens"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/anthropic/v1/messages/count_tokens"),
 		request,
 		anthropic.AnthropicRequestBuildConfig{
 			Provider:                  schemas.DeepSeek,

--- a/core/providers/elevenlabs/elevenlabs.go
+++ b/core/providers/elevenlabs/elevenlabs.go
@@ -52,10 +52,7 @@ func NewElevenlabsProvider(config *schemas.ProviderConfig, logger schemas.Logger
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.elevenlabs.io"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.elevenlabs.io")
 
 	return &ElevenlabsProvider{
 		logger:               logger,
@@ -86,7 +83,7 @@ func (provider *ElevenlabsProvider) listModelsByKey(ctx *schemas.BifrostContext,
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Build URL using centralized URL construction
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/models"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 
@@ -570,7 +567,7 @@ func (provider *ElevenlabsProvider) Transcription(ctx *schemas.BifrostContext, k
 	if isCompleteURL {
 		req.SetRequestURI(requestPath)
 	} else {
-		req.SetRequestURI(provider.networkConfig.BaseURL + requestPath)
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + requestPath)
 	}
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(contentType)
@@ -844,7 +841,7 @@ func (provider *ElevenlabsProvider) VideoRemix(_ *schemas.BifrostContext, _ sche
 
 // buildSpeechRequestURL constructs the full request URL using the provider's configuration for speech.
 func (provider *ElevenlabsProvider) buildBaseSpeechRequestURL(ctx *schemas.BifrostContext, defaultPath string, requestType schemas.RequestType, request *schemas.BifrostSpeechRequest) string {
-	baseURL := provider.networkConfig.BaseURL
+	baseURL := provider.networkConfig.BaseURL.GetValue()
 	requestPath, isCompleteURL := providerUtils.GetRequestPath(ctx, defaultPath, provider.customProviderConfig, requestType)
 
 	var finalURL string

--- a/core/providers/elevenlabs/realtime.go
+++ b/core/providers/elevenlabs/realtime.go
@@ -22,7 +22,7 @@ func (provider *ElevenlabsProvider) RealtimeWebSocketURL(_ schemas.Key, model, i
 	if intent == "transcription" {
 		return "", providerUtils.NewUnsupportedOperationError(schemas.RealtimeRequest, provider.GetProviderKey())
 	}
-	base := provider.networkConfig.BaseURL
+	base := provider.networkConfig.BaseURL.GetValue()
 	base = strings.Replace(base, "https://", "wss://", 1)
 	base = strings.Replace(base, "http://", "ws://", 1)
 	return base + "/v1/convai/conversation?agent_id=" + model, nil

--- a/core/providers/fireworks/fireworks.go
+++ b/core/providers/fireworks/fireworks.go
@@ -3,7 +3,6 @@ package fireworks
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
@@ -46,10 +45,7 @@ func NewFireworksProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.fireworks.ai/inference"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.fireworks.ai/inference")
 
 	return &FireworksProvider{
 		logger:              logger,
@@ -99,7 +95,7 @@ func (provider *FireworksProvider) TextCompletion(ctx *schemas.BifrostContext, k
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -117,7 +113,7 @@ func (provider *FireworksProvider) TextCompletionStream(ctx *schemas.BifrostCont
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -140,7 +136,7 @@ func (provider *FireworksProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 		return anthropic.HandleAnthropicChatCompletionRequest(
 			ctx,
 			provider.client,
-			provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
+			provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
 			request,
 			anthropic.AnthropicRequestBuildConfig{
 				Provider:                  schemas.Fireworks,
@@ -158,7 +154,7 @@ func (provider *FireworksProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -191,7 +187,7 @@ func (provider *FireworksProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 		return anthropic.HandleAnthropicChatCompletionStreaming(
 			ctx,
 			provider.streamingClient,
-			provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
+			provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
 			jsonData,
 			provider.anthropicHeaders(key),
 			provider.networkConfig.ExtraHeaders,
@@ -211,7 +207,7 @@ func (provider *FireworksProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -237,7 +233,7 @@ func (provider *FireworksProvider) Responses(ctx *schemas.BifrostContext, key sc
 		return anthropic.HandleAnthropicResponsesRequest(
 			ctx,
 			provider.client,
-			provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
+			provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
 			request,
 			anthropic.AnthropicRequestBuildConfig{
 				Provider:                  schemas.Fireworks,
@@ -256,7 +252,7 @@ func (provider *FireworksProvider) Responses(ctx *schemas.BifrostContext, key sc
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -287,7 +283,7 @@ func (provider *FireworksProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 		return anthropic.HandleAnthropicResponsesStream(
 			ctx,
 			provider.streamingClient,
-			provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
+			provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/messages"),
 			jsonData,
 			provider.anthropicHeaders(key),
 			provider.networkConfig.ExtraHeaders,
@@ -307,7 +303,7 @@ func (provider *FireworksProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -331,7 +327,7 @@ func (provider *FireworksProvider) Embedding(ctx *schemas.BifrostContext, key sc
 	return openai.HandleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/fireworks/fireworks_test.go
+++ b/core/providers/fireworks/fireworks_test.go
@@ -430,7 +430,7 @@ func newTestFireworksProvider(t *testing.T, baseURL string) *fireworksprovider.F
 
 	provider, err := fireworksprovider.NewFireworksProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        baseURL,
+			BaseURL:                        schemas.NewSecretVar(baseURL),
 			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, bifrost.NewNoOpLogger())

--- a/core/providers/gemini/batch.go
+++ b/core/providers/gemini/batch.go
@@ -296,7 +296,7 @@ func (provider *GeminiProvider) downloadBatchResultsFile(ctx context.Context, ke
 
 	url := fmt.Sprintf("%s/%s:download?alt=media", baseURL, fileID)
 
-	provider.logger.Debug("gemini batch results file download url: " + url)
+	provider.logger.Debug("gemini batch results file download url: " + providerUtils.LoggableURL(provider.networkConfig.BaseURL, url))
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(url)
 	req.Header.SetMethod(http.MethodGet)

--- a/core/providers/gemini/batch.go
+++ b/core/providers/gemini/batch.go
@@ -286,7 +286,7 @@ func (provider *GeminiProvider) downloadBatchResultsFile(ctx context.Context, ke
 	// Build download URL - use the download endpoint with alt=media
 	// The base URL is like https://generativelanguage.googleapis.com/v1beta
 	// We need to change it to https://generativelanguage.googleapis.com/download/v1beta
-	baseURL := strings.Replace(provider.networkConfig.BaseURL, "/v1beta", "/download/v1beta", 1)
+	baseURL := strings.Replace(provider.networkConfig.BaseURL.GetValue(), "/v1beta", "/download/v1beta", 1)
 
 	// Ensure fileName has proper format
 	fileID := fileName

--- a/core/providers/gemini/cachedcontents.go
+++ b/core/providers/gemini/cachedcontents.go
@@ -233,7 +233,7 @@ func (provider *GeminiProvider) CachedContentCreate(ctx *schemas.BifrostContext,
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 
-	requestURL := fmt.Sprintf("%s/cachedContents", provider.networkConfig.BaseURL)
+	requestURL := fmt.Sprintf("%s/cachedContents", provider.networkConfig.BaseURL.GetValue())
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(requestURL)
 	req.Header.SetMethod(http.MethodPost)
@@ -287,7 +287,7 @@ func (provider *GeminiProvider) cachedContentListByKey(ctx *schemas.BifrostConte
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 
-	requestURL := fmt.Sprintf("%s/cachedContents", provider.networkConfig.BaseURL)
+	requestURL := fmt.Sprintf("%s/cachedContents", provider.networkConfig.BaseURL.GetValue())
 	queryArgs := url.Values{}
 	if request.PageSize > 0 {
 		queryArgs.Set("pageSize", strconv.Itoa(request.PageSize))
@@ -366,7 +366,7 @@ func (provider *GeminiProvider) cachedContentRetrieveByKey(ctx *schemas.BifrostC
 	defer fasthttp.ReleaseResponse(resp)
 
 	name := normalizeCachedContentName(request.Name)
-	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, name)
+	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL.GetValue(), name)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(requestURL)
@@ -462,7 +462,7 @@ func (provider *GeminiProvider) cachedContentUpdateByKey(ctx *schemas.BifrostCon
 	defer fasthttp.ReleaseResponse(resp)
 
 	name := normalizeCachedContentName(request.Name)
-	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, name)
+	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL.GetValue(), name)
 	if len(updateMaskFields) > 0 {
 		requestURL += "?updateMask=" + strings.Join(updateMaskFields, ",")
 	}
@@ -548,7 +548,7 @@ func (provider *GeminiProvider) cachedContentDeleteByKey(ctx *schemas.BifrostCon
 	defer fasthttp.ReleaseResponse(resp)
 
 	name := normalizeCachedContentName(request.Name)
-	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, name)
+	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL.GetValue(), name)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(requestURL)

--- a/core/providers/gemini/fileupload_test.go
+++ b/core/providers/gemini/fileupload_test.go
@@ -102,7 +102,7 @@ func TestFileUploadSendsContentTypeToGemini(t *testing.T) {
 	defer ts.Close()
 
 	provider := NewGeminiProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: ts.URL + "/v1beta"},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(ts.URL + "/v1beta")},
 	}, testNoopLogger{})
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -3015,7 +3015,7 @@ func (provider *GeminiProvider) batchCancelByKey(ctx *schemas.BifrostContext, ke
 		requestURL = fmt.Sprintf("%s/batches/%s:cancel", provider.networkConfig.BaseURL.GetValue(), batchID)
 	}
 
-	provider.logger.Debug("gemini batch cancel url: " + requestURL)
+	provider.logger.Debug("gemini batch cancel url: " + providerUtils.LoggableURL(provider.networkConfig.BaseURL, requestURL))
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(requestURL)
 	req.Header.SetMethod(http.MethodPost)
@@ -3101,7 +3101,7 @@ func (provider *GeminiProvider) batchDeleteByKey(ctx *schemas.BifrostContext, ke
 		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL.GetValue(), batchID)
 	}
 
-	provider.logger.Debug("gemini batch delete url: " + requestURL)
+	provider.logger.Debug("gemini batch delete url: " + providerUtils.LoggableURL(provider.networkConfig.BaseURL, requestURL))
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(requestURL)
 	req.Header.SetMethod(http.MethodDelete)
@@ -3309,7 +3309,7 @@ func (provider *GeminiProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL.GetValue(), batchID)
 	}
 
-	provider.logger.Debug("gemini batch results url: " + requestURL)
+	provider.logger.Debug("gemini batch results url: " + providerUtils.LoggableURL(provider.networkConfig.BaseURL, requestURL))
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(requestURL)
 	req.Header.SetMethod(http.MethodGet)

--- a/core/providers/gemini/gemini.go
+++ b/core/providers/gemini/gemini.go
@@ -81,10 +81,7 @@ func NewGeminiProvider(config *schemas.ProviderConfig, logger schemas.Logger) *G
 	streamingClient := providerUtils.BuildStreamingClient(client)
 
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://generativelanguage.googleapis.com/v1beta"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://generativelanguage.googleapis.com/v1beta")
 
 	return &GeminiProvider{
 		logger:               logger,
@@ -121,7 +118,7 @@ func (provider *GeminiProvider) completeRequest(ctx *schemas.BifrostContext, mod
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Use Gemini's generateContent endpoint
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/models/"+model+endpoint))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/models/"+model+endpoint))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -204,7 +201,7 @@ func (provider *GeminiProvider) listModelsByKey(ctx *schemas.BifrostContext, key
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Build URL using centralized URL construction
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, fmt.Sprintf("/models?pageSize=%d", schemas.DefaultPageSize)))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, fmt.Sprintf("/models?pageSize=%d", schemas.DefaultPageSize)))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -384,7 +381,7 @@ func (provider *GeminiProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	return HandleGeminiChatCompletionStream(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"),
 		jsonData,
 		headers,
 		provider.networkConfig.ExtraHeaders,
@@ -769,7 +766,7 @@ func (provider *GeminiProvider) responsesWithLargeResponseDetection(
 
 	// Set up request (same as completeRequest)
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":generateContent"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":generateContent"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -912,7 +909,7 @@ func (provider *GeminiProvider) ResponsesStream(ctx *schemas.BifrostContext, pos
 	return HandleGeminiResponsesStream(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"),
 		jsonData,
 		headers,
 		provider.networkConfig.ExtraHeaders,
@@ -1257,7 +1254,7 @@ func (provider *GeminiProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Use Gemini's batchEmbedContents endpoint
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":batchEmbedContents"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":batchEmbedContents"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -1454,7 +1451,7 @@ func (provider *GeminiProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 	defer fasthttp.ReleaseRequest(req)
 
 	req.Header.SetMethod(http.MethodPost)
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"))
 	req.Header.SetContentType("application/json")
 
 	// Set headers for streaming
@@ -1744,7 +1741,7 @@ func (provider *GeminiProvider) TranscriptionStream(ctx *schemas.BifrostContext,
 	defer fasthttp.ReleaseRequest(req)
 
 	req.Header.SetMethod(http.MethodPost)
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":streamGenerateContent?alt=sse"))
 	req.Header.SetContentType("application/json")
 
 	// Set any extra headers from network config
@@ -2035,7 +2032,7 @@ func (provider *GeminiProvider) handleImagenImageGeneration(ctx *schemas.Bifrost
 		return nil, bifrostErr
 	}
 
-	baseURL := provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":predict")
+	baseURL := provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":predict")
 	// Create HTTP request
 	req := fasthttp.AcquireRequest()
 	resp := fasthttp.AcquireResponse()
@@ -2130,7 +2127,7 @@ func (provider *GeminiProvider) ImageEdit(ctx *schemas.BifrostContext, key schem
 			return nil, bifrostErr
 		}
 
-		baseURL := provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":predict")
+		baseURL := provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/models/"+request.Model+":predict")
 		req := fasthttp.AcquireRequest()
 		resp := fasthttp.AcquireResponse()
 		defer fasthttp.ReleaseRequest(req)
@@ -2293,7 +2290,7 @@ func (provider *GeminiProvider) VideoGeneration(ctx *schemas.BifrostContext, key
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Use Gemini's predictLongRunning endpoint for video generation
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/models/"+model+":predictLongRunning"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/models/"+model+":predictLongRunning"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -2365,7 +2362,7 @@ func (provider *GeminiProvider) VideoRetrieve(ctx *schemas.BifrostContext, key s
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/"+operationID))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/"+operationID))
 	req.Header.SetMethod(http.MethodGet)
 	if key.Value.GetValue() != "" {
 		req.Header.Set("x-goog-api-key", key.Value.GetValue())
@@ -2615,7 +2612,7 @@ func (provider *GeminiProvider) BatchCreate(ctx *schemas.BifrostContext, key sch
 	if model == "" {
 		model = "gemini-2.5-flash"
 	}
-	url := fmt.Sprintf("%s/models/%s:batchGenerateContent", provider.networkConfig.BaseURL, model)
+	url := fmt.Sprintf("%s/models/%s:batchGenerateContent", provider.networkConfig.BaseURL.GetValue(), model)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(url)
@@ -2728,7 +2725,7 @@ func (provider *GeminiProvider) batchListByKey(ctx *schemas.BifrostContext, key 
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL for listing batches
-	baseURL := fmt.Sprintf("%s/batches", provider.networkConfig.BaseURL)
+	baseURL := fmt.Sprintf("%s/batches", provider.networkConfig.BaseURL.GetValue())
 	values := url.Values{}
 	if request.PageSize > 0 {
 		values.Set("pageSize", fmt.Sprintf("%d", request.PageSize))
@@ -2896,9 +2893,9 @@ func (provider *GeminiProvider) batchRetrieveByKey(ctx *schemas.BifrostContext, 
 	batchID := request.BatchID
 	var requestURL string
 	if strings.HasPrefix(batchID, "batches/") {
-		requestURL = fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, batchID)
+		requestURL = fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL.GetValue(), batchID)
 	} else {
-		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL, batchID)
+		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL.GetValue(), batchID)
 	}
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -3013,9 +3010,9 @@ func (provider *GeminiProvider) batchCancelByKey(ctx *schemas.BifrostContext, ke
 	batchID := request.BatchID
 	var requestURL string
 	if strings.HasPrefix(batchID, "batches/") {
-		requestURL = fmt.Sprintf("%s/%s:cancel", provider.networkConfig.BaseURL, batchID)
+		requestURL = fmt.Sprintf("%s/%s:cancel", provider.networkConfig.BaseURL.GetValue(), batchID)
 	} else {
-		requestURL = fmt.Sprintf("%s/batches/%s:cancel", provider.networkConfig.BaseURL, batchID)
+		requestURL = fmt.Sprintf("%s/batches/%s:cancel", provider.networkConfig.BaseURL.GetValue(), batchID)
 	}
 
 	provider.logger.Debug("gemini batch cancel url: " + requestURL)
@@ -3099,9 +3096,9 @@ func (provider *GeminiProvider) batchDeleteByKey(ctx *schemas.BifrostContext, ke
 	batchID := request.BatchID
 	var requestURL string
 	if strings.HasPrefix(batchID, "batches/") {
-		requestURL = fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, batchID)
+		requestURL = fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL.GetValue(), batchID)
 	} else {
-		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL, batchID)
+		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL.GetValue(), batchID)
 	}
 
 	provider.logger.Debug("gemini batch delete url: " + requestURL)
@@ -3307,9 +3304,9 @@ func (provider *GeminiProvider) batchResultsByKey(ctx *schemas.BifrostContext, k
 	batchID := request.BatchID
 	var requestURL string
 	if strings.HasPrefix(batchID, "batches/") {
-		requestURL = fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, batchID)
+		requestURL = fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL.GetValue(), batchID)
 	} else {
-		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL, batchID)
+		requestURL = fmt.Sprintf("%s/batches/%s", provider.networkConfig.BaseURL.GetValue(), batchID)
 	}
 
 	provider.logger.Debug("gemini batch results url: " + requestURL)
@@ -3506,7 +3503,7 @@ func (provider *GeminiProvider) FileUpload(ctx *schemas.BifrostContext, key sche
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL - use upload endpoint
-	baseURL := strings.Replace(provider.networkConfig.BaseURL, "/v1beta", "/upload/v1beta", 1)
+	baseURL := strings.Replace(provider.networkConfig.BaseURL.GetValue(), "/v1beta", "/upload/v1beta", 1)
 	requestURL := fmt.Sprintf("%s/files", baseURL)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
@@ -3591,7 +3588,7 @@ func (provider *GeminiProvider) fileListByKey(ctx *schemas.BifrostContext, key s
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL with pagination
-	requestURL := fmt.Sprintf("%s/files", provider.networkConfig.BaseURL)
+	requestURL := fmt.Sprintf("%s/files", provider.networkConfig.BaseURL.GetValue())
 	values := url.Values{}
 	if request.Limit > 0 {
 		values.Set("pageSize", fmt.Sprintf("%d", request.Limit))
@@ -3765,7 +3762,7 @@ func (provider *GeminiProvider) fileRetrieveByKey(ctx *schemas.BifrostContext, k
 	if !strings.HasPrefix(fileID, "files/") {
 		fileID = "files/" + fileID
 	}
-	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, fileID)
+	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL.GetValue(), fileID)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(requestURL)
@@ -3879,7 +3876,7 @@ func (provider *GeminiProvider) fileDeleteByKey(ctx *schemas.BifrostContext, key
 	if !strings.HasPrefix(fileID, "files/") {
 		fileID = "files/" + fileID
 	}
-	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL, fileID)
+	requestURL := fmt.Sprintf("%s/%s", provider.networkConfig.BaseURL.GetValue(), fileID)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	req.SetRequestURI(requestURL)
@@ -4003,7 +4000,7 @@ func (provider *GeminiProvider) CountTokens(ctx *schemas.BifrostContext, key sch
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 	path := fmt.Sprintf("/models/%s:countTokens", model)
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, path))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, path))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -4124,7 +4121,7 @@ func (provider *GeminiProvider) Passthrough(
 	if err := providerUtils.CheckOperationAllowed(schemas.Gemini, provider.customProviderConfig, schemas.PassthroughRequest); err != nil {
 		return nil, err
 	}
-	url := provider.networkConfig.BaseURL + req.Path
+	url := provider.networkConfig.BaseURL.GetValue() + req.Path
 	if req.RawQuery != "" {
 		url += "?" + req.RawQuery
 	}
@@ -4205,7 +4202,7 @@ func (provider *GeminiProvider) PassthroughStream(
 		return nil, err
 	}
 
-	url := provider.networkConfig.BaseURL + req.Path
+	url := provider.networkConfig.BaseURL.GetValue() + req.Path
 	if req.RawQuery != "" {
 		url += "?" + req.RawQuery
 	}

--- a/core/providers/gemini/list_models_single_payload_test.go
+++ b/core/providers/gemini/list_models_single_payload_test.go
@@ -41,7 +41,7 @@ func TestListModelsByKey_ParsesSingleModelPayload(t *testing.T) {
 	defer ts.Close()
 
 	provider := NewGeminiProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: ts.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(ts.URL)},
 	}, testNoopLogger{})
 
 	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)

--- a/core/providers/gemini/passthrough_test.go
+++ b/core/providers/gemini/passthrough_test.go
@@ -46,7 +46,7 @@ func TestPassthroughFollowsFileDownloadRedirect(t *testing.T) {
 	defer ts.Close()
 
 	provider := NewGeminiProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: ts.URL + "/v1beta"},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(ts.URL + "/v1beta")},
 	}, testNoopLogger{})
 	key := schemas.Key{Value: *schemas.NewSecretVar("dummy-key")}
 

--- a/core/providers/githubcopilot/githubcopilot.go
+++ b/core/providers/githubcopilot/githubcopilot.go
@@ -20,7 +20,6 @@ package githubcopilot
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/openai"
@@ -82,7 +81,7 @@ func NewGithubCopilotProvider(config *schemas.ProviderConfig, logger schemas.Log
 	exchangeClient.MaxResponseBodySize = maxExchangeBodyBytes
 	exchangeClient.StreamResponseBody = false
 
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "")
 
 	return &githubCopilotProvider{
 		logger:              logger,
@@ -110,7 +109,7 @@ func (p *githubCopilotProvider) ListModels(ctx *schemas.BifrostContext, keys []s
 		return nil, configurationError("github copilot: no keys configured")
 	}
 
-	creds, bErr := resolveCredentials(ctx, keys[0], p.exchangeClient, p.networkConfig.BaseURL, p.logger)
+	creds, bErr := resolveCredentials(ctx, keys[0], p.exchangeClient, p.networkConfig.BaseURL.GetValue(), p.logger)
 	if bErr != nil {
 		return nil, bErr
 	}
@@ -163,7 +162,7 @@ func (p *githubCopilotProvider) TextCompletionStream(ctx *schemas.BifrostContext
 
 // ChatCompletion performs a chat completion request to the Copilot API.
 func (p *githubCopilotProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	creds, bErr := resolveCredentials(ctx, key, p.exchangeClient, p.networkConfig.BaseURL, p.logger)
+	creds, bErr := resolveCredentials(ctx, key, p.exchangeClient, p.networkConfig.BaseURL.GetValue(), p.logger)
 	if bErr != nil {
 		return nil, bErr
 	}
@@ -187,7 +186,7 @@ func (p *githubCopilotProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 
 // ChatCompletionStream performs a streaming chat completion request to the Copilot API.
 func (p *githubCopilotProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	creds, bErr := resolveCredentials(ctx, key, p.exchangeClient, p.networkConfig.BaseURL, p.logger)
+	creds, bErr := resolveCredentials(ctx, key, p.exchangeClient, p.networkConfig.BaseURL.GetValue(), p.logger)
 	if bErr != nil {
 		return nil, bErr
 	}

--- a/core/providers/githubcopilot/githubcopilot_test.go
+++ b/core/providers/githubcopilot/githubcopilot_test.go
@@ -20,7 +20,7 @@ func TestProviderConstructor(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, schemas.GithubCopilot, provider.GetProviderKey())
-		assert.Empty(t, provider.networkConfig.BaseURL,
+		assert.Empty(t, provider.networkConfig.BaseURL.GetValue(),
 			"a default base URL here would pin every account to the public host")
 		assert.NotNil(t, provider.streamingClient)
 		assert.NotSame(t, provider.client, provider.streamingClient,
@@ -29,12 +29,12 @@ func TestProviderConstructor(t *testing.T) {
 
 	t.Run("honours a configured base URL and strips the trailing slash", func(t *testing.T) {
 		config := &schemas.ProviderConfig{
-			NetworkConfig: schemas.NetworkConfig{BaseURL: "https://copilot.ghe.acme.com/"},
+			NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://copilot.ghe.acme.com/")},
 		}
 		provider, err := NewGithubCopilotProvider(config, nil)
 		require.NoError(t, err)
 
-		assert.Equal(t, "https://copilot.ghe.acme.com", provider.networkConfig.BaseURL)
+		assert.Equal(t, "https://copilot.ghe.acme.com", provider.networkConfig.BaseURL.GetValue())
 	})
 }
 

--- a/core/providers/groq/groq.go
+++ b/core/providers/groq/groq.go
@@ -3,7 +3,6 @@ package groq
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/openai"
@@ -50,10 +49,7 @@ func NewGroqProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*Gr
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.groq.com/openai"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.groq.com/openai")
 
 	return &GroqProvider{
 		logger:              logger,
@@ -76,7 +72,7 @@ func (provider *GroqProvider) ListModels(ctx *schemas.BifrostContext, keys []sch
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Groq,
@@ -102,7 +98,7 @@ func (provider *GroqProvider) ChatCompletion(ctx *schemas.BifrostContext, key sc
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -124,7 +120,7 @@ func (provider *GroqProvider) ChatCompletionStream(ctx *schemas.BifrostContext, 
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/chat/completions",
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -180,7 +176,7 @@ func (provider *GroqProvider) Speech(ctx *schemas.BifrostContext, key schemas.Ke
 	return openai.HandleOpenAISpeechRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/audio/speech"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/audio/speech"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -215,7 +211,7 @@ func (provider *GroqProvider) Transcription(ctx *schemas.BifrostContext, key sch
 	return openai.HandleOpenAITranscriptionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/huggingface/huggingface.go
+++ b/core/providers/huggingface/huggingface.go
@@ -91,10 +91,7 @@ func NewHuggingFaceProvider(config *schemas.ProviderConfig, logger schemas.Logge
 	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = defaultInferenceBaseURL
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, defaultInferenceBaseURL)
 
 	return &HuggingFaceProvider{
 		logger:                    logger,
@@ -119,7 +116,7 @@ func (provider *HuggingFaceProvider) buildRequestURL(ctx *schemas.BifrostContext
 	if isCompleteURL {
 		return path
 	}
-	return provider.networkConfig.BaseURL + path
+	return provider.networkConfig.BaseURL.GetValue() + path
 }
 
 // completeRequestWithModelAliasCache performs a request and retries once on 404 by clearing the cache and refetching model info

--- a/core/providers/mistral/custom_provider_test.go
+++ b/core/providers/mistral/custom_provider_test.go
@@ -60,7 +60,7 @@ func TestMistralProvider_CustomAliasChatStreamUsesBaseCompatibilityAndAliasMetad
 	defer server.Close()
 
 	provider := NewMistralProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			CustomProviderKey: string(customMistralProviderName),
 			BaseProviderType:  schemas.Mistral,
@@ -136,7 +136,7 @@ func TestMistralProvider_CustomAliasEmbeddingReportsAliasMetadata(t *testing.T) 
 	defer server.Close()
 
 	provider := NewMistralProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			CustomProviderKey: string(customMistralProviderName),
 			BaseProviderType:  schemas.Mistral,

--- a/core/providers/mistral/mistral.go
+++ b/core/providers/mistral/mistral.go
@@ -55,10 +55,7 @@ func NewMistralProvider(config *schemas.ProviderConfig, logger schemas.Logger) *
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.mistral.ai"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.mistral.ai")
 
 	return &MistralProvider{
 		logger:               logger,
@@ -88,7 +85,7 @@ func (provider *MistralProvider) listModelsByKey(ctx *schemas.BifrostContext, ke
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/models"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -178,7 +175,7 @@ func (provider *MistralProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		provider.normalizeChatRequestForConversion(request),
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -200,7 +197,7 @@ func (provider *MistralProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/chat/completions",
 		provider.normalizeChatRequestForConversion(request),
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -251,7 +248,7 @@ func (provider *MistralProvider) Embedding(ctx *schemas.BifrostContext, key sche
 	return openai.HandleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -299,7 +296,7 @@ func (provider *MistralProvider) Transcription(ctx *schemas.BifrostContext, key 
 	// Set extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(contentType)
 	if key.Value.GetValue() != "" {
@@ -430,7 +427,7 @@ func (provider *MistralProvider) TranscriptionStream(ctx *schemas.BifrostContext
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	req.Header.SetMethod(http.MethodPost)
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"))
 
 	// Set headers
 	for headerKey, value := range headers {
@@ -677,7 +674,7 @@ func (provider *MistralProvider) OCR(ctx *schemas.BifrostContext, key schemas.Ke
 	// Set extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/ocr"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/ocr"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {

--- a/core/providers/mistral/ocr_test.go
+++ b/core/providers/mistral/ocr_test.go
@@ -604,7 +604,7 @@ func TestOCRWithMockServer(t *testing.T) {
 
 			provider := NewMistralProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
-					BaseURL:                        server.URL,
+					BaseURL:                        schemas.NewSecretVar(server.URL),
 					DefaultRequestTimeoutInSeconds: 300,
 				},
 			}, &testLogger{})
@@ -638,7 +638,7 @@ func TestOCRNilInput(t *testing.T) {
 
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        "https://api.mistral.ai",
+			BaseURL:                        schemas.NewSecretVar("https://api.mistral.ai"),
 			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
@@ -685,7 +685,7 @@ func TestOCRRequestValidation(t *testing.T) {
 
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        server.URL,
+			BaseURL:                        schemas.NewSecretVar(server.URL),
 			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
@@ -724,7 +724,7 @@ func TestMistralOCRIntegration(t *testing.T) {
 
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        "https://api.mistral.ai",
+			BaseURL:                        schemas.NewSecretVar("https://api.mistral.ai"),
 			DefaultRequestTimeoutInSeconds: 60,
 		},
 	}, &testLogger{})

--- a/core/providers/mistral/transcription_test.go
+++ b/core/providers/mistral/transcription_test.go
@@ -592,7 +592,7 @@ func TestTranscriptionWithMockServer(t *testing.T) {
 			// Create provider
 			provider := NewMistralProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
-					BaseURL:                        server.URL,
+					BaseURL:                        schemas.NewSecretVar(server.URL),
 					DefaultRequestTimeoutInSeconds: 300,
 				},
 			}, &testLogger{})
@@ -636,7 +636,7 @@ func TestTranscriptionNilInput(t *testing.T) {
 
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        "https://api.mistral.ai",
+			BaseURL:                        schemas.NewSecretVar("https://api.mistral.ai"),
 			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
@@ -786,7 +786,7 @@ func TestTranscriptionStreamWithMockServer(t *testing.T) {
 			// Create provider
 			provider := NewMistralProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
-					BaseURL:                        server.URL,
+					BaseURL:                        schemas.NewSecretVar(server.URL),
 					DefaultRequestTimeoutInSeconds: 300,
 				},
 			}, &testLogger{})
@@ -841,7 +841,7 @@ func TestTranscriptionStreamNilInput(t *testing.T) {
 
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        "https://api.mistral.ai",
+			BaseURL:                        schemas.NewSecretVar("https://api.mistral.ai"),
 			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
@@ -1271,7 +1271,7 @@ func TestTranscriptionStreamEdgeCases(t *testing.T) {
 			// Create provider
 			provider := NewMistralProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
-					BaseURL:                        server.URL,
+					BaseURL:                        schemas.NewSecretVar(server.URL),
 					DefaultRequestTimeoutInSeconds: 300,
 				},
 			}, &testLogger{})
@@ -1341,7 +1341,7 @@ func TestTranscriptionStreamContextCancellation(t *testing.T) {
 
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        server.URL,
+			BaseURL:                        schemas.NewSecretVar(server.URL),
 			DefaultRequestTimeoutInSeconds: 300,
 		},
 	}, &testLogger{})
@@ -1531,7 +1531,7 @@ func TestMistralTranscriptionIntegration(t *testing.T) {
 	// Create provider
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        "https://api.mistral.ai",
+			BaseURL:                        schemas.NewSecretVar("https://api.mistral.ai"),
 			DefaultRequestTimeoutInSeconds: 60,
 		},
 	}, &testLogger{})
@@ -1591,7 +1591,7 @@ func TestMistralTranscriptionStreamIntegration(t *testing.T) {
 	// Create provider
 	provider := NewMistralProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        "https://api.mistral.ai",
+			BaseURL:                        schemas.NewSecretVar("https://api.mistral.ai"),
 			DefaultRequestTimeoutInSeconds: 60,
 		},
 	}, &testLogger{})

--- a/core/providers/nebius/nebius.go
+++ b/core/providers/nebius/nebius.go
@@ -48,10 +48,7 @@ func NewNebiusProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.tokenfactory.nebius.com"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.tokenfactory.nebius.com")
 
 	return &NebiusProvider{
 		logger:              logger,
@@ -74,7 +71,7 @@ func (provider *NebiusProvider) ListModels(ctx *schemas.BifrostContext, keys []s
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
@@ -90,7 +87,7 @@ func (provider *NebiusProvider) TextCompletion(ctx *schemas.BifrostContext, key 
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -110,7 +107,7 @@ func (provider *NebiusProvider) TextCompletionStream(ctx *schemas.BifrostContext
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -143,7 +140,7 @@ func (provider *NebiusProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+path,
+		provider.networkConfig.BaseURL.GetValue()+path,
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -165,7 +162,7 @@ func (provider *NebiusProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -215,7 +212,7 @@ func (provider *NebiusProvider) Embedding(ctx *schemas.BifrostContext, key schem
 	return openai.HandleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -292,7 +289,7 @@ func (provider *NebiusProvider) ImageGeneration(ctx *schemas.BifrostContext, key
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + path)
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + path)
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 

--- a/core/providers/ollama/ollama.go
+++ b/core/providers/ollama/ollama.go
@@ -50,7 +50,7 @@ func NewOllamaProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "")
 
 	// BaseURL is optional when keys have ollama_key_config with per-key URLs
 	return &OllamaProvider{
@@ -74,8 +74,8 @@ func (provider *OllamaProvider) getBaseURL(key schemas.Key) string {
 	if key.OllamaKeyConfig != nil && key.OllamaKeyConfig.URL.GetValue() != "" {
 		return strings.TrimRight(key.OllamaKeyConfig.URL.GetValue(), "/")
 	}
-	if provider.networkConfig.BaseURL != "" {
-		return strings.TrimRight(provider.networkConfig.BaseURL, "/")
+	if provider.networkConfig.BaseURL.GetValue() != "" {
+		return strings.TrimRight(provider.networkConfig.BaseURL.GetValue(), "/")
 	}
 	return ""
 }

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -62,10 +62,7 @@ func NewOpenAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) *O
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.openai.com"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.openai.com")
 
 	return &OpenAIProvider{
 		logger:               logger,
@@ -90,7 +87,7 @@ func (provider *OpenAIProvider) buildRequestURL(ctx *schemas.BifrostContext, def
 	if isCompleteURL {
 		return path
 	}
-	return provider.networkConfig.BaseURL + path
+	return provider.networkConfig.BaseURL.GetValue() + path
 }
 
 func (provider *OpenAIProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
@@ -5983,7 +5980,7 @@ func (provider *OpenAIProvider) FileRetrieve(ctx *schemas.BifrostContext, keys [
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + request.FileID)
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files/" + request.FileID)
 		req.Header.SetMethod(http.MethodGet)
 		req.Header.SetContentType("application/json")
 
@@ -6059,7 +6056,7 @@ func (provider *OpenAIProvider) FileDelete(ctx *schemas.BifrostContext, keys []s
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + request.FileID)
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files/" + request.FileID)
 		req.Header.SetMethod(http.MethodDelete)
 		req.Header.SetContentType("application/json")
 
@@ -6149,7 +6146,7 @@ func (provider *OpenAIProvider) FileContent(ctx *schemas.BifrostContext, keys []
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + request.FileID + "/content")
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files/" + request.FileID + "/content")
 		req.Header.SetMethod(http.MethodGet)
 
 		if key.Value.GetValue() != "" {
@@ -6556,7 +6553,7 @@ func (provider *OpenAIProvider) BatchRetrieve(ctx *schemas.BifrostContext, keys 
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/batches/" + request.BatchID)
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/batches/" + request.BatchID)
 		req.Header.SetMethod(http.MethodGet)
 		req.Header.SetContentType("application/json")
 
@@ -6630,7 +6627,7 @@ func (provider *OpenAIProvider) BatchCancel(ctx *schemas.BifrostContext, keys []
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/batches/" + request.BatchID + "/cancel")
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/batches/" + request.BatchID + "/cancel")
 		req.Header.SetMethod(http.MethodPost)
 		req.Header.SetContentType("application/json")
 
@@ -6747,7 +6744,7 @@ func (provider *OpenAIProvider) BatchResults(ctx *schemas.BifrostContext, keys [
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + *batchResp.OutputFileID + "/content")
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files/" + *batchResp.OutputFileID + "/content")
 		req.Header.SetMethod(http.MethodGet)
 
 		if key.Value.GetValue() != "" {
@@ -7926,7 +7923,7 @@ func (provider *OpenAIProvider) Passthrough(
 // buildPassthroughURL returns the upstream URL for raw passthrough requests.
 func (provider *OpenAIProvider) buildPassthroughURL(req *schemas.BifrostPassthroughRequest) string {
 	path := req.Path
-	baseURL := provider.networkConfig.BaseURL
+	baseURL := provider.networkConfig.BaseURL.GetValue()
 	if req.UpstreamURL != "" {
 		baseURL = strings.TrimRight(req.UpstreamURL, "/")
 		if !strings.HasPrefix(path, "/") {

--- a/core/providers/openai/realtime.go
+++ b/core/providers/openai/realtime.go
@@ -22,7 +22,7 @@ func (provider *OpenAIProvider) SupportsRealtimeAPI() bool {
 
 // RealtimeWebSocketURL returns the WSS URL for the OpenAI Realtime API.
 func (provider *OpenAIProvider) RealtimeWebSocketURL(_ schemas.Key, model, intent string) (string, *schemas.BifrostError) {
-	base := provider.networkConfig.BaseURL
+	base := provider.networkConfig.BaseURL.GetValue()
 	base = strings.Replace(base, "https://", "wss://", 1)
 	base = strings.Replace(base, "http://", "ws://", 1)
 	if intent != "" {

--- a/core/providers/openai/realtime_test.go
+++ b/core/providers/openai/realtime_test.go
@@ -53,7 +53,7 @@ func TestExtractRealtimeTurnUsageSupportsDurationTranscriptionCompletion(t *test
 func TestRealtimeWebSocketURL(t *testing.T) {
 	t.Parallel()
 
-	provider := &OpenAIProvider{networkConfig: schemas.NetworkConfig{BaseURL: "https://api.openai.com"}}
+	provider := &OpenAIProvider{networkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")}}
 	if got, err := provider.RealtimeWebSocketURL(schemas.Key{}, "gpt-4o transcribe", ""); err != nil || got != "wss://api.openai.com/v1/realtime?model=gpt-4o+transcribe" {
 		t.Fatalf("RealtimeWebSocketURL() = %q, %v", got, err)
 	}

--- a/core/providers/openai/rerank_test.go
+++ b/core/providers/openai/rerank_test.go
@@ -91,7 +91,7 @@ func TestCustomOpenAIProviderRerankUsesGenericEndpoint(t *testing.T) {
 	defer server.Close()
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			CustomProviderKey: "hawk",
 			BaseProviderType:  schemas.OpenAI,
@@ -166,7 +166,7 @@ func TestCustomOpenAIRerankPreservesUpstreamDocument(t *testing.T) {
 	defer server.Close()
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			CustomProviderKey: "hawk",
 			BaseProviderType:  schemas.OpenAI,
@@ -221,7 +221,7 @@ func TestCustomOpenAIRerankLargeResponseThresholdReturnsResults(t *testing.T) {
 	defer server.Close()
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			CustomProviderKey: "hawk",
 			BaseProviderType:  schemas.OpenAI,
@@ -260,7 +260,7 @@ func TestCustomOpenAIRerankLargeResponseThresholdReturnsResults(t *testing.T) {
 
 func TestOpenAIRerankUnsupportedForNativeProvider(t *testing.T) {
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: "http://127.0.0.1:1"},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("http://127.0.0.1:1")},
 	}, testNoopLogger{})
 	_, bifrostErr := provider.Rerank(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), schemas.Key{}, &schemas.BifrostRerankRequest{Model: "rerank"})
 	assertUnsupportedRerank(t, bifrostErr, schemas.OpenAI)
@@ -268,7 +268,7 @@ func TestOpenAIRerankUnsupportedForNativeProvider(t *testing.T) {
 
 func TestCustomOpenAIRerankHonorsAllowedRequests(t *testing.T) {
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: "http://127.0.0.1:1"},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("http://127.0.0.1:1")},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			CustomProviderKey: "hawk",
 			BaseProviderType:  schemas.OpenAI,
@@ -315,7 +315,7 @@ func TestCustomOpenAIRerankMapsSearchUnits(t *testing.T) {
 	defer server.Close()
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			CustomProviderKey: "hawk",
 			BaseProviderType:  schemas.OpenAI,
@@ -370,7 +370,7 @@ func TestCustomOpenAIRerankLargePayloadStreamsBody(t *testing.T) {
 	defer server.Close()
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			CustomProviderKey: "hawk",
 			BaseProviderType:  schemas.OpenAI,

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -62,7 +62,7 @@ func completeSSEServer(t *testing.T, body string) *httptest.Server {
 
 func newStreamTestProvider(baseURL string) *OpenAIProvider {
 	return NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: baseURL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(baseURL)},
 	}, testNoopLogger{})
 }
 
@@ -567,7 +567,7 @@ func TestResponsesStreamFallbackNullDeltaFinishStillCompletes(t *testing.T) {
 	defer server.Close()
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			AllowedRequests: &schemas.AllowedRequests{
 				ChatCompletionStream: true,
@@ -838,7 +838,7 @@ func TestResponsesStreamFallbackSilentParkAfterFinishReasonEndsCleanlyOnIdleTime
 	defer server.Close()
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 		CustomProviderConfig: &schemas.CustomProviderConfig{
 			AllowedRequests: &schemas.AllowedRequests{
 				ChatCompletionStream: true,

--- a/core/providers/openai/transcription_test.go
+++ b/core/providers/openai/transcription_test.go
@@ -58,7 +58,7 @@ func TestTranscription_DiarizedJSON_StringSegmentID(t *testing.T) {
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        server.URL,
+			BaseURL:                        schemas.NewSecretVar(server.URL),
 			DefaultRequestTimeoutInSeconds: 30,
 		},
 	}, &testLogger{})
@@ -147,7 +147,7 @@ func TestTranscription_DiarizedJSON_OmitsAbsentDurationAndTask(t *testing.T) {
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        server.URL,
+			BaseURL:                        schemas.NewSecretVar(server.URL),
 			DefaultRequestTimeoutInSeconds: 30,
 		},
 	}, &testLogger{})
@@ -215,7 +215,7 @@ func TestTranscription_VerboseJSON_StillWorks(t *testing.T) {
 
 	provider := NewOpenAIProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        server.URL,
+			BaseURL:                        schemas.NewSecretVar(server.URL),
 			DefaultRequestTimeoutInSeconds: 30,
 		},
 	}, &testLogger{})

--- a/core/providers/openai/websocket.go
+++ b/core/providers/openai/websocket.go
@@ -14,7 +14,7 @@ func (provider *OpenAIProvider) SupportsWebSocketMode() bool {
 // WebSocketResponsesURL returns the WebSocket URL for the OpenAI Responses API.
 // Converts the HTTP base URL to a WSS URL: https://api.openai.com -> wss://api.openai.com/v1/responses
 func (provider *OpenAIProvider) WebSocketResponsesURL(key schemas.Key) string {
-	base := provider.networkConfig.BaseURL
+	base := provider.networkConfig.BaseURL.GetValue()
 	base = strings.Replace(base, "https://", "wss://", 1)
 	base = strings.Replace(base, "http://", "ws://", 1)
 	return base + "/v1/responses"

--- a/core/providers/opencode/opencode.go
+++ b/core/providers/opencode/opencode.go
@@ -5,7 +5,6 @@ package opencode
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/openai"
@@ -62,10 +61,7 @@ func newOpencodeProvider(
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = defaultBaseURL
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, defaultBaseURL)
 
 	return &opencodeProvider{
 		providerKey:         providerKey,
@@ -89,7 +85,7 @@ func (p *opencodeProvider) ListModels(ctx *schemas.BifrostContext, keys []schema
 		ctx,
 		p.client,
 		request,
-		p.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
+		p.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/models"),
 		keys,
 		p.networkConfig.ExtraHeaders,
 		p.providerKey,
@@ -113,7 +109,7 @@ func (p *opencodeProvider) ChatCompletion(ctx *schemas.BifrostContext, key schem
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		p.client,
-		p.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		p.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		p.networkConfig.ExtraHeaders,
@@ -132,7 +128,7 @@ func (p *opencodeProvider) ChatCompletionStream(ctx *schemas.BifrostContext, pos
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		p.streamingClient,
-		p.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		p.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		p.networkConfig.ExtraHeaders,
@@ -157,7 +153,7 @@ func (p *opencodeProvider) Responses(ctx *schemas.BifrostContext, key schemas.Ke
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
 		p.client,
-		p.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		p.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		p.networkConfig.ExtraHeaders,
@@ -176,7 +172,7 @@ func (p *opencodeProvider) ResponsesStream(ctx *schemas.BifrostContext, postHook
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx,
 		p.streamingClient,
-		p.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		p.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		p.networkConfig.ExtraHeaders,

--- a/core/providers/opencode/opencode_test.go
+++ b/core/providers/opencode/opencode_test.go
@@ -30,8 +30,8 @@ func TestOpencodeProviderConstructors(t *testing.T) {
 		if provider.GetProviderKey() != schemas.OpencodeZen {
 			t.Errorf("expected provider key %s, got %s", schemas.OpencodeZen, provider.GetProviderKey())
 		}
-		if provider.networkConfig.BaseURL != "https://opencode.ai/zen" {
-			t.Errorf("expected base URL https://opencode.ai/zen, got %s", provider.networkConfig.BaseURL)
+		if provider.networkConfig.BaseURL.GetValue() != "https://opencode.ai/zen" {
+			t.Errorf("expected base URL https://opencode.ai/zen, got %s", provider.networkConfig.BaseURL.GetValue())
 		}
 	})
 
@@ -45,8 +45,8 @@ func TestOpencodeProviderConstructors(t *testing.T) {
 		if provider.GetProviderKey() != schemas.OpencodeGo {
 			t.Errorf("expected provider key %s, got %s", schemas.OpencodeGo, provider.GetProviderKey())
 		}
-		if provider.networkConfig.BaseURL != "https://opencode.ai/zen/go" {
-			t.Errorf("expected base URL https://opencode.ai/zen/go, got %s", provider.networkConfig.BaseURL)
+		if provider.networkConfig.BaseURL.GetValue() != "https://opencode.ai/zen/go" {
+			t.Errorf("expected base URL https://opencode.ai/zen/go, got %s", provider.networkConfig.BaseURL.GetValue())
 		}
 	})
 }
@@ -367,7 +367,7 @@ func TestOpencodeResponsesRouting(t *testing.T) {
 
 			provider, err := tc.newProvider(&schemas.ProviderConfig{
 				NetworkConfig: schemas.NetworkConfig{
-					BaseURL:                        server.URL,
+					BaseURL:                        schemas.NewSecretVar(server.URL),
 					DefaultRequestTimeoutInSeconds: 10,
 				},
 			})

--- a/core/providers/openrouter/openrouter.go
+++ b/core/providers/openrouter/openrouter.go
@@ -47,10 +47,7 @@ func NewOpenRouterProvider(config *schemas.ProviderConfig, logger schemas.Logger
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://openrouter.ai/api"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://openrouter.ai/api")
 
 	return &OpenRouterProvider{
 		logger:              logger,
@@ -81,7 +78,7 @@ func (provider *OpenRouterProvider) validateKey(ctx *schemas.BifrostContext, key
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/auth/key")
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/auth/key")
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", keyValue))
 
@@ -119,7 +116,7 @@ func (provider *OpenRouterProvider) fetchEmbeddingModels(ctx *schemas.BifrostCon
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/embeddings/models")
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/embeddings/models")
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 	if keyValue := key.Value.GetValue(); keyValue != "" {
@@ -163,7 +160,7 @@ func (provider *OpenRouterProvider) listModelsByKey(ctx *schemas.BifrostContext,
 	// Set any extra headers from network config
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/models"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/models"))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.SetContentType("application/json")
 	keyValue := key.Value.GetValue()
@@ -322,7 +319,7 @@ func (provider *OpenRouterProvider) TextCompletion(ctx *schemas.BifrostContext, 
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -342,7 +339,7 @@ func (provider *OpenRouterProvider) TextCompletionStream(ctx *schemas.BifrostCon
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/completions",
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -364,7 +361,7 @@ func (provider *OpenRouterProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -386,7 +383,7 @@ func (provider *OpenRouterProvider) ChatCompletionStream(ctx *schemas.BifrostCon
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -411,7 +408,7 @@ func (provider *OpenRouterProvider) Responses(ctx *schemas.BifrostContext, key s
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -430,7 +427,7 @@ func (provider *OpenRouterProvider) ResponsesStream(ctx *schemas.BifrostContext,
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -454,7 +451,7 @@ func (provider *OpenRouterProvider) Embedding(ctx *schemas.BifrostContext, key s
 	return openai.HandleOpenAIEmbeddingRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/embeddings"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -472,7 +469,7 @@ func (provider *OpenRouterProvider) Speech(ctx *schemas.BifrostContext, key sche
 	return openai.HandleOpenAISpeechRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/audio/speech"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/audio/speech"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -505,7 +502,7 @@ func (provider *OpenRouterProvider) Transcription(ctx *schemas.BifrostContext, k
 	return openai.HandleOpenAITranscriptionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/audio/transcriptions"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/parasail/parasail.go
+++ b/core/providers/parasail/parasail.go
@@ -4,7 +4,6 @@ package parasail
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/openai"
@@ -46,10 +45,7 @@ func NewParasailProvider(config *schemas.ProviderConfig, logger schemas.Logger) 
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.parasail.io"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.parasail.io")
 
 	return &ParasailProvider{
 		logger:              logger,
@@ -72,7 +68,7 @@ func (provider *ParasailProvider) ListModels(ctx *schemas.BifrostContext, keys [
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		schemas.Parasail,
@@ -98,7 +94,7 @@ func (provider *ParasailProvider) ChatCompletion(ctx *schemas.BifrostContext, ke
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -120,7 +116,7 @@ func (provider *ParasailProvider) ChatCompletionStream(ctx *schemas.BifrostConte
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/chat/completions",
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/perplexity/perplexity.go
+++ b/core/providers/perplexity/perplexity.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/openai"
@@ -48,10 +47,7 @@ func NewPerplexityProvider(config *schemas.ProviderConfig, logger schemas.Logger
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.perplexity.ai"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.perplexity.ai")
 
 	return &PerplexityProvider{
 		logger:              logger,
@@ -136,7 +132,7 @@ func (provider *PerplexityProvider) ListModels(ctx *schemas.BifrostContext, keys
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
@@ -170,7 +166,7 @@ func (provider *PerplexityProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 		return nil, err
 	}
 
-	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonBody, provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"), key.Value.GetValue(), request.Model)
+	responseBody, latency, providerResponseHeaders, err := provider.completeRequest(ctx, jsonBody, provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/chat/completions"), key.Value.GetValue(), request.Model)
 	if err != nil {
 		return nil, providerUtils.EnrichError(ctx, err, jsonBody, nil, provider.sendBackRawRequest, provider.sendBackRawResponse, latency)
 	}
@@ -217,7 +213,7 @@ func (provider *PerplexityProvider) ChatCompletionStream(ctx *schemas.BifrostCon
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/chat/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/chat/completions",
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -252,7 +248,7 @@ func (provider *PerplexityProvider) Responses(ctx *schemas.BifrostContext, key s
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -284,7 +280,7 @@ func (provider *PerplexityProvider) ResponsesStream(ctx *schemas.BifrostContext,
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,

--- a/core/providers/replicate/replicate.go
+++ b/core/providers/replicate/replicate.go
@@ -54,11 +54,7 @@ func NewReplicateProvider(config *schemas.ProviderConfig, logger schemas.Logger)
 	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
-
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = replicateAPIBaseURL
-	}
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, replicateAPIBaseURL)
 
 	return &ReplicateProvider{
 		logger:               logger,
@@ -82,7 +78,7 @@ func (provider *ReplicateProvider) buildRequestURL(ctx *schemas.BifrostContext, 
 	if isCompleteURL {
 		return path
 	}
-	return provider.networkConfig.BaseURL + path
+	return provider.networkConfig.BaseURL.GetValue() + path
 }
 
 const (
@@ -414,7 +410,7 @@ func (provider *ReplicateProvider) ListModels(ctx *schemas.BifrostContext, keys 
 		return nil, err
 	}
 
-	if provider.networkConfig.BaseURL == "" {
+	if provider.networkConfig.BaseURL.GetValue() == "" {
 		return nil, providerUtils.NewConfigurationError("base_url is not set")
 	}
 
@@ -458,7 +454,7 @@ func (provider *ReplicateProvider) TextCompletion(ctx *schemas.BifrostContext, k
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.TextCompletionRequest,
@@ -550,7 +546,7 @@ func (provider *ReplicateProvider) TextCompletionStream(ctx *schemas.BifrostCont
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.TextCompletionStreamRequest,
@@ -808,7 +804,7 @@ func (provider *ReplicateProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.ChatCompletionRequest,
@@ -900,7 +896,7 @@ func (provider *ReplicateProvider) ChatCompletionStream(ctx *schemas.BifrostCont
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.ChatCompletionStreamRequest,
@@ -1172,7 +1168,7 @@ func (provider *ReplicateProvider) Responses(ctx *schemas.BifrostContext, key sc
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.ResponsesRequest,
@@ -1259,7 +1255,7 @@ func (provider *ReplicateProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 	// Build prediction URL
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.ResponsesStreamRequest,
@@ -1790,7 +1786,7 @@ func (provider *ReplicateProvider) ImageGeneration(ctx *schemas.BifrostContext, 
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.ImageGenerationRequest,
@@ -1892,7 +1888,7 @@ func (provider *ReplicateProvider) ImageGenerationStream(ctx *schemas.BifrostCon
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.ImageGenerationStreamRequest,
@@ -2217,7 +2213,7 @@ func (provider *ReplicateProvider) ImageEdit(ctx *schemas.BifrostContext, key sc
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.ImageEditRequest,
@@ -2317,7 +2313,7 @@ func (provider *ReplicateProvider) ImageEditStream(ctx *schemas.BifrostContext, 
 	// Build prediction URL based on model type (version ID or model name)
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.ImageEditStreamRequest,
@@ -2625,7 +2621,7 @@ func (provider *ReplicateProvider) VideoGeneration(ctx *schemas.BifrostContext, 
 	// Create prediction asynchronously and return job ID without polling.
 	predictionURL := buildPredictionURL(
 		ctx,
-		provider.networkConfig.BaseURL,
+		provider.networkConfig.BaseURL.GetValue(),
 		request.Model,
 		provider.customProviderConfig,
 		schemas.VideoGenerationRequest,
@@ -2977,7 +2973,7 @@ func (provider *ReplicateProvider) FileUpload(ctx *schemas.BifrostContext, key s
 
 	// Set headers
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files")
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files")
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(writer.FormDataContentType())
 
@@ -3053,7 +3049,7 @@ func (provider *ReplicateProvider) FileList(ctx *schemas.BifrostContext, keys []
 	defer fasthttp.ReleaseResponse(resp)
 
 	// Build URL with query params
-	requestURL := provider.networkConfig.BaseURL + "/v1/files"
+	requestURL := provider.networkConfig.BaseURL.GetValue() + "/v1/files"
 	values := url.Values{}
 	if request.Limit > 0 {
 		values.Set("limit", fmt.Sprintf("%d", request.Limit))
@@ -3165,7 +3161,7 @@ func (provider *ReplicateProvider) FileRetrieve(ctx *schemas.BifrostContext, key
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + url.PathEscape(request.FileID))
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files/" + url.PathEscape(request.FileID))
 		req.Header.SetMethod(http.MethodGet)
 		req.Header.SetContentType("application/json")
 
@@ -3242,7 +3238,7 @@ func (provider *ReplicateProvider) FileDelete(ctx *schemas.BifrostContext, keys 
 
 		// Set headers
 		providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-		req.SetRequestURI(provider.networkConfig.BaseURL + "/v1/files/" + url.PathEscape(request.FileID))
+		req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/v1/files/" + url.PathEscape(request.FileID))
 		req.Header.SetMethod(http.MethodDelete)
 		req.Header.SetContentType("application/json")
 

--- a/core/providers/replicate/replicate_test.go
+++ b/core/providers/replicate/replicate_test.go
@@ -70,7 +70,7 @@ func TestFileUpload_OrdersMetadataBeforeFile(t *testing.T) {
 	defer server.Close()
 
 	provider, err := replicate.NewReplicateProvider(&schemas.ProviderConfig{
-		NetworkConfig: schemas.NetworkConfig{BaseURL: server.URL},
+		NetworkConfig: schemas.NetworkConfig{BaseURL: schemas.NewSecretVar(server.URL)},
 	}, &testLogger{})
 	require.NoError(t, err)
 

--- a/core/providers/runware/runware.go
+++ b/core/providers/runware/runware.go
@@ -51,10 +51,7 @@ func NewRunwareProvider(config *schemas.ProviderConfig, logger schemas.Logger) (
 	streamingClient := providerUtils.BuildStreamingClient(client)
 
 	// Set default BaseURL if not provided. Runware's single endpoint already includes /v1.
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.runware.ai/v1"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.runware.ai/v1")
 
 	return &RunwareProvider{
 		logger:              logger,
@@ -156,7 +153,7 @@ func (provider *RunwareProvider) ChatCompletion(ctx *schemas.BifrostContext, key
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -177,7 +174,7 @@ func (provider *RunwareProvider) ChatCompletionStream(ctx *schemas.BifrostContex
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -287,7 +284,7 @@ func (provider *RunwareProvider) handleImageInference(ctx *schemas.BifrostContex
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, ""))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, ""))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -387,7 +384,7 @@ func (provider *RunwareProvider) sendTaskArray(ctx *schemas.BifrostContext, key 
 	defer fasthttp.ReleaseResponse(resp)
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, ""))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, ""))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -752,7 +749,7 @@ func (provider *RunwareProvider) ContainerFileDelete(_ *schemas.BifrostContext, 
 // passthrough path is stripped to avoid duplicating it — both /runware_passthrough and
 // /runware_passthrough/v1 therefore map to the base endpoint.
 func (provider *RunwareProvider) buildPassthroughURL(req *schemas.BifrostPassthroughRequest) string {
-	baseURL := provider.networkConfig.BaseURL
+	baseURL := provider.networkConfig.BaseURL.GetValue()
 	if req.UpstreamURL != "" {
 		baseURL = strings.TrimRight(req.UpstreamURL, "/")
 	}

--- a/core/providers/runway/runway.go
+++ b/core/providers/runway/runway.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
@@ -46,10 +45,7 @@ func NewRunwayProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.dev.runwayml.com"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.dev.runwayml.com")
 
 	return &RunwayProvider{
 		logger:              logger,
@@ -168,7 +164,7 @@ func (provider *RunwayProvider) HandleRunwayImageTask(ctx *schemas.BifrostContex
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/text_to_image"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/text_to_image"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("X-Runway-Version", "2024-11-06")
@@ -277,7 +273,7 @@ func (provider *RunwayProvider) retrieveRunwayTask(ctx *schemas.BifrostContext, 
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/tasks/"+taskID))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/tasks/"+taskID))
 	req.Header.SetMethod(http.MethodGet)
 	req.Header.Set("X-Runway-Version", "2024-11-06")
 	if key.Value.GetValue() != "" {
@@ -380,7 +376,7 @@ func (provider *RunwayProvider) VideoGeneration(ctx *schemas.BifrostContext, key
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Set request URI and headers
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, endpoint))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, endpoint))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	req.Header.Set("X-Runway-Version", "2024-11-06")
@@ -462,7 +458,7 @@ func (provider *RunwayProvider) VideoRetrieve(ctx *schemas.BifrostContext, key s
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
 	// Set request URI and headers
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/tasks/"+taskID))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/tasks/"+taskID))
 	req.Header.SetMethod("GET")
 	req.Header.Set("X-Runway-Version", "2024-11-06")
 	if key.Value.GetValue() != "" {
@@ -614,7 +610,7 @@ func (provider *RunwayProvider) VideoDelete(ctx *schemas.BifrostContext, key sch
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/v1/tasks/"+taskID))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/v1/tasks/"+taskID))
 	req.Header.SetMethod(http.MethodDelete)
 	req.Header.Set("X-Runway-Version", "2024-11-06")
 	if key.Value.GetValue() != "" {

--- a/core/providers/sarvam/sarvam.go
+++ b/core/providers/sarvam/sarvam.go
@@ -52,10 +52,7 @@ func NewSarvamProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.sarvam.ai"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.sarvam.ai")
 
 	return &SarvamProvider{
 		logger:              logger,
@@ -78,7 +75,7 @@ func (provider *SarvamProvider) ListModels(ctx *schemas.BifrostContext, keys []s
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
@@ -102,7 +99,7 @@ func (provider *SarvamProvider) ChatCompletion(ctx *schemas.BifrostContext, key 
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -124,7 +121,7 @@ func (provider *SarvamProvider) ChatCompletionStream(ctx *schemas.BifrostContext
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/chat/completions",
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -195,7 +192,7 @@ func (provider *SarvamProvider) Speech(ctx *schemas.BifrostContext, key schemas.
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/text-to-speech")
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/text-to-speech")
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -307,7 +304,7 @@ func (provider *SarvamProvider) SpeechStream(ctx *schemas.BifrostContext, postHo
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/text-to-speech/stream")
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/text-to-speech/stream")
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
 	if key.Value.GetValue() != "" {
@@ -473,7 +470,7 @@ func (provider *SarvamProvider) Transcription(ctx *schemas.BifrostContext, key s
 
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
 
-	req.SetRequestURI(provider.networkConfig.BaseURL + "/speech-to-text")
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + "/speech-to-text")
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(contentType)
 	if key.Value.GetValue() != "" {

--- a/core/providers/sgl/sgl.go
+++ b/core/providers/sgl/sgl.go
@@ -55,7 +55,7 @@ func NewSGLProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*SGL
 	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "")
 
 	// BaseURL is optional when keys have sgl_key_config with per-key URLs
 	return &SGLProvider{
@@ -79,8 +79,8 @@ func (provider *SGLProvider) getBaseURL(key schemas.Key) string {
 	if key.SGLKeyConfig != nil && key.SGLKeyConfig.URL.GetValue() != "" {
 		return strings.TrimRight(key.SGLKeyConfig.URL.GetValue(), "/")
 	}
-	if provider.networkConfig.BaseURL != "" {
-		return strings.TrimRight(provider.networkConfig.BaseURL, "/")
+	if provider.networkConfig.BaseURL.GetValue() != "" {
+		return strings.TrimRight(provider.networkConfig.BaseURL.GetValue(), "/")
 	}
 	return ""
 }

--- a/core/providers/utils/baseurl_test.go
+++ b/core/providers/utils/baseurl_test.go
@@ -62,3 +62,38 @@ func TestNormalizeBaseURL(t *testing.T) {
 		NormalizeBaseURL(nil, "https://api.example.com")
 	})
 }
+
+// TestLoggableURL covers the log-safe rendering of provider request URLs: a literal
+// base_url is logged verbatim, while a reference-resolved base_url has its resolved
+// scheme and host replaced by the reference.
+func TestLoggableURL(t *testing.T) {
+	t.Run("literal base_url is logged as-is", func(t *testing.T) {
+		base := schemas.NewSecretVar("https://api.example.com/v1beta")
+		assert.Equal(t, "https://api.example.com/v1beta/batches/123:cancel", LoggableURL(base, "https://api.example.com/v1beta/batches/123:cancel"))
+	})
+
+	t.Run("nil base_url is logged as-is", func(t *testing.T) {
+		assert.Equal(t, "https://api.example.com/x", LoggableURL(nil, "https://api.example.com/x"))
+	})
+
+	t.Run("reference-resolved base_url hides the resolved host", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_LOGGABLE_BASE_URL", "https://secret-host.example.com/v1beta")
+		base := schemas.NewSecretVar("env.BIFROST_TEST_LOGGABLE_BASE_URL")
+		got := LoggableURL(base, "https://secret-host.example.com/v1beta/batches/123:cancel?alt=media")
+		assert.Equal(t, "env.BIFROST_TEST_LOGGABLE_BASE_URL/v1beta/batches/123:cancel?alt=media", got)
+		assert.NotContains(t, got, "secret-host")
+	})
+
+	t.Run("reference-resolved base_url hides a rewritten host too", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_LOGGABLE_BASE_URL", "https://secret-host.example.com/v1beta")
+		base := schemas.NewSecretVar("env.BIFROST_TEST_LOGGABLE_BASE_URL")
+		got := LoggableURL(base, "https://secret-host.example.com/download/v1beta/files/abc:download?alt=media")
+		assert.Equal(t, "env.BIFROST_TEST_LOGGABLE_BASE_URL/download/v1beta/files/abc:download?alt=media", got)
+	})
+
+	t.Run("unparseable URL under a reference falls back to the reference alone", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_LOGGABLE_BASE_URL", "https://secret-host.example.com")
+		base := schemas.NewSecretVar("env.BIFROST_TEST_LOGGABLE_BASE_URL")
+		assert.Equal(t, "env.BIFROST_TEST_LOGGABLE_BASE_URL", LoggableURL(base, "://not a url"))
+	})
+}

--- a/core/providers/utils/baseurl_test.go
+++ b/core/providers/utils/baseurl_test.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalizeBaseURL covers the provider-constructor normalization of
+// NetworkConfig.BaseURL: defaults apply only when nothing is configured, trailing
+// slashes are trimmed, an env. reference survives normalization, and the caller's
+// original SecretVar is never mutated in place.
+func TestNormalizeBaseURL(t *testing.T) {
+	t.Run("nil base_url takes the default", func(t *testing.T) {
+		nc := schemas.NetworkConfig{}
+		NormalizeBaseURL(&nc, "https://api.example.com/")
+		assert.Equal(t, "https://api.example.com", nc.BaseURL.GetValue())
+		assert.False(t, nc.BaseURL.IsFromSecret())
+	})
+
+	t.Run("empty plain base_url takes the default", func(t *testing.T) {
+		nc := schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("")}
+		NormalizeBaseURL(&nc, "https://api.example.com")
+		assert.Equal(t, "https://api.example.com", nc.BaseURL.GetValue())
+	})
+
+	t.Run("nil base_url with no default stays nil", func(t *testing.T) {
+		nc := schemas.NetworkConfig{}
+		NormalizeBaseURL(&nc, "")
+		assert.Nil(t, nc.BaseURL)
+		assert.Empty(t, nc.BaseURL.GetValue())
+	})
+
+	t.Run("configured literal wins over the default and loses trailing slashes", func(t *testing.T) {
+		nc := schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://custom.example.com/v1///")}
+		NormalizeBaseURL(&nc, "https://api.example.com")
+		assert.Equal(t, "https://custom.example.com/v1", nc.BaseURL.GetValue())
+	})
+
+	t.Run("env. reference keeps its reference after normalization", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_NORMALIZE_BASE_URL", "https://resolved.example.com/")
+		nc := schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("env.BIFROST_TEST_NORMALIZE_BASE_URL")}
+		NormalizeBaseURL(&nc, "https://api.example.com")
+		assert.Equal(t, "https://resolved.example.com", nc.BaseURL.GetValue())
+		assert.True(t, nc.BaseURL.IsFromEnv())
+		assert.Equal(t, "env.BIFROST_TEST_NORMALIZE_BASE_URL", nc.BaseURL.GetRawRef())
+		assert.Equal(t, "env.BIFROST_TEST_NORMALIZE_BASE_URL", schemas.SecretVarAsString(nc.BaseURL))
+	})
+
+	t.Run("the caller's SecretVar is cloned, not mutated", func(t *testing.T) {
+		original := schemas.NewSecretVar("https://shared.example.com/")
+		nc := schemas.NetworkConfig{BaseURL: original}
+		NormalizeBaseURL(&nc, "")
+		require.NotSame(t, original, nc.BaseURL)
+		assert.Equal(t, "https://shared.example.com/", original.GetValue())
+		assert.Equal(t, "https://shared.example.com", nc.BaseURL.GetValue())
+	})
+
+	t.Run("nil network config is a no-op", func(t *testing.T) {
+		NormalizeBaseURL(nil, "https://api.example.com")
+	})
+}

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -840,6 +840,27 @@ func createTLSConfigWithCA(caCertPEM string) (*tls.Config, error) {
 	}, nil
 }
 
+// NormalizeBaseURL prepares networkConfig.BaseURL for a provider constructor: when no
+// base URL is configured it applies defaultURL (pass "" for providers whose base URL is
+// optional, e.g. when every key carries its own URL), and it trims trailing slashes from
+// the resolved value. The SecretVar is cloned before it is mutated so a config-store
+// copy sharing the pointer is never edited in place, and its env./vault. reference is
+// retained so serializing the config emits the reference, never the resolved URL.
+func NormalizeBaseURL(networkConfig *schemas.NetworkConfig, defaultURL string) {
+	if networkConfig == nil {
+		return
+	}
+	if !networkConfig.BaseURL.IsSet() {
+		if defaultURL == "" {
+			return
+		}
+		networkConfig.BaseURL = schemas.NewSecretVar(defaultURL)
+	}
+	baseURL := networkConfig.BaseURL.Clone()
+	baseURL.Val = strings.TrimRight(baseURL.Val, "/")
+	networkConfig.BaseURL = baseURL
+}
+
 // ConfigureTLS applies TLS settings from NetworkConfig to the fasthttp client.
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -861,6 +861,21 @@ func NormalizeBaseURL(networkConfig *schemas.NetworkConfig, defaultURL string) {
 	networkConfig.BaseURL = baseURL
 }
 
+// LoggableURL returns fullURL in a form safe for logs. When the provider's base_url
+// came from an env./vault. reference, the resolved scheme and host are replaced with
+// the reference (e.g. "env.UPSTREAM_URL/v1beta/batches/123"), so the resolved endpoint
+// never reaches the logs; a literal base_url is logged as-is.
+func LoggableURL(baseURL *schemas.SecretVar, fullURL string) string {
+	if !baseURL.IsFromSecret() {
+		return fullURL
+	}
+	parsed, err := url.Parse(fullURL)
+	if err != nil || parsed.Host == "" {
+		return baseURL.GetRawRef()
+	}
+	return baseURL.GetRawRef() + parsed.RequestURI()
+}
+
 // ConfigureTLS applies TLS settings from NetworkConfig to the fasthttp client.
 // It merges with any existing TLSConfig (e.g., from ConfigureProxy).
 func ConfigureTLS(client *fasthttp.Client, networkConfig schemas.NetworkConfig, logger schemas.Logger) *fasthttp.Client {

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -47,7 +47,7 @@ func NewVLLMProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*VL
 	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "")
 
 	// BaseURL is optional when keys have vllm_key_config with per-key URLs
 	return &VLLMProvider{

--- a/core/providers/wafer/wafer.go
+++ b/core/providers/wafer/wafer.go
@@ -46,10 +46,7 @@ func NewWaferProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*W
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
 	// Set default BaseURL if not provided
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://pass.wafer.ai/v1"
-	}
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://pass.wafer.ai/v1")
 
 	return &WaferProvider{
 		logger:              logger,
@@ -72,7 +69,7 @@ func (provider *WaferProvider) ListModels(ctx *schemas.BifrostContext, keys []sc
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
@@ -89,7 +86,7 @@ func (provider *WaferProvider) TextCompletion(ctx *schemas.BifrostContext, key s
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -110,7 +107,7 @@ func (provider *WaferProvider) TextCompletionStream(ctx *schemas.BifrostContext,
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -133,7 +130,7 @@ func (provider *WaferProvider) ChatCompletion(ctx *schemas.BifrostContext, key s
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -156,7 +153,7 @@ func (provider *WaferProvider) ChatCompletionStream(ctx *schemas.BifrostContext,
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -322,7 +319,7 @@ func (provider *WaferProvider) FileUpload(ctx *schemas.BifrostContext, key schem
 
 	// Set headers after extra headers so the request's typed fields win.
 	providerUtils.SetExtraHeaders(ctx, req, provider.networkConfig.ExtraHeaders, nil)
-	req.SetRequestURI(provider.networkConfig.BaseURL + providerUtils.GetPathFromContext(ctx, "/files"))
+	req.SetRequestURI(provider.networkConfig.BaseURL.GetValue() + providerUtils.GetPathFromContext(ctx, "/files"))
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType(contentType)
 	req.Header.Set("X-Wafer-Purpose", string(request.Purpose))

--- a/core/providers/wafer/wafer_test.go
+++ b/core/providers/wafer/wafer_test.go
@@ -114,7 +114,7 @@ func TestWaferFileUpload(t *testing.T) {
 
 	provider, err := wafer.NewWaferProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        server.URL + "/v1",
+			BaseURL:                        schemas.NewSecretVar(server.URL + "/v1"),
 			DefaultRequestTimeoutInSeconds: 10,
 		},
 	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
@@ -215,7 +215,7 @@ func TestWaferFileUploadRequiredFields(t *testing.T) {
 
 	provider, err := wafer.NewWaferProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        server.URL + "/v1",
+			BaseURL:                        schemas.NewSecretVar(server.URL + "/v1"),
 			DefaultRequestTimeoutInSeconds: 10,
 		},
 	}, bifrost.NewDefaultLogger(schemas.LogLevelError))
@@ -284,7 +284,7 @@ func TestWaferChatImageFileID(t *testing.T) {
 
 	provider, err := wafer.NewWaferProvider(&schemas.ProviderConfig{
 		NetworkConfig: schemas.NetworkConfig{
-			BaseURL:                        server.URL + "/v1",
+			BaseURL:                        schemas.NewSecretVar(server.URL + "/v1"),
 			DefaultRequestTimeoutInSeconds: 10,
 		},
 	}, bifrost.NewDefaultLogger(schemas.LogLevelError))

--- a/core/providers/xai/xai.go
+++ b/core/providers/xai/xai.go
@@ -4,7 +4,6 @@ package xai
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/openai"
@@ -45,11 +44,7 @@ func NewXAIProvider(config *schemas.ProviderConfig, logger schemas.Logger) (*XAI
 	client = providerUtils.ConfigureDialer(client, config.NetworkConfig.AllowPrivateNetwork)
 	client = providerUtils.ConfigureTLS(client, config.NetworkConfig, logger)
 	streamingClient := providerUtils.BuildStreamingClient(client)
-	config.NetworkConfig.BaseURL = strings.TrimRight(config.NetworkConfig.BaseURL, "/")
-
-	if config.NetworkConfig.BaseURL == "" {
-		config.NetworkConfig.BaseURL = "https://api.x.ai"
-	}
+	providerUtils.NormalizeBaseURL(&config.NetworkConfig, "https://api.x.ai")
 
 	return &XAIProvider{
 		logger:              logger,
@@ -68,14 +63,14 @@ func (provider *XAIProvider) GetProviderKey() schemas.ModelProvider {
 
 // ListModels performs a list models request to xAI's API.
 func (provider *XAIProvider) ListModels(ctx *schemas.BifrostContext, keys []schemas.Key, request *schemas.BifrostListModelsRequest) (*schemas.BifrostListModelsResponse, *schemas.BifrostError) {
-	if provider.networkConfig.BaseURL == "" {
+	if provider.networkConfig.BaseURL.GetValue() == "" {
 		return nil, providerUtils.NewConfigurationError("base_url is not set")
 	}
 	return openai.HandleOpenAIListModelsRequest(
 		ctx,
 		provider.client,
 		request,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/models"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/models"),
 		keys,
 		provider.networkConfig.ExtraHeaders,
 		provider.GetProviderKey(),
@@ -89,7 +84,7 @@ func (provider *XAIProvider) TextCompletion(ctx *schemas.BifrostContext, key sch
 	return openai.HandleOpenAITextCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -109,7 +104,7 @@ func (provider *XAIProvider) TextCompletionStream(ctx *schemas.BifrostContext, p
 	return openai.HandleOpenAITextCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/completions",
 		request,
 		nil,
 		provider.networkConfig.ExtraHeaders,
@@ -131,7 +126,7 @@ func (provider *XAIProvider) ChatCompletion(ctx *schemas.BifrostContext, key sch
 	response, bifrostErr := openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/chat/completions"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -158,7 +153,7 @@ func (provider *XAIProvider) ChatCompletionStream(ctx *schemas.BifrostContext, p
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+"/v1/chat/completions",
+		provider.networkConfig.BaseURL.GetValue()+"/v1/chat/completions",
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -183,7 +178,7 @@ func (provider *XAIProvider) Responses(ctx *schemas.BifrostContext, key schemas.
 	response, bifrostErr := openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -207,7 +202,7 @@ func (provider *XAIProvider) ResponsesStream(ctx *schemas.BifrostContext, postHo
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamingClient,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,
@@ -266,7 +261,7 @@ func (provider *XAIProvider) ImageGeneration(ctx *schemas.BifrostContext, key sc
 	response, bifrostErr := openai.HandleOpenAIImageGenerationRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/images/generations"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/images/generations"),
 		request,
 		key,
 		provider.networkConfig.ExtraHeaders,
@@ -402,7 +397,7 @@ func (provider *XAIProvider) Compaction(ctx *schemas.BifrostContext, key schemas
 	return openai.HandleOpenAICompactionRequest(
 		ctx,
 		provider.client,
-		provider.networkConfig.BaseURL+providerUtils.GetPathFromContext(ctx, "/v1/responses/compact"),
+		provider.networkConfig.BaseURL.GetValue()+providerUtils.GetPathFromContext(ctx, "/v1/responses/compact"),
 		request,
 		openai.BearerAuthHeader(key),
 		provider.networkConfig.ExtraHeaders,

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -242,7 +242,11 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 	return json.Marshal(alias)
 }
 
-// Redacted returns a redacted copy of the network configuration with CACertPEM masked.
+// Redacted returns a redacted copy of the network configuration: CACertPEM is masked,
+// and a BaseURL that resolved from an env./vault. reference has its resolved value
+// masked too, so the copy exposes only the reference. A literal base_url is left
+// readable, since it is not a secret and the UI displays it. Both SecretVars are
+// cloned so the copy never shares pointers with the original.
 func (nc *NetworkConfig) Redacted() *NetworkConfig {
 	if nc == nil {
 		return nil
@@ -250,6 +254,13 @@ func (nc *NetworkConfig) Redacted() *NetworkConfig {
 	redacted := *nc
 	if nc.CACertPEM != nil && nc.CACertPEM.IsSet() {
 		redacted.CACertPEM = nc.CACertPEM.Redacted()
+	}
+	if nc.BaseURL != nil {
+		if nc.BaseURL.IsFromSecret() {
+			redacted.BaseURL = nc.BaseURL.Redacted()
+		} else {
+			redacted.BaseURL = nc.BaseURL.Clone()
+		}
 	}
 	return &redacted
 }

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"strings"
 	"time"
 )
 
@@ -58,8 +59,10 @@ const (
 //   - Duration string: "500ms", "5s", "1m" — parsed via time.ParseDuration (preferred)
 //   - Integer: treated as milliseconds (legacy format, e.g. 500 means 500ms)
 type NetworkConfig struct {
-	// BaseURL is supported for OpenAI, Anthropic, Cohere, Mistral, and Ollama providers (required for Ollama)
-	BaseURL                        string            `json:"base_url,omitempty"`                       // Base URL for the provider (optional)
+	// BaseURL is supported for OpenAI, Anthropic, Cohere, Mistral, and Ollama providers (required for Ollama).
+	// Accepts a plain URL or a SecretVar reference ("env.VAR" / "vault.path"), like CACertPEM and
+	// ProxyConfig.URL; read the dialable URL with BaseURL.GetValue().
+	BaseURL                        *SecretVar        `json:"base_url,omitempty"`                       // Base URL for the provider (optional, supports env.*)
 	ExtraHeaders                   map[string]string `json:"extra_headers,omitempty"`                  // Additional headers to include in requests (optional)
 	DefaultRequestTimeoutInSeconds int               `json:"default_request_timeout_in_seconds"`       // Default timeout for requests
 	MaxRetries                     int               `json:"max_retries"`                              // Maximum number of retries
@@ -76,7 +79,9 @@ type NetworkConfig struct {
 	AllowPrivateNetwork            bool              `json:"allow_private_network,omitempty"`          // Allow connections to RFC 1918 private IPs (for k8s pods, LAN deployments). Link-local (169.254.x.x) is always blocked.
 }
 
-// UnmarshalJSON customizes JSON unmarshaling for NetworkConfig.
+// UnmarshalJSON customizes JSON unmarshaling for NetworkConfig. base_url accepts
+// a plain URL or a SecretVar reference ("env.VAR" / "vault.path"); a reference that
+// resolves to an empty value is an error.
 //
 // RetryBackoffInitial and RetryBackoffMax accept two formats:
 //   - Duration string (preferred): "500ms", "5s", "1m" — parsed via time.ParseDuration
@@ -85,7 +90,7 @@ type NetworkConfig struct {
 func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	// Use an alias type to avoid infinite recursion
 	type NetworkConfigAlias struct {
-		BaseURL                        string            `json:"base_url,omitempty"`
+		BaseURL                        *SecretVar        `json:"base_url,omitempty"`
 		ExtraHeaders                   map[string]string `json:"extra_headers,omitempty"`
 		DefaultRequestTimeoutInSeconds int               `json:"default_request_timeout_in_seconds"`
 		MaxRetries                     int               `json:"max_retries"`
@@ -108,6 +113,21 @@ func (nc *NetworkConfig) UnmarshalJSON(data []byte) error {
 	}
 
 	// Copy all non-duration fields
+	// base_url accepts the same SecretVar reference forms ("env.VAR", "vault.path") already
+	// supported for ca_cert_pem, proxy.url, and the Ollama/SGL key URLs, so an upstream URL
+	// never has to be committed in plaintext. SecretVar.UnmarshalJSON performs the lookup and
+	// retains the reference, so MarshalJSON round-trips "env.VAR" rather than the resolved URL.
+	//
+	// A reference that resolves to an empty value is a fail-loud config error rather than a
+	// silent empty string (the fail-closed stance ConfigureTLS takes for ca_cert_pem): a
+	// misconfigured Key fails closed upstream with a 401, but a misconfigured base_url would
+	// otherwise be dialed as an empty host.
+	if alias.BaseURL != nil && alias.BaseURL.IsFromSecret() {
+		alias.BaseURL.Val = strings.TrimSpace(alias.BaseURL.Val)
+		if alias.BaseURL.Val == "" {
+			return fmt.Errorf("network_config.base_url references %q but it resolved to an empty value", alias.BaseURL.GetRawRef())
+		}
+	}
 	nc.BaseURL = alias.BaseURL
 	nc.ExtraHeaders = alias.ExtraHeaders
 	nc.DefaultRequestTimeoutInSeconds = alias.DefaultRequestTimeoutInSeconds
@@ -174,9 +194,10 @@ func parseNetworkBackoffDuration(data json.RawMessage, fieldName string) (time.D
 	return time.Duration(ms) * time.Millisecond, nil
 }
 
-// MarshalJSON customizes JSON marshaling for NetworkConfig.
-// RetryBackoffInitial and RetryBackoffMax are converted from time.Duration (nanoseconds)
-// to milliseconds (integers) in JSON.
+// MarshalJSON customizes JSON marshaling for NetworkConfig. base_url and ca_cert_pem
+// are emitted in their SecretVar wire form (the "env.VAR"/"vault.path" reference when
+// configured as one, never the resolved value). RetryBackoffInitial and RetryBackoffMax
+// are converted from time.Duration (nanoseconds) to milliseconds (integers) in JSON.
 func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 	// Use an alias type to avoid infinite recursion
 	type NetworkConfigAlias struct {
@@ -198,7 +219,7 @@ func (nc NetworkConfig) MarshalJSON() ([]byte, error) {
 	}
 
 	alias := NetworkConfigAlias{
-		BaseURL:                        nc.BaseURL,
+		BaseURL:                        SecretVarAsString(nc.BaseURL),
 		ExtraHeaders:                   nc.ExtraHeaders,
 		DefaultRequestTimeoutInSeconds: nc.DefaultRequestTimeoutInSeconds,
 		MaxRetries:                     nc.MaxRetries,

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -1280,6 +1280,44 @@ func TestNetworkConfig_BaseURLSecretRef(t *testing.T) {
 	})
 }
 
+// TestNetworkConfig_Redacted_BaseURL covers the redacted copy's base_url handling: a
+// reference-resolved value is masked (the JSON still carries the reference), a literal
+// stays readable, and neither shares a pointer with the original.
+func TestNetworkConfig_Redacted_BaseURL(t *testing.T) {
+	t.Run("reference-resolved base_url is masked and cloned", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_REDACT_BASE_URL", "https://secret-host.example.com")
+		var nc NetworkConfig
+		require.NoError(t, json.Unmarshal([]byte(`{"base_url":"env.BIFROST_TEST_REDACT_BASE_URL"}`), &nc))
+
+		redacted := nc.Redacted()
+		require.NotNil(t, redacted.BaseURL)
+		assert.NotSame(t, nc.BaseURL, redacted.BaseURL)
+		assert.NotContains(t, redacted.BaseURL.GetValue(), "secret-host")
+		assert.True(t, redacted.BaseURL.IsRedacted())
+		assert.Equal(t, "env.BIFROST_TEST_REDACT_BASE_URL", redacted.BaseURL.GetRawRef())
+
+		out, err := json.Marshal(redacted)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"base_url":"env.BIFROST_TEST_REDACT_BASE_URL"`)
+		assert.NotContains(t, string(out), "secret-host")
+
+		// The original keeps the dialable value.
+		assert.Equal(t, "https://secret-host.example.com", nc.BaseURL.GetValue())
+	})
+
+	t.Run("literal base_url stays readable but is cloned", func(t *testing.T) {
+		nc := NetworkConfig{BaseURL: NewSecretVar("https://api.example.com")}
+		redacted := nc.Redacted()
+		assert.NotSame(t, nc.BaseURL, redacted.BaseURL)
+		assert.Equal(t, "https://api.example.com", redacted.BaseURL.GetValue())
+	})
+
+	t.Run("nil base_url stays nil", func(t *testing.T) {
+		nc := NetworkConfig{}
+		assert.Nil(t, nc.Redacted().BaseURL)
+	})
+}
+
 // TestNormalizeResponsesToolType verifies that versioned/provider-specific tool type
 // strings are normalized to their canonical ResponsesToolType values.
 func TestNormalizeResponsesToolType(t *testing.T) {

--- a/core/schemas/serialization_test.go
+++ b/core/schemas/serialization_test.go
@@ -3,6 +3,7 @@ package schemas
 import (
 	"encoding/json"
 	"math"
+	"os"
 	"strings"
 	"testing"
 
@@ -1111,7 +1112,7 @@ func TestResponsesToolMCPApprovalSetting_MarshalJSON_Deterministic(t *testing.T)
 // round-trip correctly through JSON marshaling (used by config.json).
 func TestNetworkConfig_TLSFieldsRoundTrip(t *testing.T) {
 	nc := NetworkConfig{
-		BaseURL:                        "https://example.com",
+		BaseURL:                        NewSecretVar("https://example.com"),
 		DefaultRequestTimeoutInSeconds: 60,
 		MaxRetries:                     3,
 		InsecureSkipVerify:             true,
@@ -1179,6 +1180,104 @@ func TestNetworkConfig_HTTP2PingInterval(t *testing.T) {
 	cfgOverflow := &ProviderConfig{NetworkConfig: NetworkConfig{EnforceHTTP2: true, HTTP2PingIntervalInSeconds: HTTP2PingIntervalUpperBoundSeconds + 1}}
 	cfgOverflow.CheckAndSetDefaults()
 	assert.Equal(t, HTTP2PingIntervalUpperBoundSeconds, cfgOverflow.NetworkConfig.HTTP2PingIntervalInSeconds)
+}
+
+// TestNetworkConfig_BaseURLSecretRef covers base_url's SecretVar handling: a plain
+// literal round-trips as itself; an absent base_url stays nil and is omitted; an env.
+// reference resolves at decode, keeps its reference, and round-trips as the reference
+// (never the resolved URL); and unset, empty, whitespace-only, and unresolvable vault.
+// references fail loud instead of dialing an empty host.
+func TestNetworkConfig_BaseURLSecretRef(t *testing.T) {
+	t.Run("plain literal is passed through unchanged and round-trips as itself", func(t *testing.T) {
+		var nc NetworkConfig
+		require.NoError(t, json.Unmarshal([]byte(`{"base_url":"https://api.example.com"}`), &nc))
+		assert.Equal(t, "https://api.example.com", nc.BaseURL.GetValue())
+		assert.False(t, nc.BaseURL.IsFromSecret())
+
+		out, err := json.Marshal(nc)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"base_url":"https://api.example.com"`)
+	})
+
+	t.Run("absent base_url stays nil, reads as empty, and is omitted on output", func(t *testing.T) {
+		var nc NetworkConfig
+		require.NoError(t, json.Unmarshal([]byte(`{"max_retries":1}`), &nc))
+		assert.Nil(t, nc.BaseURL)
+		assert.Empty(t, nc.BaseURL.GetValue())
+
+		out, err := json.Marshal(nc)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "base_url")
+	})
+
+	t.Run("env. reference resolves through SecretVar and keeps its reference", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_BASE_URL", "https://resolved.example.com")
+		var nc NetworkConfig
+		require.NoError(t, json.Unmarshal([]byte(`{"base_url":"env.BIFROST_TEST_BASE_URL"}`), &nc))
+		assert.Equal(t, "https://resolved.example.com", nc.BaseURL.GetValue())
+		assert.True(t, nc.BaseURL.IsFromEnv())
+		assert.Equal(t, "env.BIFROST_TEST_BASE_URL", nc.BaseURL.GetRawRef())
+	})
+
+	t.Run("env. reference round-trips as the reference, never the resolved URL", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_BASE_URL", "https://resolved.example.com")
+		var nc NetworkConfig
+		require.NoError(t, json.Unmarshal([]byte(`{"base_url":"env.BIFROST_TEST_BASE_URL"}`), &nc))
+
+		out, err := json.Marshal(nc)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"base_url":"env.BIFROST_TEST_BASE_URL"`)
+		assert.NotContains(t, string(out), "resolved.example.com")
+
+		// A second decode of the emitted JSON resolves again, so config-store persistence
+		// and API responses stay reference-shaped while the runtime value stays dialable.
+		var again NetworkConfig
+		require.NoError(t, json.Unmarshal(out, &again))
+		assert.Equal(t, "https://resolved.example.com", again.BaseURL.GetValue())
+	})
+
+	t.Run("surrounding whitespace in a resolved reference is trimmed", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_BASE_URL_PADDED", " https://resolved.example.com\n")
+		var nc NetworkConfig
+		require.NoError(t, json.Unmarshal([]byte(`{"base_url":"env.BIFROST_TEST_BASE_URL_PADDED"}`), &nc))
+		assert.Equal(t, "https://resolved.example.com", nc.BaseURL.GetValue())
+	})
+
+	t.Run("unset env. reference is a fail-loud config error, never an empty dial", func(t *testing.T) {
+		const key = "BIFROST_TEST_BASE_URL_DEFINITELY_UNSET"
+		// t.Setenv registers restoration of the host's prior state; the explicit Unsetenv
+		// makes the test independent of whatever the host environment carries.
+		t.Setenv(key, "placeholder")
+		require.NoError(t, os.Unsetenv(key))
+
+		var nc NetworkConfig
+		err := json.Unmarshal([]byte(`{"base_url":"env.`+key+`"}`), &nc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "env."+key)
+		assert.Nil(t, nc.BaseURL)
+	})
+
+	t.Run("empty env. reference is also a fail-loud config error", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_BASE_URL_EMPTY", "")
+		var nc NetworkConfig
+		err := json.Unmarshal([]byte(`{"base_url":"env.BIFROST_TEST_BASE_URL_EMPTY"}`), &nc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "env.BIFROST_TEST_BASE_URL_EMPTY")
+	})
+
+	t.Run("whitespace-only env. reference is treated as empty", func(t *testing.T) {
+		t.Setenv("BIFROST_TEST_BASE_URL_BLANK", "   ")
+		var nc NetworkConfig
+		err := json.Unmarshal([]byte(`{"base_url":"env.BIFROST_TEST_BASE_URL_BLANK"}`), &nc)
+		require.Error(t, err)
+	})
+
+	t.Run("unresolvable vault. reference is a fail-loud config error", func(t *testing.T) {
+		var nc NetworkConfig
+		err := json.Unmarshal([]byte(`{"base_url":"vault.bifrost/test/definitely-missing"}`), &nc)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "vault.bifrost/test/definitely-missing")
+	})
 }
 
 // TestNormalizeResponsesToolType verifies that versioned/provider-specific tool type

--- a/docs/quickstart/gateway/provider-configuration.mdx
+++ b/docs/quickstart/gateway/provider-configuration.mdx
@@ -183,6 +183,7 @@ export COHERE_API_KEY="your-cohere-api-key"
 **Environment Variable Handling:**
 
 - Use `"value": "env.VARIABLE_NAME"` to reference environment variables
+- `network_config.base_url` also accepts `env.VARIABLE_NAME` (or a `vault.` reference), so a private endpoint URL never has to be committed in plaintext; the reference is kept on read-back and a reference that resolves to an empty value is rejected at load time
 - Use `"value": "sk-proj-xxxxxxxxx"` to pass keys directly
 - All sensitive data is automatically redacted in GET requests and UI responses for security
 

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -7856,12 +7856,13 @@ func migrationAddOllamaSGLConfigColumns(ctx context.Context, db *gorm.DB, logger
 					logger.Info("[Migration] Failed to parse network_config for provider %s (id=%d), skipping: %v", p.Name, p.ID, err)
 					continue
 				}
-				if nc.BaseURL == "" {
+				if !nc.BaseURL.IsSet() {
 					continue
 				}
 
-				// Create a new key with the provider's base_url
-				urlSecretVar := schemas.SecretVar{Val: nc.BaseURL}
+				// Create a new key with the provider's base_url (a SecretVar, so an env./vault.
+				// reference is carried over as the reference rather than its resolved value)
+				urlSecretVar := *nc.BaseURL.Clone()
 				enabled := true
 				weight := 1.0
 				newKey := tables.TableKey{

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -351,8 +351,8 @@ func (h *ProviderHandler) addProvider(ctx *fasthttp.RequestCtx) {
 			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid retry backoff: %v", err))
 			return
 		}
-		if payload.NetworkConfig.BaseURL != "" {
-			if err := bifrost.ValidateExternalURL(payload.NetworkConfig.BaseURL, payload.NetworkConfig.AllowPrivateNetwork); err != nil {
+		if baseURL := payload.NetworkConfig.BaseURL.GetValue(); baseURL != "" {
+			if err := bifrost.ValidateExternalURL(baseURL, payload.NetworkConfig.AllowPrivateNetwork); err != nil {
 				SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid base URL: %v", err))
 				return
 			}
@@ -565,8 +565,8 @@ func (h *ProviderHandler) updateProvider(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid retry backoff: %v", err))
 		return
 	}
-	if nc.BaseURL != "" {
-		if err := bifrost.ValidateExternalURL(nc.BaseURL, nc.AllowPrivateNetwork); err != nil {
+	if baseURL := nc.BaseURL.GetValue(); baseURL != "" {
+		if err := bifrost.ValidateExternalURL(baseURL, nc.AllowPrivateNetwork); err != nil {
 			SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid base URL: %v", err))
 			return
 		}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -2898,7 +2898,7 @@ func makeProviderConfigWithNetwork(keyName, keyValue, baseURL string) configstor
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: baseURL,
+			BaseURL: schemas.NewSecretVar(baseURL),
 		},
 	}
 }
@@ -2908,7 +2908,7 @@ func makeProviderConfigWithMultipleKeys(keys []schemas.Key, baseURL string) conf
 	return configstore.ProviderConfig{
 		Keys: keys,
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: baseURL,
+			BaseURL: schemas.NewSecretVar(baseURL),
 		},
 	}
 }
@@ -3976,7 +3976,7 @@ func TestGenerateProviderConfigHash(t *testing.T) {
 			{ID: "key-1", Name: "test-key", Value: *schemas.NewSecretVar("sk-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		SendBackRawResponse: true,
 	}
@@ -3997,7 +3997,7 @@ func TestGenerateProviderConfigHash(t *testing.T) {
 			{ID: "different-id", Name: "different-name", Value: *schemas.NewSecretVar("different-value"), Weight: 2}, // Keys should NOT affect hash
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		SendBackRawResponse: true,
 	}
@@ -4017,7 +4017,7 @@ func TestGenerateProviderConfigHash(t *testing.T) {
 			{ID: "key-1", Name: "test-key", Value: *schemas.NewSecretVar("sk-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://different-api.example.com", // Different base URL
+			BaseURL: schemas.NewSecretVar("https://different-api.example.com"), // Different base URL
 		},
 		SendBackRawResponse: true,
 	}
@@ -4047,7 +4047,7 @@ func TestGenerateProviderConfigHash(t *testing.T) {
 			{ID: "key-1", Name: "test-key", Value: *schemas.NewSecretVar("sk-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		SendBackRawResponse: false, // Different SendBackRawResponse
 	}
@@ -4067,7 +4067,7 @@ func TestGenerateProviderConfigHash(t *testing.T) {
 			{ID: "key-1", Name: "test-key", Value: *schemas.NewSecretVar("sk-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		SendBackRawResponse: true,
 		ConcurrencyAndBufferSize: &schemas.ConcurrencyAndBufferSize{
@@ -4091,7 +4091,7 @@ func TestGenerateProviderConfigHash(t *testing.T) {
 			{ID: "key-1", Name: "test-key", Value: *schemas.NewSecretVar("sk-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		SendBackRawResponse: true,
 		ProxyConfig: &schemas.ProxyConfig{
@@ -4115,7 +4115,7 @@ func TestGenerateProviderConfigHash(t *testing.T) {
 			{ID: "key-1", Name: "test-key", Value: *schemas.NewSecretVar("sk-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		SendBackRawResponse: true,
 		CustomProviderConfig: &schemas.CustomProviderConfig{
@@ -4463,7 +4463,7 @@ func TestProviderHashComparison_MatchingHash(t *testing.T) {
 			{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-file-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -4480,7 +4480,7 @@ func TestProviderHashComparison_MatchingHash(t *testing.T) {
 			{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-db-different"), Weight: 1}, // DB may have different key value (edited via dashboard)
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com"),
 		},
 		SendBackRawResponse: false,
 		ConfigHash:          fileHash, // Same hash as file
@@ -4514,7 +4514,7 @@ func TestProviderHashComparison_DifferentHash(t *testing.T) {
 			{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-file-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v2", // Changed URL
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v2"), // Changed URL
 		},
 		SendBackRawResponse: true, // Changed setting
 	}
@@ -4533,7 +4533,7 @@ func TestProviderHashComparison_DifferentHash(t *testing.T) {
 			{ID: "key-2", Name: "dashboard-added-key", Value: *schemas.NewSecretVar("sk-dashboard"), Weight: 1}, // Key added via dashboard
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com", // Old URL
+			BaseURL: schemas.NewSecretVar("https://api.openai.com"), // Old URL
 		},
 		SendBackRawResponse: false, // Old setting
 		ConfigHash:          "old-different-hash",
@@ -4581,8 +4581,8 @@ func TestProviderHashComparison_DifferentHash(t *testing.T) {
 	// Verify file config is now used
 	resultConfig := providersInConfigStore[schemas.OpenAI]
 
-	if resultConfig.NetworkConfig.BaseURL != "https://api.openai.com/v2" {
-		t.Errorf("Expected file BaseURL, got %s", resultConfig.NetworkConfig.BaseURL)
+	if resultConfig.NetworkConfig.BaseURL.GetValue() != "https://api.openai.com/v2" {
+		t.Errorf("Expected file BaseURL, got %s", resultConfig.NetworkConfig.BaseURL.GetValue())
 	}
 
 	if !resultConfig.SendBackRawResponse {
@@ -4621,7 +4621,7 @@ func TestProviderHashComparison_ProviderOnlyInDB(t *testing.T) {
 			{ID: "key-1", Name: "dashboard-provider-key", Value: *schemas.NewSecretVar("sk-dashboard-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.custom-provider.com",
+			BaseURL: schemas.NewSecretVar("https://api.custom-provider.com"),
 		},
 		SendBackRawResponse: true,
 	}
@@ -4684,7 +4684,7 @@ func TestProviderHashComparison_RoundTrip(t *testing.T) {
 			{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-original-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -4707,7 +4707,7 @@ func TestProviderHashComparison_RoundTrip(t *testing.T) {
 			{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-original-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -4740,7 +4740,7 @@ func TestProviderHashComparison_DashboardEditThenSameFile(t *testing.T) {
 			{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-original-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -4754,7 +4754,7 @@ func TestProviderHashComparison_DashboardEditThenSameFile(t *testing.T) {
 			{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-dashboard-modified-456"), Weight: 1}, // Modified via dashboard
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com"),
 		},
 		SendBackRawResponse: false,
 		ConfigHash:          fileHash, // Hash based on provider config, not keys
@@ -4770,7 +4770,7 @@ func TestProviderHashComparison_DashboardEditThenSameFile(t *testing.T) {
 			{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-original-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -4809,7 +4809,7 @@ func TestProviderHashComparison_OptionalFieldsPresence(t *testing.T) {
 	configWithNetwork := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -4898,7 +4898,7 @@ func TestProviderHashComparison_OptionalFieldsPresence(t *testing.T) {
 	configAllFields := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		ConcurrencyAndBufferSize: &schemas.ConcurrencyAndBufferSize{
 			Concurrency: 10,
@@ -5060,7 +5060,7 @@ func TestProviderHashComparison_FieldValueChanges(t *testing.T) {
 	baseConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -5071,7 +5071,7 @@ func TestProviderHashComparison_FieldValueChanges(t *testing.T) {
 	configChangedURL := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.different.com", // Changed
+			BaseURL: schemas.NewSecretVar("https://api.different.com"), // Changed
 		},
 		SendBackRawResponse: false,
 	}
@@ -5086,7 +5086,7 @@ func TestProviderHashComparison_FieldValueChanges(t *testing.T) {
 	configWithHeaders := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 			ExtraHeaders: map[string]string{
 				"X-Custom-Header": "value",
 			},
@@ -5137,7 +5137,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 	originalConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 			ExtraHeaders: map[string]string{
 				"X-Custom": "value",
 			},
@@ -5180,7 +5180,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 	configNoConcurrency := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 			ExtraHeaders: map[string]string{
 				"X-Custom": "value",
 			},
@@ -5203,7 +5203,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 	configNoProxy := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 			ExtraHeaders: map[string]string{
 				"X-Custom": "value",
 			},
@@ -5226,7 +5226,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 	configNoRawResponse := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 			ExtraHeaders: map[string]string{
 				"X-Custom": "value",
 			},
@@ -5252,7 +5252,7 @@ func TestProviderHashComparison_FieldRemoved(t *testing.T) {
 	configNoHeaders := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.example.com",
+			BaseURL: schemas.NewSecretVar("https://api.example.com"),
 			// ExtraHeaders removed
 		},
 		ConcurrencyAndBufferSize: &schemas.ConcurrencyAndBufferSize{
@@ -5396,7 +5396,7 @@ func TestProviderHashComparison_PartialFieldChanges(t *testing.T) {
 	baseConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:                        "https://api.example.com",
+			BaseURL:                        schemas.NewSecretVar("https://api.example.com"),
 			DefaultRequestTimeoutInSeconds: 30,
 			MaxRetries:                     3,
 		},
@@ -5408,7 +5408,7 @@ func TestProviderHashComparison_PartialFieldChanges(t *testing.T) {
 	configNoTimeout := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:                        "https://api.example.com",
+			BaseURL:                        schemas.NewSecretVar("https://api.example.com"),
 			DefaultRequestTimeoutInSeconds: 0, // Removed/default
 			MaxRetries:                     3,
 		},
@@ -5424,7 +5424,7 @@ func TestProviderHashComparison_PartialFieldChanges(t *testing.T) {
 	configNoRetries := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:                        "https://api.example.com",
+			BaseURL:                        schemas.NewSecretVar("https://api.example.com"),
 			DefaultRequestTimeoutInSeconds: 30,
 			MaxRetries:                     0, // Removed/default
 		},
@@ -5440,7 +5440,7 @@ func TestProviderHashComparison_PartialFieldChanges(t *testing.T) {
 	configDifferentTimeout := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "test", Value: *schemas.NewSecretVar("sk-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:                        "https://api.example.com",
+			BaseURL:                        schemas.NewSecretVar("https://api.example.com"),
 			DefaultRequestTimeoutInSeconds: 60, // Changed from 30
 			MaxRetries:                     3,
 		},
@@ -5459,7 +5459,7 @@ func TestProviderHashComparison_FullLifecycle(t *testing.T) {
 	initialConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-initial-123"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -5478,8 +5478,8 @@ func TestProviderHashComparison_FullLifecycle(t *testing.T) {
 	newFileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-new-456"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.openai.com/v2", // Changed!
-			MaxRetries: 5,                           // Added!
+			BaseURL:    schemas.NewSecretVar("https://api.openai.com/v2"), // Changed!
+			MaxRetries: 5,                                                 // Added!
 		},
 		SendBackRawResponse: true, // Changed!
 	}
@@ -5506,7 +5506,7 @@ func TestProviderHashComparison_FullLifecycle(t *testing.T) {
 	if updatedDBConfig.ConfigHash != newFileHash {
 		t.Error("Expected DB to be updated with new hash")
 	}
-	if updatedDBConfig.NetworkConfig.BaseURL != "https://api.openai.com/v2" {
+	if updatedDBConfig.NetworkConfig.BaseURL.GetValue() != "https://api.openai.com/v2" {
 		t.Error("Expected DB to have new BaseURL from file")
 	}
 	if !updatedDBConfig.SendBackRawResponse {
@@ -5519,7 +5519,7 @@ func TestProviderHashComparison_FullLifecycle(t *testing.T) {
 	sameFileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "openai-key", Value: *schemas.NewSecretVar("sk-new-456"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.openai.com/v2",
+			BaseURL:    schemas.NewSecretVar("https://api.openai.com/v2"),
 			MaxRetries: 5,
 		},
 		SendBackRawResponse: true,
@@ -5545,7 +5545,7 @@ func TestProviderHashComparison_FullLifecycle(t *testing.T) {
 
 	// === STEP 5: Verify DB wasn't modified (still has step 3 values) ===
 	finalDBConfig := providersInDB[schemas.OpenAI]
-	if finalDBConfig.NetworkConfig.BaseURL != "https://api.openai.com/v2" {
+	if finalDBConfig.NetworkConfig.BaseURL.GetValue() != "https://api.openai.com/v2" {
 		t.Error("DB should still have v2 URL")
 	}
 	if finalDBConfig.NetworkConfig.MaxRetries != 5 {
@@ -5567,7 +5567,7 @@ func TestProviderHashComparison_MultipleUpdates(t *testing.T) {
 	config1 := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "key", Value: *schemas.NewSecretVar("sk-v1"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.v1.com",
+			BaseURL: schemas.NewSecretVar("https://api.v1.com"),
 		},
 	}
 	hash1, _ := config1.GenerateConfigHash("openai")
@@ -5584,7 +5584,7 @@ func TestProviderHashComparison_MultipleUpdates(t *testing.T) {
 	config2 := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "key", Value: *schemas.NewSecretVar("sk-v2"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.v2.com", // Changed
+			BaseURL: schemas.NewSecretVar("https://api.v2.com"), // Changed
 		},
 	}
 	hash2, _ := config2.GenerateConfigHash("openai")
@@ -5604,8 +5604,8 @@ func TestProviderHashComparison_MultipleUpdates(t *testing.T) {
 	config3 := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "key", Value: *schemas.NewSecretVar("sk-v3"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.v3.com", // Changed again
-			MaxRetries: 3,                    // Added
+			BaseURL:    schemas.NewSecretVar("https://api.v3.com"), // Changed again
+			MaxRetries: 3,                                          // Added
 		},
 		SendBackRawResponse: true, // Added
 	}
@@ -5626,7 +5626,7 @@ func TestProviderHashComparison_MultipleUpdates(t *testing.T) {
 	config4 := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "key", Value: *schemas.NewSecretVar("sk-v3"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.v3.com",
+			BaseURL:    schemas.NewSecretVar("https://api.v3.com"),
 			MaxRetries: 3,
 		},
 		SendBackRawResponse: true,
@@ -5645,7 +5645,7 @@ func TestProviderHashComparison_MultipleUpdates(t *testing.T) {
 	config5 := configstore.ProviderConfig{
 		Keys: []schemas.Key{{ID: "key-1", Name: "key", Value: *schemas.NewSecretVar("sk-v1"), Weight: 1}},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.v1.com",
+			BaseURL: schemas.NewSecretVar("https://api.v1.com"),
 		},
 	}
 	hash5, _ := config5.GenerateConfigHash("openai")
@@ -5693,7 +5693,7 @@ func TestProviderHashComparison_ProviderChangedKeysUnchanged(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{originalKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.openai.com/v1",
+			BaseURL:    schemas.NewSecretVar("https://api.openai.com/v1"),
 			MaxRetries: 3,
 		},
 		SendBackRawResponse: false,
@@ -5717,8 +5717,8 @@ func TestProviderHashComparison_ProviderChangedKeysUnchanged(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{sameKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.openai.com/v2", // CHANGED!
-			MaxRetries: 5,                           // CHANGED!
+			BaseURL:    schemas.NewSecretVar("https://api.openai.com/v2"), // CHANGED!
+			MaxRetries: 5,                                                 // CHANGED!
 		},
 		SendBackRawResponse: true, // CHANGED!
 	}
@@ -5764,7 +5764,7 @@ func TestProviderHashComparison_ProviderChangedKeysUnchanged(t *testing.T) {
 	}
 
 	// Verify provider config is updated
-	if updatedConfig.NetworkConfig.BaseURL != "https://api.openai.com/v2" {
+	if updatedConfig.NetworkConfig.BaseURL.GetValue() != "https://api.openai.com/v2" {
 		t.Error("Expected BaseURL to be updated from file")
 	}
 	if updatedConfig.NetworkConfig.MaxRetries != 5 {
@@ -5792,7 +5792,7 @@ func TestProviderHashComparison_KeysChangedProviderUnchanged(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{originalKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.openai.com/v1",
+			BaseURL:    schemas.NewSecretVar("https://api.openai.com/v1"),
 			MaxRetries: 3,
 		},
 		SendBackRawResponse: false,
@@ -5816,8 +5816,8 @@ func TestProviderHashComparison_KeysChangedProviderUnchanged(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{changedKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.openai.com/v1", // SAME
-			MaxRetries: 3,                           // SAME
+			BaseURL:    schemas.NewSecretVar("https://api.openai.com/v1"), // SAME
+			MaxRetries: 3,                                                 // SAME
 		},
 		SendBackRawResponse: false, // SAME
 	}
@@ -5852,7 +5852,7 @@ func TestProviderHashComparison_KeysChangedProviderUnchanged(t *testing.T) {
 	}
 
 	// Verify provider config is preserved
-	if updatedConfig.NetworkConfig.BaseURL != "https://api.openai.com/v1" {
+	if updatedConfig.NetworkConfig.BaseURL.GetValue() != "https://api.openai.com/v1" {
 		t.Error("Expected BaseURL to be preserved from DB")
 	}
 	if updatedConfig.NetworkConfig.MaxRetries != 3 {
@@ -5894,7 +5894,7 @@ func TestProviderHashComparison_BothChangedIndependently(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{originalKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -5916,8 +5916,8 @@ func TestProviderHashComparison_BothChangedIndependently(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{changedKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://api.openai.com/v2", // CHANGED
-			MaxRetries: 5,                           // ADDED
+			BaseURL:    schemas.NewSecretVar("https://api.openai.com/v2"), // CHANGED
+			MaxRetries: 5,                                                 // ADDED
 		},
 		SendBackRawResponse: true, // CHANGED
 	}
@@ -5944,7 +5944,7 @@ func TestProviderHashComparison_BothChangedIndependently(t *testing.T) {
 	updatedConfig.ConfigHash = fileProviderHash
 
 	// Verify both provider and keys are updated
-	if updatedConfig.NetworkConfig.BaseURL != "https://api.openai.com/v2" {
+	if updatedConfig.NetworkConfig.BaseURL.GetValue() != "https://api.openai.com/v2" {
 		t.Error("Expected BaseURL to be updated")
 	}
 	if !updatedConfig.SendBackRawResponse {
@@ -5975,7 +5975,7 @@ func TestProviderHashComparison_NeitherChanged(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{originalKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -5998,7 +5998,7 @@ func TestProviderHashComparison_NeitherChanged(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{sameKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1", // SAME
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"), // SAME
 		},
 		SendBackRawResponse: false, // SAME
 	}
@@ -6046,7 +6046,7 @@ func TestKeyLevelSync_ProviderHashMatch_SingleKeyChanged(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{dbKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"),
 		},
 	}
 	dbProviderHash, _ := dbConfig.GenerateConfigHash("openai")
@@ -6068,7 +6068,7 @@ func TestKeyLevelSync_ProviderHashMatch_SingleKeyChanged(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{fileKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1", // SAME
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"), // SAME
 		},
 	}
 	fileProviderHash, _ := fileConfig.GenerateConfigHash("openai")
@@ -6162,7 +6162,7 @@ func TestKeyLevelSync_ProviderHashMatch_NewKeyInFile(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{dbKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"),
 		},
 	}
 	dbProviderHash, _ := dbConfig.GenerateConfigHash("openai")
@@ -6187,7 +6187,7 @@ func TestKeyLevelSync_ProviderHashMatch_NewKeyInFile(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{fileKey1, newFileKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1", // SAME
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"), // SAME
 		},
 	}
 	fileProviderHash, _ := fileConfig.GenerateConfigHash("openai")
@@ -6291,7 +6291,7 @@ func TestKeyLevelSync_ProviderHashMatch_KeyOnlyInDB(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{dbKey1, dashboardKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"),
 		},
 	}
 	dbProviderHash, _ := dbConfig.GenerateConfigHash("openai")
@@ -6309,7 +6309,7 @@ func TestKeyLevelSync_ProviderHashMatch_KeyOnlyInDB(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{fileKey1}, // Dashboard key NOT here
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1", // SAME
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"), // SAME
 		},
 	}
 	fileProviderHash, _ := fileConfig.GenerateConfigHash("openai")
@@ -6416,7 +6416,7 @@ func TestKeyLevelSync_ProviderHashMatch_MixedScenario(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{unchangedKey, changedKey, dashboardKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"),
 		},
 	}
 	dbProviderHash, _ := dbConfig.GenerateConfigHash("openai")
@@ -6449,7 +6449,7 @@ func TestKeyLevelSync_ProviderHashMatch_MixedScenario(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{fileUnchangedKey, fileChangedKey, newFileKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1", // SAME
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"), // SAME
 		},
 	}
 	fileProviderHash, _ := fileConfig.GenerateConfigHash("openai")
@@ -6576,7 +6576,7 @@ func TestKeyLevelSync_ProviderHashMatch_MultipleKeysChanged(t *testing.T) {
 	dbConfig := configstore.ProviderConfig{
 		Keys: dbKeys,
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1",
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"),
 		},
 	}
 	dbProviderHash, _ := dbConfig.GenerateConfigHash("openai")
@@ -6592,7 +6592,7 @@ func TestKeyLevelSync_ProviderHashMatch_MultipleKeysChanged(t *testing.T) {
 	fileConfig := configstore.ProviderConfig{
 		Keys: fileKeys,
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.openai.com/v1", // SAME
+			BaseURL: schemas.NewSecretVar("https://api.openai.com/v1"), // SAME
 		},
 	}
 	fileProviderHash, _ := fileConfig.GenerateConfigHash("openai")
@@ -6727,7 +6727,7 @@ func TestProviderHashComparison_NewProvider(t *testing.T) {
 			{ID: "key-1", Name: "anthropic-key", Value: *schemas.NewSecretVar("sk-ant-123"), Weight: 1},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.anthropic.com",
+			BaseURL: schemas.NewSecretVar("https://api.anthropic.com"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -7321,7 +7321,7 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 	initialConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{initialAzureKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://myazure.openai.azure.com/openai",
+			BaseURL: schemas.NewSecretVar("https://myazure.openai.azure.com/openai"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -7355,7 +7355,7 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 	dbConfigAfterDashboardEdit := configstore.ProviderConfig{
 		Keys: []schemas.Key{dashboardEditedKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://myazure.openai.azure.com/openai",
+			BaseURL: schemas.NewSecretVar("https://myazure.openai.azure.com/openai"),
 		},
 		SendBackRawResponse: false,
 		ConfigHash:          initialProviderHash, // Provider hash unchanged (only key value changed)
@@ -7385,7 +7385,7 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://myazure.openai.azure.com/openai",
+			BaseURL: schemas.NewSecretVar("https://myazure.openai.azure.com/openai"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -7421,7 +7421,7 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://new-azure.openai.azure.com/openai", // Changed!
+			BaseURL: schemas.NewSecretVar("https://new-azure.openai.azure.com/openai"), // Changed!
 		},
 		SendBackRawResponse: true, // Changed!
 	}
@@ -7488,8 +7488,8 @@ func TestProviderHashComparison_AzureProviderFullLifecycle(t *testing.T) {
 	finalConfig := providersInDB["azure"]
 
 	// Verify provider config updated
-	if finalConfig.NetworkConfig.BaseURL != "https://new-azure.openai.azure.com/openai" {
-		t.Errorf("Expected updated BaseURL, got %s", finalConfig.NetworkConfig.BaseURL)
+	if finalConfig.NetworkConfig.BaseURL.GetValue() != "https://new-azure.openai.azure.com/openai" {
+		t.Errorf("Expected updated BaseURL, got %s", finalConfig.NetworkConfig.BaseURL.GetValue())
 	}
 	if !finalConfig.SendBackRawResponse {
 		t.Error("Expected SendBackRawResponse to be true")
@@ -7531,7 +7531,7 @@ func TestProviderHashComparison_BedrockProviderFullLifecycle(t *testing.T) {
 	initialConfig := configstore.ProviderConfig{
 		Keys: []schemas.Key{initialBedrockKey},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-east-1.amazonaws.com",
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-east-1.amazonaws.com"),
 			MaxRetries: 3,
 		},
 		SendBackRawResponse: false,
@@ -7591,7 +7591,7 @@ func TestProviderHashComparison_BedrockProviderFullLifecycle(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-east-1.amazonaws.com",
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-east-1.amazonaws.com"),
 			MaxRetries: 3,
 		},
 		SendBackRawResponse: false,
@@ -7631,8 +7631,8 @@ func TestProviderHashComparison_BedrockProviderFullLifecycle(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-west-2.amazonaws.com", // Changed!
-			MaxRetries: 5,                                                 // Changed!
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-west-2.amazonaws.com"), // Changed!
+			MaxRetries: 5,                                                                       // Changed!
 		},
 		SendBackRawResponse: true, // Changed!
 	}
@@ -7686,8 +7686,8 @@ func TestProviderHashComparison_BedrockProviderFullLifecycle(t *testing.T) {
 	finalConfig := providersInDB["bedrock"]
 
 	// Verify provider config updated
-	if finalConfig.NetworkConfig.BaseURL != "https://bedrock-runtime.us-west-2.amazonaws.com" {
-		t.Errorf("Expected updated BaseURL, got %s", finalConfig.NetworkConfig.BaseURL)
+	if finalConfig.NetworkConfig.BaseURL.GetValue() != "https://bedrock-runtime.us-west-2.amazonaws.com" {
+		t.Errorf("Expected updated BaseURL, got %s", finalConfig.NetworkConfig.BaseURL.GetValue())
 	}
 	if finalConfig.NetworkConfig.MaxRetries != 5 {
 		t.Errorf("Expected MaxRetries to be 5, got %d", finalConfig.NetworkConfig.MaxRetries)
@@ -7759,7 +7759,7 @@ func TestProviderHashComparison_BedrockProviderFullLifecycle(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-west-2.amazonaws.com",
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-west-2.amazonaws.com"),
 			MaxRetries: 5,
 		},
 		SendBackRawResponse: true,
@@ -7799,7 +7799,7 @@ func TestProviderHashComparison_AzureNewProviderFromConfig(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://myazure.openai.azure.com/openai",
+			BaseURL: schemas.NewSecretVar("https://myazure.openai.azure.com/openai"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -7867,7 +7867,7 @@ func TestProviderHashComparison_BedrockNewProviderFromConfig(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-east-1.amazonaws.com",
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-east-1.amazonaws.com"),
 			MaxRetries: 3,
 		},
 		SendBackRawResponse: false,
@@ -7934,7 +7934,7 @@ func TestProviderHashComparison_AzureDBValuePreservedWhenHashMatches(t *testing.
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://myazure.openai.azure.com/openai",
+			BaseURL: schemas.NewSecretVar("https://myazure.openai.azure.com/openai"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -7962,7 +7962,7 @@ func TestProviderHashComparison_AzureDBValuePreservedWhenHashMatches(t *testing.
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://myazure.openai.azure.com/openai", // Same
+			BaseURL: schemas.NewSecretVar("https://myazure.openai.azure.com/openai"), // Same
 		},
 		SendBackRawResponse: false, // Same
 	}
@@ -8020,7 +8020,7 @@ func TestProviderHashComparison_BedrockDBValuePreservedWhenHashMatches(t *testin
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-east-1.amazonaws.com",
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-east-1.amazonaws.com"),
 			MaxRetries: 3,
 		},
 		SendBackRawResponse: false,
@@ -8050,8 +8050,8 @@ func TestProviderHashComparison_BedrockDBValuePreservedWhenHashMatches(t *testin
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-east-1.amazonaws.com", // Same
-			MaxRetries: 3,                                                 // Same
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-east-1.amazonaws.com"), // Same
+			MaxRetries: 3,                                                                       // Same
 		},
 		SendBackRawResponse: false, // Same
 	}
@@ -8109,7 +8109,7 @@ func TestProviderHashComparison_AzureConfigChangedInFile(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://old-azure.openai.azure.com/openai",
+			BaseURL: schemas.NewSecretVar("https://old-azure.openai.azure.com/openai"),
 		},
 		SendBackRawResponse: false,
 	}
@@ -8136,7 +8136,7 @@ func TestProviderHashComparison_AzureConfigChangedInFile(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://NEW-azure.openai.azure.com/openai", // Changed!
+			BaseURL: schemas.NewSecretVar("https://NEW-azure.openai.azure.com/openai"), // Changed!
 		},
 		SendBackRawResponse: true, // Changed!
 	}
@@ -8192,7 +8192,7 @@ func TestProviderHashComparison_BedrockConfigChangedInFile(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-east-1.amazonaws.com",
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-east-1.amazonaws.com"),
 			MaxRetries: 3,
 		},
 		SendBackRawResponse: false,
@@ -8223,8 +8223,8 @@ func TestProviderHashComparison_BedrockConfigChangedInFile(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL:    "https://bedrock-runtime.us-west-2.amazonaws.com", // Changed!
-			MaxRetries: 5,                                                 // Changed!
+			BaseURL:    schemas.NewSecretVar("https://bedrock-runtime.us-west-2.amazonaws.com"), // Changed!
+			MaxRetries: 5,                                                                       // Changed!
 		},
 		SendBackRawResponse: true, // Changed!
 	}
@@ -9427,8 +9427,8 @@ func TestSQLite_Provider_HashMismatch_FileSync(t *testing.T) {
 	}
 
 	// Verify the new BaseURL is in memory
-	if config2.Providers[schemas.OpenAI].NetworkConfig.BaseURL != "https://api.openai.com/v2" {
-		t.Errorf("Expected BaseURL to be updated, got %s", config2.Providers[schemas.OpenAI].NetworkConfig.BaseURL)
+	if config2.Providers[schemas.OpenAI].NetworkConfig.BaseURL.GetValue() != "https://api.openai.com/v2" {
+		t.Errorf("Expected BaseURL to be updated, got %s", config2.Providers[schemas.OpenAI].NetworkConfig.BaseURL.GetValue())
 	}
 }
 
@@ -9462,7 +9462,7 @@ func TestSQLite_Provider_DBOnlyProvider_Preserved(t *testing.T) {
 			},
 		},
 		NetworkConfig: &schemas.NetworkConfig{
-			BaseURL: "https://api.anthropic.com",
+			BaseURL: schemas.NewSecretVar("https://api.anthropic.com"),
 		},
 	}
 	anthropicHash, _ := anthropicConfig.GenerateConfigHash("anthropic")
@@ -9529,7 +9529,7 @@ func TestSQLite_SourceOfTruthConfigJSON_ProviderAndKeysPruned(t *testing.T) {
 			Value:  *schemas.NewSecretVar("sk-anthropic-123"),
 			Weight: 1,
 		}},
-		NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.anthropic.com"},
+		NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.anthropic.com")},
 	}
 	require.NoError(t, config1.ConfigStore.UpdateProvidersConfig(ctx, existingProviders))
 	config1.Close(ctx)
@@ -9618,7 +9618,7 @@ func TestSQLite_Key_NewKeyFromFile(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: uuid.NewString(), Name: "openai-key-1", Value: *schemas.NewSecretVar("sk-key1-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")},
 		},
 	}
 	configData := makeConfigDataWithProvidersAndDir(providers, tempDir)
@@ -9653,7 +9653,7 @@ func TestSQLite_Key_HashMatch_DBKeyPreserved(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: uuid.NewString(), Name: "key-1", Value: *schemas.NewSecretVar("sk-key1-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")},
 		},
 	}
 	configData := makeConfigDataWithProvidersAndDir(providers, tempDir)
@@ -9703,7 +9703,7 @@ func TestSQLite_Key_DashboardAddedKey_Preserved(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: keyID1, Name: "file-key", Value: *schemas.NewSecretVar("sk-file-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")},
 		},
 	}
 	configData := makeConfigDataWithProvidersAndDir(providers, tempDir)
@@ -9770,7 +9770,7 @@ func TestSQLite_Key_KeyValueChange_Detected(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: keyID, Name: "test-key", Value: *schemas.NewSecretVar("sk-original-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")},
 		},
 	}
 	configData := makeConfigDataWithProvidersAndDir(providers, tempDir)
@@ -9796,7 +9796,7 @@ func TestSQLite_Key_KeyValueChange_Detected(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: keyID, Name: "test-key", Value: *schemas.NewSecretVar("sk-modified-456"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com/v2"}, // Changed to trigger hash mismatch
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com/v2")}, // Changed to trigger hash mismatch
 		},
 	}
 	configData2 := makeConfigDataWithProvidersAndDir(providers2, tempDir)
@@ -9830,7 +9830,7 @@ func TestSQLite_Key_MultipleKeys_MergeLogic(t *testing.T) {
 				{ID: keyID1, Name: "key-1", Value: *schemas.NewSecretVar("sk-key1-123"), Weight: 1},
 				{ID: keyID2, Name: "key-2", Value: *schemas.NewSecretVar("sk-key2-456"), Weight: 2},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")},
 		},
 	}
 	configData := makeConfigDataWithProvidersAndDir(providers, tempDir)
@@ -10278,7 +10278,7 @@ func TestSQLite_VirtualKey_MergePath_WithProviderConfigKeys(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: keyID, Name: "openai-key-1", Value: *schemas.NewSecretVar("sk-test-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")},
 		},
 	}
 	vks := []tables.TableVirtualKey{
@@ -10611,7 +10611,7 @@ func TestSQLite_VKProviderConfig_KeyReference(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: keyID, Name: "openai-key-1", Value: *schemas.NewSecretVar("sk-test-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")},
 		},
 	}
 
@@ -10873,7 +10873,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				{ID: keyID2, Name: "openai-key-2", Value: *schemas.NewSecretVar("sk-openai-456"), Weight: 2},
 			},
 			NetworkConfig: &schemas.NetworkConfig{
-				BaseURL: "https://api.openai.com",
+				BaseURL: schemas.NewSecretVar("https://api.openai.com"),
 			},
 			ConcurrencyAndBufferSize: &schemas.ConcurrencyAndBufferSize{
 				Concurrency: 10,
@@ -10885,7 +10885,7 @@ func TestSQLite_FullLifecycle_InitialLoad(t *testing.T) {
 				{ID: uuid.NewString(), Name: "anthropic-key-1", Value: *schemas.NewSecretVar("sk-anthropic-123"), Weight: 1},
 			},
 			NetworkConfig: &schemas.NetworkConfig{
-				BaseURL: "https://api.anthropic.com",
+				BaseURL: schemas.NewSecretVar("https://api.anthropic.com"),
 			},
 		},
 	}
@@ -11048,7 +11048,7 @@ func TestSQLite_FullLifecycle_FileChange_Selective(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: uuid.NewString(), Name: "anthropic-key-1", Value: *schemas.NewSecretVar("sk-anthropic-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.anthropic.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.anthropic.com")},
 		},
 	}
 	vks := []tables.TableVirtualKey{
@@ -11082,7 +11082,7 @@ func TestSQLite_FullLifecycle_FileChange_Selective(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: uuid.NewString(), Name: "anthropic-key-1", Value: *schemas.NewSecretVar("sk-anthropic-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.anthropic.com"}, // Unchanged
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.anthropic.com")}, // Unchanged
 		},
 	}
 	vks2 := []tables.TableVirtualKey{
@@ -11138,7 +11138,7 @@ func TestSQLite_FullLifecycle_DashboardEdits_ThenFileUnchanged(t *testing.T) {
 			Keys: []schemas.Key{
 				{ID: keyID, Name: "openai-key-1", Value: *schemas.NewSecretVar("sk-original-123"), Weight: 1},
 			},
-			NetworkConfig: &schemas.NetworkConfig{BaseURL: "https://api.openai.com"},
+			NetworkConfig: &schemas.NetworkConfig{BaseURL: schemas.NewSecretVar("https://api.openai.com")},
 		},
 	}
 	vks := []tables.TableVirtualKey{
@@ -16625,12 +16625,12 @@ func TestGenerateProviderHash_RuntimeVsMigrationParity(t *testing.T) {
 	// Test case 1: NetworkConfig
 	t.Run("NetworkConfig_GORMRoundTrip", func(t *testing.T) {
 		networkConfig := &schemas.NetworkConfig{
-			BaseURL:                        "https://api.custom.com",
+			BaseURL:                        schemas.NewSecretVar("https://api.custom.com"),
 			DefaultRequestTimeoutInSeconds: 300,
 		}
 
 		providerToSave := tables.TableProvider{
-			Name:                networkConfig.BaseURL, // Use unique name
+			Name:                networkConfig.BaseURL.GetValue(), // Use unique name
 			NetworkConfig:       networkConfig,
 			SendBackRawResponse: true,
 		}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -4279,8 +4279,7 @@
       "properties": {
         "base_url": {
           "type": "string",
-          "format": "uri",
-          "description": "Base URL for the provider (optional, required for Ollama)"
+          "description": "Base URL for the provider (optional, required for Ollama). Accepts a URL or an env.VAR_NAME / vault.path secret reference that resolves to the URL."
         },
         "extra_headers": {
           "type": "object",

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
@@ -7,7 +7,7 @@ import { Switch } from "@/components/ui/switch";
 import { DefaultNetworkConfig } from "@/lib/constants/config";
 import { getErrorMessage, useCreateProviderMutation } from "@/lib/store";
 import { BaseProvider, ModelProviderName } from "@/lib/types/config";
-import { allowedRequestsSchema } from "@/lib/types/schemas";
+import { allowedRequestsSchema, baseURLSchema } from "@/lib/types/schemas";
 import { cleanPathOverrides } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -20,7 +20,7 @@ import { AllowedRequestsFields } from "../fragments/allowedRequestsFields";
 const formSchema = z.object({
 	name: z.string().min(1),
 	baseFormat: z.string().min(1),
-	base_url: z.string().min(1, "Base URL is required").url("Must be a valid URL"),
+	base_url: z.string().min(1, "Base URL is required").pipe(baseURLSchema),
 	allowed_requests: allowedRequestsSchema,
 	request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
 	is_key_less: z.boolean().optional(),
@@ -209,6 +209,9 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 												value={field.value || ""}
 											/>
 										</FormControl>
+										<FormDescription>
+											A URL, or an <code>env.VAR_NAME</code> / <code>vault.path</code> reference resolved on the server.
+										</FormDescription>
 										<FormMessage />
 									</div>
 								</FormItem>

--- a/ui/app/workspace/providers/fragments/networkFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/networkFormFragment.tsx
@@ -200,6 +200,9 @@ export function NetworkFormFragment({ provider }: NetworkFormFragmentProps) {
 												disabled={!hasUpdateProviderAccess}
 											/>
 										</FormControl>
+										<FormDescription>
+											A URL, or an <code>env.VAR_NAME</code> / <code>vault.path</code> reference resolved on the server.
+										</FormDescription>
 										<FormMessage />
 									</FormItem>
 								)}

--- a/ui/lib/schemas/providerForm.ts
+++ b/ui/lib/schemas/providerForm.ts
@@ -1,6 +1,6 @@
 import { KnownProvidersNames } from "@/lib/constants/logs";
 import { aliasConfigSchema, githubCopilotKeyConfigComplete, githubCopilotKeyConfigSchema, secretVarSchema } from "@/lib/types/schemas";
-import { isValidAliases, isValidVertexAuthCredentials } from "@/lib/utils/validation";
+import { BASE_URL_VALIDATION_MESSAGE, isValidAliases, isValidBaseURL, isValidVertexAuthCredentials } from "@/lib/utils/validation";
 import { z } from "zod";
 
 // Base schemas for reusable types
@@ -286,10 +286,10 @@ export const ProviderFormSchema = z
 				});
 			}
 
-			if (data.networkConfig?.base_url && !/^https?:\/\/.+/.test(data.networkConfig.base_url)) {
+			if (data.networkConfig?.base_url && !isValidBaseURL(data.networkConfig.base_url)) {
 				ctx.addIssue({
 					code: z.ZodIssueCode.custom,
-					message: "Base URL must start with http:// or https://",
+					message: BASE_URL_VALIDATION_MESSAGE,
 					path: ["networkConfig", "base_url"],
 				});
 			}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1,6 +1,6 @@
 import { validateModelRegex } from "@/components/modelAccess/utils";
 import { KnownProvidersNames } from "@/lib/constants/logs";
-import { isRedacted } from "@/lib/utils/validation";
+import { BASE_URL_VALIDATION_MESSAGE, isRedacted, isValidBaseURL } from "@/lib/utils/validation";
 import { z } from "zod";
 
 // Global error map - turns Zod's default messages into readable, human-friendly ones.
@@ -557,10 +557,14 @@ export const modelProviderKeySchema = z
 		},
 	);
 
+// Provider base URL: an http(s) URL or an env./vault. reference (the server-side field is a
+// SecretVar, so "env.MY_UPSTREAM_URL" resolves at load time and round-trips as the reference).
+export const baseURLSchema = z.string().trim().refine(isValidBaseURL, BASE_URL_VALIDATION_MESSAGE);
+
 // Network config schema
 export const networkConfigSchema = z
 	.object({
-		base_url: z.union([z.string().url("Must be a valid URL"), z.string().length(0)]).optional(),
+		base_url: z.union([baseURLSchema, z.string().length(0)]).optional(),
 		extra_headers: z.record(z.string(), z.string()).optional(),
 		default_request_timeout_in_seconds: z
 			.number()
@@ -606,17 +610,7 @@ export const networkConfigSchema = z
 // Network form schema - more lenient for form inputs
 export const networkFormConfigSchema = z
 	.object({
-		base_url: z
-			.union([
-				z
-					.string()
-					.url("Must be a valid URL")
-					.refine((url) => url.startsWith("https://") || url.startsWith("http://"), {
-						message: "Must be a valid HTTP or HTTPS URL",
-					}),
-				z.string().length(0),
-			])
-			.optional(),
+		base_url: z.union([baseURLSchema, z.string().length(0)]).optional(),
 		extra_headers: z.record(z.string(), z.string()).optional(),
 		default_request_timeout_in_seconds: z.coerce
 			.number("Timeout must be a number")

--- a/ui/lib/utils/validation.test.ts
+++ b/ui/lib/utils/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getPasswordPolicyFailures, hasCopilotApiToken, isRedacted } from "./validation";
+import { getPasswordPolicyFailures, hasCopilotApiToken, isRedacted, isSecretReference, isValidBaseURL } from "./validation";
 
 describe("isRedacted", () => {
 	it.each(["<redacted>", "<REDACTED>", "[redacted]", "[REDACTED]"])("recognizes the backend sentinel %s", (value) => {
@@ -50,4 +50,30 @@ describe("hasCopilotApiToken", () => {
 			expect(hasCopilotApiToken(input as never)).toBe(false);
 		},
 	);
+});
+
+describe("isSecretReference", () => {
+	it.each(["env.UPSTREAM_URL", "vault.bifrost/upstream/url"])("accepts %s", (value) => {
+		expect(isSecretReference(value)).toBe(true);
+	});
+
+	it.each(["", "env.", "vault.", "env. spaced", "environment", "https://env.example.com"])("rejects %s", (value) => {
+		expect(isSecretReference(value)).toBe(false);
+	});
+});
+
+describe("isValidBaseURL", () => {
+	it.each([
+		"https://api.example.com",
+		"http://localhost:8000",
+		"https://vllm-endpoint:8000/v1",
+		"env.UPSTREAM_URL",
+		"vault.bifrost/upstream/url",
+	])("accepts %s", (value) => {
+		expect(isValidBaseURL(value)).toBe(true);
+	});
+
+	it.each(["", "api.example.com", "ftp://files.example.com", "env.", "not a url", "https://"])("rejects %s", (value) => {
+		expect(isValidBaseURL(value)).toBe(false);
+	});
 });

--- a/ui/lib/utils/validation.ts
+++ b/ui/lib/utils/validation.ts
@@ -192,6 +192,37 @@ export function isRedacted(value: string): boolean {
 	return false;
 }
 
+/**
+ * Checks if a value is a secret reference the server resolves: "env.VAR_NAME" or
+ * "vault.path/to/secret" with a non-empty name or path.
+ */
+export function isSecretReference(value: string): boolean {
+	return /^(env|vault)\.\S+$/.test(value);
+}
+
+/**
+ * Validates a provider base URL. The server's NetworkConfig.base_url is a SecretVar,
+ * so it accepts either an http(s) URL or an env./vault. reference that resolves to one.
+ * @param value - The base URL field value
+ * @returns true if the value is an http(s) URL or a secret reference
+ */
+export function isValidBaseURL(value: string): boolean {
+	if (!value) {
+		return false;
+	}
+	if (isSecretReference(value)) {
+		return true;
+	}
+	try {
+		const url = new URL(value);
+		return (url.protocol === "http:" || url.protocol === "https:") && url.hostname.length > 0;
+	} catch {
+		return false;
+	}
+}
+
+export const BASE_URL_VALIDATION_MESSAGE = "Must be a valid HTTP or HTTPS URL, or an env.VAR_NAME / vault.path reference";
+
 const PASSWORD_REQUIREMENTS = [
 	{ label: "at least 12 characters", test: (password: string) => password.length >= 12 },
 	{ label: "one uppercase letter", test: (password: string) => /[A-Z]/.test(password) },


### PR DESCRIPTION
## Summary

`network_config.base_url` sits alongside config fields that already accept a `SecretVar` reference (`ca_cert_pem`, `proxy.url`, the Ollama/SGL key URLs), but a `"base_url": "env.SOME_VAR"` was never resolved: it was passed through and dialed as a literal hostname. Requests to that provider fail to connect with no diagnostic pointing at the real problem.

This makes `base_url` a `SecretVar` like the other reference-capable fields, so an upstream URL can be kept out of committed config the same way credentials already can.

## Changes

- `NetworkConfig.BaseURL` is now `*schemas.SecretVar` (`json:"base_url"`), the same shape as `CACertPEM` and `ProxyConfig.URL`. `SecretVar.UnmarshalJSON` handles plain URLs, `env.`, and `vault.` references; `MarshalJSON` emits `SecretVarAsString(nc.BaseURL)`, so config-store persistence, `ProviderConfig` hashing, and API responses stay reference-shaped. No shadow field.
- Every read site goes through `BaseURL.GetValue()`: all providers (including `databricks` and `github-copilot`, which landed on `dev` after this PR was opened), the OpenAI/ElevenLabs realtime paths, and the provider HTTP handler's `ValidateExternalURL` check.
- The per-provider default-URL / trailing-slash block in every constructor is folded into one `providerUtils.NormalizeBaseURL(&config.NetworkConfig, defaultURL)` helper (`""` for ollama, sgl, vllm, databricks, and github-copilot, whose base URL is optional). It clones the `SecretVar` before trimming, so a pointer shared with a config-store copy is never mutated in place, and the `env.`/`vault.` reference survives normalization.
- Fail-loud at decode on a reference that resolves to an empty value: `network_config.base_url references "env.X" but it resolved to an empty value`. Same fail-closed stance `ConfigureTLS` takes for `ca_cert_pem`; the alternative is dialing an empty host. Surrounding whitespace in a resolved value is trimmed.
- The ollama/sgl key-backfill migration copies the `SecretVar` into the key URL (reference preserved) instead of wrapping the resolved string.
- `config.schema.json`: `base_url` documents the reference form and drops `"format": "uri"`, which an `env.` reference would not satisfy. The wire form is still a string, so the UI types are unaffected.
- One line in `docs/quickstart/gateway/provider-configuration.mdx`.
- Review follow-ups (third commit): `NetworkConfig.Redacted` clones `BaseURL` and masks the resolved value when it came from a reference (literal URLs stay readable for the UI); `providerUtils.LoggableURL` keeps a reference-resolved base URL out of the four Gemini batch debug logs.
- UI (second commit): the provider network form, the provider-form schema, and the custom-provider sheet previously rejected anything that was not a URL. One shared `isValidBaseURL` predicate (http(s) URL or a non-empty `env.`/`vault.` reference) now backs all four validation sites via `baseURLSchema`, and the base URL inputs describe the reference form. Wire shape unchanged.

Revision history: v1 hand-rolled `os.LookupEnv` prefix handling; v2 resolved through `SecretVar` but kept `BaseURL` a `string` with a hidden retained reference (reviewer: a workaround); v3 (this) converts the field itself and updates the callers, per review.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Framework (configstore migration)
- [x] Transports (provider handler, `config.schema.json`)
- [x] Docs
- [x] UI

## How to test

```sh
# in core/, framework/, transports/ (go.work via `make setup-workspace`)
go build ./... && go vet ./...

cd core && go test -count=1 ./schemas/ ./providers/...
cd transports && go test -count=1 ./bifrost-http/lib/
cd framework && go test -count=1 ./configstore/

# UI
cd ui && npm ci --ignore-scripts && npx vitest run lib/utils/validation.test.ts
```

- `TestNetworkConfig_BaseURLSecretRef` (core/schemas): literal passthrough and round-trip; absent stays nil and is omitted; `env.` resolves, keeps its reference, and round-trips as the reference (never the resolved URL); whitespace trimmed; unset, empty, whitespace-only `env.` and unresolvable `vault.` fail loud.
- `isSecretReference` / `isValidBaseURL` (ui/lib/utils/validation.test.ts): accepts http(s) URLs and `env.`/`vault.` references; rejects bare hosts, non-http schemes, empty references, and `https://env.example.com`-style lookalikes.
- `TestNetworkConfig_Redacted_BaseURL` (core/schemas) and `TestLoggableURL` (core/providers/utils): redacted copies clone and mask reference-resolved base URLs, and debug-log rendering hides the resolved host.
- `TestNormalizeBaseURL` (core/providers/utils): default only when unset; trailing slashes trimmed; `env.` reference retained; caller's `SecretVar` cloned, not mutated; no-op with no default.

Verified locally on Go 1.27 (toolchain auto) against current `dev` @ `03ab39186`: `core`, `framework`, `transports`, and all `plugins/*` build and vet clean; `core` schemas/providers tests, `framework/configstore` tests, and `transports/bifrost-http/lib` tests pass, with one exception: `TestGenerateMCPClientHash_RuntimeVsMigrationParity` fails identically on a clean `dev` checkout and is unrelated to this change. `validate-schema-sync.sh` reports the same three errors on `dev` and on this branch. UI: `vitest` passes for the touched file (the one failing test file in the suite, `logs/views/columns.test.ts`, fails identically on `dev`); `tsc --noEmit` reports no errors in the touched files (the 97 route-typing errors it reports are identical on `dev`); `oxlint` and `oxfmt --check` are clean for the touched code.

## Breaking changes

- [x] Yes, for Go consumers of the `core` module only

`NetworkConfig.BaseURL` changes type from `string` to `*schemas.SecretVar`; downstream Go code reads it with `GetValue()` and sets it with `schemas.NewSecretVar(...)`. The JSON wire form (`config.json`, config store, HTTP API) is unchanged: a plain URL string still works, and `env.`/`vault.` strings that were previously dialed literally now resolve.

## Related issues

Found while migrating a downstream deployment ([LaneTally](https://github.com/feedback-loop-ai/lanetally)) from `transports/v1.5.16` to `transports/v2.0.0`.

## Security considerations

Lets operators keep upstream endpoints out of committed config and out of the config store, using the same reference mechanism already trusted for credentials. The resolved URL never appears in marshaled output while the reference still resolves to it.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)
