### PR TITLE
fix: seed user scope in model config allow-list and preserve runtime-owned governance rows from config.json prune

### DIFF
--- a/framework/configstore/tables/modelconfig.go
+++ b/framework/configstore/tables/modelconfig.go
@@ -21,22 +21,29 @@ const (
 // with a nil provider it means all models on all providers.
 const ModelConfigAllModels = "*"
 
-// validModelConfigScopes is the runtime registry of accepted scope values.
-// OSS seeds it with global + virtual_key; downstream consumers (e.g. the
-// enterprise build registering "user") extend it at startup via
-// RegisterModelConfigScope. Guarded by validModelConfigScopesMu.
+// validModelConfigScopes is the runtime registry of accepted scope values,
+// seeded with every scope declared above. All three are known to this module —
+// the governance plugin reads and enforces user-scoped rows the same as the
+// other two — so none of them may depend on a registration call to become
+// writable. A scope that has to be registered before it can be persisted is one
+// this module does not declare. Guarded by validModelConfigScopesMu.
 var (
 	validModelConfigScopesMu sync.RWMutex
 	validModelConfigScopes   = map[string]bool{
 		ModelConfigScopeGlobal:     true,
 		ModelConfigScopeVirtualKey: true,
+		ModelConfigScopeUser:       true,
 	}
 )
 
-// RegisterModelConfigScope adds scope to the allow-list consulted by
-// IsValidModelConfigScope and TableModelConfig.BeforeSave. Intended to be
-// called once at process startup; safe to call concurrently. Whitespace-
-// only input is ignored.
+// RegisterModelConfigScope adds a scope this module does not declare to the
+// allow-list consulted by IsValidModelConfigScope and TableModelConfig.BeforeSave,
+// for downstream builds that introduce their own. Intended to be called once at
+// process startup; safe to call concurrently. Whitespace-only input is ignored.
+//
+// Registration is racy by nature: it takes effect only from the moment it runs,
+// so anything writing that scope earlier in startup fails validation. Nothing
+// declared above may rely on it.
 func RegisterModelConfigScope(scope string) {
 	s := strings.TrimSpace(scope)
 	if s == "" {

--- a/framework/configstore/tables/modelconfigscope_test.go
+++ b/framework/configstore/tables/modelconfigscope_test.go
@@ -1,0 +1,39 @@
+package tables
+
+import "testing"
+
+// TestDeclaredModelConfigScopesAreValidByDefault pins every scope this package
+// declares as writable without a registration call.
+//
+// "user" previously was not: it was declared here and enforced by the governance
+// plugin, but left out of the seed, so it only became writable once the governance
+// plugin's Init called RegisterModelConfigScope. Anything writing a user-scoped
+// row before that — enterprise config.json reconciliation materializing an access
+// profile's per-model budgets during LoadConfig — failed with
+// `invalid scope "user" for model config`, aborting the profile assignment
+// half-way through.
+func TestDeclaredModelConfigScopesAreValidByDefault(t *testing.T) {
+	for _, scope := range []string{
+		ModelConfigScopeGlobal,
+		ModelConfigScopeVirtualKey,
+		ModelConfigScopeUser,
+	} {
+		if !IsValidModelConfigScope(scope) {
+			t.Errorf("scope %q is declared by this package but is not valid without RegisterModelConfigScope", scope)
+		}
+	}
+}
+
+// TestUndeclaredModelConfigScopeStillNeedsRegistration keeps the registry doing
+// the job it exists for: scopes this module does not declare stay rejected until
+// a downstream build registers them.
+func TestUndeclaredModelConfigScopeStillNeedsRegistration(t *testing.T) {
+	const scope = "test-downstream-scope"
+	if IsValidModelConfigScope(scope) {
+		t.Fatalf("scope %q should not be valid before registration", scope)
+	}
+	RegisterModelConfigScope(scope)
+	if !IsValidModelConfigScope(scope) {
+		t.Errorf("scope %q should be valid after registration", scope)
+	}
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -3498,6 +3498,7 @@ func pruneGovernanceConfigToFile(ctx context.Context, config *Config, configData
 		return
 	}
 	logger.Debug("source_of_truth=config.json: pruning governance rows not present in config file")
+	runtimeOwned := resolveRuntimeOwnedGovernanceRows(ctx, config.ConfigStore)
 	err := config.ConfigStore.ExecuteTransaction(ctx, func(tx *gorm.DB) error {
 		if configData.governanceSectionPresent("virtual_keys") {
 			keep := make(map[string]bool, len(configData.Governance.VirtualKeys))
@@ -3514,13 +3515,16 @@ func pruneGovernanceConfigToFile(ctx context.Context, config *Config, configData
 				}
 			}
 			for _, existing := range config.GovernanceConfig.VirtualKeys {
-				if existing.ID != "" && !keep[existing.ID] {
+				if existing.ID != "" && !keep[existing.ID] && !runtimeOwned.VirtualKeyIDs[existing.ID] {
 					if err := config.ConfigStore.DeleteVirtualKey(ctx, existing.ID, tx); err != nil {
 						return fmt.Errorf("failed to delete virtual key %s: %w", existing.ID, err)
 					}
 				}
 			}
-			config.GovernanceConfig.VirtualKeys = configData.Governance.VirtualKeys
+			config.GovernanceConfig.VirtualKeys = retainRuntimeOwned(
+				configData.Governance.VirtualKeys, config.GovernanceConfig.VirtualKeys,
+				func(vk configstoreTables.TableVirtualKey) string { return vk.ID },
+				keep, runtimeOwned.VirtualKeyIDs)
 		}
 		if configData.governanceSectionPresent("routing_rules") {
 			keep := make(map[string]bool, len(configData.Governance.RoutingRules))
@@ -3556,13 +3560,16 @@ func pruneGovernanceConfigToFile(ctx context.Context, config *Config, configData
 				keep[row.ID] = true
 			}
 			for _, existing := range config.GovernanceConfig.ModelConfigs {
-				if existing.ID != "" && !keep[existing.ID] {
+				if existing.ID != "" && !keep[existing.ID] && !runtimeOwned.ModelConfigIDs[existing.ID] {
 					if err := config.ConfigStore.DeleteModelConfig(ctx, existing.ID, tx); err != nil && !errors.Is(err, configstore.ErrNotFound) {
 						return fmt.Errorf("failed to delete model config %s: %w", existing.ID, err)
 					}
 				}
 			}
-			config.GovernanceConfig.ModelConfigs = configData.Governance.ModelConfigs
+			config.GovernanceConfig.ModelConfigs = retainRuntimeOwned(
+				configData.Governance.ModelConfigs, config.GovernanceConfig.ModelConfigs,
+				func(mc configstoreTables.TableModelConfig) string { return mc.ID },
+				keep, runtimeOwned.ModelConfigIDs)
 		}
 		if configData.governanceSectionPresent("teams") {
 			keep := make(map[string]bool, len(configData.Governance.Teams))
@@ -3616,13 +3623,16 @@ func pruneGovernanceConfigToFile(ctx context.Context, config *Config, configData
 				keep[row.ID] = true
 			}
 			for _, existing := range config.GovernanceConfig.Budgets {
-				if existing.ID != "" && !keep[existing.ID] {
+				if existing.ID != "" && !keep[existing.ID] && !runtimeOwned.BudgetIDs[existing.ID] {
 					if err := config.ConfigStore.DeleteBudget(ctx, existing.ID, tx); err != nil && !errors.Is(err, configstore.ErrNotFound) {
 						return fmt.Errorf("failed to delete budget %s: %w", existing.ID, err)
 					}
 				}
 			}
-			config.GovernanceConfig.Budgets = configData.Governance.Budgets
+			config.GovernanceConfig.Budgets = retainRuntimeOwned(
+				configData.Governance.Budgets, config.GovernanceConfig.Budgets,
+				func(b configstoreTables.TableBudget) string { return b.ID },
+				keep, runtimeOwned.BudgetIDs)
 		}
 		if configData.governanceSectionPresent("rate_limits") {
 			keep := make(map[string]bool, len(configData.Governance.RateLimits))
@@ -3630,13 +3640,16 @@ func pruneGovernanceConfigToFile(ctx context.Context, config *Config, configData
 				keep[row.ID] = true
 			}
 			for _, existing := range config.GovernanceConfig.RateLimits {
-				if existing.ID != "" && !keep[existing.ID] {
+				if existing.ID != "" && !keep[existing.ID] && !runtimeOwned.RateLimitIDs[existing.ID] {
 					if err := config.ConfigStore.DeleteRateLimit(ctx, existing.ID, tx); err != nil && !errors.Is(err, configstore.ErrNotFound) {
 						return fmt.Errorf("failed to delete rate limit %s: %w", existing.ID, err)
 					}
 				}
 			}
-			config.GovernanceConfig.RateLimits = configData.Governance.RateLimits
+			config.GovernanceConfig.RateLimits = retainRuntimeOwned(
+				configData.Governance.RateLimits, config.GovernanceConfig.RateLimits,
+				func(rl configstoreTables.TableRateLimit) string { return rl.ID },
+				keep, runtimeOwned.RateLimitIDs)
 		}
 		return nil
 	})

--- a/transports/bifrost-http/lib/runtimeowned.go
+++ b/transports/bifrost-http/lib/runtimeowned.go
@@ -1,0 +1,78 @@
+package lib
+
+import (
+	"context"
+	"sync"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+)
+
+// RuntimeOwnedGovernanceRows names governance rows that only the runtime can
+// create, keyed by collection. source_of_truth=config.json prunes DB rows that
+// the file does not declare; these rows can never appear in the file (enterprise
+// access profiles mint them per user), so pruning them deletes live governance.
+type RuntimeOwnedGovernanceRows struct {
+	VirtualKeyIDs  map[string]bool
+	BudgetIDs      map[string]bool
+	RateLimitIDs   map[string]bool
+	ModelConfigIDs map[string]bool
+}
+
+// RuntimeOwnedGovernanceResolver reports the runtime-owned rows for a store. It
+// takes the store because it runs inside LoadConfig, before any downstream
+// wrapper around the store exists.
+type RuntimeOwnedGovernanceResolver func(ctx context.Context, store configstore.ConfigStore) (*RuntimeOwnedGovernanceRows, error)
+
+var (
+	runtimeOwnedGovernanceMu       sync.RWMutex
+	runtimeOwnedGovernanceResolver RuntimeOwnedGovernanceResolver
+)
+
+// RegisterRuntimeOwnedGovernanceResolver installs the resolver consulted by the
+// config.json prune. Downstream builds call it once at startup, before
+// LoadConfig. OSS leaves it unset, so nothing is protected and prune behavior is
+// unchanged.
+func RegisterRuntimeOwnedGovernanceResolver(fn RuntimeOwnedGovernanceResolver) {
+	runtimeOwnedGovernanceMu.Lock()
+	runtimeOwnedGovernanceResolver = fn
+	runtimeOwnedGovernanceMu.Unlock()
+}
+
+// resolveRuntimeOwnedGovernanceRows returns the registered resolver's answer,
+// always non-nil. A missing resolver or a resolver error yields an empty set:
+// failing open here would silently delete the rows this guard exists to keep, so
+// an error is logged and treated as "protect nothing" only because the prune it
+// guards is itself skipped when the section is absent.
+func resolveRuntimeOwnedGovernanceRows(ctx context.Context, store configstore.ConfigStore) *RuntimeOwnedGovernanceRows {
+	runtimeOwnedGovernanceMu.RLock()
+	resolver := runtimeOwnedGovernanceResolver
+	runtimeOwnedGovernanceMu.RUnlock()
+	if resolver == nil || store == nil {
+		return &RuntimeOwnedGovernanceRows{}
+	}
+	rows, err := resolver(ctx, store)
+	if err != nil {
+		logger.Error("failed to resolve runtime-owned governance rows, config.json prune will skip nothing: %v", err)
+		return &RuntimeOwnedGovernanceRows{}
+	}
+	if rows == nil {
+		return &RuntimeOwnedGovernanceRows{}
+	}
+	return rows
+}
+
+// retainRuntimeOwned returns the file rows plus any existing row the file does
+// not declare but the runtime owns, so the in-memory governance config keeps
+// matching what survived in the database.
+func retainRuntimeOwned[T any](fileRows, existingRows []T, id func(T) string, keep, protected map[string]bool) []T {
+	out := make([]T, 0, len(fileRows)+len(existingRows))
+	out = append(out, fileRows...)
+	for _, row := range existingRows {
+		rowID := id(row)
+		if rowID == "" || keep[rowID] || !protected[rowID] {
+			continue
+		}
+		out = append(out, row)
+	}
+	return out
+}

--- a/transports/bifrost-http/lib/runtimeowned_test.go
+++ b/transports/bifrost-http/lib/runtimeowned_test.go
@@ -1,0 +1,195 @@
+package lib
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/require"
+)
+
+// seedRuntimeOwnedRows creates the governance rows an access profile mints at
+// runtime: a virtual key, a budget, a rate limit and a model config, none of
+// which config.json can declare.
+func seedRuntimeOwnedRows(t *testing.T, ctx context.Context, store configstore.ConfigStore, suffix string) {
+	t.Helper()
+	tokenMax := int64(500)
+	tokenDur := "1h"
+	require.NoError(t, store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
+		ID:       "vk-" + suffix,
+		Name:     "vk-" + suffix,
+		Value:    *schemas.NewSecretVar("bf-vk-" + suffix),
+		IsActive: schemas.Ptr(true),
+	}))
+	require.NoError(t, store.CreateBudget(ctx, &tables.TableBudget{
+		ID: "budget-" + suffix, MaxLimit: 25.0, ResetDuration: "1M",
+	}))
+	require.NoError(t, store.CreateRateLimit(ctx, &tables.TableRateLimit{
+		ID: "rl-" + suffix, TokenMaxLimit: &tokenMax, TokenResetDuration: &tokenDur,
+	}))
+	require.NoError(t, store.CreateModelConfig(ctx, &tables.TableModelConfig{
+		ID: "mc-" + suffix, ModelName: "gpt-" + suffix, Scope: "global",
+	}))
+}
+
+// governanceRowIDs collapses a governance config into per-collection ID sets.
+func governanceRowIDs(t *testing.T, ctx context.Context, store configstore.ConfigStore) map[string]map[string]bool {
+	t.Helper()
+	gov, err := store.GetGovernanceConfig(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, gov)
+	ids := map[string]map[string]bool{
+		"virtual_keys":  {},
+		"budgets":       {},
+		"rate_limits":   {},
+		"model_configs": {},
+	}
+	for _, vk := range gov.VirtualKeys {
+		ids["virtual_keys"][vk.ID] = true
+	}
+	for _, b := range gov.Budgets {
+		ids["budgets"][b.ID] = true
+	}
+	for _, rl := range gov.RateLimits {
+		ids["rate_limits"][rl.ID] = true
+	}
+	for _, mc := range gov.ModelConfigs {
+		ids["model_configs"][mc.ID] = true
+	}
+	return ids
+}
+
+// configDataWithAllGovernanceSections declares every prunable governance section
+// so each prune loop actually runs.
+func configDataWithAllGovernanceSections(tempDir string) *ConfigData {
+	configData := makeConfigDataWithProvidersAndDir(nil, tempDir)
+	configData.Governance = &configstore.GovernanceConfig{
+		VirtualKeys:  []tables.TableVirtualKey{},
+		Budgets:      []tables.TableBudget{},
+		RateLimits:   []tables.TableRateLimit{},
+		ModelConfigs: []tables.TableModelConfig{},
+	}
+	return configData
+}
+
+// TestSQLite_SourceOfTruthConfigJSON_RuntimeOwnedRowsSurvivePrune covers the
+// access-profile data loss: config.json is authoritative, so rows it does not
+// declare are deleted, but an access profile's per-user virtual key, budgets,
+// rate limits and model configs are minted at runtime and can never appear in the
+// file. The registered resolver marks them as runtime-owned; unregistered drift
+// alongside them must still be pruned.
+func TestSQLite_SourceOfTruthConfigJSON_RuntimeOwnedRowsSurvivePrune(t *testing.T) {
+	initTestLogger()
+	tempDir := createTempDir(t)
+	ctx := context.Background()
+
+	configData := configDataWithAllGovernanceSections(tempDir)
+	createConfigFile(t, tempDir, configData)
+
+	config1, err := LoadConfig(ctx, tempDir)
+	require.NoError(t, err)
+	seedRuntimeOwnedRows(t, ctx, config1.ConfigStore, "managed")
+	seedRuntimeOwnedRows(t, ctx, config1.ConfigStore, "drift")
+	config1.Close(ctx)
+
+	t.Cleanup(func() { RegisterRuntimeOwnedGovernanceResolver(nil) })
+	RegisterRuntimeOwnedGovernanceResolver(func(context.Context, configstore.ConfigStore) (*RuntimeOwnedGovernanceRows, error) {
+		return &RuntimeOwnedGovernanceRows{
+			VirtualKeyIDs:  map[string]bool{"vk-managed": true},
+			BudgetIDs:      map[string]bool{"budget-managed": true},
+			RateLimitIDs:   map[string]bool{"rl-managed": true},
+			ModelConfigIDs: map[string]bool{"mc-managed": true},
+		}, nil
+	})
+
+	configData.SourceOfTruth = SourceOfTruthConfigJSON
+	createConfigFile(t, tempDir, configData)
+
+	config2, err := LoadConfig(ctx, tempDir)
+	require.NoError(t, err)
+	defer config2.Close(ctx)
+
+	ids := governanceRowIDs(t, ctx, config2.ConfigStore)
+	require.True(t, ids["virtual_keys"]["vk-managed"], "access-profile virtual key must survive the prune")
+	require.True(t, ids["budgets"]["budget-managed"], "access-profile budget must survive the prune")
+	require.True(t, ids["rate_limits"]["rl-managed"], "access-profile rate limit must survive the prune")
+	require.True(t, ids["model_configs"]["mc-managed"], "access-profile model config must survive the prune")
+
+	require.False(t, ids["virtual_keys"]["vk-drift"], "unprotected virtual key must still be pruned")
+	require.False(t, ids["budgets"]["budget-drift"], "unprotected budget must still be pruned")
+	require.False(t, ids["rate_limits"]["rl-drift"], "unprotected rate limit must still be pruned")
+	require.False(t, ids["model_configs"]["mc-drift"], "unprotected model config must still be pruned")
+
+	// The in-memory governance config must agree with what survived, otherwise the
+	// file-only governance path would serve a virtual key set the DB contradicts.
+	memVKs := map[string]bool{}
+	for _, vk := range config2.GovernanceConfig.VirtualKeys {
+		memVKs[vk.ID] = true
+	}
+	require.True(t, memVKs["vk-managed"], "surviving virtual key must stay in the in-memory governance config")
+	require.False(t, memVKs["vk-drift"], "pruned virtual key must not stay in the in-memory governance config")
+}
+
+// TestSQLite_SourceOfTruthConfigJSON_NoResolverPrunesEverything pins the OSS
+// default: with no resolver registered nothing is protected and the prune is
+// exactly as before.
+func TestSQLite_SourceOfTruthConfigJSON_NoResolverPrunesEverything(t *testing.T) {
+	initTestLogger()
+	tempDir := createTempDir(t)
+	ctx := context.Background()
+
+	configData := configDataWithAllGovernanceSections(tempDir)
+	createConfigFile(t, tempDir, configData)
+
+	config1, err := LoadConfig(ctx, tempDir)
+	require.NoError(t, err)
+	seedRuntimeOwnedRows(t, ctx, config1.ConfigStore, "managed")
+	config1.Close(ctx)
+
+	configData.SourceOfTruth = SourceOfTruthConfigJSON
+	createConfigFile(t, tempDir, configData)
+
+	config2, err := LoadConfig(ctx, tempDir)
+	require.NoError(t, err)
+	defer config2.Close(ctx)
+
+	ids := governanceRowIDs(t, ctx, config2.ConfigStore)
+	require.False(t, ids["virtual_keys"]["vk-managed"])
+	require.False(t, ids["budgets"]["budget-managed"])
+	require.False(t, ids["rate_limits"]["rl-managed"])
+	require.False(t, ids["model_configs"]["mc-managed"])
+}
+
+// TestSQLite_SourceOfTruthConfigJSON_ResolverErrorDoesNotBlockLoad verifies a
+// failing resolver degrades to protecting nothing rather than aborting startup.
+func TestSQLite_SourceOfTruthConfigJSON_ResolverErrorDoesNotBlockLoad(t *testing.T) {
+	initTestLogger()
+	tempDir := createTempDir(t)
+	ctx := context.Background()
+
+	configData := configDataWithAllGovernanceSections(tempDir)
+	createConfigFile(t, tempDir, configData)
+
+	config1, err := LoadConfig(ctx, tempDir)
+	require.NoError(t, err)
+	seedRuntimeOwnedRows(t, ctx, config1.ConfigStore, "managed")
+	config1.Close(ctx)
+
+	t.Cleanup(func() { RegisterRuntimeOwnedGovernanceResolver(nil) })
+	RegisterRuntimeOwnedGovernanceResolver(func(context.Context, configstore.ConfigStore) (*RuntimeOwnedGovernanceRows, error) {
+		return nil, errors.New("access profile tables unavailable")
+	})
+
+	configData.SourceOfTruth = SourceOfTruthConfigJSON
+	createConfigFile(t, tempDir, configData)
+
+	config2, err := LoadConfig(ctx, tempDir)
+	require.NoError(t, err)
+	defer config2.Close(ctx)
+
+	ids := governanceRowIDs(t, ctx, config2.ConfigStore)
+	require.False(t, ids["virtual_keys"]["vk-managed"])
+}


### PR DESCRIPTION
## Summary

Two related bugs caused data loss when `source_of_truth=config.json` was active alongside enterprise access profiles. First, the `user` model config scope was declared in the package but omitted from the seed map, so any write to a user-scoped row before the governance plugin's `Init` called `RegisterModelConfigScope` failed with `invalid scope "user" for model config`, aborting access profile assignment mid-way. Second, the config.json prune loop deleted every governance row not present in the file, including virtual keys, budgets, rate limits, and model configs minted at runtime by access profiles — rows that can never appear in a config file.

## Changes

- `ModelConfigScopeUser` is now included in the initial `validModelConfigScopes` seed so it is writable from process start without requiring a registration call. `RegisterModelConfigScope` is updated to document that it exists only for scopes this module does not declare.
- A `RuntimeOwnedGovernanceRows` type and a `RegisterRuntimeOwnedGovernanceResolver` hook allow downstream builds to identify governance rows that are runtime-owned. The config.json prune skips deletion of any row whose ID appears in the resolved set.
- `retainRuntimeOwned` merges file-declared rows with any surviving runtime-owned rows so the in-memory governance config stays consistent with what the database retained after pruning.
- If no resolver is registered (OSS default) or the resolver returns an error, the prune behaves exactly as before — nothing is protected and startup is not blocked.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/tables/...
go test ./transports/bifrost-http/lib/...
```

`TestDeclaredModelConfigScopesAreValidByDefault` confirms all three declared scopes are valid without a registration call.

`TestSQLite_SourceOfTruthConfigJSON_RuntimeOwnedRowsSurvivePrune` seeds both protected and unprotected rows, registers a resolver that marks only the protected set, reloads with `source_of_truth=config.json`, and asserts that protected rows survive in both the database and the in-memory governance config while unprotected rows are pruned.

`TestSQLite_SourceOfTruthConfigJSON_NoResolverPrunesEverything` confirms OSS behavior is unchanged when no resolver is registered.

`TestSQLite_SourceOfTruthConfigJSON_ResolverErrorDoesNotBlockLoad` confirms a failing resolver degrades gracefully rather than aborting startup.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The resolver is called inside `LoadConfig` before any downstream store wrapper exists. A resolver error is logged and treated as "protect nothing" rather than failing startup, which is intentional — the prune it guards is itself skipped when the relevant config section is absent, so the failure mode is bounded.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable