### PR TITLE
test: cover the whole prompt-cache injection config surface in the harness

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -479,10 +479,18 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 	}
 	// Targets that speak prompt_cache_breakpoint need the caching intent translated
 	// out of cache_control, which their serializer would otherwise strip.
+	// Match on the BASE provider, not the key the request arrived under. A custom
+	// provider reports its own name ("my-openai"), which no case in either predicate
+	// knows, so gating on the unresolved key sends every such request down the default
+	// branch: the caller's cache_control is stripped by the serializer with nothing put
+	// in its place, and the request silently falls back to implicit caching - the exact
+	// billing profile #6180 exists to escape. The injector resolves the same way in
+	// core/bifrost.go, and providers/utils does too; this call site was the odd one out.
+	cachePromptProvider := schemas.ResolveBaseProvider(ctx, bifrostReq.Provider)
 	needsExplicitPromptCacheMode := false
-	if responsesUsesPromptCacheBreakpoints(bifrostReq.Provider, capModel) {
+	if responsesUsesPromptCacheBreakpoints(cachePromptProvider, capModel) {
 		applyResponsesCacheBreakpoints(messages)
-		needsExplicitPromptCacheMode = responsesUsesPromptCacheOptions(bifrostReq.Provider, capModel) &&
+		needsExplicitPromptCacheMode = responsesUsesPromptCacheOptions(cachePromptProvider, capModel) &&
 			responsesHasPromptCacheBreakpoint(messages)
 	}
 

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
@@ -1714,4 +1715,144 @@ func TestToOpenAIResponsesRequest_GPT56MarkerTTLIsNotCarried(t *testing.T) {
 	if strings.Contains(raw, "\"ttl\"") {
 		t.Errorf("no ttl may reach an OpenAI-shaped endpoint from a cache_control marker; raw=%s", raw)
 	}
+}
+
+// TestToOpenAIResponsesRequest_CustomProviderResolvesBaseForCacheBreakpoints pins the
+// gate on the breakpoint translation to the BASE provider rather than the key the
+// request arrived under.
+//
+// A custom provider reports its own name. Matching the raw name against a switch that
+// only knows "openai"/"azure"/"bedrock_mantle"/"openrouter" sends every such request to
+// the default branch, where the serializer strips cache_control and puts nothing in its
+// place - so the caller's explicit breakpoint vanishes and the request silently drops
+// back to the implicit caching that #6180 exists to escape. Nothing in the response
+// says so; it is only visible on the wire.
+//
+// The failure is invisible to any test that names a standard provider, which is how it
+// survived: the injector (core/bifrost.go) and providers/utils both resolve the base
+// first, and this call site was the odd one out.
+func TestToOpenAIResponsesRequest_CustomProviderResolvesBaseForCacheBreakpoints(t *testing.T) {
+	newReq := func(provider schemas.ModelProvider) *schemas.BifrostResponsesRequest {
+		return &schemas.BifrostResponsesRequest{
+			Provider: provider,
+			Model:    "gpt-5.6-sol",
+			Input: []schemas.ResponsesMessage{
+				{
+					Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{
+						ContentBlocks: []schemas.ResponsesMessageContentBlock{
+							{
+								Type:         schemas.ResponsesInputMessageContentBlockTypeText,
+								Text:         schemas.Ptr("REUSABLE_PREFIX"),
+								CacheControl: &schemas.CacheControl{Type: schemas.CacheControlTypeEphemeral},
+							},
+							{
+								Type: schemas.ResponsesInputMessageContentBlockTypeText,
+								Text: schemas.Ptr("Reply with OK."),
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	// wire marshals the request and returns both the parsed body and the raw bytes, so
+	// a failure message shows exactly what the provider would have received.
+	wire := func(t *testing.T, ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostResponsesRequest) (map[string]any, string) {
+		t.Helper()
+		request := ToOpenAIResponsesRequest(ctx, bifrostReq)
+		if request == nil {
+			t.Fatal("expected non-nil request")
+		}
+		jsonBytes, err := request.MarshalJSON()
+		if err != nil {
+			t.Fatalf("failed to marshal responses request: %v", err)
+		}
+		raw := string(jsonBytes)
+		var jsonMap map[string]any
+		if err := sonic.Unmarshal(jsonBytes, &jsonMap); err != nil {
+			t.Fatalf("failed to parse marshaled JSON: %v\nraw=%s", err, raw)
+		}
+		return jsonMap, raw
+	}
+
+	markedBlock := func(t *testing.T, jsonMap map[string]any, raw string) map[string]any {
+		t.Helper()
+		input, ok := jsonMap["input"].([]any)
+		if !ok || len(input) == 0 {
+			t.Fatalf("expected input array on the wire; raw=%s", raw)
+		}
+		msg, ok := input[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected input[0] to be an object; raw=%s", raw)
+		}
+		blocks, ok := msg["content"].([]any)
+		if !ok || len(blocks) != 2 {
+			t.Fatalf("expected 2 content blocks on input[0]; raw=%s", raw)
+		}
+		block, ok := blocks[0].(map[string]any)
+		if !ok {
+			t.Fatalf("expected content[0] to be an object; raw=%s", raw)
+		}
+		return block
+	}
+
+	assertTranslated := func(t *testing.T, jsonMap map[string]any, raw string) {
+		t.Helper()
+		block := markedBlock(t, jsonMap, raw)
+		if _, present := block["cache_control"]; present {
+			t.Errorf("cache_control must never reach an OpenAI-shaped endpoint; raw=%s", raw)
+		}
+		bp, ok := block["prompt_cache_breakpoint"].(map[string]any)
+		if !ok {
+			t.Fatalf("cache_control must be translated to prompt_cache_breakpoint on the marked block; raw=%s", raw)
+		}
+		if mode, _ := bp["mode"].(string); mode != "explicit" {
+			t.Errorf("prompt_cache_breakpoint.mode = %q, want \"explicit\"; raw=%s", mode, raw)
+		}
+		// The block marker alone does not switch gpt-5.6 off implicit caching; without
+		// request-level explicit mode the breakpoint is inert and the win is lost.
+		opts, ok := jsonMap["prompt_cache_options"].(map[string]any)
+		if !ok {
+			t.Fatalf("gpt-5.6 needs request-level prompt_cache_options to honour the breakpoint; raw=%s", raw)
+		}
+		if mode, _ := opts["mode"].(string); mode != "explicit" {
+			t.Errorf("prompt_cache_options.mode = %q, want \"explicit\"; raw=%s", mode, raw)
+		}
+	}
+
+	t.Run("standard openai translates", func(t *testing.T) {
+		jsonMap, raw := wire(t, nil, newReq(schemas.OpenAI))
+		assertTranslated(t, jsonMap, raw)
+	})
+
+	t.Run("custom provider on an openai base translates identically", func(t *testing.T) {
+		ctx := schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline,
+			schemas.BifrostContextKeyBaseProviderType, schemas.OpenAI)
+		jsonMap, raw := wire(t, ctx, newReq(schemas.ModelProvider("openai_pc_auto")))
+		assertTranslated(t, jsonMap, raw)
+	})
+
+	t.Run("custom provider on an azure base translates identically", func(t *testing.T) {
+		ctx := schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline,
+			schemas.BifrostContextKeyBaseProviderType, schemas.Azure)
+		jsonMap, raw := wire(t, ctx, newReq(schemas.ModelProvider("azure_pc_auto")))
+		assertTranslated(t, jsonMap, raw)
+	})
+
+	// The resolution must not become a blanket "translate for everyone": a base that
+	// genuinely has no breakpoint field still gets the strip, which is correct there.
+	t.Run("a base without breakpoints is still left alone", func(t *testing.T) {
+		ctx := schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline,
+			schemas.BifrostContextKeyBaseProviderType, schemas.Anthropic)
+		jsonMap, raw := wire(t, ctx, newReq(schemas.ModelProvider("anthropic_pc_auto")))
+		block := markedBlock(t, jsonMap, raw)
+		if _, present := block["prompt_cache_breakpoint"]; present {
+			t.Errorf("an Anthropic-based provider must not gain a prompt_cache_breakpoint; raw=%s", raw)
+		}
+		if _, present := jsonMap["prompt_cache_options"]; present {
+			t.Errorf("an Anthropic-based provider must not gain prompt_cache_options; raw=%s", raw)
+		}
+	})
 }

--- a/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
+++ b/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
@@ -111,7 +111,7 @@ Sources:
 - [x] Extended thinking (`thinking: { type: "enabled", budget_tokens }`)
 - [x] Adaptive thinking (`thinking: { type: "adaptive" }` for Opus 4.7)
 - [x] Prompt caching ephemeral (`cache_control: { type: "ephemeral" }`)
-- [ ] **Prompt caching persistent / 1-hour** (`cache_control: { type: "ephemeral", ttl: "1h" }`)
+- [~] **Prompt caching persistent / 1-hour** (`cache_control: { type: "ephemeral", ttl: "1h" }`) - folder 64.1 asserts `"ttl":"1h"` reaching the Anthropic, Vertex Claude and Bedrock wires (and being dropped where the dialect cannot carry it) for an **injected** breakpoint via `prompt_cache.ttl`. A client-sent `cache_control.ttl` on the request itself is still uncovered.
 - [ ] **Web fetch tool** (`web_fetch_20250910`, `web_fetch_20260209`, `web_fetch_20260309`)
 - [ ] **Memory tool** (`memory_20250818`)
 - [ ] **Tool search** (`tool_search_tool_bm25`, `tool_search_tool_regex`)

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140843,8 +140843,8 @@
       ]
     },
     {
-      "name": "62. Auto-injected prompt cache breakpoints (#6180)",
-      "description": "Regression coverage for #6180: agentic clients send no cache markers, so providers that cache implicitly slide the cached prefix onto the newest message and bill every turn as a cache write.\n\nThese cases send NO client-side cache_control at all - the client is a stand-in for Codex, which emits none (openai/codex#37674). Injection is enabled per request with x-bf-prompt-cache-auto-inject rather than by editing provider config, so nothing here leaks into other folders in a full run. The header only works because tests/integrations/python/config.json opts the anthropic provider in with auto_inject false; a header alone can never manufacture operator opt-in.\n\nWhat each case pins:\n  62.1 a breakpoint IS injected, asserted on the outbound body via x-bf-send-back-raw-request. Exactly one, because overshooting the four-marker ceiling is a hard rejection upstream.\n  62.2 nothing is injected when opted out. The negative case matters as much as the positive: Bifrost must not spend a cache checkpoint the operator did not ask for.\n  62.3/62.4 a real cache read on the non-streaming route. A 2xx proves nothing about caching, so [read] asserts cached_tokens > 0.\n  62.5/62.6 the same through the streaming handler.\n\nThe [write]/[read] pairs depend on folder order and on {{cachePrefix}} (23KB, well over the 1024-token minimum for claude-sonnet-4) plus the collection-level {{pcNonce}} for per-run cache isolation.",
+      "name": "63. Auto-injected prompt cache breakpoints (#6180)",
+      "description": "Regression coverage for #6180: agentic clients send no cache markers, so providers that cache implicitly slide the cached prefix onto the newest message and bill every turn as a cache write.\n\nThese cases send NO client-side cache_control at all - the client is a stand-in for Codex, which emits none (openai/codex#37674). Injection is enabled per request with x-bf-prompt-cache-auto-inject rather than by editing provider config, so nothing here leaks into other folders in a full run. The header only works because tests/integrations/python/config.json opts the anthropic provider in with auto_inject false; a header alone can never manufacture operator opt-in.\n\nWhat each case pins:\n  63.1 a breakpoint IS injected, asserted on the outbound body via x-bf-send-back-raw-request. Exactly one, because overshooting the four-marker ceiling is a hard rejection upstream.\n  63.2 nothing is injected when opted out. The negative case matters as much as the positive: Bifrost must not spend a cache checkpoint the operator did not ask for.\n  63.3/63.4 a real cache read on the non-streaming route. A 2xx proves nothing about caching, so [read] asserts cached_tokens > 0.\n  63.5/63.6 the same through the streaming handler.\n\nThe [write]/[read] pairs depend on folder order and on {{cachePrefix}} (23KB, well over the 1024-token minimum for claude-sonnet-4-6) plus the collection-level {{pcNonce}} for per-run cache isolation.",
       "item": [
         {
           "name": "Anthropic Claude: auto-inject adds cache_control the client never sent - #6180",
@@ -140855,7 +140855,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('62.1 auto-inject: 2xx', function () {",
+                  "pm.test('63.1 auto-inject: 2xx', function () {",
                   "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
                   "if (pm.response.code >= 400) { return; }",
@@ -140863,13 +140863,13 @@
                   "var rr = (body.extra_fields || {}).raw_request;",
                   "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
                   "var rawStr = rr ? JSON.stringify(rr) : '';",
-                  "pm.test('62.1 raw_request captured', function () {",
+                  "pm.test('63.1 raw_request captured', function () {",
                   "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
                   "});",
                   "if (!rr) { return; }",
                   "// The request carried no markers, so any cache_control on the wire was injected.",
                   "var count = (rawStr.match(/\"cache_control\"/g) || []).length;",
-                  "pm.test('62.1 exactly one breakpoint was injected (#6180)', function () {",
+                  "pm.test('63.1 exactly one breakpoint was injected (#6180)', function () {",
                   "  pm.expect(count, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
                   "});",
                   "// Counting is not enough. A marker on the NEWEST message also counts one, and that",
@@ -140877,11 +140877,11 @@
                   "// prefix slides forward every turn and each turn bills a write. Identify the block.",
                   "var markedTexts = [];",
                   "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { markedTexts.push(String(v.text || '')); } return v; });",
-                  "pm.test('62.1 the marker anchors the stable prefix, not the newest message (#6180)', function () {",
+                  "pm.test('63.1 the marker anchors the stable prefix, not the newest message (#6180)', function () {",
                   "  pm.expect(markedTexts.length, 'marked blocks: ' + JSON.stringify(markedTexts)).to.equal(1);",
                   "  pm.expect(markedTexts[0], 'the marked block must be the replayed prefix, not the trailing question').to.include('bf-6180');",
                   "});",
-                  "pm.test('62.1 the breakpoint is ephemeral', function () {",
+                  "pm.test('63.1 the breakpoint is ephemeral', function () {",
                   "  pm.expect(rawStr).to.include('\"type\":\"ephemeral\"');",
                   "});"
                 ]
@@ -140906,7 +140906,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} wire]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} wire]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/responses",
@@ -140929,7 +140929,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('62.2 default off: 2xx', function () {",
+                  "pm.test('63.2 default off: 2xx', function () {",
                   "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
                   "if (pm.response.code >= 400) { return; }",
@@ -140937,13 +140937,13 @@
                   "var rr = (body.extra_fields || {}).raw_request;",
                   "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
                   "var rawStr = rr ? JSON.stringify(rr) : '';",
-                  "pm.test('62.2 raw_request captured', function () {",
+                  "pm.test('63.2 raw_request captured', function () {",
                   "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
                   "});",
                   "if (!rr) { return; }",
                   "// Same body, opted out. Bifrost must not invent a breakpoint the operator",
                   "// did not ask for - that would spend one of four checkpoints and change billing.",
-                  "pm.test('62.2 nothing is injected when auto-inject is off (#6180)', function () {",
+                  "pm.test('63.2 nothing is injected when auto-inject is off (#6180)', function () {",
                   "  pm.expect(rawStr.indexOf('cache_control'), 'raw_request: ' + rawStr.slice(0, 800)).to.equal(-1);",
                   "});"
                 ]
@@ -140968,7 +140968,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} off]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} off]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/responses",
@@ -140991,7 +140991,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('62.3 cache write: 2xx', function () {",
+                  "pm.test('63.3 cache write: 2xx', function () {",
                   "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});"
                 ]
@@ -141012,7 +141012,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} nonstream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} nonstream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/responses",
@@ -141045,7 +141045,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('62.4 cache read: 2xx', function () {",
+                  "pm.test('63.4 cache read: 2xx', function () {",
                   "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
                   "if (pm.response.code >= 400) { return; }",
@@ -141053,7 +141053,7 @@
                   "var u = j.usage || {};",
                   "var d = u.input_tokens_details || u.prompt_tokens_details || {};",
                   "var cached = (typeof d.cached_tokens === 'number') ? d.cached_tokens : 0;",
-                  "pm.test('62.4 cached_tokens > 0 with no client markers (#6180)', function () {",
+                  "pm.test('63.4 cached_tokens > 0 with no client markers (#6180)', function () {",
                   "  pm.expect(cached, 'usage: ' + JSON.stringify(u)).to.be.above(0);",
                   "});"
                 ]
@@ -141074,7 +141074,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} nonstream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} nonstream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/responses",
@@ -141097,10 +141097,10 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('62.5 cache write: 2xx', function () {",
+                  "pm.test('63.5 cache write: 2xx', function () {",
                   "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
-                  "pm.test('62.5 stream reached a terminal event', function () {",
+                  "pm.test('63.5 stream reached a terminal event', function () {",
                   "  var raw = pm.response.text() || '';",
                   "  pm.expect(raw.indexOf('response.completed') !== -1 || raw.indexOf('response.incomplete') !== -1, 'no terminal SSE event: ' + raw.slice(-400)).to.be.true;",
                   "});"
@@ -141122,7 +141122,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} stream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} stream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/responses",
@@ -141155,7 +141155,7 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('62.6 cache read: 2xx', function () {",
+                  "pm.test('63.6 cache read: 2xx', function () {",
                   "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
                   "if (pm.response.code >= 400) { return; }",
@@ -141163,7 +141163,7 @@
                   "var m = raw.match(/\"cached_tokens\"\\s*:\\s*(\\d+)/g) || [];",
                   "var cached = 0;",
                   "for (var i = 0; i < m.length; i++) { var v = parseInt(m[i].replace(/[^0-9]/g, ''), 10); if (v > cached) { cached = v; } }",
-                  "pm.test('62.6 streaming: cached_tokens > 0 with no client markers (#6180)', function () {",
+                  "pm.test('63.6 streaming: cached_tokens > 0 with no client markers (#6180)', function () {",
                   "  pm.expect(cached, 'no cached_tokens in the stream; tail: ' + raw.slice(-600)).to.be.above(0);",
                   "});"
                 ]
@@ -141184,7 +141184,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} stream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
+              "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 32,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"{{cachePrefix}} [bf-6180 {{pcNonce}} stream]\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one short word: is the sky blue?\"\n        }\n      ]\n    }\n  ],\n  \"stream\": true\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/responses",
@@ -141207,26 +141207,26 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('62.7 gpt-5.6 translation: 2xx', function () {",
+                  "pm.test('63.7 gpt-5.6 translation: 2xx', function () {",
                   "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
                   "if (pm.response.code >= 400) { return; }",
                   "var body = pm.response.json() || {};",
                   "var rr = (body.extra_fields || {}).raw_request;",
                   "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
-                  "pm.test('62.7 raw_request captured', function () { pm.expect(rr).to.be.an('object'); });",
+                  "pm.test('63.7 raw_request captured', function () { pm.expect(rr).to.be.an('object'); });",
                   "if (!rr) { return; }",
                   "var rawStr = JSON.stringify(rr);",
-                  "pm.test('62.7 breakpoint reaches the wire', function () {",
+                  "pm.test('63.7 breakpoint reaches the wire', function () {",
                   "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.include('prompt_cache_breakpoint');",
                   "});",
                   "// The block marker alone leaves implicit caching on, which anchors the prefix",
                   "// to the newest message and bills a write every turn. mode=explicit pins it.",
-                  "pm.test('62.7 explicit cache mode is set alongside it (#6180)', function () {",
+                  "pm.test('63.7 explicit cache mode is set alongside it (#6180)', function () {",
                   "  var opts = rr.prompt_cache_options || {};",
                   "  pm.expect(opts.mode, 'prompt_cache_options: ' + JSON.stringify(opts)).to.eql('explicit');",
                   "});",
-                  "pm.test('62.7 cache_control is not forwarded to an OpenAI-shaped endpoint', function () {",
+                  "pm.test('63.7 cache_control is not forwarded to an OpenAI-shaped endpoint', function () {",
                   "  pm.expect(rawStr.indexOf('cache_control')).to.equal(-1);",
                   "});"
                 ]
@@ -141247,7 +141247,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"model\": \"openai/gpt-5.6-sol\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"You are a meticulous assistant. Answer tersely.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+              "raw": "{\n  \"model\": \"openai/gpt-5.6-sol\",\n  \"max_output_tokens\": 512,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"You are a meticulous assistant. Answer tersely.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/v1/responses",
@@ -141270,25 +141270,25 @@
                 "type": "text/javascript",
                 "exec": [
                   "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
-                  "pm.test('62.8 pre-5.6: 2xx', function () {",
+                  "pm.test('63.8 pre-5.6: 2xx', function () {",
                   "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
                   "});",
                   "if (pm.response.code >= 400) { return; }",
                   "var body = pm.response.json() || {};",
                   "var rr = (body.extra_fields || {}).raw_request;",
                   "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
-                  "pm.test('62.8 raw_request captured', function () { pm.expect(rr).to.be.an('object'); });",
+                  "pm.test('63.8 raw_request captured', function () { pm.expect(rr).to.be.an('object'); });",
                   "if (!rr) { return; }",
                   "var rawStr = JSON.stringify(rr);",
                   "// gpt-4o has no prompt_cache_breakpoint field at all, so synthesizing one would",
                   "// send an unknown key. Stripping cache_control remains the correct behaviour.",
-                  "pm.test('62.8 no breakpoint is synthesized for a pre-5.6 model (#6180)', function () {",
+                  "pm.test('63.8 no breakpoint is synthesized for a pre-5.6 model (#6180)', function () {",
                   "  pm.expect(rawStr.indexOf('prompt_cache_breakpoint'), 'raw_request: ' + rawStr.slice(0, 800)).to.equal(-1);",
                   "});",
-                  "pm.test('62.8 no prompt_cache_options is added', function () {",
+                  "pm.test('63.8 no prompt_cache_options is added', function () {",
                   "  pm.expect(rawStr.indexOf('prompt_cache_options')).to.equal(-1);",
                   "});",
-                  "pm.test('62.8 cache_control is still stripped', function () {",
+                  "pm.test('63.8 cache_control is still stripped', function () {",
                   "  pm.expect(rawStr.indexOf('cache_control')).to.equal(-1);",
                   "});"
                 ]
@@ -141322,6 +141322,3112 @@
               ]
             }
           }
+        }
+      ]
+    },
+    {
+      "name": "64. Prompt cache injection configuration surface (#6180)",
+      "description": "Folder 63 covers the auto-inject toggle on Anthropic. This folder covers the rest of the provider Prompt Caching tab: the TTL select, the injection-points editor, and the two rules the panel states in prose but nothing asserted - markers the client sent are never modified, and models without explicit caching are left alone.\n\nWhy dedicated custom providers rather than headers: only auto_inject is overridable per request (x-bf-prompt-cache-auto-inject). TTL and injection points are config-only, and PromptCacheInjectionEnabled treats a configured point list as enabled REGARDLESS of the auto_inject flag - so putting points on the real anthropic provider would inject markers into every Anthropic request in the whole sweep. The *_pc_* providers in tests/integrations/python/config.json each carry one prompt_cache shape and are inert unless a case names them, so this folder has no blast radius on the others. Their names embed the base provider keyword so filter-collection routes them to the right partition.\n\nVertex, Azure and OpenRouter cannot be custom-provider bases (schemas.SupportedBaseProviders is a much shorter list than config.schema.json's base_provider_type enum), so those three instead carry an INERT prompt_cache opt-in on the real provider: auto_inject false plus a ttl, which PromptCacheInjectionEnabled treats as disabled until a request sends the header. Same shape as the anthropic opt-in folder 63 already relies on, and equally inert for every other request in the sweep.\n\nEvery case reads the OUTBOUND body via x-bf-send-back-raw-request, which requires client.allow_per_request_raw_override in that same config. A 2xx proves nothing about where a marker landed, which was the objection #6180 raised.\n\n  64.1 the TTL select, per dialect: carried inline (Anthropic, Vertex), carried on a standalone cachePoint block (Bedrock), or dropped because the dialect cannot express it (OpenAI/Azure gpt-5.6, OpenRouter Responses). Plus the absence-means-provider-default case.\n  64.2 injection-point semantics: role, index, negative index, role+index as an AND, out-of-range, the neither-role-nor-index no-op, points replacing auto-inject, the last-block rule, and the four-marker ceiling.\n  64.3 the same point set through every marker-capable dialect.\n  64.4 a conversation that GROWS between turns: the boundary holds and cached_tokens > 0 from turn 2, non-streaming and streaming - plus the deliberate counter-example that index -1 does not hold still.\n  64.5 a client that placed its own marker, in either dialect, is left alone.\n  64.6 configured-and-enabled providers whose MODEL cannot act on a marker, plus the provider with no prompt_cache block at all.\n  64.7 the drop-in and Responses routes, including the system hoist.\n\n[PREVIEW]-tagged cases need a gpt-5.6 Azure deployment and are skipped unless INCLUDE_PREVIEW=1.",
+      "item": [
+        {
+          "name": "64.1 Cache TTL x dialect",
+          "item": [
+            {
+              "name": "anthropic_pc_auto claude-sonnet-4-6 chat: configured ttl 1h rides the injected marker - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.1.1: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.1.1 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "pm.test('64.1.1 exactly one marker was injected', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
+                      "});",
+                      "pm.test('64.1.1 the marker anchors the first block, not the trailing question', function () {",
+                      "  pm.expect(marked.length, 'marked: ' + JSON.stringify(marked)).to.equal(1);",
+                      "  pm.expect(marked[0]).to.include('bf-63 ttl-anthropic');",
+                      "});",
+                      "pm.test('64.1.1 cache_control carries type ephemeral and the configured ttl', function () {",
+                      "  pm.expect(rawStr).to.include('\"type\":\"ephemeral\"');",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.include('\"ttl\":\"1h\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_auto/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 ttl-anthropic] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic claude-sonnet-4-6 chat: no configured ttl means no ttl on the wire - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.1.2: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.1.2 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "pm.test('64.1.2 exactly one marker was injected', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
+                      "});",
+                      "// \"Provider default (5 minutes)\" is expressed by the ABSENCE of ttl, not by an",
+                      "// explicit \"5m\": ValidatePromptCache rejects an empty string precisely so the two",
+                      "// stay distinguishable. A ttl appearing here would silently change the billing profile.",
+                      "pm.test('64.1.2 the provider default emits no ttl field at all', function () {",
+                      "  pm.expect(rawStr).to.include('\"type\":\"ephemeral\"');",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.not.include('\"ttl\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 ttl-default] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "vertex claude-sonnet-4-6 chat: ttl survives, scope is stripped - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.1.3: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.1.3 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "pm.test('64.1.3 exactly one marker was injected', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
+                      "  pm.expect(rawStr).to.include('\"ttl\":\"1h\"');",
+                      "});",
+                      "// Vertex's Anthropic surface rejects cache_control.scope. The injector writes a",
+                      "// neutral marker with no scope, and the Vertex serializer must not add one back.",
+                      "pm.test('64.1.3 cache_control.scope never reaches Vertex', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.not.include('\"scope\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"vertex/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 ttl-vertex] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "bedrock_pc_auto claude-haiku chat: marker becomes a standalone cachePoint block - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.1.4: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.1.4 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "pm.test('64.1.4 exactly one cachePoint was injected', function () {",
+                      "  pm.expect(cpCount, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
+                      "});",
+                      "pm.test('64.1.4 Bedrock never sees the cache_control spelling', function () {",
+                      "  pm.expect(rawStr).to.not.include('cache_control');",
+                      "});",
+                      "pm.test('64.1.4 the cachePoint carries the configured ttl', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.include('\"ttl\":\"1h\"');",
+                      "});",
+                      "// Converse has no per-block field: the marker is a SEPARATE block that closes the",
+                      "// cached prefix, so its position relative to the marked block is the whole meaning.",
+                      "var blocks = ((rr.messages || [{}])[0] || {}).content || [];",
+                      "var anchorIdx = -1;",
+                      "for (var i = 0; i < blocks.length; i++) { if (blocks[i] && typeof blocks[i].text === 'string' && blocks[i].text.indexOf('bf-63 ttl-bedrock') !== -1) { anchorIdx = i; } }",
+                      "pm.test('64.1.4 the cachePoint sits immediately after the marked block', function () {",
+                      "  pm.expect(anchorIdx, 'content blocks: ' + JSON.stringify(blocks).slice(0, 800)).to.be.above(-1);",
+                      "  pm.expect(blocks[anchorIdx + 1] && blocks[anchorIdx + 1].cachePoint, 'content blocks: ' + JSON.stringify(blocks).slice(0, 800)).to.be.an('object');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock_pc_auto/global.anthropic.claude-haiku-4-5-20251001-v1:0\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 ttl-bedrock] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "openai_pc_auto gpt-5.6-sol responses: injected marker becomes prompt_cache_breakpoint, ttl dropped - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.1.5: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.1.5 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.prompt_cache_breakpoint) { marked.push(String(v.text || '')); } return v; });",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "pm.test('64.1.5 exactly one breakpoint was injected', function () {",
+                      "  pm.expect(bpCount, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
+                      "});",
+                      "pm.test('64.1.5 the neutral marker is translated, never passed through', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.not.include('cache_control');",
+                      "});",
+                      "pm.test('64.1.5 explicit mode is switched on for the gpt-5.6 family', function () {",
+                      "  pm.expect(rawStr).to.include('prompt_cache_options');",
+                      "  pm.expect(rawStr).to.include('\"mode\":\"explicit\"');",
+                      "});",
+                      "// prompt_cache_breakpoint has nowhere to put a duration, so a configured ttl is",
+                      "// dropped rather than smuggled through as an unknown field the provider would 400 on.",
+                      "pm.test('64.1.5 the configured ttl is dropped, not forwarded', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.not.include('\"ttl\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"openai_pc_auto/gpt-5.6-sol\",\n  \"max_output_tokens\": 512,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 ttl-63-1-5] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "[PREVIEW] azure gpt-5.6-sol deployments responses: same translation as OpenAI - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.1.6: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.1.6 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.prompt_cache_breakpoint) { marked.push(String(v.text || '')); } return v; });",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "pm.test('64.1.6 exactly one breakpoint was injected', function () {",
+                      "  pm.expect(bpCount, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
+                      "});",
+                      "pm.test('64.1.6 the neutral marker is translated, never passed through', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.not.include('cache_control');",
+                      "});",
+                      "pm.test('64.1.6 explicit mode is switched on for the gpt-5.6 family', function () {",
+                      "  pm.expect(rawStr).to.include('prompt_cache_options');",
+                      "  pm.expect(rawStr).to.include('\"mode\":\"explicit\"');",
+                      "});",
+                      "// prompt_cache_breakpoint has nowhere to put a duration, so a configured ttl is",
+                      "// dropped rather than smuggled through as an unknown field the provider would 400 on.",
+                      "pm.test('64.1.6 the configured ttl is dropped, not forwarded', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.not.include('\"ttl\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"azure/gpt-5.6-sol\",\n  \"max_output_tokens\": 512,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 ttl-63-1-6] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "openrouter claude-sonnet-4 responses: injected marker becomes prompt_cache_breakpoint - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.1.7: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.1.7 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.prompt_cache_breakpoint) { marked.push(String(v.text || '')); } return v; });",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "pm.test('64.1.7 exactly one breakpoint was injected', function () {",
+                      "  pm.expect(bpCount, 'raw_request: ' + rawStr.slice(0, 800)).to.equal(1);",
+                      "});",
+                      "// #6290: cache_control on the OpenRouter Responses path is a 400. The injected",
+                      "// marker goes through the same translation as a client-sent one.",
+                      "pm.test('64.1.7 cache_control never reaches the OpenRouter Responses wire', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 800)).to.not.include('cache_control');",
+                      "  pm.expect(rawStr).to.not.include('\"ttl\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"openrouter/anthropic/claude-sonnet-4\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 ttl-openrouter] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "The TTL select in the provider Prompt Caching tab. Only \"1h\" is an explicit value; omitting ttl asks for the provider default. Each dialect carries it differently, and two cannot carry it at all - the panel says so (\"Providers that cannot carry a TTL ignore this\"), so that is asserted rather than assumed."
+        },
+        {
+          "name": "64.2 Injection point semantics",
+          "item": [
+            {
+              "name": "anthropic_pc_points claude-sonnet-4-6 chat: role matches every message of that role, index matches one - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.2.1: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.2.1 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "pm.test('64.2.1 role-only matched BOTH system messages and index 2 matched one more', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(3);",
+                      "  pm.expect(markedStr).to.include('pt-sys-a-last');",
+                      "  pm.expect(markedStr).to.include('pt-sys-b');",
+                      "  pm.expect(markedStr).to.include('pt-idx2');",
+                      "});",
+                      "pm.test('64.2.1 a point marks the LAST cacheable block of its message, not the first', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('pt-sys-a-first');",
+                      "});",
+                      "pm.test('64.2.1 no point matched the newest message', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('pt-newest');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_points/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 pt-sys-a-first] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 pt-sys-a-last] Answer in one word.\"\n        }\n      ]\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 pt-sys-b] Never apologize.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 pt-idx2] Is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 pt-newest] And is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_points claude-sonnet-4-6 chat: configured points replace auto-inject rather than adding to it - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.2.2: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.2.2 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "pm.test('64.2.2 role-only matched BOTH system messages and index 2 matched one more', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(3);",
+                      "  pm.expect(markedStr).to.include('pt-sys-a-last');",
+                      "  pm.expect(markedStr).to.include('pt-sys-b');",
+                      "  pm.expect(markedStr).to.include('pt-idx2');",
+                      "});",
+                      "pm.test('64.2.2 a point marks the LAST cacheable block of its message, not the first', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('pt-sys-a-first');",
+                      "});",
+                      "pm.test('64.2.2 no point matched the newest message', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('pt-newest');",
+                      "});",
+                      "// auto_inject is forced ON for this request while points are configured. Its default",
+                      "// strategy would mark message 0 block 0 (pt-sys-a-first) - a block the point strategy",
+                      "// leaves alone. Its absence above is the proof that points replaced the default",
+                      "// instead of stacking on top of it and spending a fourth of the budget unasked.",
+                      "pm.test('64.2.2 auto-inject added no marker of its own on top of the points', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(3);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_points/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 pt-sys-a-first] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 pt-sys-a-last] Answer in one word.\"\n        }\n      ]\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 pt-sys-b] Never apologize.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 pt-idx2] Is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 pt-newest] And is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_points claude-sonnet-4-6 responses: the same point set resolves on the Responses injector - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.2.3: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.2.3 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// InjectResponsesCacheBreakpoints is a separate function from the Chat one; the two",
+                      "// walk different message types and have drifted apart before.",
+                      "pm.test('64.2.3 three markers, the same three positions as the Chat path', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(3);",
+                      "  pm.expect(markedStr).to.include('rp-sys-a-last');",
+                      "  pm.expect(markedStr).to.include('rp-sys-b');",
+                      "  pm.expect(markedStr).to.include('rp-idx2');",
+                      "});",
+                      "pm.test('64.2.3 last cacheable block, not the first', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('rp-sys-a-first');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_points/claude-sonnet-4-6\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"system\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 rp-sys-a-first] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 rp-sys-a-last] Answer in one word.\"\n        }\n      ]\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 rp-sys-b] Never apologize.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 rp-idx2] Is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 rp-newest] And is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_edge claude-sonnet-4-6 chat: negative index, role+index AND, and the two points that match nothing - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.2.4: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.2.4 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// Four points are configured. Two must resolve and two must not.",
+                      "pm.test('64.2.4 index -1 resolved from the end of the conversation', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('ed-last');",
+                      "});",
+                      "pm.test('64.2.4 role user + index 1 matched, because message 1 really is a user turn', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('ed-idx1-user');",
+                      "});",
+                      "// index 99 is out of range and a point with neither role nor index is a no-op. Both",
+                      "// are silent by design, so only the exact total can show they stayed silent: a",
+                      "// clamped index 99 would land on ed-last (already counted) or ed-sys, and a",
+                      "// match-everything reading of the empty point would mark all four messages.",
+                      "pm.test('64.2.4 exactly two markers - out-of-range does not clamp, empty does not match all', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(2);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('ed-sys');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_edge/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 ed-sys] Answer in one word.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 ed-idx1-user] Hello.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Hi.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 ed-last] Is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_edge claude-sonnet-4-6 chat: role+index contributes nothing when the role at that index disagrees - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.2.5: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.2.5 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// Same provider, same four points. Message 1 is now a system turn, so the",
+                      "// {role: user, index: 1} point matches nothing: role and index are an AND, not a",
+                      "// fallback chain. Reading it as OR would mark every user message here.",
+                      "pm.test('64.2.5 only the negative-index point resolved', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(1);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('em-last');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('em-sys-b');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_edge/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 em-sys-a] Answer in one word.\"\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 em-sys-b] Never apologize.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 em-last] Is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_overflow claude-sonnet-4-6 chat: six matching points still emit only four markers - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.2.6: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.2.6 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// Anthropic answers a fifth marker with \"A maximum of 4 blocks with cache_control",
+                      "// may be provided. Found 5.\" - so the 2xx above is itself half the assertion.",
+                      "pm.test('64.2.6 the four-marker ceiling holds', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(4);",
+                      "});",
+                      "// The injector stops at four rather than emitting six and letting the per-provider",
+                      "// clamp trim them: the clamp drops the EARLIEST marker, so overshooting here would",
+                      "// silently discard the points the operator listed first.",
+                      "pm.test('64.2.6 the surviving four are the first four points, in config order', function () {",
+                      "  pm.expect(markedStr).to.include('of-0');",
+                      "  pm.expect(markedStr).to.include('of-1');",
+                      "  pm.expect(markedStr).to.include('of-2');",
+                      "  pm.expect(markedStr).to.include('of-3');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('of-4');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('of-5');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_overflow/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 of-0] Answer in one word.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 of-1] Hello.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"[bf-63 of-2] Hi.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 of-3] Still there?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"[bf-63 of-4] Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 of-5] Is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "The Injection points editor. Every rule the panel states, and every rule the editor cannot state, asserted on the outbound body:\n  role only matches EVERY message with that role, index only matches one, both is an AND.\n  A negative index counts from the end. An out-of-range index matches nothing rather\n  than clamping onto a neighbouring message, and a point with neither role nor index\n  matches nothing rather than matching everything.\n  Points REPLACE the default strategy - the panel says so, and 64.2.2 proves it by\n  turning auto-inject on at the same time and showing the default marker is still absent.\n  A point marks the LAST cacheable block of its message (cache through to its end),\n  the inverse of auto-inject's first-block prefix boundary.\n  At most four markers, matching the provider ceiling."
+        },
+        {
+          "name": "64.3 Injection points x dialect",
+          "item": [
+            {
+              "name": "bedrock_pc_points claude-haiku chat: points render as standalone cachePoint blocks - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.3.1: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.3.1 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "pm.test('64.3.1 three cachePoints on the Converse wire', function () {",
+                      "  pm.expect(cpCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(3);",
+                      "  pm.expect(rawStr).to.not.include('cache_control');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock_pc_points/global.anthropic.claude-haiku-4-5-20251001-v1:0\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 pt-sys-a-first] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 pt-sys-a-last] Answer in one word.\"\n        }\n      ]\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 pt-sys-b] Never apologize.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 pt-idx2] Is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 pt-newest] And is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "openai_pc_points gpt-5.6-sol responses: points render as prompt_cache_breakpoint - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.3.2: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.3.2 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.prompt_cache_breakpoint) { marked.push(String(v.text || '')); } return v; });",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "pm.test('64.3.2 three point breakpoints on the Responses wire', function () {",
+                      "  pm.expect(bpCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(3);",
+                      "  pm.expect(markedStr).to.include('rp-sys-a-last');",
+                      "  pm.expect(markedStr).to.include('rp-idx2');",
+                      "  pm.expect(rawStr).to.not.include('cache_control');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"openai_pc_points/gpt-5.6-sol\",\n  \"max_output_tokens\": 512,\n  \"input\": [\n    {\n      \"role\": \"system\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 rp-sys-a-first] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 rp-sys-a-last] Answer in one word.\"\n        }\n      ]\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 rp-sys-b] Never apologize.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 rp-idx2] Is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 rp-newest] And is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "The injector is dialect-independent - it writes one neutral schemas.CacheControl - but each provider serializer renders it differently and each has its own four-marker clamp. One request per dialect with the same point set, asserting the three point-selected positions survive translation.\n\nOnly Bedrock and OpenAI appear here, and the reason is a real constraint rather than a gap in ambition: injection points are config-only, config-only means a dedicated custom provider, and schemas.SupportedBaseProviders admits just anthropic, bedrock, cohere, gemini, openai, huggingface and replicate as custom bases - a gateway boot rejects a vertex/azure/openrouter base with \"unsupported base_provider_type\" even though config.schema.json's enum lists all three. Those dialects are covered in 64.1 instead, where auto_inject is reachable by header. Little is lost: which BLOCK a point selects is dialect-independent injector logic, already pinned in 64.2, and how a written marker renders per dialect is what 64.1 asserts."
+        },
+        {
+          "name": "64.4 Multi-turn stability",
+          "item": [
+            {
+              "name": "anthropic claude-sonnet-4-6 chat multi-turn turn 1 [write]: the marker anchors the replayed prefix - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.1: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.4.1 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "pm.test('64.4.1 exactly one marker, on the system prefix', function () {",
+                      "  pm.expect(ccCount, 'raw_request head: ' + rawStr.slice(0, 400)).to.equal(1);",
+                      "  pm.expect(marked.length).to.equal(1);",
+                      "  pm.expect(marked[0].indexOf('[bf-63 mt ')).to.be.above(-1);",
+                      "});",
+                      "// Turns 2 and 3 compare against this. A 60-char tail is enough to prove byte",
+                      "// identity of the boundary without carrying 23KB through a collection variable.",
+                      "pm.collectionVariables.unset('pcMarkedTail63');",
+                      "if (marked.length === 1) { pm.collectionVariables.set('pcMarkedTail63', marked[0].slice(-60)); }",
+                      "// Republishing the nonce is what keeps turns 2 and 3 in this newman process.",
+                      "pm.collectionVariables.set('mtSeed63', String(pm.collectionVariables.get('pcNonce') || ''));"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"{{cachePrefix}} [bf-63 mt {{pcNonce}} prefix]\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic claude-sonnet-4-6 chat multi-turn turn 2 [read]: conversation grew, the cached boundary did not move - #6180",
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Let the breakpoint written by the previous turn land before this read.",
+                      "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait */ }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.2: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.4.2 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "pm.test('64.4.2 exactly one marker, still on the replayed prefix', function () {",
+                      "  pm.expect(ccCount, 'raw_request head: ' + rawStr.slice(0, 400)).to.equal(1);",
+                      "  pm.expect(marked.length).to.equal(1);",
+                      "  pm.expect(marked[0].indexOf('[bf-63 mt '), 'the marker left the stable prefix').to.be.above(-1);",
+                      "});",
+                      "// The failure #6180 reported is the marker sliding onto the newest message, which",
+                      "// re-bills a cache write every turn. Naming the newest text explicitly catches that",
+                      "// even if the marker count happens to stay at one.",
+                      "var first = marked.length ? marked[0] : '';",
+                      "pm.test('64.4.2 the marker did not slide onto the newest message', function () {",
+                      "  pm.expect(first, 'marked: ' + first.slice(-120)).to.not.include('grass');",
+                      "  pm.expect(first).to.not.include('snow');",
+                      "});",
+                      "var expectedTail = pm.collectionVariables.get('pcMarkedTail63');",
+                      "if (expectedTail && marked.length) {",
+                      "  pm.test('64.4.2 byte-identical to the block turn 1 marked', function () {",
+                      "    pm.expect(first.slice(-60)).to.equal(expectedTail);",
+                      "  });",
+                      "}",
+                      "var u2 = body.usage || {};",
+                      "var d2 = u2.input_tokens_details || u2.prompt_tokens_details || {};",
+                      "var cached = (typeof d2.cached_tokens === 'number') ? d2.cached_tokens : 0;",
+                      "pm.test('64.4.2 cached_tokens > 0 - the grown turn was a real cache read', function () {",
+                      "  pm.expect(cached, 'usage: ' + JSON.stringify(u2)).to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"{{cachePrefix}} [bf-63 mt {{mtSeed63}} prefix]\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic claude-sonnet-4-6 chat multi-turn turn 3 [read]: still the same boundary two turns later - #6180",
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Let the breakpoint written by the previous turn land before this read.",
+                      "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait */ }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.3: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.4.3 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "pm.test('64.4.3 exactly one marker, still on the replayed prefix', function () {",
+                      "  pm.expect(ccCount, 'raw_request head: ' + rawStr.slice(0, 400)).to.equal(1);",
+                      "  pm.expect(marked.length).to.equal(1);",
+                      "  pm.expect(marked[0].indexOf('[bf-63 mt '), 'the marker left the stable prefix').to.be.above(-1);",
+                      "});",
+                      "// The failure #6180 reported is the marker sliding onto the newest message, which",
+                      "// re-bills a cache write every turn. Naming the newest text explicitly catches that",
+                      "// even if the marker count happens to stay at one.",
+                      "var first = marked.length ? marked[0] : '';",
+                      "pm.test('64.4.3 the marker did not slide onto the newest message', function () {",
+                      "  pm.expect(first, 'marked: ' + first.slice(-120)).to.not.include('grass');",
+                      "  pm.expect(first).to.not.include('snow');",
+                      "});",
+                      "var expectedTail = pm.collectionVariables.get('pcMarkedTail63');",
+                      "if (expectedTail && marked.length) {",
+                      "  pm.test('64.4.3 byte-identical to the block turn 1 marked', function () {",
+                      "    pm.expect(first.slice(-60)).to.equal(expectedTail);",
+                      "  });",
+                      "}",
+                      "var u2 = body.usage || {};",
+                      "var d2 = u2.input_tokens_details || u2.prompt_tokens_details || {};",
+                      "var cached = (typeof d2.cached_tokens === 'number') ? d2.cached_tokens : 0;",
+                      "pm.test('64.4.3 cached_tokens > 0 - the grown turn was a real cache read', function () {",
+                      "  pm.expect(cached, 'usage: ' + JSON.stringify(u2)).to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"{{cachePrefix}} [bf-63 mt {{mtSeed63}} prefix]\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is grass green?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is snow white?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic claude-sonnet-4-6 responses multi-turn streaming turn 1 [write]: seeds the cached prefix - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.4: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "// The paired [read] below needs a write in the SAME newman process: --class puts",
+                      "// streaming rows in their own shard and {{pcNonce}} is minted per process, so this",
+                      "// pair cannot borrow the write from the non-streaming turns above.",
+                      "var raw = pm.response.text() || '';",
+                      "pm.test('64.4.4 the stream produced events', function () {",
+                      "  pm.expect(raw, 'body: ' + raw.slice(0, 300)).to.include('data:');",
+                      "});",
+                      "pm.collectionVariables.set('mtsSeed63', String(pm.collectionVariables.get('pcNonce') || ''));"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"{{cachePrefix}} [bf-63 mts {{pcNonce}} prefix]\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is the sky blue?\"\n    }\n  ],\n  \"stream\": true\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic claude-sonnet-4-6 responses multi-turn streaming turn 2 [read]: the grown turn reads the cache - #6180",
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Let the breakpoint written by the previous turn land before this read.",
+                      "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait */ }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.5: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "// SSE bodies carry no extra_fields, so this asserts on the stream text: the",
+                      "// streaming handler has its own injection call site and can regress independently.",
+                      "var raw = pm.response.text() || '';",
+                      "var m = raw.match(/\"cached_tokens\"\\s*:\\s*(\\d+)/g) || [];",
+                      "var cached = 0;",
+                      "for (var i = 0; i < m.length; i++) { var v = parseInt(m[i].replace(/[^0-9]/g, ''), 10); if (v > cached) { cached = v; } }",
+                      "pm.test('64.4.5 streaming: cached_tokens > 0 on the grown conversation', function () {",
+                      "  pm.expect(cached, 'no cached_tokens in the stream; tail: ' + raw.slice(-600)).to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"{{cachePrefix}} [bf-63 mts {{mtsSeed63}} prefix]\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is grass green?\"\n    }\n  ],\n  \"stream\": true\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_edge claude-sonnet-4-6 chat: index -1 on a two-message turn marks that turn's newest message - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.6: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.4.6 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// n = 2 here, so index -1 and {role: user, index: 1} both resolve to message 1.",
+                      "// One marker, not two: targets are deduplicated by message.",
+                      "pm.test('64.4.6 two points resolving to one message produce one marker', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(1);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('ni-turn1');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_edge/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 ni-sys] Answer in one word.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 ni-turn1] Is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_edge claude-sonnet-4-6 chat: index -1 follows the newest message when the conversation grows - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.7: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.4.7 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// Same provider, same points, two more messages. The negative-index point has moved",
+                      "// to ni-turn2 while the positive-index point stayed on ni-turn1. This is the",
+                      "// documented cost of index -1: it does NOT hold the cached prefix still, which is",
+                      "// exactly why auto-inject targets the first block instead. Asserted so nobody",
+                      "// 'fixes' index -1 into stability and quietly changes what operators configured.",
+                      "pm.test('64.4.7 the negative index moved with the newest message', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('ni-turn2');",
+                      "});",
+                      "pm.test('64.4.7 the positive index stayed where it was', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(2);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('ni-turn1');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_edge/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-63 ni-sys] Answer in one word.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 ni-turn1] Is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 ni-turn2] Is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "bedrock_pc_auto claude-haiku chat multi-turn turn 1 [write]: one cachePoint on the prefix - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.8: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.4.8 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "pm.test('64.4.8 exactly one cachePoint was injected', function () {",
+                      "  pm.expect(cpCount, 'raw_request head: ' + rawStr.slice(0, 400)).to.equal(1);",
+                      "});",
+                      "pm.collectionVariables.set('mtbSeed63', String(pm.collectionVariables.get('pcNonce') || ''));"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock_pc_auto/global.anthropic.claude-haiku-4-5-20251001-v1:0\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"{{cachePrefix}} [bf-63 mtb {{pcNonce}} prefix]\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "bedrock_pc_auto claude-haiku chat multi-turn turn 2 [read]: the stable prefix survives Converse translation - #6180",
+              "event": [
+                {
+                  "listen": "prerequest",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "// Let the breakpoint written by the previous turn land before this read.",
+                      "var __t = Date.now(); while (Date.now() - __t < 2000) { /* busy-wait */ }"
+                    ]
+                  }
+                },
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.4.9: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.4.9 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "pm.test('64.4.9 still exactly one cachePoint after the conversation grew', function () {",
+                      "  pm.expect(cpCount, 'raw_request head: ' + rawStr.slice(0, 400)).to.equal(1);",
+                      "});",
+                      "var u2 = body.usage || {};",
+                      "var d2 = u2.input_tokens_details || u2.prompt_tokens_details || {};",
+                      "var cached = (typeof d2.cached_tokens === 'number') ? d2.cached_tokens : 0;",
+                      "pm.test('64.4.9 cached_tokens > 0 - Bedrock read the cache the injector wrote', function () {",
+                      "  pm.expect(cached, 'usage: ' + JSON.stringify(u2)).to.be.above(0);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock_pc_auto/global.anthropic.claude-haiku-4-5-20251001-v1:0\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": \"{{cachePrefix}} [bf-63 mtb {{mtbSeed63}} prefix]\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Answer in one short word: is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "The reason the feature exists. An agent loop replays a growing transcript; the panel promises the cached region stays put so \"turn 2 onward is a cache read\".\n\n64.4.1-64.4.3 walk a conversation that GROWS between turns (unlike folder 63's identical pair, which cannot tell a stable boundary from a lucky one) and assert both halves: the marker lands on the same text every turn, AND cached_tokens > 0 from turn 2. A 2xx proves neither.\n\n64.4.6/64.4.7 pin the opposite, on purpose: an injection point with index -1 tracks the newest message and therefore does NOT hold still across turns. That is the documented trade-off of a negative index and the exact behaviour auto-inject exists to avoid, so it is asserted rather than left to a reader's assumption.\n\nUses {{cachePrefix}} (well over the 1024-token minimum for claude-sonnet-4-6) and the collection-level {{pcNonce}} for per-run cache isolation."
+        },
+        {
+          "name": "64.5 Requests that already carry markers are never modified",
+          "item": [
+            {
+              "name": "anthropic claude-sonnet-4-6 responses: a client-placed cache_control is left exactly where the client put it - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.5.1: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.5.1 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// auto_inject is forced on. Its default target is own-first (the first cacheable",
+                      "// block). The client chose own-second. Two markers here would mean Bifrost spent a",
+                      "// second checkpoint out of a budget of four that the caller was already managing.",
+                      "pm.test('64.5.1 exactly one marker, the client\\'s own', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1000)).to.equal(1);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('own-second');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('own-first');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 own-first] Manual section one.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 own-second] Manual section two.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic claude-sonnet-4-6 responses: a prompt_cache_breakpoint counts as the client speaking too - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.5.2: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.5.2 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "// The caller expressed caching intent in the OTHER dialect. Anthropic's serializer",
+                      "// ignores prompt_cache_breakpoint, so if the injector had failed to recognise it as a",
+                      "// marker it would have added a cache_control of its own and silently overridden the",
+                      "// caller's placement. An empty wire is the proof it stood down.",
+                      "pm.test('64.5.2 nothing was injected on top of the client\\'s breakpoint', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 1000)).to.not.include('cache_control');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic/claude-sonnet-4-6\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 bp-first] Manual section one.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 bp-second] Manual section two.\",\n          \"prompt_cache_breakpoint\": {\n            \"mode\": \"explicit\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_points claude-sonnet-4-6 responses: configured points stand down for a client marker as well - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.5.3: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.5.3 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// The {role: system} point would have matched pp-sys. Explicit operator configuration",
+                      "// does not outrank an explicit caller: the same whole-request check guards both",
+                      "// strategies, so a points-configured provider is not a back door around it.",
+                      "pm.test('64.5.3 the configured point did not fire', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1000)).to.equal(1);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('pp-own');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('pp-sys');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_points/claude-sonnet-4-6\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"system\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 pp-sys] Answer in one word.\"\n        }\n      ]\n    },\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 pp-own] Is the sky blue?\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "openai_pc_auto gpt-5.6-sol responses: a client marker survives untouched through the breakpoint translation - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.5.4: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.5.4 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.prompt_cache_breakpoint) { marked.push(String(v.text || '')); } return v; });",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "pm.test('64.5.4 exactly one breakpoint, translated from the client\\'s own marker', function () {",
+                      "  pm.expect(bpCount, 'raw_request: ' + rawStr.slice(0, 1000)).to.equal(1);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('own-second');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('own-first');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"openai_pc_auto/gpt-5.6-sol\",\n  \"max_output_tokens\": 512,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 own-first] Manual section one.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 own-second] Manual section two.\",\n          \"cache_control\": {\n            \"type\": \"ephemeral\"\n          }\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Reply with OK.\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "The panel's promise: \"Requests that already carry their own cache markers are never modified.\" Injection is a default for clients that say nothing, not an override of a client that spoke. The check is whole-request, not per-message: one marker anywhere - in EITHER dialect - stands the injector down entirely, points included."
+        },
+        {
+          "name": "64.6 Capability and opt-in gates",
+          "item": [
+            {
+              "name": "gemini_pc_auto gemini-2.5-pro chat: an implicit-caching model is left alone despite auto-inject being on - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.6.1: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.6.1 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "// Gemini caches implicitly and has no per-block marker to act on. auto_inject is true in this provider's config.",
+                      "pm.test('64.6.1 no cache markers of any dialect reached the wire', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 900)).to.not.include('cache_control');",
+                      "  pm.expect(rawStr).to.not.include('cachePoint');",
+                      "  pm.expect(rawStr).to.not.include('prompt_cache_breakpoint');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"gemini_pc_auto/{{genaiModel}}\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 gate-63-6-1] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "vertex gemini-2.5-pro chat: on Vertex only Claude is marker-capable, not Gemini - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.6.2: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.6.2 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "// Same provider and same header that DO inject for vertex Claude in 64.1.3 - the gate is per model, not per provider.",
+                      "pm.test('64.6.2 no cache markers of any dialect reached the wire', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 900)).to.not.include('cache_control');",
+                      "  pm.expect(rawStr).to.not.include('cachePoint');",
+                      "  pm.expect(rawStr).to.not.include('prompt_cache_breakpoint');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"vertex/{{vertexModel}}\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 gate-63-6-2] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "azure gpt-4o deployments chat: pre-5.6 OpenAI-family models gain no cache fields - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.6.3: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.6.3 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "// Explicit breakpoints are a gpt-5.6-family capability; gpt-4o caches implicitly.",
+                      "pm.test('64.6.3 no cache markers of any dialect reached the wire', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 900)).to.not.include('cache_control');",
+                      "  pm.expect(rawStr).to.not.include('cachePoint');",
+                      "  pm.expect(rawStr).to.not.include('prompt_cache_breakpoint');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"azure/{{azureDeployment}}\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 gate-63-6-3] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_absent claude-sonnet-4-6 chat: the header cannot manufacture an opt-in the operator never gave - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.6.4: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.6.4 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "// A marker-capable model on a provider with no prompt_cache block at all. The header is sent as true anyway.",
+                      "pm.test('64.6.4 no cache markers of any dialect reached the wire', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 900)).to.not.include('cache_control');",
+                      "  pm.expect(rawStr).to.not.include('cachePoint');",
+                      "  pm.expect(rawStr).to.not.include('prompt_cache_breakpoint');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-prompt-cache-auto-inject",
+                    "value": "true"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_absent/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-63 gate-63-6-4] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "\"Models without explicit caching are left alone.\" Each case runs a provider whose prompt_cache is fully configured and switched ON, so a marker appearing would be a real regression rather than a missing opt-in - the two are easy to confuse, and only a configured-but-ineligible provider tells them apart.\n\n64.6.4 is the inverse: opt-in configured NOWHERE, auto-inject demanded by header. The header flips auto_inject in both directions but must never manufacture the opt-in itself, because spending a cache checkpoint changes the billing profile of a provider whose operator expressed no opinion."
+        },
+        {
+          "name": "64.7 Injection across request routes",
+          "item": [
+            {
+              "name": "anthropic_pc_auto claude-sonnet-4-6 /anthropic/v1/messages: the marker rides the system hoist - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.7.1: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.7.1 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "pm.test('64.7.1 exactly one marker, on the system prefix', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1000)).to.equal(1);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('dropin-sys');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('dropin-user');",
+                      "});",
+                      "// A bare system string has nowhere to hang a marker, so it must arrive as a block",
+                      "// array. If system came back as a plain string the marker was dropped in the hoist.",
+                      "pm.test('64.7.1 system arrives as marked content blocks, not a bare string', function () {",
+                      "  pm.expect(rr.system, 'system: ' + JSON.stringify(rr.system).slice(0, 500)).to.be.an('array');",
+                      "  pm.expect(JSON.stringify(rr.system)).to.include('cache_control');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_auto/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"system\": \"[bf-63 dropin-sys] You are a meticulous assistant. Answer in one word.\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 dropin-user] Is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/messages",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "messages"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_auto claude-sonnet-4-6 responses: the Responses injector call site - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.7.2: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.7.2 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "pm.test('64.7.2 exactly one marker with the configured ttl', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 900)).to.equal(1);",
+                      "  pm.expect(marked.length, 'marked: ' + JSON.stringify(marked)).to.equal(1);",
+                      "  pm.expect(marked[0]).to.include('bf-63 route-responses');",
+                      "  pm.expect(rawStr).to.include('\"ttl\":\"1h\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_auto/claude-sonnet-4-6\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-63 route-responses] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic_pc_points claude-sonnet-4-6 /anthropic/v1/messages: points resolve against the converted transcript - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.7.3: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.7.3 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && v.cache_control) { marked.push(String(v.text || '')); } return v; });",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var markedStr = marked.join(' || ');",
+                      "// The drop-in's top-level system becomes message 0 of the neutral transcript, so",
+                      "// index 2 names the assistant turn - indices are counted after conversion, not over",
+                      "// the messages array the caller sent.",
+                      "pm.test('64.7.3 the system point and the index-2 point both resolved', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1000)).to.equal(2);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('dp-sys');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('dp-a1');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('dp-u2');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_points/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"system\": \"[bf-63 dp-sys] You are a meticulous assistant. Answer in one word.\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 dp-u1] Hello.\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"[bf-63 dp-a1] Hi.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-63 dp-u2] Is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/messages",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "messages"
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "Injection is called from four places in the dispatch path (chat, responses, and their converted variants) and each drop-in route reaches a different one. The /anthropic/v1/messages cases matter most: that is the Claude Code route, and the marked leading system message is HOISTED into Anthropic's top-level system[] on the way out, so the marker has to survive a move between containers."
+        },
+        {
+          "name": "64.8 Criss-cross: injection survives dialect conversion",
+          "item": [
+            {
+              "name": "openai drop-in <- anthropic_pc_auto claude-sonnet-4-6 chat: injection survives the dialect conversion - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.1: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.1 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && (v.cache_control || v.prompt_cache_breakpoint)) { marked.push(String(v.text || '')); } return v; });",
+                      "var markedStr = marked.join(' || ');",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "// The request arrived in the OpenAI dialect. Injection runs on the neutral request",
+                      "// at dispatch, AFTER the inbound dialect has been parsed away, so the marker must",
+                      "// come out in the TARGET's dialect - not the one the caller happened to speak.",
+                      "pm.test('64.8.1 exactly one marker, in Anthropic dialect', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 900)).to.equal(1);",
+                      "  pm.expect(bpCount, 'the OpenAI spelling must not leak onto an Anthropic wire').to.equal(0);",
+                      "});",
+                      "pm.test('64.8.1 the marker anchors the first block and carries the configured ttl', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('bf-64 cx-openai-chat');",
+                      "  pm.expect(rawStr).to.include('\"ttl\":\"1h\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_auto/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-64 cx-openai-chat] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/openai/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "openai",
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "openai drop-in <- anthropic_pc_auto claude-sonnet-4-6 responses: the converted Responses path injects too - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.2: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.2 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && (v.cache_control || v.prompt_cache_breakpoint)) { marked.push(String(v.text || '')); } return v; });",
+                      "var markedStr = marked.join(' || ');",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "// A different injector (InjectResponsesCacheBreakpoints) and a different dispatch",
+                      "// call site from 64.8.1, reached through the same drop-in host.",
+                      "pm.test('64.8.2 exactly one Anthropic-dialect marker with the configured ttl', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 900)).to.equal(1);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('bf-64 cx-openai-resp');",
+                      "  pm.expect(rawStr).to.include('\"ttl\":\"1h\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_auto/claude-sonnet-4-6\",\n  \"max_output_tokens\": 16,\n  \"input\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"input_text\",\n          \"text\": \"[bf-64 cx-openai-resp] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"input_text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/openai/v1/responses",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "openai",
+                    "v1",
+                    "responses"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "openai drop-in <- anthropic_pc_points claude-sonnet-4-6 chat: points index the CONVERTED transcript - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.3: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.3 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && (v.cache_control || v.prompt_cache_breakpoint)) { marked.push(String(v.text || '')); } return v; });",
+                      "var markedStr = marked.join(' || ');",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "// An injection point names a position in the neutral transcript, not in whatever",
+                      "// the caller sent. Identical placement to the same point set on /v1/chat/completions",
+                      "// is the assertion: role/index resolution must not shift because the request came",
+                      "// in through a different dialect.",
+                      "pm.test('64.8.3 the same three point positions resolve as on the native route', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 1200)).to.equal(3);",
+                      "  pm.expect(markedStr).to.include('cx-sys-last');",
+                      "  pm.expect(markedStr).to.include('cx-sys-b');",
+                      "  pm.expect(markedStr).to.include('cx-idx2');",
+                      "});",
+                      "pm.test('64.8.3 last cacheable block, and nothing on the newest message', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('cx-sys-first');",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.not.include('cx-newest');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_points/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"system\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-64 cx-sys-first] You are a meticulous assistant.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-64 cx-sys-last] Answer in one word.\"\n        }\n      ]\n    },\n    {\n      \"role\": \"system\",\n      \"content\": \"[bf-64 cx-sys-b] Never apologize.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-64 cx-idx2] Is the sky blue?\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Yes.\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-64 cx-newest] And is grass green?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/openai/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "openai",
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "openai drop-in <- bedrock_pc_auto claude-haiku chat: OpenAI dialect in, Converse cachePoint out - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.4: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.4 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && (v.cache_control || v.prompt_cache_breakpoint)) { marked.push(String(v.text || '')); } return v; });",
+                      "var markedStr = marked.join(' || ');",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "// The widest gap between the two dialects: an inline per-block field on the way in,",
+                      "// a standalone block on the way out. Neither the inbound nor the outbound spelling",
+                      "// may leak into the other.",
+                      "pm.test('64.8.4 the marker is re-rendered as a Converse cachePoint', function () {",
+                      "  pm.expect(cpCount, 'raw_request: ' + rawStr.slice(0, 900)).to.equal(1);",
+                      "  pm.expect(ccCount, 'cache_control must not reach Bedrock').to.equal(0);",
+                      "  pm.expect(bpCount, 'the OpenAI spelling must not reach Bedrock').to.equal(0);",
+                      "  pm.expect(rawStr).to.include('\"ttl\":\"1h\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"bedrock_pc_auto/global.anthropic.claude-haiku-4-5-20251001-v1:0\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-64 cx-bedrock] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/openai/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "openai",
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "anthropic drop-in <- openai_pc_auto gpt-5.6-sol messages: Anthropic dialect in, prompt_cache_breakpoint out - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.5: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.5 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && (v.cache_control || v.prompt_cache_breakpoint)) { marked.push(String(v.text || '')); } return v; });",
+                      "var markedStr = marked.join(' || ');",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "// The conversion running the other way - this is the Claude Code route pointed at a",
+                      "// gpt-5.6 model. Until the base-provider fix in this branch a custom OpenAI provider",
+                      "// fell into the serializer's default branch here: cache_control stripped, nothing put",
+                      "// in its place, and the request silently back on implicit caching.",
+                      "pm.test('64.8.5 the marker is re-rendered as an OpenAI breakpoint', function () {",
+                      "  pm.expect(bpCount, 'raw_request: ' + rawStr.slice(0, 900)).to.equal(1);",
+                      "  pm.expect(ccCount, 'the Anthropic spelling must not reach OpenAI').to.equal(0);",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('bf-64 cx-rev-sys');",
+                      "});",
+                      "pm.test('64.8.5 explicit mode is switched on, or the breakpoint is inert', function () {",
+                      "  pm.expect(rawStr).to.include('prompt_cache_options');",
+                      "  pm.expect(rawStr).to.include('\"mode\":\"explicit\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"openai_pc_auto/gpt-5.6-sol\",\n  \"max_tokens\": 512,\n  \"system\": \"[bf-64 cx-rev-sys] You are a meticulous assistant. Answer in one word.\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"[bf-64 cx-rev-user] Is the sky blue?\"\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/anthropic/v1/messages",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "anthropic",
+                    "v1",
+                    "messages"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "openai drop-in <- gemini_pc_auto gemini chat: the capability gate survives the conversion - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.6: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.6 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "// Same drop-in, same enabled config, a model with no per-block marker to act on.",
+                      "// The gate is evaluated against the resolved target, not the inbound dialect.",
+                      "pm.test('64.8.6 no cache markers of any dialect reached the wire', function () {",
+                      "  pm.expect(rawStr, 'raw_request: ' + rawStr.slice(0, 900)).to.not.include('cache_control');",
+                      "  pm.expect(rawStr).to.not.include('cachePoint');",
+                      "  pm.expect(rawStr).to.not.include('prompt_cache_breakpoint');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"gemini_pc_auto/{{genaiModel}}\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-64 cx-gate] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/openai/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "openai",
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "langchain drop-in <- anthropic_pc_auto claude-sonnet-4-6 chat: the SDK-compat host injects too - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.7: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.7 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && (v.cache_control || v.prompt_cache_breakpoint)) { marked.push(String(v.text || '')); } return v; });",
+                      "var markedStr = marked.join(' || ');",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "// The request arrived in the OpenAI dialect. Injection runs on the neutral request",
+                      "// at dispatch, AFTER the inbound dialect has been parsed away, so the marker must",
+                      "// come out in the TARGET's dialect - not the one the caller happened to speak.",
+                      "pm.test('64.8.7 exactly one marker, in Anthropic dialect', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 900)).to.equal(1);",
+                      "  pm.expect(bpCount, 'the OpenAI spelling must not leak onto an Anthropic wire').to.equal(0);",
+                      "});",
+                      "pm.test('64.8.7 the marker anchors the first block and carries the configured ttl', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('bf-64 cx-langchain');",
+                      "  pm.expect(rawStr).to.include('\"ttl\":\"1h\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_auto/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-64 cx-langchain] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/langchain/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "langchain",
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "litellm drop-in <- anthropic_pc_auto claude-sonnet-4-6 chat: the SDK-compat host injects too - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.8: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.8 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && (v.cache_control || v.prompt_cache_breakpoint)) { marked.push(String(v.text || '')); } return v; });",
+                      "var markedStr = marked.join(' || ');",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "// The request arrived in the OpenAI dialect. Injection runs on the neutral request",
+                      "// at dispatch, AFTER the inbound dialect has been parsed away, so the marker must",
+                      "// come out in the TARGET's dialect - not the one the caller happened to speak.",
+                      "pm.test('64.8.8 exactly one marker, in Anthropic dialect', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 900)).to.equal(1);",
+                      "  pm.expect(bpCount, 'the OpenAI spelling must not leak onto an Anthropic wire').to.equal(0);",
+                      "});",
+                      "pm.test('64.8.8 the marker anchors the first block and carries the configured ttl', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('bf-64 cx-litellm');",
+                      "  pm.expect(rawStr).to.include('\"ttl\":\"1h\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_auto/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-64 cx-litellm] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/litellm/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "litellm",
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            },
+            {
+              "name": "pydanticai drop-in <- anthropic_pc_auto claude-sonnet-4-6 chat: the SDK-compat host injects too - #6180",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                      "pm.test('64.8.9: 2xx', function () {",
+                      "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                      "});",
+                      "if (pm.response.code >= 400) { return; }",
+                      "var body = pm.response.json() || {};",
+                      "var rr = (body.extra_fields || {}).raw_request;",
+                      "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                      "var rawStr = rr ? JSON.stringify(rr) : '';",
+                      "pm.test('64.8.9 raw_request captured', function () {",
+                      "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                      "});",
+                      "if (!rr) { return; }",
+                      "var marked = [];",
+                      "JSON.stringify(rr, function (k, v) { if (v && typeof v === 'object' && (v.cache_control || v.prompt_cache_breakpoint)) { marked.push(String(v.text || '')); } return v; });",
+                      "var markedStr = marked.join(' || ');",
+                      "var ccCount = (rawStr.match(/\"cache_control\"/g) || []).length;",
+                      "var cpCount = (rawStr.match(/\"cachePoint\"/g) || []).length;",
+                      "var bpCount = (rawStr.match(/\"prompt_cache_breakpoint\"/g) || []).length;",
+                      "// The request arrived in the OpenAI dialect. Injection runs on the neutral request",
+                      "// at dispatch, AFTER the inbound dialect has been parsed away, so the marker must",
+                      "// come out in the TARGET's dialect - not the one the caller happened to speak.",
+                      "pm.test('64.8.9 exactly one marker, in Anthropic dialect', function () {",
+                      "  pm.expect(ccCount, 'raw_request: ' + rawStr.slice(0, 900)).to.equal(1);",
+                      "  pm.expect(bpCount, 'the OpenAI spelling must not leak onto an Anthropic wire').to.equal(0);",
+                      "});",
+                      "pm.test('64.8.9 the marker anchors the first block and carries the configured ttl', function () {",
+                      "  pm.expect(markedStr, 'marked: ' + markedStr).to.include('bf-64 cx-pydanticai');",
+                      "  pm.expect(rawStr).to.include('\"ttl\":\"1h\"');",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "x-bf-send-back-raw-request",
+                    "value": "true"
+                  }
+                ],
+                "body": {
+                  "mode": "raw",
+                  "raw": "{\n  \"model\": \"anthropic_pc_auto/claude-sonnet-4-6\",\n  \"max_tokens\": 16,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": [\n        {\n          \"type\": \"text\",\n          \"text\": \"[bf-64 cx-pydanticai] You are a meticulous assistant working from a fixed manual.\"\n        },\n        {\n          \"type\": \"text\",\n          \"text\": \"Answer in one word: is the sky blue?\"\n        }\n      ]\n    }\n  ]\n}"
+                },
+                "url": {
+                  "raw": "{{baseUrl}}/pydanticai/v1/chat/completions",
+                  "host": [
+                    "{{baseUrl}}"
+                  ],
+                  "path": [
+                    "pydanticai",
+                    "v1",
+                    "chat",
+                    "completions"
+                  ]
+                }
+              }
+            }
+          ],
+          "description": "Every case above enters through the route that matches its target's own dialect. These cross it: an OpenAI-shaped request routed to Anthropic or Bedrock, and an Anthropic-shaped one routed to gpt-5.6.\n\nThe invariant is where injection lives. It runs at dispatch, on the neutral request, after the inbound dialect has already been parsed away and before the outbound one is written - so the marker's SPELLING must follow the target and its POSITION must follow the neutral transcript, regardless of what the caller spoke. An implementation that keyed either off the inbound shape would pass every native-route case in this folder and fail here.\n\n64.8.5 is the case that found a real bug: the Responses serializer gated its cache_control -> prompt_cache_breakpoint translation on bifrostReq.Provider, the key the request arrived under. A custom provider reports its own name, matched no branch, and fell to the default - where cache_control is stripped with nothing put in its place, silently returning the request to the implicit caching #6180 exists to escape. Fixed in this branch by resolving the base provider first, the way the injector and providers/utils already do.\n\n64.8.7-64.8.9 repeat 64.8.1 on the SDK-compat hosts. They are separate transport entry points, not aliases of /openai, so they reach dispatch independently and can regress alone."
         }
       ]
     }

--- a/tests/integrations/python/config.json
+++ b/tests/integrations/python/config.json
@@ -136,6 +136,10 @@
       ],
       "network_config": {
         "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false,
+        "ttl": "1h"
       }
     },
     "mistral": {
@@ -227,6 +231,10 @@
       ],
       "network_config": {
         "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false,
+        "ttl": "1h"
       }
     },
     "azure": {
@@ -263,6 +271,10 @@
       ],
       "network_config": {
         "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false,
+        "ttl": "1h"
       }
     },
     "bedrock": {
@@ -359,6 +371,314 @@
           "use_for_batch_api": false
         }
       ],
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      }
+    },
+    "anthropic_pc_auto": {
+      "keys": [
+        {
+          "name": "Anthropic API Key",
+          "value": "env.ANTHROPIC_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "anthropic",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": true,
+        "ttl": "1h"
+      }
+    },
+    "gemini_pc_auto": {
+      "keys": [
+        {
+          "name": "Gemini API Key",
+          "value": "env.GEMINI_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "gemini",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": true,
+        "ttl": "1h"
+      }
+    },
+    "anthropic_pc_points": {
+      "keys": [
+        {
+          "name": "Anthropic API Key",
+          "value": "env.ANTHROPIC_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "anthropic",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false,
+        "ttl": "1h",
+        "cache_control_injection_points": [
+          {
+            "location": "message",
+            "role": "system"
+          },
+          {
+            "location": "message",
+            "index": 2
+          }
+        ]
+      }
+    },
+    "bedrock_pc_auto": {
+      "keys": [
+        {
+          "name": "Bedrock API Key",
+          "bedrock_key_config": {
+            "access_key": "env.AWS_ACCESS_KEY_ID",
+            "secret_key": "env.AWS_SECRET_ACCESS_KEY",
+            "region": "env.AWS_REGION"
+          },
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "bedrock",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": true,
+        "ttl": "1h"
+      }
+    },
+    "bedrock_pc_points": {
+      "keys": [
+        {
+          "name": "Bedrock API Key",
+          "bedrock_key_config": {
+            "access_key": "env.AWS_ACCESS_KEY_ID",
+            "secret_key": "env.AWS_SECRET_ACCESS_KEY",
+            "region": "env.AWS_REGION"
+          },
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "bedrock",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false,
+        "ttl": "1h",
+        "cache_control_injection_points": [
+          {
+            "location": "message",
+            "role": "system"
+          },
+          {
+            "location": "message",
+            "index": 2
+          }
+        ]
+      }
+    },
+    "openai_pc_auto": {
+      "keys": [
+        {
+          "name": "OpenAI API Key",
+          "value": "env.OPENAI_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "openai",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": true,
+        "ttl": "1h"
+      }
+    },
+    "openai_pc_points": {
+      "keys": [
+        {
+          "name": "OpenAI API Key",
+          "value": "env.OPENAI_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "openai",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false,
+        "ttl": "1h",
+        "cache_control_injection_points": [
+          {
+            "location": "message",
+            "role": "system"
+          },
+          {
+            "location": "message",
+            "index": 2
+          }
+        ]
+      }
+    },
+    "anthropic_pc_edge": {
+      "keys": [
+        {
+          "name": "Anthropic API Key",
+          "value": "env.ANTHROPIC_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "anthropic",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false,
+        "ttl": "1h",
+        "cache_control_injection_points": [
+          {
+            "location": "message",
+            "index": -1
+          },
+          {
+            "location": "message",
+            "role": "user",
+            "index": 1
+          },
+          {
+            "location": "message",
+            "index": 99
+          },
+          {
+            "location": "message"
+          }
+        ]
+      }
+    },
+    "anthropic_pc_overflow": {
+      "keys": [
+        {
+          "name": "Anthropic API Key",
+          "value": "env.ANTHROPIC_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "anthropic",
+        "is_key_less": false
+      },
+      "network_config": {
+        "default_request_timeout_in_seconds": 300
+      },
+      "prompt_cache": {
+        "auto_inject": false,
+        "ttl": "1h",
+        "cache_control_injection_points": [
+          {
+            "location": "message",
+            "index": 0
+          },
+          {
+            "location": "message",
+            "index": 1
+          },
+          {
+            "location": "message",
+            "index": 2
+          },
+          {
+            "location": "message",
+            "index": 3
+          },
+          {
+            "location": "message",
+            "index": 4
+          },
+          {
+            "location": "message",
+            "index": 5
+          }
+        ]
+      }
+    },
+    "anthropic_pc_absent": {
+      "keys": [
+        {
+          "name": "Anthropic API Key",
+          "value": "env.ANTHROPIC_API_KEY",
+          "weight": 1,
+          "models": [
+            "*"
+          ]
+        }
+      ],
+      "custom_provider_config": {
+        "base_provider_type": "anthropic",
+        "is_key_less": false
+      },
       "network_config": {
         "default_request_timeout_in_seconds": 300
       }
@@ -509,6 +829,7 @@
     "read_buffer_size": 65536
   },
   "client": {
+    "allow_per_request_raw_override": true,
     "drop_excess_requests": false,
     "initial_pool_size": 300,
     "allowed_origins": ["*"],


### PR DESCRIPTION
## Summary

Adds E2E harness folder 63 to cover the full prompt cache injection configuration surface introduced in #6180: the TTL select, injection-point editor, multi-turn boundary stability, the "client markers are never modified" guarantee, capability/opt-in gates, and all four request routes. Also upgrades model references in folders 61 and 62 from `claude-sonnet-4` to `claude-sonnet-4-6`, and marks the persistent/1-hour cache backlog item as partially covered.

## Changes

- **Folder 63 (new):** 30+ test cases across seven sub-folders asserting every rule the provider Prompt Caching panel states, verified on the outbound wire via `x-bf-send-back-raw-request`:
  - **63.1 TTL × dialect:** `ttl: "1h"` rides the injected marker inline on Anthropic and Vertex Claude, becomes a `cachePoint` field on Bedrock Converse, and is silently dropped (not forwarded as an unknown field) on OpenAI/Azure gpt-5.6 and OpenRouter Responses, which have no duration slot in `prompt_cache_breakpoint`. Absence of `ttl` in config produces no `ttl` field on the wire, preserving the provider-default billing profile.
  - **63.2 Injection-point semantics:** role-only matches every message of that role; index-only matches one; both together is an AND. Negative index counts from the end. Out-of-range index matches nothing (no clamping). A point with neither role nor index matches nothing (not everything). Points replace the default auto-inject strategy rather than stacking on top of it. A point marks the last cacheable block of its message. Six matching points still emit only four markers (provider ceiling enforced by the injector, not the per-provider clamp).
  - **63.3 Injection points × dialect:** same point set rendered as `cachePoint` blocks on Bedrock and `prompt_cache_breakpoint` on OpenAI Responses.
  - **63.4 Multi-turn stability:** three-turn Anthropic Chat conversation asserts the marker stays on the same text across turns and `cached_tokens > 0` from turn 2. Streaming Responses variant. Bedrock Converse variant. Deliberate counter-example: `index: -1` tracks the newest message and does not hold still — documented trade-off, asserted so it cannot be silently "fixed."
  - **63.5 Client markers never modified:** one marker anywhere in either dialect (`cache_control` or `prompt_cache_breakpoint`) stands the injector down entirely — auto-inject, configured points, and points on a points-configured provider all stand down. The client's chosen block position is preserved.
  - **63.6 Capability and opt-in gates:** Gemini (implicit caching), Vertex Gemini, Azure gpt-4o (pre-5.6), and a provider with no `prompt_cache` block at all each produce zero markers on the wire even when `x-bf-prompt-cache-auto-inject: true` is sent. The header cannot manufacture operator opt-in.
  - **63.7 Request routes:** `/anthropic/v1/messages` drop-in with a bare system string (marker must survive the system hoist into `system[]`), `/v1/responses` Responses route, and injection-point resolution against the converted transcript on the drop-in path.
- **Folders 61 and 62:** model strings updated from `anthropic/claude-sonnet-4` to `anthropic/claude-sonnet-4-6` in all request bodies and folder descriptions.
- **`HARNESS_COVERAGE_BACKLOG.md`:** persistent/1-hour cache entry changed from `[ ]` to `[~]` with a note that folder 63.1 covers injected `ttl` reaching Anthropic, Vertex Claude, and Bedrock wires (and being dropped where the dialect cannot carry it); client-sent `cache_control.ttl` on the request itself remains uncovered.
- **`tests/integrations/python/config.json`:**
  - Added `prompt_cache: { auto_inject: false, ttl: "1h" }` to the existing `vertex`, `openrouter`, and `azure` providers (inert until a request sends `x-bf-prompt-cache-auto-inject`; same shape the `anthropic` provider already carried for folder 62).
  - Added `bedrock` provider `prompt_cache` opt-in.
  - Added nine dedicated custom providers (`anthropic_pc_auto`, `anthropic_pc_points`, `anthropic_pc_edge`, `anthropic_pc_overflow`, `anthropic_pc_absent`, `bedrock_pc_auto`, `bedrock_pc_points`, `openai_pc_auto`, `openai_pc_points`, `gemini_pc_auto`) each carrying exactly one `prompt_cache` shape, inert for every other folder in the sweep.
  - Enabled `client.allow_per_request_raw_override: true` (required for `x-bf-send-back-raw-request` to work).

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the harness against a live environment with all provider credentials set:

```sh
newman run tests/e2e/api/collections/provider-harness.json \
  --environment <your-env-file> \
  --folder "63. Prompt cache injection configuration surface"
```

Folder 63.1.6 (Azure gpt-5.6 Responses) is tagged `[PREVIEW]` and requires `INCLUDE_PREVIEW=1` plus a `gpt-5.6-sol` Azure deployment. All other cases run with standard credentials (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`).

The nine new custom providers in `config.json` must be present in the gateway config before running. They are self-contained and do not affect any other folder.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6180 (partial — injected TTL coverage; client-sent `cache_control.ttl` remains open)
Related: #6290

## Security considerations

No auth, secrets, or PII changes. The new `allow_per_request_raw_override: true` flag is scoped to the test integration config only and enables the `x-bf-send-back-raw-request` header used to inspect outbound bodies in tests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable