### PR TITLE
feat: add support for serving virtual MCPs at slug endpoints

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1437,9 +1437,12 @@ func (gs *LocalGovernanceStore) permitForVirtualKey(ctx context.Context, vk *con
 		acc.addMCPConfig(&vk.MCPConfigs[i])
 	}
 	for _, id := range vmcpIDs {
-		if def := gs.virtualMCPByID(id); def != nil && def.Enabled {
-			acc.addVirtualMCP(def)
+		def := gs.virtualMCPByID(id)
+		if def == nil || !def.Enabled {
+			continue
 		}
+		acc.addVirtualMCP(def)
+		RecordGrantedVirtualMCP(ctx, def)
 	}
 	mcpPermits := gs.mcpPermitsFromAccumulator(acc, vk.Name)
 	mcpPermits = AppendMCPPermitsAllowedByDefault(mcpPermits, acc.configuredClients(), allowedByDefaultClients)
@@ -1461,6 +1464,101 @@ func (gs *LocalGovernanceStore) assignedVirtualMCPIDs(vkID string) []uint {
 		return v.([]uint)
 	}
 	return nil
+}
+
+// grantedVirtualMCPsKey keys the per-request set of addressable Virtual MCPs.
+type grantedVirtualMCPsKey struct{}
+
+// grantedVirtualMCPs is the per-request set of vMCPs reachable at /mcp/<slug>, keyed by slug. Only the
+// addressable paths record here (direct key assignment; enterprise access profiles); legacy
+// team/customer/provider scopes don't, so those grant on /mcp but not /mcp/<slug>.
+type grantedVirtualMCPs struct {
+	bySlug map[string]configstoreTables.TableVirtualMCP
+}
+
+// grantedVirtualMCPsMu guards the per-request set's get-or-create and its bySlug map. Resolution is
+// single-goroutine per request today, so it is uncontended; it stops a concurrent-map panic if a
+// record path is ever parallelized.
+var grantedVirtualMCPsMu sync.Mutex
+
+// RecordGrantedVirtualMCP records an enabled vMCP as reachable at /mcp/<slug> for this request. No-op
+// off the gateway path or for a disabled/slug-less vMCP. Exported so enterprise records profile vMCPs.
+func RecordGrantedVirtualMCP(ctx context.Context, vmcp *configstoreTables.TableVirtualMCP) {
+	if vmcp == nil || !vmcp.Enabled || vmcp.EndpointSlug == "" {
+		return
+	}
+	bctx, ok := ctx.(*schemas.BifrostContext)
+	if !ok {
+		return
+	}
+	if gateway, _ := bctx.Value(schemas.BifrostContextKeyIsMCPGateway).(bool); !gateway {
+		return
+	}
+	grantedVirtualMCPsMu.Lock()
+	defer grantedVirtualMCPsMu.Unlock()
+	set, _ := bctx.Value(grantedVirtualMCPsKey{}).(*grantedVirtualMCPs)
+	if set == nil {
+		set = &grantedVirtualMCPs{bySlug: make(map[string]configstoreTables.TableVirtualMCP)}
+		bctx.SetValue(grantedVirtualMCPsKey{}, set)
+	}
+	set.bySlug[vmcp.EndpointSlug] = *vmcp
+}
+
+// grantedVirtualMCP returns the Virtual MCP recorded under slug for the request, if any.
+func grantedVirtualMCP(ctx context.Context, slug string) (*configstoreTables.TableVirtualMCP, bool) {
+	bctx, ok := ctx.(*schemas.BifrostContext)
+	if !ok {
+		return nil, false
+	}
+	grantedVirtualMCPsMu.Lock()
+	defer grantedVirtualMCPsMu.Unlock()
+	set, _ := bctx.Value(grantedVirtualMCPsKey{}).(*grantedVirtualMCPs)
+	if set == nil {
+		return nil, false
+	}
+	v, ok := set.bySlug[slug]
+	if !ok {
+		return nil, false
+	}
+	return &v, true
+}
+
+// VirtualMCPToolAccess resolves the tool include-list a /mcp/<slug> request may see. The slug must
+// have been recorded addressable during resolution (assigned=false → the caller answers 403); its
+// tools are then narrowed to what the request's access grants, so an excluded tool can't leak. A nil
+// access restricts nothing, so the vMCP's own tools are served as-is.
+func (gs *LocalGovernanceStore) VirtualMCPToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) (served []string, assigned bool) {
+	target, ok := grantedVirtualMCP(ctx, slug)
+	if !ok {
+		return nil, false
+	}
+
+	var clientNames map[string]string
+	if gs.inMemoryStore != nil {
+		clientNames = gs.inMemoryStore.GetMCPClientNames()
+	}
+	requested := make([]string, 0, len(target.ParsedTools))
+	for _, spec := range target.ParsedTools {
+		name := clientNames[spec.MCPClientID]
+		if name == "" {
+			// Client no longer configured (or unnamed): nothing to serve for it.
+			continue
+		}
+		if len(spec.ToolNames) == 0 {
+			requested = append(requested, name+"-"+grant.Wildcard)
+			continue
+		}
+		for _, tool := range spec.ToolNames {
+			if tool == "" {
+				continue
+			}
+			requested = append(requested, name+"-"+tool)
+		}
+	}
+	if access == nil {
+		return requested, true
+	}
+	return access.NarrowMCPToolIncludeList(requested), true
 }
 
 // loadVirtualMCPs fills both caches from the store at startup; surgical updates keep them current

--- a/plugins/governance/virtualmcpaccess_test.go
+++ b/plugins/governance/virtualmcpaccess_test.go
@@ -1,0 +1,82 @@
+package governance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/grant"
+	"github.com/stretchr/testify/assert"
+)
+
+// gatewayCtx builds an MCP-gateway request context with the given Virtual MCPs recorded as
+// addressable, the way resolution records them during a real /mcp request.
+func gatewayCtx(vmcps ...configstoreTables.TableVirtualMCP) *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(time.Minute))
+	ctx.SetValue(schemas.BifrostContextKeyIsMCPGateway, true)
+	for i := range vmcps {
+		RecordGrantedVirtualMCP(ctx, &vmcps[i])
+	}
+	return ctx
+}
+
+// TestVirtualMCPToolAccess covers the /mcp/<slug> resolution: the slug's Virtual MCP must have been
+// recorded as addressable during resolution (else refused), its tools are named through the
+// client-name map, and are narrowed to what the request's access permits.
+func TestVirtualMCPToolAccess(t *testing.T) {
+	names := map[string]string{"cA": "alpha", "cB": "beta"}
+	store := func(clientNames map[string]string) *LocalGovernanceStore {
+		return &LocalGovernanceStore{inMemoryStore: &mockInMemoryStore{clientNames: clientNames}, logger: NewMockLogger()}
+	}
+	// The addressable vMCP "g" grants alpha read+write and every tool of beta.
+	assigned := configstoreTables.TableVirtualMCP{
+		Name: "grp", EndpointSlug: "g", Enabled: true,
+		ParsedTools: []configstoreTables.MCPToolSpec{spec("cA", "read", "write"), spec("cB")},
+	}
+
+	t.Run("a slug not recorded as addressable is refused", func(t *testing.T) {
+		served, ok := store(names).VirtualMCPToolAccess(gatewayCtx(assigned), "unknown", nil)
+		assert.False(t, ok)
+		assert.Nil(t, served)
+	})
+
+	t.Run("a request with nothing recorded is refused", func(t *testing.T) {
+		served, ok := store(names).VirtualMCPToolAccess(gatewayCtx(), "g", nil)
+		assert.False(t, ok)
+		assert.Nil(t, served)
+	})
+
+	t.Run("nil access serves the vMCP's own tools, named through the client map", func(t *testing.T) {
+		served, ok := store(names).VirtualMCPToolAccess(gatewayCtx(assigned), "g", nil)
+		assert.True(t, ok)
+		assert.ElementsMatch(t, []string{"alpha-read", "alpha-write", "beta-" + grant.Wildcard}, served)
+	})
+
+	t.Run("access narrows the served tools to what the request may reach", func(t *testing.T) {
+		// The request's access permits only alpha-read.
+		accessPermit := permitFor(buildVKNoMCPConfigs(), []configstoreTables.TableVirtualMCP{
+			{Name: "acc", EndpointSlug: "acc", Enabled: true, ParsedTools: []configstoreTables.MCPToolSpec{spec("cA", "read")}},
+		}, names, nil)
+		access := grant.NewAccess([]schemas.Permit{accessPermit}, nil, "", nil)
+
+		served, ok := store(names).VirtualMCPToolAccess(gatewayCtx(assigned), "g", access)
+		assert.True(t, ok)
+		assert.Equal(t, []string{"alpha-read"}, served, "alpha-write and beta are excluded by the access")
+	})
+
+	t.Run("a client no longer in the name map is skipped", func(t *testing.T) {
+		served, ok := store(map[string]string{"cA": "alpha"}).VirtualMCPToolAccess(gatewayCtx(assigned), "g", nil)
+		assert.True(t, ok)
+		assert.ElementsMatch(t, []string{"alpha-read", "alpha-write"}, served, "beta (cB) is dropped: no longer configured")
+	})
+
+	t.Run("recording is a no-op off the gateway path", func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(time.Minute))
+		RecordGrantedVirtualMCP(ctx, &assigned) // no IsMCPGateway flag: must not record
+		served, ok := store(names).VirtualMCPToolAccess(ctx, "g", nil)
+		assert.False(t, ok)
+		assert.Nil(t, served)
+	})
+}

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -50,6 +50,17 @@ type MCPGatewayAdmitter interface {
 	AdmitMCPGatewayRequest(ctx *schemas.BifrostContext) (schemas.Access, *schemas.BifrostError)
 }
 
+// virtualMCPGatewayResolver is the optional capability behind a Virtual MCP endpoint (/mcp/<slug>): it resolves
+// the tools a request may see for the Virtual MCP the slug names, gated on that vMCP being assigned to
+// the request's key. Satisfied by the same admitter that resolves gateway access. Absent (or nil)
+// means there is no governance store to resolve assignment against, so /mcp/<slug> is refused.
+type virtualMCPGatewayResolver interface {
+	// VirtualMCPToolAccess returns the served tool include-list and whether the slug's Virtual MCP is
+	// assigned to the request's key (assigned=false → 403). The tools are already narrowed to what the
+	// request's access permits.
+	VirtualMCPToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) (served []string, assigned bool)
+}
+
 // VirtualKeyCache resolves a virtual key by its row ID from an in-memory cache,
 // letting the JWT auth path avoid a per-request database read. Satisfied by the
 // governance plugin's in-memory store. Optional: when nil (or a cache miss), the
@@ -142,6 +153,9 @@ func (h *MCPServerHandler) RegisterRoutes(r *router.Router, middlewares ...schem
 	// MCP server endpoint - supports both POST (JSON-RPC) and GET (SSE)
 	r.POST("/mcp", lib.ChainMiddlewares(h.handleMCPServer, middlewares...))
 	r.GET("/mcp", lib.ChainMiddlewares(h.handleMCPServerSSE, middlewares...))
+	// Virtual MCP endpoints: same handlers, narrowed to the slug's vMCP in admit.
+	r.POST("/mcp/{slug}", lib.ChainMiddlewares(h.handleMCPServer, middlewares...))
+	r.GET("/mcp/{slug}", lib.ChainMiddlewares(h.handleMCPServerSSE, middlewares...))
 }
 
 func (h *MCPServerHandler) handleMCPServer(ctx *fasthttp.RequestCtx) {
@@ -514,7 +528,29 @@ func (h *MCPServerHandler) admit(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.B
 		return &mcpRefusal{status: status, message: bifrost.GetErrorMessage(refused)}
 	}
 
+	// A Virtual MCP endpoint (/mcp/<slug>) serves one Virtual MCP: gate on it being assigned to the key and
+	// narrow the tools to it. The plain /mcp route carries no slug and serves the full access.
+	if slug, _ := ctx.UserValue("slug").(string); slug != "" {
+		return h.admitVirtualMCP(bifrostCtx, slug, access)
+	}
+
 	stampToolAccess(bifrostCtx, access)
+	return nil
+}
+
+// admitVirtualMCP narrows an already-admitted request to the Virtual MCP its slug names. The vMCP must be
+// assigned to the request's key, or the request is refused with 403; otherwise the tools it may see
+// are stamped as the served include-list. Reached only from admit, after access is resolved.
+func (h *MCPServerHandler) admitVirtualMCP(bifrostCtx *schemas.BifrostContext, slug string, access schemas.Access) *mcpRefusal {
+	resolver, ok := h.admitter.(virtualMCPGatewayResolver)
+	if !ok {
+		return &mcpRefusal{status: fasthttp.StatusForbidden, message: "access_denied"}
+	}
+	served, assigned := resolver.VirtualMCPToolAccess(bifrostCtx, slug, access)
+	if !assigned {
+		return &mcpRefusal{status: fasthttp.StatusForbidden, message: "access_denied"}
+	}
+	bifrostCtx.SetValue(schemas.MCPContextKeyIncludeTools, served)
 	return nil
 }
 

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -1506,6 +1506,23 @@ func (s *BifrostHTTPServer) AdmitMCPGatewayRequest(ctx *schemas.BifrostContext) 
 	return ctx.Grant().Access(), nil
 }
 
+// VirtualMCPToolAccess resolves what a /mcp/<slug> request may see, delegating to the governance store
+// (which reads the addressable-vMCP set recorded on ctx during resolution). No governance store → the
+// endpoint is refused.
+func (s *BifrostHTTPServer) VirtualMCPToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) (served []string, assigned bool) {
+	governancePlugin, err := s.getGovernancePlugin()
+	if err != nil {
+		return nil, false
+	}
+	resolver, ok := governancePlugin.GetGovernanceStore().(interface {
+		VirtualMCPToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) ([]string, bool)
+	})
+	if !ok {
+		return nil, false
+	}
+	return resolver.VirtualMCPToolAccess(ctx, slug, access)
+}
+
 // backgroundCtx returns the server-lifetime context background workers should
 // hang off. Falls back to context.Background() before Bootstrap has set s.Ctx.
 func (s *BifrostHTTPServer) backgroundCtx() context.Context {


### PR DESCRIPTION
## Summary

This PR introduces per-slug Virtual MCP endpoints (`/mcp/<slug>`), allowing a Virtual MCP to be addressed directly by its endpoint slug. Previously, Virtual MCPs were only reachable via the top-level `/mcp` route. Now, a key's direct assignment to a Virtual MCP makes it addressable at `/mcp/<slug>`, with tools narrowed to what the request's access permits.

## Changes

- Registered `/mcp/{slug}` POST and GET routes alongside the existing `/mcp` routes, reusing the same handlers.
- Added a per-request `grantedVirtualMCPs` set (keyed on `grantedVirtualMCPsKey`) that records which Virtual MCPs are addressable for a given request. Only direct key assignments (and enterprise access profiles) populate this set; legacy team/customer/provider scopes do not, so those grant access on `/mcp` but not `/mcp/<slug>`.
- Added `RecordGrantedVirtualMCP` (exported so enterprise can record profile vMCPs) to populate the per-request set during resolution. It is a no-op off the gateway path or for disabled/slug-less vMCPs.
- Added `VirtualMCPToolAccess` on `LocalGovernanceStore`, which looks up the recorded vMCP by slug, resolves tool names through the MCP client name map, and narrows the result to what the request's access permits via `NarrowMCPToolIncludeList`. A slug not recorded as addressable returns `assigned=false`, causing a 403.
- Introduced the `virtualMCPGatewayResolver` interface in the HTTP handler layer, satisfied by the server's admitter, so the handler can delegate slug resolution without a direct dependency on the governance store.
- Added `admitVirtualMCP` on `MCPServerHandler` to gate slug requests: if the resolver is absent or the slug is unassigned, the request is refused with 403; otherwise the narrowed tool list is stamped onto the context.
- Added `VirtualMCPToolAccess` on `BifrostHTTPServer` to bridge the handler interface to the governance store via the governance plugin.
- Added `virtualmcpaccess_test.go` covering: unrecorded slugs are refused, nil access serves the vMCP's own tools, access narrows the served tools, missing clients are skipped, and recording is a no-op off the gateway path.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... ./transports/bifrost-http/...
```

- Issue a request to `/mcp/<slug>` with a key that has the Virtual MCP directly assigned and confirm the response is limited to the vMCP's tools, further narrowed by the key's access.
- Issue a request to `/mcp/<slug>` with a key that does not have the Virtual MCP assigned and confirm a 403 is returned.
- Issue a request to `/mcp/<slug>` with a slug that does not correspond to any configured Virtual MCP and confirm a 403 is returned.
- Issue a request to the plain `/mcp` route and confirm existing behavior is unchanged.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The slug-based endpoint enforces that a Virtual MCP must be explicitly assigned to the requesting key before its tools are served. Tools are additionally narrowed to what the request's access permits, so a tool excluded from the key's access cannot leak through the slug endpoint. Requests off the gateway path cannot record or resolve Virtual MCPs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable