### PR TITLE
feat: add vk assignments list support to vmcps and fix whitelisting convention for tools

### DIFF
--- a/framework/configstore/errors.go
+++ b/framework/configstore/errors.go
@@ -14,6 +14,11 @@ var ErrAlreadyExists = errors.New("already exists")
 // the table's own unique index and surfaces as a generic unique-constraint error.)
 var ErrVirtualMCPEndpointExists = errors.New("a virtual MCP with this endpoint already exists")
 
+// ErrVirtualKeyAccessProfileManaged is returned by AttachVirtualMCPToVirtualKey (enterprise) when the
+// target virtual key is managed by an access profile: its MCP access is governed by the profile, so it
+// cannot be assigned a Virtual MCP directly. OSS never returns it (no access profiles).
+var ErrVirtualKeyAccessProfileManaged = errors.New("access-profile-managed virtual keys cannot be assigned a virtual MCP directly")
+
 // ErrConfigUnreadable marks a stored configuration value that could not be
 // decoded or that failed validation — the value is present but this version
 // cannot make sense of it.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4620,6 +4620,25 @@ func (s *RDBConfigStore) GetVirtualKeyIDsForVirtualMCP(ctx context.Context, vmcp
 	return ids, err
 }
 
+// GetVirtualKeyIDsForVirtualMCPs returns assigned virtual-key IDs for a set of Virtual MCPs in one
+// query, grouped by Virtual MCP ID.
+func (s *RDBConfigStore) GetVirtualKeyIDsForVirtualMCPs(ctx context.Context, vmcpIDs []uint) (map[uint][]string, error) {
+	result := make(map[uint][]string, len(vmcpIDs))
+	if len(vmcpIDs) == 0 {
+		return result, nil
+	}
+	var rows []tables.TableVirtualKeyVirtualMCP
+	if err := s.DB().WithContext(ctx).
+		Where("tool_group_id IN ?", vmcpIDs).
+		Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		result[row.VirtualMCPID] = append(result[row.VirtualMCPID], row.VirtualKeyID)
+	}
+	return result, nil
+}
+
 // GetVirtualKeyMCPConfigsByMCPClientIDs retrieves all VK MCP configs for a set of MCP client IDs in one query.
 func (s *RDBConfigStore) GetVirtualKeyMCPConfigsByMCPClientIDs(ctx context.Context, mcpClientIDs []uint) ([]tables.TableVirtualKeyMCPConfig, error) {
 	if len(mcpClientIDs) == 0 {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -372,6 +372,9 @@ type ConfigStore interface {
 	AttachVirtualMCPToVirtualKey(ctx context.Context, vmcpID uint, virtualKeyID string) error
 	DetachVirtualMCPFromVirtualKey(ctx context.Context, vmcpID uint, virtualKeyID string) error
 	GetVirtualKeyIDsForVirtualMCP(ctx context.Context, vmcpID uint) ([]string, error)
+	// GetVirtualKeyIDsForVirtualMCPs returns assigned virtual-key IDs for a set of Virtual MCPs in one
+	// query, grouped by Virtual MCP ID. Used by the list view to avoid a per-row lookup.
+	GetVirtualKeyIDsForVirtualMCPs(ctx context.Context, vmcpIDs []uint) (map[uint][]string, error)
 
 	// Team CRUD
 	GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error)

--- a/framework/configstore/tables/virtualmcp.go
+++ b/framework/configstore/tables/virtualmcp.go
@@ -8,11 +8,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// MCPToolSpec is one entry in a Virtual MCP: a source client and the tools it
-// exposes. Empty ToolNames means all of the client's tools, current and future.
+// MCPToolSpec is one entry in a Virtual MCP: a source client and the tools it exposes.
 type MCPToolSpec struct {
-	MCPClientID string   `json:"mcp_client_id"` // source MCP client ID
-	ToolNames   []string `json:"tool_names"`    // specific tools; empty = all tools from the client
+	MCPClientID string `json:"mcp_client_id"` // source MCP client ID
+	// ToolNames follows WhiteList semantics: ["*"] = all tools from the client (incl. future),
+	// [] = no tools (deny-by-default), a named list = only those tools.
+	ToolNames []string `json:"tool_names"`
 }
 
 // TableVirtualMCP is a Virtual MCP server: a named bundle of tool specs from one
@@ -45,7 +46,7 @@ func (g *TableVirtualMCP) BeforeSave(tx *gorm.DB) error {
 	if g.ParsedTools != nil {
 		for i := range g.ParsedTools {
 			if g.ParsedTools[i].ToolNames == nil {
-				// Keep "all tools" as [] not null, for clean JSON downstream.
+				// Normalize nil to [] for clean JSON; both mean deny-by-default (no tools).
 				g.ParsedTools[i].ToolNames = []string{}
 			}
 		}

--- a/plugins/governance/mcp.go
+++ b/plugins/governance/mcp.go
@@ -78,7 +78,8 @@ func (acc *MCPToolAccumulator) addMCPConfig(cfg *configstoreTables.TableVirtualK
 	}
 }
 
-// AddVirtualMCP folds in an enabled Virtual MCP; a spec with no tool names means the whole client.
+// AddVirtualMCP folds in an enabled Virtual MCP. Each spec's tool names follow WhiteList semantics:
+// ["*"] grants the whole client, [] grants nothing, and a named list grants those tools.
 func (acc *MCPToolAccumulator) AddVirtualMCP(vmcp *configstoreTables.TableVirtualMCP) {
 	if vmcp == nil || !vmcp.Enabled {
 		return
@@ -87,10 +88,9 @@ func (acc *MCPToolAccumulator) AddVirtualMCP(vmcp *configstoreTables.TableVirtua
 		if spec.MCPClientID == "" {
 			continue
 		}
-		if len(spec.ToolNames) == 0 {
-			acc.GrantWholeClient(spec.MCPClientID)
-			continue
-		}
+		// Register the client even with an empty list, so it counts as configured and the
+		// allowed-by-default fallback can't reopen it.
+		acc.client(spec.MCPClientID)
 		for _, tool := range spec.ToolNames {
 			acc.GrantTool(spec.MCPClientID, tool)
 		}

--- a/plugins/governance/mcp_test.go
+++ b/plugins/governance/mcp_test.go
@@ -67,10 +67,16 @@ func TestPermitForVirtualKey_VirtualMCPsMirrorConfigs(t *testing.T) {
 		assert.Equal(t, map[string][]string{"cA": {"x", "y"}}, toolsByClient(permit.MCPPermits()))
 	})
 
-	t.Run("empty tool names grants the whole client as a wildcard", func(t *testing.T) {
+	t.Run("a wildcard tool name grants the whole client", func(t *testing.T) {
+		vk := buildVKNoMCPConfigs()
+		permit := permitFor(vk, []configstoreTables.TableVirtualMCP{vmcp("g", true, spec("cB", grant.Wildcard))}, names, nil)
+		assert.Equal(t, map[string][]string{"cB": {grant.Wildcard}}, toolsByClient(permit.MCPPermits()))
+	})
+
+	t.Run("empty tool names grant nothing (deny-by-default)", func(t *testing.T) {
 		vk := buildVKNoMCPConfigs()
 		permit := permitFor(vk, []configstoreTables.TableVirtualMCP{vmcp("g", true, spec("cB"))}, names, nil)
-		assert.Equal(t, map[string][]string{"cB": {grant.Wildcard}}, toolsByClient(permit.MCPPermits()))
+		assert.Empty(t, permit.MCPPermits())
 	})
 
 	t.Run("a disabled virtual MCP contributes nothing", func(t *testing.T) {
@@ -92,6 +98,14 @@ func TestPermitForVirtualKey_VirtualMCPsMirrorConfigs(t *testing.T) {
 		permit := permitFor(vk, []configstoreTables.TableVirtualMCP{vmcp("g", true, spec("cB", "read"))}, names, map[string]string{"cB": "beta"})
 		assert.Equal(t, map[string][]string{"cB": {"read"}}, toolsByClient(permit.MCPPermits()),
 			"an assigned virtual MCP scopes an otherwise-open client, mirroring an explicit config")
+	})
+
+	t.Run("an empty tool list denies even an allowed-by-default client", func(t *testing.T) {
+		// cB is open to every key by default. An empty-tool spec must still scope it to nothing, not
+		// let the allowed-by-default fallback reopen it — the spec has to register cB as configured.
+		vk := buildVKNoMCPConfigs()
+		permit := permitFor(vk, []configstoreTables.TableVirtualMCP{vmcp("g", true, spec("cB"))}, names, map[string]string{"cB": "beta"})
+		assert.Empty(t, permit.MCPPermits(), "an empty allow-list blocks the allowed-by-default wildcard")
 	})
 }
 

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1545,10 +1545,8 @@ func (gs *LocalGovernanceStore) VirtualMCPToolAccess(ctx *schemas.BifrostContext
 			// Client no longer configured (or unnamed): nothing to serve for it.
 			continue
 		}
-		if len(spec.ToolNames) == 0 {
-			requested = append(requested, name+"-"+grant.Wildcard)
-			continue
-		}
+		// WhiteList semantics: ["*"] serves the whole client (name-*), [] serves nothing, a named list
+		// serves those tools. grant.Wildcard is "*", so the loop below produces name-* for the all case.
 		for _, tool := range spec.ToolNames {
 			if tool == "" {
 				continue

--- a/plugins/governance/virtualmcpaccess_test.go
+++ b/plugins/governance/virtualmcpaccess_test.go
@@ -33,7 +33,7 @@ func TestVirtualMCPToolAccess(t *testing.T) {
 	// The addressable vMCP "g" grants alpha read+write and every tool of beta.
 	assigned := configstoreTables.TableVirtualMCP{
 		Name: "grp", EndpointSlug: "g", Enabled: true,
-		ParsedTools: []configstoreTables.MCPToolSpec{spec("cA", "read", "write"), spec("cB")},
+		ParsedTools: []configstoreTables.MCPToolSpec{spec("cA", "read", "write"), spec("cB", grant.Wildcard)},
 	}
 
 	t.Run("a slug not recorded as addressable is refused", func(t *testing.T) {

--- a/transports/bifrost-http/handlers/virtualmcp.go
+++ b/transports/bifrost-http/handlers/virtualmcp.go
@@ -65,14 +65,13 @@ type VirtualMCPResponse struct {
 	UpdatedAt     string                          `json:"updated_at"`
 }
 
-func (h *VirtualMCPHandler) toResponse(ctx context.Context, def *configstoreTables.TableVirtualMCP) VirtualMCPResponse {
+// toResponse builds the API shape from a definition and its assigned virtual keys. vkIDs are passed in
+// rather than loaded here: the list batch-loads them for the whole page in one query, while the
+// single-definition paths load them via withVKs.
+func (h *VirtualMCPHandler) toResponse(def *configstoreTables.TableVirtualMCP, vkIDs []string) VirtualMCPResponse {
 	tools := def.ParsedTools
 	if tools == nil {
 		tools = []configstoreTables.MCPToolSpec{}
-	}
-	vkIDs, err := h.store.ConfigStore.GetVirtualKeyIDsForVirtualMCP(ctx, def.ID)
-	if err != nil {
-		h.logger.Error("failed to load VK assignments for virtual MCP %d: %v", def.ID, err)
 	}
 	if vkIDs == nil {
 		vkIDs = []string{}
@@ -88,6 +87,18 @@ func (h *VirtualMCPHandler) toResponse(ctx context.Context, def *configstoreTabl
 		CreatedAt:     def.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 		UpdatedAt:     def.UpdatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
+}
+
+// withVKs builds the response with the definition's assigned virtual keys loaded (one query). The list
+// path uses toResponse(def, nil) instead, since it does not show per-row assignment.
+// withVKs returns the lookup error rather than a stale-empty list: get/update feed the edit sheet,
+// where empty-on-error would make a save detach real assignments. (The list path degrades instead.)
+func (h *VirtualMCPHandler) withVKs(ctx context.Context, def *configstoreTables.TableVirtualMCP) (VirtualMCPResponse, error) {
+	vkIDs, err := h.store.ConfigStore.GetVirtualKeyIDsForVirtualMCP(ctx, def.ID)
+	if err != nil {
+		return VirtualMCPResponse{}, err
+	}
+	return h.toResponse(def, vkIDs), nil
 }
 
 // validateToolSpecs rejects specs whose MCP client is not configured. Tool names are not checked
@@ -138,9 +149,19 @@ func (h *VirtualMCPHandler) listVirtualMCPs(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
 		return
 	}
+	ids := make([]uint, len(defs))
+	for i := range defs {
+		ids[i] = defs[i].ID
+	}
+	// One batch query for all VK assignments on the page (not an N+1), so the list can show "Assigned to".
+	vkIDsByVMCP, err := h.store.ConfigStore.GetVirtualKeyIDsForVirtualMCPs(ctx, ids)
+	if err != nil {
+		h.logger.Error("failed to load VK assignments for virtual MCPs: %v", err)
+		vkIDsByVMCP = map[uint][]string{}
+	}
 	responses := make([]VirtualMCPResponse, len(defs))
 	for i := range defs {
-		responses[i] = h.toResponse(ctx, &defs[i])
+		responses[i] = h.toResponse(&defs[i], vkIDsByVMCP[defs[i].ID])
 	}
 	SendJSON(ctx, map[string]any{
 		"virtual_mcps": responses,
@@ -161,7 +182,13 @@ func (h *VirtualMCPHandler) getVirtualMCP(ctx *fasthttp.RequestCtx) {
 		h.sendLookupError(ctx, err)
 		return
 	}
-	SendJSON(ctx, map[string]any{"virtual_mcp": h.toResponse(ctx, def)})
+	resp, err := h.withVKs(ctx, def)
+	if err != nil {
+		h.logger.Error("failed to load VK assignments for virtual MCP %d: %v", def.ID, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSON(ctx, map[string]any{"virtual_mcp": resp})
 }
 
 func (h *VirtualMCPHandler) createVirtualMCP(ctx *fasthttp.RequestCtx) {
@@ -200,7 +227,7 @@ func (h *VirtualMCPHandler) createVirtualMCP(ctx *fasthttp.RequestCtx) {
 	}
 	h.refreshDefinition(ctx, def.ID)
 	ctx.SetStatusCode(fasthttp.StatusCreated)
-	SendJSON(ctx, map[string]any{"virtual_mcp": h.toResponse(ctx, def)})
+	SendJSON(ctx, map[string]any{"virtual_mcp": h.toResponse(def, nil)})
 }
 
 func (h *VirtualMCPHandler) updateVirtualMCP(ctx *fasthttp.RequestCtx) {
@@ -245,7 +272,13 @@ func (h *VirtualMCPHandler) updateVirtualMCP(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	h.refreshDefinition(ctx, def.ID)
-	SendJSON(ctx, map[string]any{"virtual_mcp": h.toResponse(ctx, def)})
+	resp, err := h.withVKs(ctx, def)
+	if err != nil {
+		h.logger.Error("failed to load VK assignments for virtual MCP %d: %v", def.ID, err)
+		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
+		return
+	}
+	SendJSON(ctx, map[string]any{"virtual_mcp": resp})
 }
 
 func (h *VirtualMCPHandler) deleteVirtualMCP(ctx *fasthttp.RequestCtx) {
@@ -290,6 +323,10 @@ func (h *VirtualMCPHandler) attachVirtualKey(ctx *fasthttp.RequestCtx) {
 		return
 	}
 	if err := h.store.ConfigStore.AttachVirtualMCPToVirtualKey(ctx, id, vkID); err != nil {
+		if errors.Is(err, configstore.ErrVirtualKeyAccessProfileManaged) {
+			SendError(ctx, fasthttp.StatusConflict, "this virtual key is managed by an access profile; assign the Virtual MCP through that access profile instead")
+			return
+		}
 		h.logger.Error("failed to attach virtual MCP %d to VK %s: %v", id, vkID, err)
 		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
 		return

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1123,6 +1123,10 @@ func (m *MockConfigStore) GetVirtualKeyIDsForVirtualMCP(ctx context.Context, vmc
 	return nil, nil
 }
 
+func (m *MockConfigStore) GetVirtualKeyIDsForVirtualMCPs(ctx context.Context, vmcpIDs []uint) (map[uint][]string, error) {
+	return map[uint][]string{}, nil
+}
+
 func (m *MockConfigStore) CreateVirtualKeyMCPConfig(ctx context.Context, virtualKeyMCPConfig *tables.TableVirtualKeyMCPConfig, tx ...*gorm.DB) error {
 	return nil
 }


### PR DESCRIPTION
## Summary

This PR fixes an N+1 query problem on the Virtual MCP list endpoint and tightens the tool-name semantics for Virtual MCPs from "empty = all tools" to explicit WhiteList semantics where `["*"]` grants all tools and `[]` grants nothing.

## Changes

- **Batch VK assignment loading**: Introduced `GetVirtualKeyIDsForVirtualMCPs` (plural) on the config store, which loads virtual-key assignments for an entire page of Virtual MCPs in a single query. The list handler now uses this instead of issuing one query per row.
- **Refactored `toResponse`**: Decoupled the DB lookup from response building. `toResponse` now accepts pre-loaded `vkIDs` directly. A new `withVKs` helper handles the single-definition case (get, update), while create and list pass IDs in explicitly.
- **WhiteList semantics for tool names**: Changed `MCPToolSpec.ToolNames` so that `[]` means "grant nothing" (deny-by-default) and `["*"]` means "grant all tools from the client." Previously, an empty slice was treated as a wildcard. `AddVirtualMCP` and `VirtualMCPToolAccess` both updated to remove the `len == 0 → GrantWholeClient` shortcut and rely on `grant.Wildcard` passing through the loop instead.
- **`ErrVirtualKeyAccessProfileManaged`**: Added a new sentinel error for the enterprise case where a virtual key is governed by an access profile and cannot be assigned a Virtual MCP directly. The attach handler now returns HTTP 409 with a descriptive message when this error is encountered.
- **Tests updated**: Test cases renamed and added to reflect the new deny-by-default behavior (`empty tool names grant nothing`) and the wildcard-explicit behavior (`a wildcard tool name grants the whole client`).

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/configstore/...
go test ./plugins/governance/...
go test ./transports/bifrost-http/...
```

**List endpoint**: Verify that fetching a page of Virtual MCPs issues a single batch query for VK assignments rather than one per row.

**Tool name semantics**: Create a Virtual MCP with a spec where `tool_names` is `[]` and confirm the key receives no tool grants. Create one with `tool_names: ["*"]` and confirm all tools are granted.

**Access-profile conflict**: In an enterprise environment, attempt to attach a Virtual MCP to an access-profile-managed virtual key and confirm a `409 Conflict` response with the message `"this virtual key is managed by an access profile; assign the Virtual MCP through that access profile instead"`.

## Breaking changes

- [x] Yes
- [ ] No

Any Virtual MCP definitions that relied on an empty `tool_names` array to mean "all tools" will now grant nothing. Existing specs must be updated to use `["*"]` to preserve the previous all-tools behavior.

## Related issues

## Security considerations

The shift to deny-by-default for empty `tool_names` reduces the blast radius of misconfigured Virtual MCPs: an accidentally empty tool list no longer silently grants full client access.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable