### PR TITLE
feat: add vMCP CRUD support

### DIFF
--- a/framework/configstore/errors.go
+++ b/framework/configstore/errors.go
@@ -9,6 +9,11 @@ import (
 var ErrNotFound = errors.New("not found")
 var ErrAlreadyExists = errors.New("already exists")
 
+// ErrVirtualMCPEndpointExists is returned by CreateVirtualMCP when the resolved endpoint slug is
+// already taken, so callers can answer with a clear message and a 409. (Name uniqueness is left to
+// the table's own unique index and surfaces as a generic unique-constraint error.)
+var ErrVirtualMCPEndpointExists = errors.New("a virtual MCP with this endpoint already exists")
+
 // ErrConfigUnreadable marks a stored configuration value that could not be
 // decoded or that failed validation — the value is present but this version
 // cannot make sense of it.

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -1905,7 +1905,7 @@ func backfillVirtualMCPEndpointSlugs(tx *gorm.DB) error {
 	}
 
 	for i := range rows {
-		slug := uniqueVirtualMCPSlug(virtualMCPSlugify(rows[i].Name), rows[i].ID, taken)
+		slug := uniqueVirtualMCPSlug(VirtualMCPSlugify(rows[i].Name), rows[i].ID, taken)
 		taken[slug] = true
 		if err := tx.Model(&tables.TableVirtualMCP{}).
 			Where("id = ?", rows[i].ID).
@@ -1916,9 +1916,9 @@ func backfillVirtualMCPEndpointSlugs(tx *gorm.DB) error {
 	return nil
 }
 
-// virtualMCPSlugify lowercases a name and collapses non-alphanumeric runs to
+// VirtualMCPSlugify lowercases a name and collapses non-alphanumeric runs to
 // single hyphens, trimmed at the ends.
-func virtualMCPSlugify(name string) string {
+func VirtualMCPSlugify(name string) string {
 	var b strings.Builder
 	prevHyphen := false
 	for _, r := range strings.ToLower(strings.TrimSpace(name)) {

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4500,6 +4500,126 @@ func (s *RDBConfigStore) GetVirtualMCPAssignments(ctx context.Context) (map[stri
 	return out, nil
 }
 
+// CreateVirtualMCP inserts a Virtual MCP. The endpoint_slug is taken from the caller's slug when set,
+// else derived from the name; a slug collision is reported as ErrVirtualMCPEndpointExists rather than
+// auto-suffixed. Name uniqueness is left to the table's own unique index.
+func (s *RDBConfigStore) CreateVirtualMCP(ctx context.Context, def *tables.TableVirtualMCP) error {
+	db := s.DB().WithContext(ctx)
+	base := def.EndpointSlug
+	if base == "" {
+		base = def.Name
+	}
+	def.EndpointSlug = VirtualMCPSlugify(base)
+	if def.EndpointSlug == "" {
+		return errors.New("could not derive an endpoint from the name; provide an endpoint_slug")
+	}
+
+	if taken, err := s.virtualMCPSlugTaken(ctx, def.EndpointSlug, 0); err != nil {
+		return err
+	} else if taken {
+		return ErrVirtualMCPEndpointExists
+	}
+
+	// Capture intent before Create: enabled has a default:true, which gorm applies to a false and
+	// writes back into the struct, so the check must use the pre-insert value.
+	wantEnabled := def.Enabled
+	return db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(def).Error; err != nil {
+			if isUniqueConstraintError(err) {
+				if taken, checkErr := s.virtualMCPSlugTaken(ctx, def.EndpointSlug, 0); checkErr == nil && taken {
+					return ErrVirtualMCPEndpointExists
+				}
+			}
+			return err
+		}
+		if !wantEnabled {
+			return tx.Model(def).Update("enabled", false).Error
+		}
+		return nil
+	})
+}
+
+// virtualMCPSlugTaken reports whether another row (excluding excludeID) has the same endpoint_slug.
+func (s *RDBConfigStore) virtualMCPSlugTaken(ctx context.Context, slug string, excludeID uint) (bool, error) {
+	q := s.DB().WithContext(ctx).Model(&tables.TableVirtualMCP{}).Where("endpoint_slug = ?", slug)
+	if excludeID != 0 {
+		q = q.Where("id <> ?", excludeID)
+	}
+	var count int64
+	err := q.Count(&count).Error
+	return count > 0, err
+}
+
+func (s *RDBConfigStore) GetVirtualMCPByID(ctx context.Context, id uint) (*tables.TableVirtualMCP, error) {
+	var def tables.TableVirtualMCP
+	err := s.ScopedDB(ctx).First(&def, id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &def, nil
+}
+
+func (s *RDBConfigStore) GetVirtualMCPsPaginated(ctx context.Context, params VirtualMCPsQueryParams) ([]tables.TableVirtualMCP, int64, error) {
+	q := s.ScopedDB(ctx).Model(&tables.TableVirtualMCP{})
+	if params.Search != "" {
+		q = q.Where("LOWER(name) LIKE ?", "%"+strings.ToLower(params.Search)+"%")
+	}
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	var defs []tables.TableVirtualMCP
+	// id DESC breaks ties so rows sharing a created_at keep a stable order across offset pages.
+	q = q.Order("created_at DESC").Order("id DESC").Offset(params.Offset)
+	if params.Limit > 0 {
+		q = q.Limit(params.Limit)
+	}
+	if err := q.Find(&defs).Error; err != nil {
+		return nil, 0, err
+	}
+	return defs, total, nil
+}
+
+// UpdateVirtualMCP persists a Virtual MCP, keeping endpoint_slug and created_at immutable. Name
+// uniqueness is enforced by the table's own unique index.
+func (s *RDBConfigStore) UpdateVirtualMCP(ctx context.Context, def *tables.TableVirtualMCP) error {
+	return s.DB().WithContext(ctx).Omit("endpoint_slug", "created_at").Save(def).Error
+}
+
+// DeleteVirtualMCP removes a Virtual MCP and its VK assignments (explicit, so it holds on any DB
+// regardless of FK cascade support).
+func (s *RDBConfigStore) DeleteVirtualMCP(ctx context.Context, id uint) error {
+	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("tool_group_id = ?", id).Delete(&tables.TableVirtualKeyVirtualMCP{}).Error; err != nil {
+			return err
+		}
+		return tx.Delete(&tables.TableVirtualMCP{}, id).Error
+	})
+}
+
+// AttachVirtualMCPToVirtualKey links a Virtual MCP to a VK, idempotently.
+func (s *RDBConfigStore) AttachVirtualMCPToVirtualKey(ctx context.Context, vmcpID uint, virtualKeyID string) error {
+	assoc := tables.TableVirtualKeyVirtualMCP{VirtualMCPID: vmcpID, VirtualKeyID: virtualKeyID}
+	return s.DB().WithContext(ctx).Where(assoc).FirstOrCreate(&assoc).Error
+}
+
+func (s *RDBConfigStore) DetachVirtualMCPFromVirtualKey(ctx context.Context, vmcpID uint, virtualKeyID string) error {
+	return s.DB().WithContext(ctx).
+		Where("tool_group_id = ? AND virtual_key_id = ?", vmcpID, virtualKeyID).
+		Delete(&tables.TableVirtualKeyVirtualMCP{}).Error
+}
+
+func (s *RDBConfigStore) GetVirtualKeyIDsForVirtualMCP(ctx context.Context, vmcpID uint) ([]string, error) {
+	var ids []string
+	err := s.DB().WithContext(ctx).Model(&tables.TableVirtualKeyVirtualMCP{}).
+		Where("tool_group_id = ?", vmcpID).
+		Pluck("virtual_key_id", &ids).Error
+	return ids, err
+}
+
 // GetVirtualKeyMCPConfigsByMCPClientIDs retrieves all VK MCP configs for a set of MCP client IDs in one query.
 func (s *RDBConfigStore) GetVirtualKeyMCPConfigsByMCPClientIDs(ctx context.Context, mcpClientIDs []uint) ([]tables.TableVirtualKeyMCPConfig, error) {
 	if len(mcpClientIDs) == 0 {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -99,6 +99,13 @@ type MCPClientsQueryParams struct {
 	VirtualKeyIDs        []string // include clients explicitly assigned to any of these VK IDs
 }
 
+// VirtualMCPsQueryParams holds pagination and search parameters for Virtual MCP list queries.
+type VirtualMCPsQueryParams struct {
+	Limit  int
+	Offset int
+	Search string // matches name (case-insensitive)
+}
+
 // MCPLibraryQueryParams holds pagination, filtering, search, and sort
 // parameters for MCP library catalog queries. All fields are optional — an
 // empty struct returns the first default-sized page ordered by name.
@@ -354,6 +361,17 @@ type ConfigStore interface {
 	// by VK row ID. Neither is DAC-scoped: holder grant data, not an admin catalog view.
 	GetVirtualMCPs(ctx context.Context) ([]tables.TableVirtualMCP, error)
 	GetVirtualMCPAssignments(ctx context.Context) (map[string][]uint, error)
+
+	// Virtual MCP CRUD. CreateVirtualMCP fills endpoint_slug from the name when unset and enforces
+	// its uniqueness; UpdateVirtualMCP never changes the slug (immutable after creation).
+	CreateVirtualMCP(ctx context.Context, def *tables.TableVirtualMCP) error
+	GetVirtualMCPByID(ctx context.Context, id uint) (*tables.TableVirtualMCP, error)
+	GetVirtualMCPsPaginated(ctx context.Context, params VirtualMCPsQueryParams) ([]tables.TableVirtualMCP, int64, error)
+	UpdateVirtualMCP(ctx context.Context, def *tables.TableVirtualMCP) error
+	DeleteVirtualMCP(ctx context.Context, id uint) error
+	AttachVirtualMCPToVirtualKey(ctx context.Context, vmcpID uint, virtualKeyID string) error
+	DetachVirtualMCPFromVirtualKey(ctx context.Context, vmcpID uint, virtualKeyID string) error
+	GetVirtualKeyIDsForVirtualMCP(ctx context.Context, vmcpID uint) ([]string, error)
 
 	// Team CRUD
 	GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error)

--- a/framework/configstore/tables/virtualmcp.go
+++ b/framework/configstore/tables/virtualmcp.go
@@ -30,9 +30,11 @@ type TableVirtualMCP struct {
 	ParsedTools []MCPToolSpec `gorm:"-" json:"tools"`     // decoded tool specs
 	ConfigHash  string        `gorm:"type:varchar(255);null" json:"config_hash,omitempty"`
 
-	CreatedAt time.Time `gorm:"index;not null" json:"created_at"`
-	UpdatedAt time.Time `gorm:"index;not null" json:"updated_at"`
-	// created_by_user_id is enterprise DAC only; enterprise adds and reads it separately.
+	// CreatedByUserID records the creator, like TableVirtualKey. It is populated in enterprise (where
+	// DAC scopes rows by it) and left null in pure OSS; the DAC scoping logic lives in enterprise.
+	CreatedByUserID *string   `gorm:"column:created_by_user_id;type:varchar(255);index:idx_mcp_tool_groups_created_by_user_id" json:"created_by_user_id,omitempty"`
+	CreatedAt       time.Time `gorm:"index;not null" json:"created_at"`
+	UpdatedAt       time.Time `gorm:"index;not null" json:"updated_at"`
 }
 
 // TableName retains the original physical name so existing rows are reused.

--- a/framework/configstore/virtualmcp_crud_test.go
+++ b/framework/configstore/virtualmcp_crud_test.go
@@ -1,0 +1,159 @@
+package configstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupVirtualMCPTestStore(t *testing.T) *RDBConfigStore {
+	store := setupRDBTestStore(t)
+	require.NoError(t, store.DB().AutoMigrate(&tables.TableVirtualMCP{}, &tables.TableVirtualKeyVirtualMCP{}))
+	return store
+}
+
+func vmcpSpec(clientID string, tools ...string) tables.MCPToolSpec {
+	return tables.MCPToolSpec{MCPClientID: clientID, ToolNames: tools}
+}
+
+func TestVirtualMCP_CreateSlugFromName(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	def := &tables.TableVirtualMCP{Name: "Machine Learning Team", Enabled: true, ParsedTools: []tables.MCPToolSpec{vmcpSpec("sentry", "list-issues")}}
+	require.NoError(t, store.CreateVirtualMCP(ctx, def))
+	assert.Equal(t, "machine-learning-team", def.EndpointSlug)
+
+	got, err := store.GetVirtualMCPByID(ctx, def.ID)
+	require.NoError(t, err)
+	require.Len(t, got.ParsedTools, 1, "ParsedTools decoded by AfterFind")
+	assert.Equal(t, "sentry", got.ParsedTools[0].MCPClientID)
+	assert.Equal(t, []string{"list-issues"}, got.ParsedTools[0].ToolNames)
+}
+
+func TestVirtualMCP_RejectsExactDuplicateName(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	// Distinct endpoints, same name: the table's own unique index on name rejects the second.
+	require.NoError(t, store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Engineering", EndpointSlug: "eng-a", Enabled: true}))
+
+	err := store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Engineering", EndpointSlug: "eng-b", Enabled: true})
+	assert.Error(t, err, "the pre-existing name unique index still rejects an exact duplicate name")
+	assert.NotErrorIs(t, err, ErrVirtualMCPEndpointExists, "a name collision must not be mislabeled as an endpoint conflict")
+}
+
+func TestVirtualMCP_CaseVariantNamesCoexistWithDistinctEndpoints(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	// Name uniqueness is exact (not case-insensitive): case variants may coexist, as long as their
+	// endpoints differ. Endpoints are the real constraint.
+	require.NoError(t, store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Engineering", EndpointSlug: "eng-a", Enabled: true}))
+	require.NoError(t, store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "engineering", EndpointSlug: "eng-b", Enabled: true}))
+}
+
+func TestVirtualMCP_RejectsDuplicateEndpoint(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	// Two distinct names that slugify to the same endpoint.
+	require.NoError(t, store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Support (Legacy)", Enabled: true}))
+
+	err := store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Support - Legacy", Enabled: true})
+	assert.ErrorIs(t, err, ErrVirtualMCPEndpointExists, "distinct names may still collide on endpoint, and that is rejected")
+}
+
+func TestVirtualMCP_CreateHonorsDisabled(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	def := &tables.TableVirtualMCP{Name: "off", Enabled: false}
+	require.NoError(t, store.CreateVirtualMCP(ctx, def))
+
+	got, err := store.GetVirtualMCPByID(ctx, def.ID)
+	require.NoError(t, err)
+	assert.False(t, got.Enabled, "a disabled create must not be flipped to true by the column default")
+}
+
+func TestVirtualMCP_UpdateKeepsSlugImmutable(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	def := &tables.TableVirtualMCP{Name: "Engineering", Enabled: true}
+	require.NoError(t, store.CreateVirtualMCP(ctx, def))
+	originalSlug := def.EndpointSlug
+
+	def.Name = "Platform"
+	def.EndpointSlug = "platform" // must be ignored
+	def.Enabled = false
+	require.NoError(t, store.UpdateVirtualMCP(ctx, def))
+
+	got, err := store.GetVirtualMCPByID(ctx, def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "Platform", got.Name)
+	assert.Equal(t, originalSlug, got.EndpointSlug, "endpoint_slug is immutable")
+	assert.False(t, got.Enabled)
+}
+
+func TestVirtualMCP_AttachDetachIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	def := &tables.TableVirtualMCP{Name: "eng", Enabled: true}
+	require.NoError(t, store.CreateVirtualMCP(ctx, def))
+
+	require.NoError(t, store.AttachVirtualMCPToVirtualKey(ctx, def.ID, "vk-1"))
+	require.NoError(t, store.AttachVirtualMCPToVirtualKey(ctx, def.ID, "vk-1")) // idempotent
+	require.NoError(t, store.AttachVirtualMCPToVirtualKey(ctx, def.ID, "vk-2"))
+
+	ids, err := store.GetVirtualKeyIDsForVirtualMCP(ctx, def.ID)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"vk-1", "vk-2"}, ids)
+
+	require.NoError(t, store.DetachVirtualMCPFromVirtualKey(ctx, def.ID, "vk-1"))
+	ids, err = store.GetVirtualKeyIDsForVirtualMCP(ctx, def.ID)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"vk-2"}, ids)
+}
+
+func TestVirtualMCP_DeleteRemovesAssignments(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	def := &tables.TableVirtualMCP{Name: "eng", Enabled: true}
+	require.NoError(t, store.CreateVirtualMCP(ctx, def))
+	require.NoError(t, store.AttachVirtualMCPToVirtualKey(ctx, def.ID, "vk-1"))
+
+	require.NoError(t, store.DeleteVirtualMCP(ctx, def.ID))
+
+	_, err := store.GetVirtualMCPByID(ctx, def.ID)
+	assert.True(t, errors.Is(err, ErrNotFound))
+	ids, err := store.GetVirtualKeyIDsForVirtualMCP(ctx, def.ID)
+	require.NoError(t, err)
+	assert.Empty(t, ids, "assignments are removed with the definition")
+}
+
+func TestVirtualMCP_Paginated(t *testing.T) {
+	ctx := context.Background()
+	store := setupVirtualMCPTestStore(t)
+
+	for _, name := range []string{"Engineering", "Research", "Support"} {
+		require.NoError(t, store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: name, Enabled: true}))
+	}
+
+	all, total, err := store.GetVirtualMCPsPaginated(ctx, VirtualMCPsQueryParams{Limit: 10})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), total)
+	assert.Len(t, all, 3)
+
+	found, total, err := store.GetVirtualMCPsPaginated(ctx, VirtualMCPsQueryParams{Limit: 10, Search: "sea"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	require.Len(t, found, 1)
+	assert.Equal(t, "Research", found[0].Name)
+}

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -63,6 +63,11 @@ type GovernanceManager interface {
 	RemoveProvider(ctx context.Context, provider schemas.ModelProvider) error
 	UpsertPricingOverride(ctx context.Context, override *configstoreTables.TablePricingOverride) error
 	DeletePricingOverride(ctx context.Context, id string) error
+	// Virtual MCP cache refresh after a write, surgically per operation (mirrors the VK/team callbacks).
+	ReloadVirtualMCP(ctx context.Context, id uint) (*configstoreTables.TableVirtualMCP, error)
+	RemoveVirtualMCP(ctx context.Context, id uint) error
+	AttachVirtualMCPToVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error
+	DetachVirtualMCPFromVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error
 }
 
 // BudgetUsageResetOwner identifies the entity whose budgets had their usage reset.

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -177,6 +177,56 @@ func (m *mockRotateGovernanceManager) ReloadVirtualKey(ctx context.Context, id s
 	return m.store.GetVirtualKey(ctx, id)
 }
 
+func (m *budgetOverrideTestGovernanceManager) ReloadVirtualMCP(ctx context.Context, id uint) (*configstoreTables.TableVirtualMCP, error) {
+	return nil, nil
+}
+func (m *budgetOverrideTestGovernanceManager) RemoveVirtualMCP(ctx context.Context, id uint) error {
+	return nil
+}
+func (m *budgetOverrideTestGovernanceManager) AttachVirtualMCPToVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	return nil
+}
+func (m *budgetOverrideTestGovernanceManager) DetachVirtualMCPFromVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	return nil
+}
+
+func (m *mockRotateGovernanceManager) ReloadVirtualMCP(ctx context.Context, id uint) (*configstoreTables.TableVirtualMCP, error) {
+	return nil, nil
+}
+func (m *mockRotateGovernanceManager) RemoveVirtualMCP(ctx context.Context, id uint) error { return nil }
+func (m *mockRotateGovernanceManager) AttachVirtualMCPToVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	return nil
+}
+func (m *mockRotateGovernanceManager) DetachVirtualMCPFromVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	return nil
+}
+
+func (m pricingOverrideTestGovernanceManager) ReloadVirtualMCP(ctx context.Context, id uint) (*configstoreTables.TableVirtualMCP, error) {
+	return nil, nil
+}
+func (m pricingOverrideTestGovernanceManager) RemoveVirtualMCP(ctx context.Context, id uint) error {
+	return nil
+}
+func (m pricingOverrideTestGovernanceManager) AttachVirtualMCPToVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	return nil
+}
+func (m pricingOverrideTestGovernanceManager) DetachVirtualMCPFromVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	return nil
+}
+
+func (m *providerGovernanceAdoptionManager) ReloadVirtualMCP(ctx context.Context, id uint) (*configstoreTables.TableVirtualMCP, error) {
+	return nil, nil
+}
+func (m *providerGovernanceAdoptionManager) RemoveVirtualMCP(ctx context.Context, id uint) error {
+	return nil
+}
+func (m *providerGovernanceAdoptionManager) AttachVirtualMCPToVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	return nil
+}
+func (m *providerGovernanceAdoptionManager) DetachVirtualMCPFromVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	return nil
+}
+
 // TestVirtualKeyBudgetOverrideLifecycle verifies finite, replacement, and clear mutations preserve base budget state.
 func TestVirtualKeyBudgetOverrideLifecycle(t *testing.T) {
 	SetLogger(&mockLogger{})

--- a/transports/bifrost-http/handlers/virtualmcp.go
+++ b/transports/bifrost-http/handlers/virtualmcp.go
@@ -1,0 +1,389 @@
+// Package handlers provides HTTP request handlers for the Bifrost HTTP transport.
+// This file contains Virtual MCP server management handlers.
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strconv"
+	"strings"
+
+	"github.com/fasthttp/router"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+// VirtualMCPHandler manages CRUD for Virtual MCP servers and their VK assignments.
+type VirtualMCPHandler struct {
+	store             *lib.Config
+	client            *bifrost.Bifrost
+	governanceManager GovernanceManager
+	logger            schemas.Logger
+}
+
+// NewVirtualMCPHandler creates a Virtual MCP handler.
+func NewVirtualMCPHandler(store *lib.Config, client *bifrost.Bifrost, governanceManager GovernanceManager, logger schemas.Logger) *VirtualMCPHandler {
+	return &VirtualMCPHandler{store: store, client: client, governanceManager: governanceManager, logger: logger}
+}
+
+// RegisterRoutes registers the Virtual MCP routes.
+func (h *VirtualMCPHandler) RegisterRoutes(r *router.Router, middlewares ...schemas.BifrostHTTPMiddleware) {
+	r.GET("/api/mcp/virtual-mcps", lib.ChainMiddlewares(h.listVirtualMCPs, middlewares...))
+	r.GET("/api/mcp/virtual-mcps/{id}", lib.ChainMiddlewares(h.getVirtualMCP, middlewares...))
+	r.POST("/api/mcp/virtual-mcps", lib.ChainMiddlewares(h.createVirtualMCP, middlewares...))
+	r.PUT("/api/mcp/virtual-mcps/{id}", lib.ChainMiddlewares(h.updateVirtualMCP, middlewares...))
+	r.DELETE("/api/mcp/virtual-mcps/{id}", lib.ChainMiddlewares(h.deleteVirtualMCP, middlewares...))
+	r.POST("/api/mcp/virtual-mcps/{id}/virtual-keys/{vkId}", lib.ChainMiddlewares(h.attachVirtualKey, middlewares...))
+	r.DELETE("/api/mcp/virtual-mcps/{id}/virtual-keys/{vkId}", lib.ChainMiddlewares(h.detachVirtualKey, middlewares...))
+}
+
+// VirtualMCPRequest is the create/update body. EndpointSlug is honored only on create (immutable
+// after); Enabled is a pointer so a false is not lost to the column default.
+type VirtualMCPRequest struct {
+	Name         string                          `json:"name"`
+	EndpointSlug string                          `json:"endpoint_slug,omitempty"`
+	Description  *string                         `json:"description,omitempty"`
+	Enabled      *bool                           `json:"enabled,omitempty"`
+	Tools        []configstoreTables.MCPToolSpec `json:"tools"`
+}
+
+// VirtualMCPResponse is a Virtual MCP with its VK assignments.
+type VirtualMCPResponse struct {
+	ID            uint                            `json:"id"`
+	Name          string                          `json:"name"`
+	EndpointSlug  string                          `json:"endpoint_slug"`
+	Description   *string                         `json:"description,omitempty"`
+	Enabled       bool                            `json:"enabled"`
+	Tools         []configstoreTables.MCPToolSpec `json:"tools"`
+	VirtualKeyIDs []string                        `json:"virtual_key_ids"`
+	CreatedAt     string                          `json:"created_at"`
+	UpdatedAt     string                          `json:"updated_at"`
+}
+
+func (h *VirtualMCPHandler) toResponse(ctx context.Context, def *configstoreTables.TableVirtualMCP) VirtualMCPResponse {
+	tools := def.ParsedTools
+	if tools == nil {
+		tools = []configstoreTables.MCPToolSpec{}
+	}
+	vkIDs, err := h.store.ConfigStore.GetVirtualKeyIDsForVirtualMCP(ctx, def.ID)
+	if err != nil {
+		h.logger.Error("failed to load VK assignments for virtual MCP %d: %v", def.ID, err)
+	}
+	if vkIDs == nil {
+		vkIDs = []string{}
+	}
+	return VirtualMCPResponse{
+		ID:            def.ID,
+		Name:          def.Name,
+		EndpointSlug:  def.EndpointSlug,
+		Description:   def.Description,
+		Enabled:       def.Enabled,
+		Tools:         tools,
+		VirtualKeyIDs: vkIDs,
+		CreatedAt:     def.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		UpdatedAt:     def.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
+	}
+}
+
+// validateToolSpecs rejects specs whose MCP client is not configured. Tool names are not checked
+// here: a client's advertised set can change between save and use, so names are enforced at call time.
+func (h *VirtualMCPHandler) validateToolSpecs(tools []configstoreTables.MCPToolSpec) string {
+	if len(tools) == 0 {
+		return ""
+	}
+	known := map[string]bool{}
+	if h.client != nil {
+		clients, err := h.client.GetMCPClients()
+		if err != nil {
+			h.logger.Error("failed to list MCP clients for validation: %v", err)
+			return "could not validate MCP clients"
+		}
+		for _, c := range clients {
+			if c.Config != nil {
+				known[c.Config.ID] = true
+				known[c.Config.Name] = true
+			}
+		}
+	}
+	var invalid []string
+	for _, spec := range tools {
+		if spec.MCPClientID == "" || !known[spec.MCPClientID] {
+			invalid = append(invalid, spec.MCPClientID)
+		}
+	}
+	if len(invalid) > 0 {
+		return "invalid MCP client IDs: " + strings.Join(invalid, ", ")
+	}
+	return ""
+}
+
+func (h *VirtualMCPHandler) listVirtualMCPs(ctx *fasthttp.RequestCtx) {
+	limit, _ := strconv.Atoi(string(ctx.QueryArgs().Peek("limit")))
+	offset, _ := strconv.Atoi(string(ctx.QueryArgs().Peek("offset")))
+	limit, offset = ClampPaginationParams(limit, offset)
+	search := string(ctx.QueryArgs().Peek("search"))
+
+	defs, total, err := h.store.ConfigStore.GetVirtualMCPsPaginated(ctx, configstore.VirtualMCPsQueryParams{
+		Limit:  limit,
+		Offset: offset,
+		Search: search,
+	})
+	if err != nil {
+		h.logger.Error("failed to list virtual MCPs: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	responses := make([]VirtualMCPResponse, len(defs))
+	for i := range defs {
+		responses[i] = h.toResponse(ctx, &defs[i])
+	}
+	SendJSON(ctx, map[string]any{
+		"virtual_mcps": responses,
+		"count":        len(responses),
+		"total_count":  total,
+		"limit":        limit,
+		"offset":       offset,
+	})
+}
+
+func (h *VirtualMCPHandler) getVirtualMCP(ctx *fasthttp.RequestCtx) {
+	id, ok := h.parseID(ctx)
+	if !ok {
+		return
+	}
+	def, err := h.store.ConfigStore.GetVirtualMCPByID(ctx, id)
+	if err != nil {
+		h.sendLookupError(ctx, err)
+		return
+	}
+	SendJSON(ctx, map[string]any{"virtual_mcp": h.toResponse(ctx, def)})
+}
+
+func (h *VirtualMCPHandler) createVirtualMCP(ctx *fasthttp.RequestCtx) {
+	var req VirtualMCPRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.Name == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "name is required")
+		return
+	}
+	if msg := h.validateToolSpecs(req.Tools); msg != "" {
+		SendError(ctx, fasthttp.StatusBadRequest, msg)
+		return
+	}
+	enabled := true
+	if req.Enabled != nil {
+		enabled = *req.Enabled
+	}
+	def := &configstoreTables.TableVirtualMCP{
+		Name:         req.Name,
+		EndpointSlug: req.EndpointSlug,
+		Description:  req.Description,
+		Enabled:      enabled,
+		ParsedTools:  req.Tools,
+	}
+	if err := h.store.ConfigStore.CreateVirtualMCP(ctx, def); err != nil {
+		if code, msg, ok := virtualMCPConflict(err); ok {
+			SendError(ctx, code, msg)
+			return
+		}
+		h.logger.Error("failed to create virtual MCP: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	h.refreshDefinition(ctx, def.ID)
+	ctx.SetStatusCode(fasthttp.StatusCreated)
+	SendJSON(ctx, map[string]any{"virtual_mcp": h.toResponse(ctx, def)})
+}
+
+func (h *VirtualMCPHandler) updateVirtualMCP(ctx *fasthttp.RequestCtx) {
+	id, ok := h.parseID(ctx)
+	if !ok {
+		return
+	}
+	var req VirtualMCPRequest
+	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid request body")
+		return
+	}
+	def, err := h.store.ConfigStore.GetVirtualMCPByID(ctx, id)
+	if err != nil {
+		h.sendLookupError(ctx, err)
+		return
+	}
+	if req.Tools != nil {
+		if msg := h.validateToolSpecs(req.Tools); msg != "" {
+			SendError(ctx, fasthttp.StatusBadRequest, msg)
+			return
+		}
+		def.ParsedTools = req.Tools
+	}
+	if req.Name != "" {
+		def.Name = req.Name
+	}
+	if req.Description != nil {
+		def.Description = req.Description
+	}
+	if req.Enabled != nil {
+		def.Enabled = *req.Enabled
+	}
+	// EndpointSlug is immutable: ignored even if the body carries one.
+	if err := h.store.ConfigStore.UpdateVirtualMCP(ctx, def); err != nil {
+		if code, msg, ok := virtualMCPConflict(err); ok {
+			SendError(ctx, code, msg)
+			return
+		}
+		h.logger.Error("failed to update virtual MCP: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	h.refreshDefinition(ctx, def.ID)
+	SendJSON(ctx, map[string]any{"virtual_mcp": h.toResponse(ctx, def)})
+}
+
+func (h *VirtualMCPHandler) deleteVirtualMCP(ctx *fasthttp.RequestCtx) {
+	id, ok := h.parseID(ctx)
+	if !ok {
+		return
+	}
+	if _, err := h.store.ConfigStore.GetVirtualMCPByID(ctx, id); err != nil {
+		h.sendLookupError(ctx, err)
+		return
+	}
+	if err := h.store.ConfigStore.DeleteVirtualMCP(ctx, id); err != nil {
+		h.logger.Error("failed to delete virtual MCP: %v", err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	h.removeDefinition(ctx, id)
+	SendJSON(ctx, map[string]any{"success": true})
+}
+
+func (h *VirtualMCPHandler) attachVirtualKey(ctx *fasthttp.RequestCtx) {
+	id, ok := h.parseID(ctx)
+	if !ok {
+		return
+	}
+	vkID, _ := ctx.UserValue("vkId").(string)
+	if vkID == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "virtual key id is required")
+		return
+	}
+	if _, err := h.store.ConfigStore.GetVirtualMCPByID(ctx, id); err != nil {
+		h.sendLookupError(ctx, err)
+		return
+	}
+	if _, err := h.store.ConfigStore.GetVirtualKey(ctx, vkID); err != nil {
+		if errors.Is(err, configstore.ErrNotFound) {
+			SendError(ctx, fasthttp.StatusNotFound, "virtual key not found")
+			return
+		}
+		h.logger.Error("failed to look up virtual key %s: %v", vkID, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	if err := h.store.ConfigStore.AttachVirtualMCPToVirtualKey(ctx, id, vkID); err != nil {
+		h.logger.Error("failed to attach virtual MCP %d to VK %s: %v", id, vkID, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	h.refreshAttachment(ctx, vkID, id, true)
+	SendJSON(ctx, map[string]any{"success": true})
+}
+
+func (h *VirtualMCPHandler) detachVirtualKey(ctx *fasthttp.RequestCtx) {
+	id, ok := h.parseID(ctx)
+	if !ok {
+		return
+	}
+	vkID, _ := ctx.UserValue("vkId").(string)
+	if vkID == "" {
+		SendError(ctx, fasthttp.StatusBadRequest, "virtual key id is required")
+		return
+	}
+	// Gate on the vMCP like attach does: no visibility (404 under DAC), no detach.
+	if _, err := h.store.ConfigStore.GetVirtualMCPByID(ctx, id); err != nil {
+		h.sendLookupError(ctx, err)
+		return
+	}
+	if err := h.store.ConfigStore.DetachVirtualMCPFromVirtualKey(ctx, id, vkID); err != nil {
+		h.logger.Error("failed to detach virtual MCP %d from VK %s: %v", id, vkID, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	h.refreshAttachment(ctx, vkID, id, false)
+	SendJSON(ctx, map[string]any{"success": true})
+}
+
+// The refresh helpers update the governance cache after a write. A failure is logged, not returned:
+// the write already persisted, and the cache still rebuilds at startup.
+func (h *VirtualMCPHandler) refreshDefinition(ctx context.Context, id uint) {
+	if h.governanceManager == nil {
+		return
+	}
+	if _, err := h.governanceManager.ReloadVirtualMCP(ctx, id); err != nil {
+		h.logger.Error("failed to refresh virtual MCP %d in cache: %v", id, err)
+	}
+}
+
+func (h *VirtualMCPHandler) removeDefinition(ctx context.Context, id uint) {
+	if h.governanceManager == nil {
+		return
+	}
+	if err := h.governanceManager.RemoveVirtualMCP(ctx, id); err != nil {
+		h.logger.Error("failed to drop virtual MCP %d from cache: %v", id, err)
+	}
+}
+
+func (h *VirtualMCPHandler) refreshAttachment(ctx context.Context, vkID string, id uint, attached bool) {
+	if h.governanceManager == nil {
+		return
+	}
+	var err error
+	if attached {
+		err = h.governanceManager.AttachVirtualMCPToVirtualKeyInMemory(ctx, vkID, id)
+	} else {
+		err = h.governanceManager.DetachVirtualMCPFromVirtualKeyInMemory(ctx, vkID, id)
+	}
+	if err != nil {
+		h.logger.Error("failed to refresh virtual MCP %d / VK %s assignment in cache: %v", id, vkID, err)
+	}
+}
+
+func (h *VirtualMCPHandler) parseID(ctx *fasthttp.RequestCtx) (uint, bool) {
+	idStr, _ := ctx.UserValue("id").(string)
+	id, err := strconv.ParseUint(idStr, 10, 32)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusBadRequest, "invalid virtual MCP id")
+		return 0, false
+	}
+	return uint(id), true
+}
+
+// virtualMCPConflict maps a uniqueness conflict to a 409 with a clear message: an explicit endpoint
+// clash, or a name clash surfaced by the table's own unique index.
+func virtualMCPConflict(err error) (int, string, bool) {
+	switch {
+	case errors.Is(err, configstore.ErrVirtualMCPEndpointExists):
+		return fasthttp.StatusConflict, configstore.ErrVirtualMCPEndpointExists.Error(), true
+	case IsUniqueConstraintError(err):
+		return fasthttp.StatusConflict, "a virtual MCP with this name or endpoint already exists", true
+	}
+	return 0, "", false
+}
+
+func (h *VirtualMCPHandler) sendLookupError(ctx *fasthttp.RequestCtx, err error) {
+	if errors.Is(err, configstore.ErrNotFound) {
+		SendError(ctx, fasthttp.StatusNotFound, "virtual MCP not found")
+		return
+	}
+	h.logger.Error("failed to load virtual MCP: %v", err)
+	SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1091,6 +1091,38 @@ func (m *MockConfigStore) GetVirtualMCPAssignments(ctx context.Context) (map[str
 	return nil, nil
 }
 
+func (m *MockConfigStore) CreateVirtualMCP(ctx context.Context, def *tables.TableVirtualMCP) error {
+	return nil
+}
+
+func (m *MockConfigStore) GetVirtualMCPByID(ctx context.Context, id uint) (*tables.TableVirtualMCP, error) {
+	return nil, nil
+}
+
+func (m *MockConfigStore) GetVirtualMCPsPaginated(ctx context.Context, params configstore.VirtualMCPsQueryParams) ([]tables.TableVirtualMCP, int64, error) {
+	return nil, 0, nil
+}
+
+func (m *MockConfigStore) UpdateVirtualMCP(ctx context.Context, def *tables.TableVirtualMCP) error {
+	return nil
+}
+
+func (m *MockConfigStore) DeleteVirtualMCP(ctx context.Context, id uint) error {
+	return nil
+}
+
+func (m *MockConfigStore) AttachVirtualMCPToVirtualKey(ctx context.Context, vmcpID uint, virtualKeyID string) error {
+	return nil
+}
+
+func (m *MockConfigStore) DetachVirtualMCPFromVirtualKey(ctx context.Context, vmcpID uint, virtualKeyID string) error {
+	return nil
+}
+
+func (m *MockConfigStore) GetVirtualKeyIDsForVirtualMCP(ctx context.Context, vmcpID uint) ([]string, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) CreateVirtualKeyMCPConfig(ctx context.Context, virtualKeyMCPConfig *tables.TableVirtualKeyMCPConfig, tx ...*gorm.DB) error {
 	return nil
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -103,6 +103,11 @@ type ServerCallbacks interface {
 	RemoveCustomer(ctx context.Context, id string) error
 	// Virtual key related callbacks
 	ReloadVirtualKey(ctx context.Context, id string) (*tables.TableVirtualKey, error)
+	// Virtual MCP cache refresh after a write, surgically per operation (mirrors the VK/team callbacks).
+	ReloadVirtualMCP(ctx context.Context, id uint) (*tables.TableVirtualMCP, error)
+	RemoveVirtualMCP(ctx context.Context, id uint) error
+	AttachVirtualMCPToVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error
+	DetachVirtualMCPFromVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error
 	// ResetBudgetUsageInMemory clears usage for the given budgets in the governance
 	// store, leaving each reset boundary untouched. owner identifies the entity that
 	// owns them so enterprise can address the cluster broadcast that propagates the
@@ -594,6 +599,64 @@ func (s *BifrostHTTPServer) ReloadVirtualKey(ctx context.Context, id string) (*t
 	s.Config.OAuthProvider.EvictUserTokensByVirtualKey(id)
 	s.Config.MCPHeadersProvider.EvictCredentialsByVirtualKey(id)
 	return virtualKey, nil
+}
+
+// virtualMCPCache is the governance-store subset the Virtual MCP routes refresh in memory. The store
+// exposes it as a capability (type assertion), not on the shared interface, so a wrapper that has not
+// adopted it no-ops here; its cache still rebuilds at startup.
+type virtualMCPCache interface {
+	UpdateVirtualMCPInMemory(*tables.TableVirtualMCP)
+	DeleteVirtualMCPInMemory(uint)
+	AttachVirtualMCPInMemory(string, uint)
+	DetachVirtualMCPInMemory(string, uint)
+}
+
+func (s *BifrostHTTPServer) governanceVirtualMCPCache() virtualMCPCache {
+	governancePlugin, err := s.getGovernancePlugin()
+	if err != nil {
+		return nil
+	}
+	cache, _ := governancePlugin.GetGovernanceStore().(virtualMCPCache)
+	return cache
+}
+
+// ReloadVirtualMCP re-reads one definition and refreshes its cache entry, after a create or update.
+func (s *BifrostHTTPServer) ReloadVirtualMCP(ctx context.Context, id uint) (*tables.TableVirtualMCP, error) {
+	if s.Config == nil || s.Config.ConfigStore == nil {
+		return nil, nil
+	}
+	def, err := s.Config.ConfigStore.GetVirtualMCPByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if cache := s.governanceVirtualMCPCache(); cache != nil {
+		cache.UpdateVirtualMCPInMemory(def)
+	}
+	return def, nil
+}
+
+// RemoveVirtualMCP drops a definition from the cache after a delete.
+func (s *BifrostHTTPServer) RemoveVirtualMCP(ctx context.Context, id uint) error {
+	if cache := s.governanceVirtualMCPCache(); cache != nil {
+		cache.DeleteVirtualMCPInMemory(id)
+	}
+	return nil
+}
+
+// AttachVirtualMCPToVirtualKeyInMemory records a VK -> Virtual MCP assignment in the cache.
+func (s *BifrostHTTPServer) AttachVirtualMCPToVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	if cache := s.governanceVirtualMCPCache(); cache != nil {
+		cache.AttachVirtualMCPInMemory(vkID, id)
+	}
+	return nil
+}
+
+// DetachVirtualMCPFromVirtualKeyInMemory removes a VK -> Virtual MCP assignment from the cache.
+func (s *BifrostHTTPServer) DetachVirtualMCPFromVirtualKeyInMemory(ctx context.Context, vkID string, id uint) error {
+	if cache := s.governanceVirtualMCPCache(); cache != nil {
+		cache.DetachVirtualMCPInMemory(vkID, id)
+	}
+	return nil
 }
 
 // ResetBudgetUsageInMemory clears usage for the given budgets in the governance
@@ -2267,6 +2330,12 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	providerHandler := handlers.NewProviderHandler(callbacks, s.Config, s.Client)
 	oauthHandler := handlers.NewOAuthHandler(s.Config.OAuthProvider, s.Client, s.Config)
 	mcpHandler := handlers.NewMCPHandler(callbacks, callbacks, s.Client, s.Config, oauthHandler, callbacks)
+	// Virtual MCP routes read the config store on every call; skip them when persistence is disabled
+	// (nil ConfigStore) rather than nil-deref, like routingHandler below.
+	var virtualMCPHandler *handlers.VirtualMCPHandler
+	if s.Config.ConfigStore != nil {
+		virtualMCPHandler = handlers.NewVirtualMCPHandler(s.Config, s.Client, callbacks, logger)
+	}
 	mcpPerUserHeadersHandler := handlers.NewMCPPerUserHeadersHandler(callbacks, s.Config, s.TempTokens)
 	mcpSessionsHandler := handlers.NewMCPSessionsHandler(s.Config, callbacks)
 	configHandler := handlers.NewConfigHandler(callbacks, s.Config)
@@ -2288,6 +2357,9 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	healthHandler.RegisterRoutes(s.Router, middlewares...)
 	providerHandler.RegisterRoutes(s.Router, middlewares...)
 	mcpHandler.RegisterRoutes(s.Router, middlewares...)
+	if virtualMCPHandler != nil {
+		virtualMCPHandler.RegisterRoutes(s.Router, middlewares...)
+	}
 	mcpPerUserHeadersHandler.RegisterRoutes(s.Router, middlewares...)
 	mcpSessionsHandler.RegisterRoutes(s.Router, middlewares...)
 	configHandler.RegisterRoutes(s.Router, middlewares...)


### PR DESCRIPTION
## Summary

This PR introduces full CRUD support for Virtual MCP servers, including Virtual Key assignment management. It adds the necessary store interface methods, database operations, HTTP handlers, and a `ReloadVirtualMCPs` governance cache hook so that writes are immediately reflected in the running governance store.

## Changes

- Added `CreateVirtualMCP`, `GetVirtualMCPByID`, `GetVirtualMCPsPaginated`, `UpdateVirtualMCP`, `DeleteVirtualMCP`, `AttachVirtualMCPToVirtualKey`, `DetachVirtualMCPFromVirtualKey`, and `GetVirtualKeyIDsForVirtualMCP` to the `ConfigStore` interface and implemented them on `RDBConfigStore`.
- `CreateVirtualMCP` derives `endpoint_slug` from the name when not explicitly provided, rejects slug collisions with the new `ErrVirtualMCPEndpointExists` error (surfaced as HTTP 409), and handles GORM's `default:true` column behavior for `Enabled: false` creates via a wrapping transaction.
- `UpdateVirtualMCP` omits `endpoint_slug` and `created_at` from the save, making the slug immutable after creation.
- `DeleteVirtualMCP` explicitly removes VK assignments in the same transaction before deleting the definition, ensuring correctness regardless of FK cascade support.
- `VirtualMCPSlugify` was exported (renamed from `virtualMCPSlugify`) so it can be called from `CreateVirtualMCP` outside the migrations file.
- Added `CreatedByUserID` field to `TableVirtualMCP` to support enterprise DAC scoping; it is nullable and ignored in OSS.
- Added `VirtualMCPsQueryParams` for paginated list queries with case-insensitive name search.
- Added `VirtualMCPHandler` with routes under `/api/mcp/virtual-mcps`, including attach/detach endpoints for VK assignments. Endpoint slug is accepted on create only and silently ignored on update.
- Tool spec validation checks that referenced MCP client IDs are known at write time; tool names are not validated (enforced at call time).
- Added `ReloadVirtualMCPs` to the `GovernanceManager` and `ServerCallbacks` interfaces, implemented on `BifrostHTTPServer` via a duck-typed governance store check. Cache reload failures are logged but do not fail the originating request.
- Added `virtualmcp_crud_test.go` covering slug derivation, duplicate name/endpoint rejection, disabled-create correctness, slug immutability on update, idempotent attach/detach, cascading delete of assignments, and paginated search.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/... -run TestVirtualMCP
go test ./transports/bifrost-http/...
go test ./...
```

Key scenarios to verify manually:
- `POST /api/mcp/virtual-mcps` with no `endpoint_slug` derives one from `name`.
- `POST /api/mcp/virtual-mcps` with two names that slugify identically returns HTTP 409 with `ErrVirtualMCPEndpointExists`.
- `POST /api/mcp/virtual-mcps` with `"enabled": false` persists as disabled (not flipped by the column default).
- `PUT /api/mcp/virtual-mcps/{id}` with a new `endpoint_slug` in the body leaves the original slug unchanged.
- `DELETE /api/mcp/virtual-mcps/{id}` removes the row and all its VK assignments.
- `POST /api/mcp/virtual-mcps/{id}/virtual-keys/{vkId}` called twice returns success both times (idempotent).

## Breaking changes

- [x] Yes
- [ ] No

`GovernanceManager` and `ServerCallbacks` interfaces gain a `ReloadVirtualMCPs(ctx context.Context) error` method. Any external implementation of these interfaces must add a stub. The existing test mocks in this PR demonstrate the required no-op stub pattern.

## Related issues

## Security considerations

`AttachVirtualMCPToVirtualKey` validates that the target Virtual Key exists before creating the association, preventing blind assignment to arbitrary VK IDs. Enterprise DAC row scoping is wired through `CreatedByUserID` but the scoping logic itself lives in the enterprise layer.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable