### PR TITLE
refactor: promote the MCP tool accumulator to a reusable component

### DIFF
--- a/plugins/governance/mcp.go
+++ b/plugins/governance/mcp.go
@@ -15,24 +15,21 @@ type mcpClientTools struct {
 	seen      map[string]bool
 	// name is the client's display name if a source carried one; else resolved at emit time.
 	name string
-	// explicit marks a client named by an MCP config: emitted even with no tools, and blocks the
-	// allowed-by-default fallback.
-	explicit bool
 }
 
-// mcpToolAccumulator gathers per-client tool grants from a key's MCP configs and Virtual MCPs,
+// MCPToolAccumulator gathers per-client tool grants from a key's MCP configs and Virtual MCPs,
 // applying the whole-client, per-client union, and wildcard-collapse rules in one place.
-type mcpToolAccumulator struct {
+type MCPToolAccumulator struct {
 	byClient map[string]*mcpClientTools
 	order    []string
 }
 
-func newMCPToolAccumulator(capacity int) *mcpToolAccumulator {
-	return &mcpToolAccumulator{byClient: make(map[string]*mcpClientTools, capacity)}
+func NewMCPToolAccumulator(capacity int) *MCPToolAccumulator {
+	return &MCPToolAccumulator{byClient: make(map[string]*mcpClientTools, capacity)}
 }
 
 // client returns a client's entry, registering it on first sight.
-func (acc *mcpToolAccumulator) client(clientID string) *mcpClientTools {
+func (acc *MCPToolAccumulator) client(clientID string) *mcpClientTools {
 	entry, ok := acc.byClient[clientID]
 	if !ok {
 		entry = &mcpClientTools{seen: make(map[string]bool)}
@@ -42,15 +39,15 @@ func (acc *mcpToolAccumulator) client(clientID string) *mcpClientTools {
 	return entry
 }
 
-// grantWholeClient grants every tool a client has.
-func (acc *mcpToolAccumulator) grantWholeClient(clientID string) {
+// GrantWholeClient grants every tool a client has.
+func (acc *MCPToolAccumulator) GrantWholeClient(clientID string) {
 	if clientID != "" {
 		acc.client(clientID).everyTool = true
 	}
 }
 
-// grantTool grants one tool, or every tool on the wildcard.
-func (acc *mcpToolAccumulator) grantTool(clientID, tool string) {
+// GrantTool grants one tool, or every tool on the wildcard.
+func (acc *MCPToolAccumulator) GrantTool(clientID, tool string) {
 	if clientID == "" || tool == "" {
 		return
 	}
@@ -67,23 +64,22 @@ func (acc *mcpToolAccumulator) grantTool(clientID, tool string) {
 
 // addMCPConfig folds in a key's own config: the client is registered even with no tools, and carries
 // its own name.
-func (acc *mcpToolAccumulator) addMCPConfig(cfg *configstoreTables.TableVirtualKeyMCPConfig) {
+func (acc *MCPToolAccumulator) addMCPConfig(cfg *configstoreTables.TableVirtualKeyMCPConfig) {
 	clientID := cfg.MCPClient.ClientID
 	if clientID == "" {
 		return
 	}
 	entry := acc.client(clientID)
-	entry.explicit = true
 	if cfg.MCPClient.Name != "" {
 		entry.name = cfg.MCPClient.Name
 	}
 	for _, tool := range cfg.ToolsToExecute {
-		acc.grantTool(clientID, tool)
+		acc.GrantTool(clientID, tool)
 	}
 }
 
-// addVirtualMCP folds in an enabled Virtual MCP; a spec with no tool names means the whole client.
-func (acc *mcpToolAccumulator) addVirtualMCP(vmcp *configstoreTables.TableVirtualMCP) {
+// AddVirtualMCP folds in an enabled Virtual MCP; a spec with no tool names means the whole client.
+func (acc *MCPToolAccumulator) AddVirtualMCP(vmcp *configstoreTables.TableVirtualMCP) {
 	if vmcp == nil || !vmcp.Enabled {
 		return
 	}
@@ -92,18 +88,39 @@ func (acc *mcpToolAccumulator) addVirtualMCP(vmcp *configstoreTables.TableVirtua
 			continue
 		}
 		if len(spec.ToolNames) == 0 {
-			acc.grantWholeClient(spec.MCPClientID)
+			acc.GrantWholeClient(spec.MCPClientID)
 			continue
 		}
 		for _, tool := range spec.ToolNames {
-			acc.grantTool(spec.MCPClientID, tool)
+			acc.GrantTool(spec.MCPClientID, tool)
 		}
 	}
 }
 
-// configuredClients is the set of clients named, whatever they granted; the allowed-by-default
+// ExcludeTool withdraws one tool from a client, registering the client either way so the
+// allowed-by-default fallback treats it as configured and does not reopen it. The tool is withdrawn
+// only from a named grant: a whole-client grant already means every tool, so the exclusion is ignored.
+func (acc *MCPToolAccumulator) ExcludeTool(clientID, tool string) {
+	if clientID == "" || tool == "" {
+		return
+	}
+	entry := acc.client(clientID)
+	if entry.everyTool || !entry.seen[tool] {
+		return
+	}
+	delete(entry.seen, tool)
+	remaining := make([]string, 0, len(entry.named))
+	for _, t := range entry.named {
+		if t != tool {
+			remaining = append(remaining, t)
+		}
+	}
+	entry.named = remaining
+}
+
+// ConfiguredClients is the set of clients named, whatever they granted; the allowed-by-default
 // fallback must not reopen them.
-func (acc *mcpToolAccumulator) configuredClients() map[string]struct{} {
+func (acc *MCPToolAccumulator) ConfiguredClients() map[string]struct{} {
 	configured := make(map[string]struct{}, len(acc.byClient))
 	for clientID := range acc.byClient {
 		configured[clientID] = struct{}{}
@@ -111,16 +128,20 @@ func (acc *mcpToolAccumulator) configuredClients() map[string]struct{} {
 	return configured
 }
 
-// mcpPermitsFromAccumulator emits one permit per client, resolving unnamed clients against the
-// configured set. A client granting no tool is dropped unless named explicitly; one with no
-// resolvable name is dropped. holderName names the holder in the warning.
-func (gs *LocalGovernanceStore) mcpPermitsFromAccumulator(acc *mcpToolAccumulator, holderName string) []schemas.MCPPermit {
+// mcpClientNames resolves client id → display name from the in-memory store, or nil.
+func (gs *LocalGovernanceStore) mcpClientNames() map[string]string {
+	if gs.inMemoryStore == nil {
+		return nil
+	}
+	return gs.inMemoryStore.GetMCPClientNames()
+}
+
+// MCPPermitsFromAccumulator emits one permit per client, naming unnamed clients from clientNames. A
+// client that reaches no tool is dropped (allowed-by-default stays blocked via ConfiguredClients, not a
+// permit); an unresolvable name is dropped and logged. A free function so any store passes its own deps.
+func MCPPermitsFromAccumulator(acc *MCPToolAccumulator, holderKind, holderName string, clientNames map[string]string, logger schemas.Logger) []schemas.MCPPermit {
 	// Sorted for a stable permit across nodes and rebuilds.
 	sort.Strings(acc.order)
-	var clientNames map[string]string
-	if gs.inMemoryStore != nil {
-		clientNames = gs.inMemoryStore.GetMCPClientNames()
-	}
 	result := make([]schemas.MCPPermit, 0, len(acc.order))
 	for _, clientID := range acc.order {
 		entry := acc.byClient[clientID]
@@ -128,7 +149,7 @@ func (gs *LocalGovernanceStore) mcpPermitsFromAccumulator(acc *mcpToolAccumulato
 		if entry.everyTool {
 			tools = []string{grant.Wildcard}
 		}
-		if len(tools) == 0 && !entry.explicit {
+		if len(tools) == 0 {
 			continue
 		}
 		clientName := entry.name
@@ -136,7 +157,9 @@ func (gs *LocalGovernanceStore) mcpPermitsFromAccumulator(acc *mcpToolAccumulato
 			clientName = clientNames[clientID]
 		}
 		if clientName == "" {
-			gs.logger.Warn("governance: virtual key %q grants tools of MCP client %q, which has no configured name; those tools are not reachable until the client is configured", holderName, clientID)
+			if logger != nil {
+				logger.Warn("governance: %s %q grants tools of MCP client %q, which has no configured name; those tools are not reachable until the client is configured", holderKind, holderName, clientID)
+			}
 			continue
 		}
 		result = append(result, schemas.MCPPermit{

--- a/plugins/governance/permits_test.go
+++ b/plugins/governance/permits_test.go
@@ -352,21 +352,23 @@ func TestPermitForVirtualKey_MCPPermits(t *testing.T) {
 		assert.Equal(t, schemas.MCPPermit{Client: "jira-id", ClientName: "jira", Tools: []string{"*"}}, permit.MCPPermits()[0])
 	})
 
-	t.Run("an explicit config owns its client, and is never widened", func(t *testing.T) {
+	t.Run("a config with no tools owns its client: dropped, and not reopened by the default", func(t *testing.T) {
 		vk := buildVirtualKey("vk-1", "sk-bf-test", "Key", true)
 		vk.MCPConfigs = []configstoreTables.TableVirtualKeyMCPConfig{
 			vkMCPConfig("github-id", "github", "read_file"),
-			// Configured with no tool at all: the client is still the key's to decide.
+			// Configured with no tool: no permit, but still the key's to decide, so the default must not reopen it.
 			vkMCPConfig("jira-id", "jira"),
 		}
 		open := map[string]string{"github-id": "github", "jira-id": "jira", "slack-id": "slack"}
 
 		permit := vkPermit(vk, open)
 
-		require.Len(t, permit.MCPPermits(), 3)
+		require.Len(t, permit.MCPPermits(), 2)
 		assert.Equal(t, schemas.WhiteList{"read_file"}, permit.MCPPermits()[0].Tools, "not widened to all tools")
-		assert.Empty(t, permit.MCPPermits()[1].Tools, "an empty config stays empty")
-		assert.Equal(t, "slack-id", permit.MCPPermits()[2].Client, "only the unconfigured client is added")
+		assert.Equal(t, "slack-id", permit.MCPPermits()[1].Client, "only the unconfigured client is added")
+		for _, mp := range permit.MCPPermits() {
+			assert.NotEqual(t, "jira-id", mp.Client, "a client configured with no tools is dropped, not reopened by the default")
+		}
 	})
 
 	t.Run("open clients are ordered, so the permit is stable", func(t *testing.T) {

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1432,7 +1432,7 @@ func (gs *LocalGovernanceStore) permitForVirtualKey(ctx context.Context, vk *con
 	// A key's own MCP configs and its Virtual MCPs build one accumulator, so a Virtual MCP grants
 	// exactly like a config: owns the clients it names, unions per client, blocks allowed-by-default.
 	vmcpIDs := gs.assignedVirtualMCPIDs(vk.ID)
-	acc := newMCPToolAccumulator(len(vk.MCPConfigs) + len(vmcpIDs))
+	acc := NewMCPToolAccumulator(len(vk.MCPConfigs) + len(vmcpIDs))
 	for i := range vk.MCPConfigs {
 		acc.addMCPConfig(&vk.MCPConfigs[i])
 	}
@@ -1441,11 +1441,12 @@ func (gs *LocalGovernanceStore) permitForVirtualKey(ctx context.Context, vk *con
 		if def == nil || !def.Enabled {
 			continue
 		}
-		acc.addVirtualMCP(def)
+		acc.AddVirtualMCP(def)
+		// A key's direct assignment makes the vMCP addressable at /mcp/<slug>.
 		RecordGrantedVirtualMCP(ctx, def)
 	}
-	mcpPermits := gs.mcpPermitsFromAccumulator(acc, vk.Name)
-	mcpPermits = AppendMCPPermitsAllowedByDefault(mcpPermits, acc.configuredClients(), allowedByDefaultClients)
+	mcpPermits := MCPPermitsFromAccumulator(acc, "virtual key", vk.Name, gs.mcpClientNames(), gs.logger)
+	mcpPermits = AppendMCPPermitsAllowedByDefault(mcpPermits, acc.ConfiguredClients(), allowedByDefaultClients)
 
 	return grant.NewPermit(grant.PermitVirtualKey, vk.ID, vk.Name, vk.IsActiveValue(), vk.IsExpiredAt(time.Now().UTC()), providerPermits, mcpPermits)
 }


### PR DESCRIPTION
## Summary

Promotes the MCP tool accumulator and its methods to exported symbols, converts `MCPPermitsFromAccumulator` from a method on `LocalGovernanceStore` to a free function, and removes the `explicit` flag from `mcpClientTools`. A client configured with no tools is now dropped from the permit list rather than emitted with an empty tool set, while still blocking the allowed-by-default fallback from reopening it. A new `ExcludeTool` method is added to support withdrawing a previously granted tool.

## Changes

- `mcpToolAccumulator` and its constructor/methods are exported (`MCPToolAccumulator`, `NewMCPToolAccumulator`, `GrantWholeClient`, `GrantTool`, `AddVirtualMCP`, `ConfiguredClients`) so they can be used outside the `governance` package.
- `mcpPermitsFromAccumulator` is replaced by the free function `MCPPermitsFromAccumulator`, which accepts `holderKind`, `holderName`, a `clientNames` map, and a `Logger` directly instead of reading them from the store receiver. This decouples permit emission from `LocalGovernanceStore` and makes it testable in isolation.
- The `explicit` field is removed from `mcpClientTools`. A client configured with no tools no longer produces a permit with an empty tool list; it is simply dropped. The client is still registered in the accumulator, so `ConfiguredClients` correctly blocks the allowed-by-default fallback from reopening it.
- `ExcludeTool` is added to `MCPToolAccumulator` to withdraw a single named tool from a client's grant without affecting whole-client grants.
- `mcpClientNames` is extracted as a small helper on `LocalGovernanceStore` to keep the call site in `permitForVirtualKey` clean.
- The warning log in `MCPPermitsFromAccumulator` is now parameterised with `holderKind` so the message correctly identifies whether the holder is a virtual key or another entity.
- The test for "explicit config owns its client" is updated to reflect the new behaviour: a client configured with no tools produces no permit and is not reopened by the default.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

Verify that a virtual key configured with an MCP client but no tools does not appear in `MCPPermits()`, and that the allowed-by-default path does not reopen that client for other tools.

## Breaking changes

- [x] Yes
- [ ] No

`mcpToolAccumulator`, `newMCPToolAccumulator`, and `mcpPermitsFromAccumulator` are replaced by their exported equivalents with different signatures. Any internal callers outside this package must be updated to use `MCPToolAccumulator`, `NewMCPToolAccumulator`, and `MCPPermitsFromAccumulator` with the new parameter set.

## Security considerations

Removing the `explicit` flag changes the semantics of an MCP config that lists a client with no tools: previously it emitted an empty-tool permit; now it emits nothing. The client is still treated as configured, so the allowed-by-default path cannot silently grant it all tools. This tightens the surface rather than widening it.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable