### PR TITLE
fix(deepseek): reject document content before egress on the Anthropic endpoint

### DIFF
--- a/core/providers/deepseek/content.go
+++ b/core/providers/deepseek/content.go
@@ -1,0 +1,88 @@
+package deepseek
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// DeepSeek's Anthropic-compatible API documents document content blocks as
+// unsupported ("Documents: Not Supported"; images are supported) but does not
+// reject them: a request carrying a document returns HTTP 200 with the
+// document silently dropped from the model's view. An upstream-error-driven
+// fallback can therefore never enforce the contract, so the provider checks
+// for document blocks itself before conversion or egress and returns a typed,
+// fallback-eligible error. The guard reads block type discriminators only; it
+// never reads file data, URLs, filenames, or text.
+//
+// Source: https://api-docs.deepseek.com/guides/anthropic_api
+
+const unsupportedDocumentCode = "deepseek_unsupported_document_content"
+
+// rejectUnsupportedChatContent fails a Chat request bound for the Anthropic
+// endpoint when any message carries a file (document) content block.
+func rejectUnsupportedChatContent(request *schemas.BifrostChatRequest) *schemas.BifrostError {
+	if request == nil {
+		return nil
+	}
+	for i := range request.Input {
+		content := request.Input[i].Content
+		if content == nil {
+			continue
+		}
+		for j := range content.ContentBlocks {
+			if content.ContentBlocks[j].Type == schemas.ChatContentBlockTypeFile {
+				return newUnsupportedDocumentError()
+			}
+		}
+	}
+	return nil
+}
+
+// rejectUnsupportedResponsesContent applies the same contract to Responses
+// requests, including file blocks inside function tool-call outputs, which
+// reach the model as content the same way a user turn does.
+func rejectUnsupportedResponsesContent(request *schemas.BifrostResponsesRequest) *schemas.BifrostError {
+	if request == nil {
+		return nil
+	}
+	for i := range request.Input {
+		message := &request.Input[i]
+		if message.Content != nil && hasResponsesFileBlock(message.Content.ContentBlocks) {
+			return newUnsupportedDocumentError()
+		}
+		if message.ResponsesToolMessage != nil && message.ResponsesToolMessage.Output != nil &&
+			hasResponsesFileBlock(message.ResponsesToolMessage.Output.ResponsesFunctionToolCallOutputBlocks) {
+			return newUnsupportedDocumentError()
+		}
+	}
+	return nil
+}
+
+// hasResponsesFileBlock reports whether any block is a file (document) block,
+// reading the type discriminator only.
+func hasResponsesFileBlock(blocks []schemas.ResponsesMessageContentBlock) bool {
+	for i := range blocks {
+		if blocks[i].Type == schemas.ResponsesInputMessageContentBlockTypeFile {
+			return true
+		}
+	}
+	return false
+}
+
+// newUnsupportedDocumentError is an Anthropic-shaped invalid_request_error that
+// explicitly permits fallbacks, so a routing rule with an enumerated next
+// provider carries the untouched request onward instead of failing the caller.
+func newUnsupportedDocumentError() *schemas.BifrostError {
+	statusCode := 400
+	errorType := "invalid_request_error"
+	allowFallbacks := true
+	return &schemas.BifrostError{
+		IsBifrostError: true,
+		StatusCode:     &statusCode,
+		AllowFallbacks: &allowFallbacks,
+		Error: &schemas.ErrorField{
+			Type:    &errorType,
+			Code:    schemas.Ptr(unsupportedDocumentCode),
+			Message: "deepseek's anthropic-compatible api does not support document content blocks; the request was not sent upstream",
+		},
+	}
+}

--- a/core/providers/deepseek/content_test.go
+++ b/core/providers/deepseek/content_test.go
@@ -1,0 +1,193 @@
+package deepseek_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// countingAnthropicServer answers like DeepSeek's /anthropic/v1/messages and
+// counts arrivals, so a test can prove a request never left the process.
+func countingAnthropicServer(hits *int32) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(hits, 1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"id":"msg_1","type":"message","role":"assistant","model":"deepseek-v4-flash","content":[{"type":"text","text":"ok"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+}
+
+// documentKey is a test key that selects DeepSeek's Anthropic-compatible endpoint.
+func documentKey() schemas.Key {
+	return schemas.Key{Value: schemas.SecretVar{Val: "test-api-key"}, UseAnthropicEndpoints: new(true)}
+}
+
+// chatWith builds a single-user-turn Chat request carrying one content block.
+func chatWith(block schemas.ChatContentBlock) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.DeepSeek,
+		Model:    "deepseek-v4-flash",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{block}},
+		}},
+	}
+}
+
+// assertUnsupportedDocument checks the guard's error contract: typed 400,
+// the deepseek_unsupported_document_content code, and AllowFallbacks set.
+func assertUnsupportedDocument(t *testing.T, bifrostErr *schemas.BifrostError) {
+	t.Helper()
+	if bifrostErr == nil || bifrostErr.Error == nil {
+		t.Fatalf("expected a typed error, got %#v", bifrostErr)
+	}
+	if bifrostErr.StatusCode == nil || *bifrostErr.StatusCode != 400 {
+		t.Fatalf("status = %v, want 400", bifrostErr.StatusCode)
+	}
+	if bifrostErr.Error.Code == nil || *bifrostErr.Error.Code != "deepseek_unsupported_document_content" {
+		t.Fatalf("code = %v, want deepseek_unsupported_document_content", bifrostErr.Error.Code)
+	}
+	if bifrostErr.AllowFallbacks == nil || !*bifrostErr.AllowFallbacks {
+		t.Fatalf("AllowFallbacks = %v, want true so an enumerated fallback can carry the request", bifrostErr.AllowFallbacks)
+	}
+}
+
+// A document block on the Anthropic endpoint is rejected locally: typed,
+// fallback-eligible, and with zero arrivals at the upstream.
+func TestChatCompletion_AnthropicEndpointRejectsDocumentBeforeEgress(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	server := countingAnthropicServer(&hits)
+	defer server.Close()
+	provider, err := newTestDeepSeekProvider(server.URL)
+	if err != nil {
+		t.Fatalf("NewDeepSeekProvider: %v", err)
+	}
+	fileData := "data:application/pdf;base64,AAAA"
+	resp, bifrostErr := provider.ChatCompletion(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), documentKey(),
+		chatWith(schemas.ChatContentBlock{Type: schemas.ChatContentBlockTypeFile, File: &schemas.ChatInputFile{FileData: &fileData}}))
+	if resp != nil {
+		t.Fatalf("document request produced a response: %#v", resp)
+	}
+	assertUnsupportedDocument(t, bifrostErr)
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("upstream received %d request(s); want 0", got)
+	}
+}
+
+// TestChatCompletionStream_AnthropicEndpointRejectsDocumentBeforeEgress is the
+// streaming Chat counterpart: no stream is opened and nothing reaches upstream.
+func TestChatCompletionStream_AnthropicEndpointRejectsDocumentBeforeEgress(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	server := countingAnthropicServer(&hits)
+	defer server.Close()
+	provider, err := newTestDeepSeekProvider(server.URL)
+	if err != nil {
+		t.Fatalf("NewDeepSeekProvider: %v", err)
+	}
+	fileData := "data:application/pdf;base64,AAAA"
+	stream, bifrostErr := provider.ChatCompletionStream(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), nil, nil, documentKey(),
+		chatWith(schemas.ChatContentBlock{Type: schemas.ChatContentBlockTypeFile, File: &schemas.ChatInputFile{FileData: &fileData}}))
+	if stream != nil {
+		t.Fatalf("document request opened a stream")
+	}
+	assertUnsupportedDocument(t, bifrostErr)
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("upstream received %d request(s); want 0", got)
+	}
+}
+
+// Images are documented as supported and must keep flowing unchanged.
+func TestChatCompletion_AnthropicEndpointStillForwardsImages(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	server := countingAnthropicServer(&hits)
+	defer server.Close()
+	provider, err := newTestDeepSeekProvider(server.URL)
+	if err != nil {
+		t.Fatalf("NewDeepSeekProvider: %v", err)
+	}
+	resp, bifrostErr := provider.ChatCompletion(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), documentKey(),
+		chatWith(schemas.ChatContentBlock{Type: schemas.ChatContentBlockTypeImage, ImageURLStruct: &schemas.ChatInputImage{URL: "data:image/png;base64,AAAA"}}))
+	if bifrostErr != nil {
+		t.Fatalf("image request failed: %v", bifrostErr.Error.Message)
+	}
+	if resp == nil || atomic.LoadInt32(&hits) != 1 {
+		t.Fatalf("image request did not reach upstream exactly once (hits=%d, resp nil=%v)", hits, resp == nil)
+	}
+}
+
+// Responses: a file block in a user turn and a file block inside a function
+// tool-call output are both rejected before egress.
+func TestResponses_AnthropicEndpointRejectsDocumentBeforeEgress(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	server := countingAnthropicServer(&hits)
+	defer server.Close()
+	provider, err := newTestDeepSeekProvider(server.URL)
+	if err != nil {
+		t.Fatalf("NewDeepSeekProvider: %v", err)
+	}
+	fileBlock := schemas.ResponsesMessageContentBlock{Type: schemas.ResponsesInputMessageContentBlockTypeFile}
+
+	userTurn := &schemas.BifrostResponsesRequest{Provider: schemas.DeepSeek, Model: "deepseek-v4-pro",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{fileBlock}},
+		}}}
+	resp, bifrostErr := provider.Responses(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), documentKey(), userTurn)
+	if resp != nil {
+		t.Fatalf("document user turn produced a response")
+	}
+	assertUnsupportedDocument(t, bifrostErr)
+
+	callID := "call_1"
+	toolOutput := &schemas.BifrostResponsesRequest{Provider: schemas.DeepSeek, Model: "deepseek-v4-pro",
+		Input: []schemas.ResponsesMessage{{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID: &callID,
+				Output: &schemas.ResponsesToolMessageOutputStruct{ResponsesFunctionToolCallOutputBlocks: []schemas.ResponsesMessageContentBlock{fileBlock}},
+			},
+		}}}
+	resp, bifrostErr = provider.Responses(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), documentKey(), toolOutput)
+	if resp != nil {
+		t.Fatalf("document tool output produced a response")
+	}
+	assertUnsupportedDocument(t, bifrostErr)
+
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("upstream received %d request(s); want 0", got)
+	}
+}
+
+// TestResponsesStream_AnthropicEndpointRejectsDocumentBeforeEgress is the
+// streaming Responses counterpart: no stream is opened and nothing reaches upstream.
+func TestResponsesStream_AnthropicEndpointRejectsDocumentBeforeEgress(t *testing.T) {
+	t.Parallel()
+	var hits int32
+	server := countingAnthropicServer(&hits)
+	defer server.Close()
+	provider, err := newTestDeepSeekProvider(server.URL)
+	if err != nil {
+		t.Fatalf("NewDeepSeekProvider: %v", err)
+	}
+	req := &schemas.BifrostResponsesRequest{Provider: schemas.DeepSeek, Model: "deepseek-v4-flash",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentBlocks: []schemas.ResponsesMessageContentBlock{{Type: schemas.ResponsesInputMessageContentBlockTypeFile}}},
+		}}}
+	stream, bifrostErr := provider.ResponsesStream(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), nil, nil, documentKey(), req)
+	if stream != nil {
+		t.Fatalf("document request opened a stream")
+	}
+	assertUnsupportedDocument(t, bifrostErr)
+	if got := atomic.LoadInt32(&hits); got != 0 {
+		t.Fatalf("upstream received %d request(s); want 0", got)
+	}
+}

--- a/core/providers/deepseek/deepseek.go
+++ b/core/providers/deepseek/deepseek.go
@@ -225,6 +225,9 @@ func (provider *DeepSeekProvider) TextCompletionStream(ctx *schemas.BifrostConte
 // ChatCompletion performs a chat completion request to DeepSeek's Anthropic-compatible API.
 func (provider *DeepSeekProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
+		if bifrostErr := rejectUnsupportedChatContent(request); bifrostErr != nil {
+			return nil, bifrostErr
+		}
 		return anthropic.HandleAnthropicChatCompletionRequest(
 			ctx,
 			provider.client,
@@ -266,6 +269,9 @@ func (provider *DeepSeekProvider) ChatCompletion(ctx *schemas.BifrostContext, ke
 // Returns a channel containing BifrostStreamChunk objects representing the stream or an error if the request fails.
 func (provider *DeepSeekProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
+		if bifrostErr := rejectUnsupportedChatContent(request); bifrostErr != nil {
+			return nil, bifrostErr
+		}
 		jsonData, bifrostErr := anthropic.BuildAnthropicChatRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
 			Provider:                  schemas.DeepSeek,
 			IsStreaming:               true,
@@ -324,6 +330,9 @@ func (provider *DeepSeekProvider) ChatCompletionStream(ctx *schemas.BifrostConte
 // Responses performs a Responses API request against DeepSeek's Anthropic-compatible endpoint.
 func (provider *DeepSeekProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
+		if bifrostErr := rejectUnsupportedResponsesContent(request); bifrostErr != nil {
+			return nil, bifrostErr
+		}
 		return anthropic.HandleAnthropicResponsesRequest(
 			ctx,
 			provider.client,
@@ -354,6 +363,9 @@ func (provider *DeepSeekProvider) Responses(ctx *schemas.BifrostContext, key sch
 // ResponsesStream performs a streaming Responses API request to DeepSeek's Anthropic-compatible endpoint.
 func (provider *DeepSeekProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
+		if bifrostErr := rejectUnsupportedResponsesContent(request); bifrostErr != nil {
+			return nil, bifrostErr
+		}
 		jsonData, bifrostErr := anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
 			Provider:                  schemas.DeepSeek,
 			IsStreaming:               true,


### PR DESCRIPTION
## Summary

DeepSeek's Anthropic-compatible API documents document content blocks as unsupported (its request-support table: "Documents: Not Supported"; images are supported) but does not reject them. A request carrying a document returns HTTP 200 with the document silently dropped from the model's view. Because there is no upstream error, no fallback can ever fire, and a caller who routed a document-bearing request through DeepSeek with an enumerated fallback gets a confident answer that never saw the document. I hit this live against the real endpoint before finding the documented contract.

## Changes

- New `core/providers/deepseek/content.go`: `rejectUnsupportedChatContent` / `rejectUnsupportedResponsesContent` scan the neutral request for file (document) blocks: user-turn content blocks, and file blocks inside function tool-call outputs (which reach the model as content the same way). Type discriminators only; no file data, URL, filename, or text is read.
- Called at the top of the Anthropic-endpoint branch in the four provider methods (`ChatCompletion`, `ChatCompletionStream`, `Responses`, `ResponsesStream`), before conversion or egress. The OpenAI-endpoint branch is untouched.
- The error is an Anthropic-shaped `invalid_request_error` (400, code `deepseek_unsupported_document_content`) with `AllowFallbacks: true`, so a routing rule with a next provider carries the untouched request onward, and a direct request gets a typed local error instead of a silent drop.
- Image blocks are deliberately not touched: DeepSeek documents them as supported (base64, url, file sources).
- Changelog entry.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
cd core
go vet ./providers/deepseek/
go test ./providers/deepseek/ -run 'RejectsDocument|StillForwardsImages' -count=1 -v
go test ./providers/deepseek/ -count=1
```

`providers/deepseek/content_test.go` drives the real provider through a counting `httptest` server standing in for `/anthropic/v1/messages`:

- a document block on each of the four paths is rejected typed (400, the code above, `AllowFallbacks` true) with **zero** upstream arrivals; all four **fail on stock `dev`** with the guard removed (the request reaches the server and returns a success);
- an image block still reaches the upstream exactly once and succeeds.

## Breaking changes

- [x] No

A document-bearing request to DeepSeek's Anthropic endpoint previously "succeeded" with the document ignored; it now fails typed or falls through to the next configured provider.

## Related issues

Reference: https://api-docs.deepseek.com/guides/anthropic_api (content block support). Second focused replacement for the closed PR 5985 (maximhq/bifrost, "Preserve DeepSeek V4 Flash and Pro Anthropic fidelity"); PR 6740 is the first. Scope is deliberately narrower than that PR's content guard, which rejected images and documents for the two V4 models with a 415: DeepSeek's current docs list images as supported, so this PR rejects documents only, applies to every model the provider serves (the contract is the endpoint's, not a model's), and returns the Anthropic-shaped 400 invalid_request_error the rest of the provider surface uses.

## Security considerations

Reduces silent data-handling surprise: a document a caller believed the model read is no longer discarded upstream without signal. The guard inspects no payload bytes.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go)
