### PR TITLE
fix(anthropic): emit and preserve output_config.effort on DeepSeek's Anthropic endpoint

### DIFF
--- a/core/providers/anthropic/nativeeffort_provider_test.go
+++ b/core/providers/anthropic/nativeeffort_provider_test.go
@@ -1,0 +1,73 @@
+package anthropic
+
+import (
+	"testing"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// The NativeEffort provider feature is the provider-wide fallback for
+// ModelCaps.SupportsNativeEffort. It must widen the answer only for providers
+// that grant it, and leave every other provider on the Claude model ladder.
+func TestDefaultSupportsNativeEffort_ProviderGrant(t *testing.T) {
+	cases := []struct {
+		provider schemas.ModelProvider
+		model    string
+		want     bool
+	}{
+		// DeepSeek's Anthropic-compatible surface accepts output_config.effort on every model it serves.
+		{schemas.DeepSeek, "deepseek-v4-flash", true},
+		{schemas.DeepSeek, "deepseek-v4-pro", true},
+		{schemas.DeepSeek, "some-future-deepseek-model", true},
+		// Anthropic itself stays on the model ladder.
+		{schemas.Anthropic, "claude-opus-4-5", true},
+		{schemas.Anthropic, "claude-3-5-haiku-latest", false},
+		// A Claude-shaped model name on a provider without the grant is unchanged.
+		{schemas.Vertex, "claude-3-5-haiku@20241022", false},
+	}
+	for _, tc := range cases {
+		caps := schemas.ResolveModelCaps(tc.provider, tc.model)
+		if got := defaultSupportsNativeEffort(caps); got != tc.want {
+			t.Errorf("defaultSupportsNativeEffort(%s, %s) = %v, want %v", tc.provider, tc.model, got, tc.want)
+		}
+	}
+}
+
+// The typed strip pass must keep output_config.effort on a provider that
+// grants NativeEffort and still remove it where the model ladder says no.
+func TestStripUnsupportedAnthropicFields_NativeEffortProviderGrant(t *testing.T) {
+	effort := "medium"
+	keep := &AnthropicMessageRequest{Model: "deepseek-v4-flash", OutputConfig: &AnthropicOutputConfig{Effort: &effort}}
+	stripUnsupportedAnthropicFields(keep, schemas.DeepSeek, "deepseek-v4-flash")
+	if keep.OutputConfig == nil || keep.OutputConfig.Effort == nil || *keep.OutputConfig.Effort != effort {
+		t.Fatalf("DeepSeek: output_config.effort was stripped: %#v", keep.OutputConfig)
+	}
+
+	strip := &AnthropicMessageRequest{Model: "claude-3-5-haiku-latest", OutputConfig: &AnthropicOutputConfig{Effort: &effort}}
+	stripUnsupportedAnthropicFields(strip, schemas.Anthropic, "claude-3-5-haiku-latest")
+	if strip.OutputConfig != nil {
+		t.Fatalf("Anthropic haiku: output_config.effort survived the strip: %#v", strip.OutputConfig)
+	}
+}
+
+// Same contract on the raw-body path.
+func TestStripUnsupportedFieldsFromRawBody_NativeEffortProviderGrant(t *testing.T) {
+	body := []byte(`{"model":"deepseek-v4-flash","max_tokens":64,"output_config":{"effort":"low"},"messages":[]}`)
+	out, err := StripUnsupportedFieldsFromRawBody(body, schemas.DeepSeek, "deepseek-v4-flash")
+	if err != nil {
+		t.Fatalf("StripUnsupportedFieldsFromRawBody: %v", err)
+	}
+	if got := providerUtils.GetJSONField(out, "output_config.effort").String(); got != "low" {
+		t.Fatalf("DeepSeek raw: output_config.effort = %q, want low; body=%s", got, out)
+	}
+
+	body = []byte(`{"model":"claude-3-5-haiku-latest","max_tokens":64,"output_config":{"effort":"low"},"messages":[]}`)
+	out, err = StripUnsupportedFieldsFromRawBody(body, schemas.Anthropic, "claude-3-5-haiku-latest")
+	if err != nil {
+		t.Fatalf("StripUnsupportedFieldsFromRawBody: %v", err)
+	}
+	if providerUtils.JSONFieldExists(out, "output_config.effort") {
+		t.Fatalf("Anthropic haiku raw: output_config.effort survived the strip; body=%s", out)
+	}
+}

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -4364,7 +4364,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 				// the model applies its own default. Synthesizing thinking here would
 				// turn it on against the caller's request on every model that defaults
 				// it off (Opus 4.6/4.7/4.8, Sonnet 4.6).
-				if caps.SupportsNativeEffort(DefaultSupportsNativeEffort(caps.Model())) {
+				if caps.SupportsNativeEffort(defaultSupportsNativeEffort(caps)) {
 					setEffortOnOutputConfig(anthropicReq, MapBifrostEffortToAnthropic(native.Effort))
 				}
 			} else {
@@ -4414,7 +4414,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 						// The neutral params collapsed the caller's effort into "none"
 						// to signal reasoning-off, so restore it from what they sent.
 						if native, ok := anthropicNativeEffortFrom(ctx); ok && native.Effort != "" &&
-							caps.SupportsNativeEffort(DefaultSupportsNativeEffort(caps.Model())) {
+							caps.SupportsNativeEffort(defaultSupportsNativeEffort(caps)) {
 							setEffortOnOutputConfig(anthropicReq, MapBifrostEffortToAnthropic(native.Effort))
 						}
 					}

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -189,6 +189,7 @@ type ProviderFeatureSupport struct {
 	ServerSideFallback     bool // native "fallbacks" request field — server-side-fallback-2026-06-01. Claude API only per docs ("not available on Amazon Bedrock, Google Cloud, or Microsoft Foundry").
 	FallbackCredit         bool // fallback_credit_token request field + stop_details credit fields — fallback-credit-2026-06-01 (AWS surfaces: -2026-06-09). Documented on the Claude API, Amazon Bedrock, Google Cloud and Microsoft Foundry, i.e. the inverse of ServerSideFallback.
 	MidConvToolChanges     bool // tool_addition/tool_removal blocks — mid-conversation-tool-changes-2026-07-01. Native Anthropic surface (Claude API + Bedrock Mantle); Bedrock is Opus 5 only, enforced upstream.
+	NativeEffort           bool // output_config.effort accepted on every model the provider serves — the provider-wide fallback for ModelCaps.SupportsNativeEffort when no datasheet row speaks; the Claude model ladder (DefaultSupportsNativeEffort) is the fallback everywhere this is false. DeepSeek: "output_config: only effort is supported" (https://api-docs.deepseek.com/guides/anthropic_api)
 }
 
 // ProviderFeatures maps each provider to its supported Anthropic features.
@@ -342,6 +343,7 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		StructuredOutputs:      true,
 		InterleavedThinking:    true,
 		ServiceTier:            true,
+		NativeEffort:           true,
 	},
 }
 

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -260,7 +260,7 @@ func stripUnsupportedAnthropicFields(req *AnthropicMessageRequest, provider sche
 	// https://platform.claude.com/docs/en/build-with-claude/effort. Models
 	// outside the supported set return: "This model does not support the
 	// effort parameter."
-	if req.OutputConfig != nil && req.OutputConfig.Effort != nil && !caps.SupportsNativeEffort(DefaultSupportsNativeEffort(caps.Model())) {
+	if req.OutputConfig != nil && req.OutputConfig.Effort != nil && !caps.SupportsNativeEffort(defaultSupportsNativeEffort(caps)) {
 		req.OutputConfig.Effort = nil
 		if req.OutputConfig.Format == nil && req.OutputConfig.TaskBudget == nil {
 			req.OutputConfig = nil
@@ -630,7 +630,7 @@ func StripUnsupportedFieldsFromRawBody(jsonBody []byte, provider schemas.ModelPr
 	// https://platform.claude.com/docs/en/build-with-claude/effort.
 	// Mirrors the typed path; same cleanup of an empty parent.
 	if providerUtils.JSONFieldExists(jsonBody, "output_config.effort") &&
-		!caps.SupportsNativeEffort(DefaultSupportsNativeEffort(caps.Model())) {
+		!caps.SupportsNativeEffort(defaultSupportsNativeEffort(caps)) {
 		jsonBody, err = providerUtils.DeleteJSONField(jsonBody, "output_config.effort")
 		if err != nil {
 			return nil, fmt.Errorf("strip raw output_config.effort: %w", err)
@@ -1032,7 +1032,25 @@ func DefaultCanDisableReasoning(model string) bool {
 // (supports_native_effort AND supports_adaptive_thinking) with no field of its
 // own: "accepts effort" minus "supports adaptive".
 func SupportsNativeEffort(caps schemas.ModelCaps) bool {
-	return caps.SupportsNativeEffort(DefaultSupportsNativeEffort(caps.Model())) && !caps.SupportsAdaptiveThinking(DefaultSupportsAdaptiveThinking(caps.Model()))
+	return caps.SupportsNativeEffort(defaultSupportsNativeEffort(caps)) && !caps.SupportsAdaptiveThinking(DefaultSupportsAdaptiveThinking(caps.Model()))
+}
+
+// defaultSupportsNativeEffort is the fallback handed to
+// ModelCaps.SupportsNativeEffort: a datasheet row still wins, but when none
+// speaks, a provider whose ProviderFeatures entry grants NativeEffort accepts
+// output_config.effort on every model it serves, and every other provider
+// falls back to the Claude model ladder in DefaultSupportsNativeEffort.
+//
+// This is what lets a non-Claude Anthropic-compatible surface (DeepSeek's
+// /anthropic/v1/messages) keep the effort knob: its model names never match
+// the Claude ladder, so without the provider-level grant the converters never
+// emit output_config.effort and the strip pass removes it if a caller sends
+// it raw.
+func defaultSupportsNativeEffort(caps schemas.ModelCaps) bool {
+	if features, ok := ProviderFeatures[caps.Provider()]; ok && features.NativeEffort {
+		return true
+	}
+	return DefaultSupportsNativeEffort(caps.Model())
 }
 
 // SupportsEffortParameter returns true if the model accepts the

--- a/core/providers/deepseek/effort_test.go
+++ b/core/providers/deepseek/effort_test.go
@@ -1,0 +1,100 @@
+package deepseek_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// captureAnthropicWire stands in for DeepSeek's /anthropic/v1/messages endpoint
+// and records the decoded request body the provider actually sent.
+func captureAnthropicWire(t *testing.T, captured *map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(body, captured); err != nil {
+			t.Errorf("decode body: %v", err)
+			http.Error(w, "decode body", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"msg_1","type":"message","role":"assistant","model":"deepseek-v4-flash","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+}
+
+func anthropicEndpointKey() schemas.Key {
+	return schemas.Key{Value: schemas.SecretVar{Val: "test-api-key"}, UseAnthropicEndpoints: new(true)}
+}
+
+// TestChatCompletion_AnthropicEndpointEmitsOutputConfigEffort: DeepSeek's
+// Anthropic-compatible API takes reasoning depth through output_config.effort
+// ("output_config: only effort is supported") and ignores thinking.budget_tokens.
+// A caller's reasoning.effort must therefore reach the wire as
+// output_config.effort rather than being collapsed into a budget the upstream
+// discards.
+func TestChatCompletion_AnthropicEndpointEmitsOutputConfigEffort(t *testing.T) {
+	t.Parallel()
+	var captured map[string]any
+	server := captureAnthropicWire(t, &captured)
+	defer server.Close()
+
+	provider, err := newTestDeepSeekProvider(server.URL)
+	if err != nil {
+		t.Fatalf("NewDeepSeekProvider: %v", err)
+	}
+	effort := "medium"
+	msg := "hello"
+	_, bifrostErr := provider.ChatCompletion(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), anthropicEndpointKey(), &schemas.BifrostChatRequest{
+		Provider: schemas.DeepSeek,
+		Model:    "deepseek-v4-flash",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: &msg}}},
+		Params:   &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: &effort}},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletion: %v", bifrostErr.Error.Message)
+	}
+	outputConfig, ok := captured["output_config"].(map[string]any)
+	if !ok || outputConfig["effort"] != effort {
+		t.Fatalf("output_config.effort = %#v, want %q; wire body = %#v", captured["output_config"], effort, captured)
+	}
+}
+
+// TestResponses_AnthropicEndpointEmitsOutputConfigEffort covers the Responses
+// converter, which has its own reasoning ladder.
+func TestResponses_AnthropicEndpointEmitsOutputConfigEffort(t *testing.T) {
+	t.Parallel()
+	var captured map[string]any
+	server := captureAnthropicWire(t, &captured)
+	defer server.Close()
+
+	provider, err := newTestDeepSeekProvider(server.URL)
+	if err != nil {
+		t.Fatalf("NewDeepSeekProvider: %v", err)
+	}
+	effort := "high"
+	msg := "hello"
+	_, bifrostErr := provider.Responses(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), anthropicEndpointKey(), &schemas.BifrostResponsesRequest{
+		Provider: schemas.DeepSeek,
+		Model:    "deepseek-v4-pro",
+		Input:    []schemas.ResponsesMessage{{Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser), Content: &schemas.ResponsesMessageContent{ContentStr: &msg}}},
+		Params:   &schemas.ResponsesParameters{Reasoning: &schemas.ResponsesParametersReasoning{Effort: &effort}},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("Responses: %v", bifrostErr.Error.Message)
+	}
+	outputConfig, ok := captured["output_config"].(map[string]any)
+	if !ok || outputConfig["effort"] != effort {
+		t.Fatalf("output_config.effort = %#v, want %q; wire body = %#v", captured["output_config"], effort, captured)
+	}
+}


### PR DESCRIPTION
## Summary

DeepSeek's Anthropic-compatible API takes reasoning depth through `output_config.effort` (its docs: "output_config: only `effort` is supported") and documents `thinking.budget_tokens` as ignored. The DeepSeek provider builds its `/anthropic/v1/messages` requests through the shared Anthropic converters, whose effort handling is gated on the Claude model ladder (`DefaultSupportsNativeEffort`). `deepseek-v4-flash` and `deepseek-v4-pro` never match that ladder, so on `dev` today:

- a caller's `reasoning.effort` is converted into `thinking: {type: enabled, budget_tokens: N}`, which DeepSeek ignores, and no `output_config.effort` is emitted;
- a raw `output_config.effort` the caller sends is removed by `stripUnsupportedAnthropicFields` / `StripUnsupportedFieldsFromRawBody`.

Either way the wire carries no effort. Reproduced against a capturing `httptest` server standing in for DeepSeek: effort-only Chat and Responses requests arrive with `output_config` absent and `thinking.budget_tokens` set.

## Changes

- `ProviderFeatureSupport` gains `NativeEffort bool`: `output_config.effort` is accepted on every model the provider serves. Set for `schemas.DeepSeek`.
- New `defaultSupportsNativeEffort(caps)` in `anthropic/utils.go` is the fallback passed to `ModelCaps.SupportsNativeEffort` at the five existing call sites (typed strip, raw strip, the `SupportsNativeEffort` helper, and the two Responses-ladder branches). A datasheet row still overrides; a provider with the grant returns true; everyone else falls back to `DefaultSupportsNativeEffort(model)` exactly as before. This follows the pattern the `ModelCaps` comment describes ("the fallback every call site passes is the provider-level answer from the ProviderFeatures matrix").
- No model-name predicate, no change to the strip functions' signatures or the Claude ladder. With the grant, the existing "native effort + budget_tokens" branch of the Chat ladder emits `output_config.effort` alongside the `thinking` block DeepSeek already receives today; the Responses ladder's native-effort-only branch forwards the effort with thinking omitted.
- Changelog entry.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
cd core
go vet ./providers/anthropic/ ./providers/deepseek/
go test ./providers/deepseek/ -run 'EmitsOutputConfigEffort' -count=1 -v
go test ./providers/anthropic/ -run 'NativeEffortProviderGrant|ProviderGrant' -count=1 -v
go test ./providers/... -count=1
```

- `providers/deepseek/effort_test.go` drives the real provider through `httptest` on `/anthropic/v1/messages` (Chat + Responses, effort-only) and asserts `output_config.effort` on the captured wire body. Both tests **fail on stock `dev`** with the non-test changes reverted (`output_config` absent).
- `providers/anthropic/nativeeffort_provider_test.go` pins the fallback for DeepSeek (any model), Anthropic (`claude-opus-4-5` true, `claude-3-5-haiku-latest` false), and a Claude-named model on a non-granting provider (Vertex, false); and asserts both strip paths keep effort for DeepSeek and still strip it for Haiku.
- Full `go test ./providers/...` passes (Azure, Vertex, Bedrock Mantle, SGL, Fireworks share the strip functions).

## Breaking changes

- [x] No

Only providers with `NativeEffort: true` change behavior, and only DeepSeek has it.

## Related issues

Reference: https://api-docs.deepseek.com/guides/anthropic_api (request-field support table). Supersedes the effort portion of #5985, which I closed as unreviewable; this is the first of its focused replacements.

## Security considerations

None. Request-shaping only; no credentials, payload logging, or network behavior change.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)
