### PR TITLE
docs: update Databricks as a popular platform integration in OTEL docs

### DIFF
--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -79,12 +79,12 @@ The plugin supports multiple trace formats to match your observability platform:
   "metrics_enabled": true,
   "metrics_endpoint": "https://collector.example.com/v1/metrics",
   "metrics_headers": {
-    "X-Databricks-Table": "my_metrics_table"
+    "x-databricks-zerobus-table-name": "my_catalog.my_schema.my_metrics_table"
   }
 }
 ```
 
-In this example the trace endpoint receives only `Authorization`, while the metrics endpoint receives both `Authorization` and `X-Databricks-Table`.
+In this example the trace endpoint receives only `Authorization`, while the metrics endpoint receives both `Authorization` and `x-databricks-zerobus-table-name`. See the [Databricks integration](#popular-platform-integrations) below for a full example.
 
 ### Resource Attributes
 
@@ -726,6 +726,48 @@ Langfuse only supports HTTP protocol. Do not use gRPC.
 </Note>
 
 See the [Langfuse OpenTelemetry documentation](https://langfuse.com/integrations/native/opentelemetry) for more details.
+
+</Tab>
+<Tab title="Databricks">
+
+Databricks' [Zerobus Ingest OTLP endpoint](https://docs.databricks.com/gcp/en/ingestion/opentelemetry/) writes OpenTelemetry data directly into Unity Catalog Delta tables. Each signal targets its **own** table (traces → the spans table, metrics → the metrics table), passed via the `x-databricks-zerobus-table-name` header in `catalog.schema.table` format. Because the header value differs per signal, put it in [`trace_headers` / `metrics_headers`](#per-signal-headers) and keep the shared `Authorization` bearer token in `headers`.
+
+```json
+{
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "otel",
+      "config": {
+        "service_name": "bifrost",
+        "collector_url": "https://<workspace-id>.zerobus.<region>.cloud.databricks.com/v1/traces",
+        "trace_type": "genai_extension",
+        "protocol": "http",
+        "headers": {
+          "Authorization": "env.DATABRICKS_TOKEN"
+        },
+        "trace_headers": {
+          "x-databricks-zerobus-table-name": "my_catalog.my_schema.my_prefix_otel_spans"
+        },
+        "metrics_enabled": true,
+        "metrics_endpoint": "https://<workspace-id>.zerobus.<region>.cloud.databricks.com/v1/metrics",
+        "metrics_headers": {
+          "x-databricks-zerobus-table-name": "my_catalog.my_schema.my_prefix_otel_metrics"
+        }
+      }
+    }
+  ]
+}
+```
+
+Set environment variable:
+```bash
+export DATABRICKS_TOKEN="Bearer <your-oauth-token>"
+```
+
+<Note>
+The token is an OAuth bearer token minted from a Databricks service principal, and static tokens expire after one hour. For long-running deployments, front Bifrost with an [OpenTelemetry Collector using `oauth2clientauthextension`](https://learn.microsoft.com/en-us/azure/databricks/ingestion/opentelemetry/configure) to refresh the token automatically, and point `collector_url` / `metrics_endpoint` at that Collector instead. See the [Databricks OTLP setup guide](https://learn.microsoft.com/en-us/azure/databricks/ingestion/opentelemetry/configure) for creating the target tables and granting the service principal access.
+</Note>
 
 </Tab>
 <Tab title="Self-Hosted">


### PR DESCRIPTION
## Summary

Adds a Databricks integration guide to the OpenTelemetry observability documentation, covering how to send traces and metrics to Databricks' Zerobus Ingest OTLP endpoint and write them into Unity Catalog Delta tables.

## Changes

- Added a new "Databricks" tab to the popular platform integrations section with a full configuration example targeting the Zerobus Ingest OTLP endpoint
- Updated the per-signal headers example to use the correct `x-databricks-zerobus-table-name` header format (`catalog.schema.table`) instead of the previous `X-Databricks-Table` placeholder
- Added a cross-reference from the per-signal headers section to the new Databricks integration tab
- Included a note about OAuth token expiry and guidance on using an OpenTelemetry Collector with `oauth2clientauthextension` for long-running deployments

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm:
- The Databricks tab appears correctly alongside other platform integrations
- The per-signal headers example reflects the updated `x-databricks-zerobus-table-name` header and links to the Databricks section
- The configuration snippet is valid JSON and environment variable instructions are accurate

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The documentation notes that Databricks OAuth bearer tokens expire after one hour and recommends using an OpenTelemetry Collector with `oauth2clientauthextension` for automatic token refresh in long-running deployments, avoiding static token exposure.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable