### PR TITLE
fix(transports): loadCustomPlugins fails closed on a required custom plugin load failure

### DIFF
--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -310,6 +310,13 @@ func (s *BifrostHTTPServer) loadBuiltinPlugins(ctx context.Context) error {
 
 // loadCustomPlugins loads plugins from PluginConfigs
 func (s *BifrostHTTPServer) loadCustomPlugins(ctx context.Context) error {
+	// Count enabled, non-enterprise custom plugins that fail to load so the
+	// function can fail closed below instead of letting Bootstrap proceed with
+	// a required plugin silently absent. The aggregate error stays a count plus
+	// a generic message: it reaches main.go's top-level bootstrap log line,
+	// while the per-plugin status/log calls in the loop already carry the full
+	// detail (a plugin path or URL can itself be sensitive).
+	failureCount := 0
 	for _, cfg := range s.Config.PluginConfigs {
 		// Skip built-ins (already loaded)
 		if lib.IsBuiltinPlugin(cfg.Name) {
@@ -347,6 +354,7 @@ func (s *BifrostHTTPServer) loadCustomPlugins(ctx context.Context) error {
 			// Use cfg.Name since plugin may be nil when InstantiatePlugin returns an error
 			s.Config.UpdatePluginOverallStatus(cfg.Name, cfg.Name, schemas.PluginStatusError,
 				[]string{fmt.Sprintf("error loading plugin %s: %v", cfg.Name, err)}, []schemas.PluginType{})
+			failureCount++
 			continue
 		}
 
@@ -355,6 +363,7 @@ func (s *BifrostHTTPServer) loadCustomPlugins(ctx context.Context) error {
 			logger.Error("plugin %s instantiated but returned nil", cfg.Name)
 			s.Config.UpdatePluginOverallStatus(cfg.Name, cfg.Name, schemas.PluginStatusError,
 				[]string{fmt.Sprintf("plugin %s instantiated but returned nil", cfg.Name)}, []schemas.PluginType{})
+			failureCount++
 			continue
 		}
 
@@ -363,6 +372,9 @@ func (s *BifrostHTTPServer) loadCustomPlugins(ctx context.Context) error {
 		s.Config.SetPluginOrderInfo(plugin.GetName(), cfg.Placement, cfg.Order)
 		s.Config.UpdatePluginOverallStatus(plugin.GetName(), cfg.Name, schemas.PluginStatusActive,
 			[]string{fmt.Sprintf("plugin %s initialized successfully", cfg.Name)}, InferPluginTypes(plugin))
+	}
+	if failureCount > 0 {
+		return fmt.Errorf("refusing to boot: %d enabled custom plugin(s) failed to load; see plugin status/logs", failureCount)
 	}
 	return nil
 }

--- a/transports/bifrost-http/server/plugins_failclosed_test.go
+++ b/transports/bifrost-http/server/plugins_failclosed_test.go
@@ -1,0 +1,113 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/plugins"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+)
+
+const failClosedTestSentinel = "sk-test-sentinel-should-never-leak-4f19c2"
+
+// TestLoadCustomPluginsFailsClosedOnInstantiateError: an enabled, non-enterprise
+// plugin whose shared object cannot be loaded must make loadCustomPlugins return
+// an error, and that error must not carry the plugin's path.
+func TestLoadCustomPluginsFailsClosedOnInstantiateError(t *testing.T) {
+	logger = noopTestLogger{}
+	path := "/no/such/path/" + failClosedTestSentinel + ".so"
+	config := &lib.Config{
+		PluginLoader: plugins.NewSharedObjectPluginLoader(nil),
+		PluginConfigs: []*schemas.PluginConfig{
+			{Enabled: true, Name: "capture", Path: &path},
+		},
+	}
+	server := &BifrostHTTPServer{Config: config}
+
+	err := server.loadCustomPlugins(context.Background())
+	if err == nil {
+		t.Fatal("loadCustomPlugins returned nil error for an enabled, non-enterprise plugin that failed to instantiate — this is exactly the fail-open defect this patch exists to close")
+	}
+	if strings.Contains(err.Error(), failClosedTestSentinel) {
+		t.Fatalf("returned aggregate error leaked plugin-config text (sentinel %q found in %q) — the aggregate must stay a count + generic message only; raw detail belongs solely in the per-plugin UpdatePluginOverallStatus/logger.Error surface", failClosedTestSentinel, err.Error())
+	}
+}
+
+// TestLoadCustomPluginsFailsClosedOnNilPlugin: a loader that returns (nil, nil)
+// hits the defensive nil-plugin branch, which must also count as a failure.
+func TestLoadCustomPluginsFailsClosedOnNilPlugin(t *testing.T) {
+	logger = noopTestLogger{}
+	path := "/irrelevant/nil-plugin.so"
+	config := &lib.Config{
+		PluginLoader: nilReturningLoader{},
+		PluginConfigs: []*schemas.PluginConfig{
+			{Enabled: true, Name: "capture", Path: &path},
+		},
+	}
+	server := &BifrostHTTPServer{Config: config}
+
+	if err := server.loadCustomPlugins(context.Background()); err == nil {
+		t.Fatal("loadCustomPlugins returned nil error when InstantiatePlugin returned a nil plugin with no error — the defensive nil-check path must also fail closed")
+	}
+}
+
+// TestLoadCustomPluginsSkipsEnterprisePluginFailure: enterprise plugins keep
+// today's skip-and-continue behavior and never trip the fail-closed error.
+func TestLoadCustomPluginsSkipsEnterprisePluginFailure(t *testing.T) {
+	logger = noopTestLogger{}
+	path := "/no/such/path/datadog.so"
+	config := &lib.Config{
+		PluginLoader: plugins.NewSharedObjectPluginLoader(nil),
+		PluginConfigs: []*schemas.PluginConfig{
+			// "datadog" is a member of enterprisePlugins (server.go) — its
+			// failure must stay silently skipped, unchanged from upstream.
+			{Enabled: true, Name: "datadog", Path: &path},
+		},
+	}
+	server := &BifrostHTTPServer{Config: config}
+
+	if err := server.loadCustomPlugins(context.Background()); err != nil {
+		t.Fatalf("loadCustomPlugins returned an error for a failed ENTERPRISE plugin — the pre-existing silent-skip behavior for enterprisePlugins must be unchanged: %v", err)
+	}
+}
+
+// TestLoadCustomPluginsReturnsNilWithNoEnabledCustomPlugins: with no enabled
+// custom plugin configured, loadCustomPlugins still returns nil.
+func TestLoadCustomPluginsReturnsNilWithNoEnabledCustomPlugins(t *testing.T) {
+	logger = noopTestLogger{}
+	path := "/no/such/path.so"
+	config := &lib.Config{
+		PluginLoader: plugins.NewSharedObjectPluginLoader(nil),
+		PluginConfigs: []*schemas.PluginConfig{
+			// Disabled: the loop's disabled-plugin branch runs (a verify
+			// call against the same missing path) but must never count
+			// toward failureCount — only an ENABLED plugin's failure does.
+			{Enabled: false, Name: "capture", Path: &path},
+		},
+	}
+	server := &BifrostHTTPServer{Config: config}
+
+	if err := server.loadCustomPlugins(context.Background()); err != nil {
+		t.Fatalf("loadCustomPlugins returned an error with zero enabled custom plugins (a disabled plugin only): %v", err)
+	}
+}
+
+// nilReturningLoader is a minimal fake plugins.PluginLoader whose LoadPlugin
+// deliberately returns (nil, nil) — a shape the real SharedObjectPluginLoader
+// never produces on its own — needed to directly exercise loadCustomPlugins'
+// defensive "plugin == nil but err == nil" branch without depending on an
+// upstream implementation quirk to reach it.
+type nilReturningLoader struct{}
+
+// LoadPlugin returns (nil, nil) to reach loadCustomPlugins' nil-plugin branch.
+func (nilReturningLoader) LoadPlugin(path string, config any) (schemas.BasePlugin, error) {
+	return nil, nil
+}
+
+// VerifyBasePlugin always succeeds so the loader is reached.
+func (nilReturningLoader) VerifyBasePlugin(path string) (string, error) {
+	return "", errors.New("not implemented in fake loader")
+}


### PR DESCRIPTION
## Summary

`loadCustomPlugins` logs a per-plugin instantiate failure, marks the plugin's status `error` via `UpdatePluginOverallStatus`, and `continue`s to the next plugin, but the function unconditionally returns `nil` regardless of how many enabled plugins failed. `Bootstrap` therefore never sees an error, never exits, and `server.Start()` proceeds: every surface (inference, admin, `/health`) keeps serving with an enabled, non-enterprise custom plugin silently absent, even though the deployment's own config declares it required.

Found via a downstream deployment's plugin-ABI conformance gate, whose negative leg (a plugin config pointing at a nonexistent `.so`) showed the process booting healthy and answering `GET /health` 200 with the configured plugin missing entirely. That is a fail-open defect for any deployment that treats an enabled custom plugin as required, such as a metadata-capture or policy-enforcement plugin with no safe degraded mode.

## Changes

- `loadCustomPlugins` counts every enabled, non-enterprise custom plugin that fails to instantiate or returns a nil plugin, and returns one aggregated error when the count is non-zero. It propagates through the existing, unmodified call chain (`loadCustomPlugins` → `LoadPlugins` → `Bootstrap` → `main.go`'s `os.Exit(1)`); no new fail-closed mechanism, the process simply never reaches `Start()`.
- The aggregate error is deliberately a count plus a generic message, never raw plugin name, path, or underlying error text. It reaches `main.go`'s top-level `"failed to bootstrap server: %v"` line, a different and less scoped logging surface than the per-plugin `UpdatePluginOverallStatus` / `logger.Error` calls, which already carry the full detail and are the right place for it (a plugin's path or URL can itself be sensitive).
- Enterprise-plugin skip behavior, per-plugin status bookkeeping, and every other loop body line are unchanged.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

```sh
source .github/workflows/scripts/setup-go-workspace.sh   # multi-module workspace, as CI does
cd transports
go vet ./bifrost-http/server/
go test ./bifrost-http/server/ -run TestLoadCustomPlugins -count=1 -v
```

Four focused tests in `plugins_failclosed_test.go`, all green:

- `TestLoadCustomPluginsFailsClosedOnInstantiateError`: an enabled plugin whose shared object cannot be loaded makes the function return an error, and the error does not contain the plugin path (sentinel-checked).
- `TestLoadCustomPluginsFailsClosedOnNilPlugin`: a loader returning `(nil, nil)` reaches the defensive nil-plugin branch, which also counts as a failure.
- `TestLoadCustomPluginsSkipsEnterprisePluginFailure`: enterprise plugins keep today's skip-and-continue behavior.
- `TestLoadCustomPluginsReturnsNilWithNoEnabledCustomPlugins`: the success path is unchanged.

The two fail-closed tests fail against stock `dev` (the function returns `nil`).

## Breaking changes

- [x] No

A deployment whose config enables a custom plugin that cannot load previously booted with that plugin silently missing; it now exits at bootstrap with a count-only error and the per-plugin detail in the existing plugin status/log surface. A deployment with a broken but unwanted plugin should disable it in config rather than rely on the silent skip.

## Related issues

None filed. Same downstream migration as #6735, #6740, #6741.

## Security considerations

Closes a fail-open path: a policy-enforcement or capture plugin that failed to load no longer leaves the gateway serving without it. The new aggregate error is sanitized by construction (count and generic text only) so the less-scoped bootstrap log line never gains plugin paths or config text.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go, in the CI workspace)
