### PR TITLE
mcp auth with ssrf checks

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -18,8 +18,15 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/network"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+// mcpDialTimeout bounds each dial attempted by the SSRF-safe HTTP client MCP
+// client connections use, matching the timeout convention used by the other
+// SSRF-guarded outbound clients in this codebase (image/document fetch, skill
+// URL sources).
+const mcpDialTimeout = 10 * time.Second
 
 // AcquireClientConn returns a live upstream MCP client connection for the
 // given client state, along with a release function the caller must invoke
@@ -2573,36 +2580,62 @@ func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *s
 	}
 }
 
-// buildTLSHTTPClient constructs an *http.Client with a custom TLS configuration derived
-// from MCPTLSConfig. Returns nil when tlsCfg is nil so callers can use the library default.
+// buildTLSHTTPClient constructs an *http.Client for MCP server connections. The
+// transport is always routed through network.PrivateNetworkDialContext, which
+// blocks link-local and unspecified destinations (including the
+// 169.254.169.254 cloud metadata endpoint) but - unlike the stricter
+// network.SSRFSafeDialContext used for image/document fetch, webhook
+// delivery, and skill URL sources - permits loopback and private-network
+// targets. Loopback/private MCP servers are the documented primary use case
+// for this feature (docs/mcp/connecting-to-servers.mdx's own HTTP-client
+// example is http://localhost:3001/mcp), so this is dial-time defense in
+// depth against the categorically illegitimate ranges, not a substitute for
+// the caller's own authorization check: an unauthenticated caller is refused
+// outright before reaching this code (rejectPrivateMCPTargetIfAuthBypassed in
+// transports/bifrost-http/handlers/mcp.go).
+//
+// Previously this returned nil when tlsCfg was nil, leaving callers to fall
+// back to the mcp-go library's own default client, which carried no guard at
+// all - not even the link-local/metadata block applied here.
+//
+// TLS customization from MCPTLSConfig is layered on top when provided.
 // InsecureSkipVerify takes priority over CACertPEM when both are set.
 func (m *MCPManager) buildTLSHTTPClient(tlsCfg *schemas.MCPTLSConfig) (*http.Client, error) {
-	if tlsCfg == nil {
-		return nil, nil
-	}
-	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
-	if tlsCfg.InsecureSkipVerify {
-		m.logger.Warn("MCP client: skipping TLS verification — do not use in production")
-		tlsConfig.InsecureSkipVerify = true
-	} else if tlsCfg.CACertPEM != nil {
-		caPEM := tlsCfg.CACertPEM.GetValue()
-		if caPEM != "" {
-			rootCAs, err := x509.SystemCertPool()
-			if err != nil {
-				rootCAs = x509.NewCertPool()
-			}
-			if !rootCAs.AppendCertsFromPEM([]byte(caPEM)) {
-				return nil, fmt.Errorf("failed to parse MCP CA certificate PEM")
-			}
-			tlsConfig.RootCAs = rootCAs
-		}
-	}
-	transport, ok := http.DefaultTransport.(*http.Transport)
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
-		transport = &http.Transport{}
+		baseTransport = &http.Transport{}
 	}
-	cloned := transport.Clone()
-	cloned.TLSClientConfig = tlsConfig
+	cloned := baseTransport.Clone()
+	// Clone() preserves DefaultTransport's http.ProxyFromEnvironment. With a
+	// proxy configured, http.Transport hands DialContext the proxy's address
+	// instead of the MCP destination, so the guard below would validate the
+	// proxy and the proxy would forward to the blocked target. Drop it: the
+	// guard is only meaningful when the dialer sees the real destination,
+	// which is also how every other SSRF-guarded client here is built (fresh,
+	// proxy-free transports in fetch.go, webhooks, and skills_serving).
+	cloned.Proxy = nil
+	cloned.DialContext = network.PrivateNetworkDialContext(mcpDialTimeout)
+
+	if tlsCfg != nil {
+		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+		if tlsCfg.InsecureSkipVerify {
+			m.logger.Warn("MCP client: skipping TLS verification — do not use in production")
+			tlsConfig.InsecureSkipVerify = true
+		} else if tlsCfg.CACertPEM != nil {
+			caPEM := tlsCfg.CACertPEM.GetValue()
+			if caPEM != "" {
+				rootCAs, err := x509.SystemCertPool()
+				if err != nil {
+					rootCAs = x509.NewCertPool()
+				}
+				if !rootCAs.AppendCertsFromPEM([]byte(caPEM)) {
+					return nil, fmt.Errorf("failed to parse MCP CA certificate PEM")
+				}
+				tlsConfig.RootCAs = rootCAs
+			}
+		}
+		cloned.TLSClientConfig = tlsConfig
+	}
 	return &http.Client{Transport: cloned}, nil
 }
 

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -3,7 +3,12 @@ package mcp
 import (
 	"context"
 	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -599,4 +604,146 @@ func TestCloseAndMarkNeedsReauth_PerCallSharedOAuth_ReturnsReconnectNotApplicabl
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable))
 	assert.NotContains(t, err.Error(), "per-user", "a genuinely shared client must not be told it's a per-user auth client")
+}
+
+// TestBuildTLSHTTPClientNeverFallsBackToUnguardedDefault proves buildTLSHTTPClient
+// always returns a non-nil client (with or without TLS configured) so callers
+// never fall back to the mcp-go library's own default HTTP client, which
+// carries no dial guard at all.
+func TestBuildTLSHTTPClientNeverFallsBackToUnguardedDefault(t *testing.T) {
+	for _, tlsCfg := range []*schemas.MCPTLSConfig{nil, {InsecureSkipVerify: true}} {
+		httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(tlsCfg)
+		require.NoError(t, err)
+		require.NotNil(t, httpClient)
+
+		transport, ok := httpClient.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.NotNil(t, transport.DialContext)
+	}
+}
+
+// TestBuildTLSHTTPClientBlocksLinkLocal proves the dial-time guard refuses
+// link-local destinations (including the 169.254.169.254 cloud metadata
+// endpoint) - the one class of target with no legitimate MCP use case under
+// any deployment topology, authenticated or not.
+func TestBuildTLSHTTPClientBlocksLinkLocal(t *testing.T) {
+	httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+	require.NoError(t, err)
+	transport := httpClient.Transport.(*http.Transport)
+
+	_, err = transport.DialContext(context.Background(), "tcp", "169.254.169.254:80")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "blocked connection to link-local address")
+}
+
+// TestBuildTLSHTTPClientAllowsLoopback proves loopback MCP servers keep
+// working: connecting to a local MCP tool server on the same host is the
+// documented primary HTTP-client use case
+// (docs/mcp/connecting-to-servers.mdx), so the dial-time guard here must not
+// reject it. The unauthenticated-caller case is refused earlier, at the HTTP
+// handler layer (rejectPrivateMCPTargetIfAuthBypassed), not here.
+func TestBuildTLSHTTPClientAllowsLoopback(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := ln.Close(); err != nil {
+			t.Errorf("failed to close test listener: %v", err)
+		}
+	})
+	// The accepted server side is handed back to the test body so both ends are closed, and
+	// their Close results checked, on the test goroutine rather than after it may have ended.
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		if conn, err := ln.Accept(); err == nil {
+			accepted <- conn
+		}
+	}()
+
+	httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+	require.NoError(t, err)
+	transport := httpClient.Transport.(*http.Transport)
+
+	conn, err := transport.DialContext(context.Background(), "tcp", ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	select {
+	case server := <-accepted:
+		require.NoError(t, server.Close())
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener never accepted the dialed connection")
+	}
+}
+
+// TestBuildTLSHTTPClientNeverRoutesThroughProxy proves the dial-time guard
+// cannot be sidestepped by a proxy. http.DefaultTransport carries
+// http.ProxyFromEnvironment, and Clone() preserves it; when a proxy is
+// configured, http.Transport hands DialContext the proxy's address rather than
+// the MCP destination, so PrivateNetworkDialContext would validate the proxy
+// and let the proxy forward to the blocked link-local target. Every other
+// SSRF-guarded client in this repo (image/document fetch, webhook delivery,
+// skill URL sources) builds a fresh proxy-free transport; the MCP client must
+// end up with the same property despite starting from a clone.
+//
+// The proxy is injected by swapping DefaultTransport.Proxy rather than via
+// HTTP_PROXY, because ProxyFromEnvironment reads the environment once per
+// process and would not see a t.Setenv made after any earlier test used it.
+// This test therefore stays sequential (no t.Parallel) and restores the
+// original Proxy on cleanup.
+func TestBuildTLSHTTPClientNeverRoutesThroughProxy(t *testing.T) {
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := proxyLn.Close(); err != nil {
+			t.Errorf("failed to close proxy listener: %v", err)
+		}
+	})
+	// Any accepted connection is itself the failure; its Close result is passed back to the
+	// test body rather than reported from the goroutine, which may outlive the subtest.
+	var proxyHits atomic.Int32
+	proxyCloseErrs := make(chan error, 8)
+	go func() {
+		for {
+			conn, err := proxyLn.Accept()
+			if err != nil {
+				return
+			}
+			proxyHits.Add(1)
+			if err := conn.Close(); err != nil {
+				select {
+				case proxyCloseErrs <- err:
+				default:
+				}
+			}
+		}
+	}()
+	proxyURL, err := url.Parse("http://" + proxyLn.Addr().String())
+	require.NoError(t, err)
+
+	base, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok)
+	origProxy := base.Proxy
+	base.Proxy = http.ProxyURL(proxyURL)
+	t.Cleanup(func() { base.Proxy = origProxy })
+
+	for _, scheme := range []string{"http", "https"} {
+		t.Run(scheme, func(t *testing.T) {
+			httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+			require.NoError(t, err)
+			httpClient.Timeout = 5 * time.Second
+
+			resp, err := httpClient.Get(scheme + "://169.254.169.254/latest/meta-data/")
+			if resp != nil {
+				require.NoError(t, resp.Body.Close())
+			}
+			require.Error(t, err, "a link-local MCP target must be refused even when a proxy is configured")
+			require.Contains(t, err.Error(), "blocked connection to link-local address",
+				"the refusal must come from the dial-time guard, not from the proxy")
+			require.Zero(t, proxyHits.Load(), "the configured proxy must never be contacted for a guarded MCP request")
+			select {
+			case closeErr := <-proxyCloseErrs:
+				t.Errorf("failed to close a proxy-side connection: %v", closeErr)
+			default:
+			}
+		})
+	}
 }

--- a/core/network/ssrf.go
+++ b/core/network/ssrf.go
@@ -280,3 +280,57 @@ func isValidHostnameLiteral(s string) bool {
 	}
 	return true
 }
+
+// PrivateNetworkDialContext returns a DialContext that, unlike
+// SSRFSafeDialContext, permits loopback, RFC1918/unique-local, and CGNAT
+// destinations. It still blocks link-local addresses (including the
+// 169.254.169.254 cloud metadata endpoint) and unspecified addresses, which
+// have no legitimate destination under any deployment topology. Same
+// DNS-rebinding protection as SSRFSafeDialContext: resolves once and dials
+// the validated IP directly.
+//
+// Use this only for features where connecting to a self-hosted or
+// private-network target is the primary, documented use case (e.g. an MCP
+// server running on the same host or inside the same private network) AND
+// that capability is already gated by genuine authentication elsewhere - this
+// function is a defense-in-depth backstop against link-local/metadata
+// targets, not an authorization check.
+func PrivateNetworkDialContext(dialTimeout time.Duration) func(ctx context.Context, netw, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: dialTimeout}
+	return func(ctx context.Context, netw, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid dial address %q: %w", addr, err)
+		}
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("DNS lookup failed for %s: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("DNS lookup for %s returned no addresses", host)
+		}
+		for _, ip := range ips {
+			if ip.IsUnspecified() {
+				return nil, fmt.Errorf("blocked connection to unspecified address %s (host %s)", ip, host)
+			}
+			if IsLinkLocal(ip) {
+				return nil, fmt.Errorf("blocked connection to link-local address %s (host %s)", ip, host)
+			}
+		}
+		// Every address resolved above passed the policy, so trying them in
+		// turn is no weaker than dialing just the first: nothing outside this
+		// one validated set is ever dialed, which is what defeats rebinding.
+		// Pinning ips[0] instead would break the feature's primary documented
+		// target: "localhost" resolves to [::1, 127.0.0.1] on a dual-stack
+		// host, and an MCP server bound only to IPv4 is unreachable at ::1.
+		var lastErr error
+		for _, ip := range ips {
+			conn, err := dialer.DialContext(ctx, netw, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		return nil, lastErr
+	}
+}

--- a/core/network/ssrf_test.go
+++ b/core/network/ssrf_test.go
@@ -351,3 +351,79 @@ func TestSSRFSafeDialContextWithAllowlist_NilAllowlistMatchesPlainDialContext(t 
 		t.Fatalf("expected blocked-connection error, got %v", err)
 	}
 }
+
+func TestPrivateNetworkDialContextBlocksLinkLocal(t *testing.T) {
+	dial := PrivateNetworkDialContext(time.Second)
+	if _, err := dial(context.Background(), "tcp", "169.254.169.254:80"); err == nil || !strings.Contains(err.Error(), "blocked connection to link-local address") {
+		t.Fatalf("expected blocked link-local error, got %v", err)
+	}
+}
+
+func TestPrivateNetworkDialContextBlocksUnspecified(t *testing.T) {
+	dial := PrivateNetworkDialContext(time.Second)
+	if _, err := dial(context.Background(), "tcp", "0.0.0.0:80"); err == nil || !strings.Contains(err.Error(), "blocked connection to unspecified address") {
+		t.Fatalf("expected blocked unspecified error, got %v", err)
+	}
+}
+
+// TestPrivateNetworkDialContextAllowsLoopback locks in the deliberate
+// difference from SSRFSafeDialContext: a self-hosted MCP server on the same
+// host is the documented primary use case, so loopback must stay dialable.
+func TestPrivateNetworkDialContextAllowsLoopback(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	dial := PrivateNetworkDialContext(time.Second)
+	conn, err := dial(context.Background(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("expected loopback dial to succeed, got %v", err)
+	}
+	conn.Close()
+}
+
+// TestPrivateNetworkDialContextFallsBackAcrossResolvedAddresses locks in the
+// multi-address behavior the MCP feature depends on: "localhost" resolves to
+// [::1, 127.0.0.1] on a dual-stack host, and an MCP server bound only to IPv4
+// must still be reachable. Pinning the first resolved address would make the
+// documented http://localhost:PORT/mcp target undialable.
+func TestPrivateNetworkDialContextFallsBackAcrossResolvedAddresses(t *testing.T) {
+	ips, err := net.DefaultResolver.LookupIP(context.Background(), "ip", "localhost")
+	if err != nil || len(ips) < 2 {
+		t.Skipf("localhost does not resolve to multiple addresses here (%v, err=%v)", ips, err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split listener address: %v", err)
+	}
+
+	dial := PrivateNetworkDialContext(2 * time.Second)
+	conn, err := dial(context.Background(), "tcp", net.JoinHostPort("localhost", port))
+	if err != nil {
+		t.Fatalf("expected dial to fall back to the reachable resolved address, got %v", err)
+	}
+	conn.Close()
+}

--- a/docs/mcp/auth/none.mdx
+++ b/docs/mcp/auth/none.mdx
@@ -103,9 +103,16 @@ STDIO connections must use `auth_type: "none"`:
 </Tab>
 <Tab title="API">
 
+<Note>
+  `auth_type: "none"` for a STDIO client is about the upstream connection, not Bifrost's own admin
+  API - creating one still requires an authenticated admin session; see the note in
+  [Connecting to Servers](/mcp/connecting-to-servers#add-stdio-client).
+</Note>
+
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-session-token>" \
   -d '{
     "name": "filesystem",
     "connection_type": "stdio",

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -197,9 +197,17 @@ Here you can:
 
 ### Add STDIO Client
 
+<Note>
+  Registering a stdio client makes Bifrost run the given `command` as a subprocess of the gateway. If [dashboard
+  authentication](/quickstart/gateway/setting-up-auth) is disabled or not yet configured, this call is refused - you
+  must either enable dashboard auth and authenticate first, or define the client in `config.json` instead. This
+  restriction applies only to `connection_type: "stdio"`; HTTP and SSE clients are unaffected.
+</Note>
+
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-session-token>" \
   -d '{
     "name": "filesystem",
     "connection_type": "stdio",
@@ -213,6 +221,15 @@ curl -X POST http://localhost:8080/api/mcp/client \
 ```
 
 ### Add HTTP Client
+
+<Note>
+  If [dashboard authentication](/quickstart/gateway/setting-up-auth) is disabled or not yet
+  configured, an HTTP or SSE client whose `connection_string` resolves to a loopback,
+  private-network, link-local, or carrier-grade-NAT address is refused - you must either enable
+  dashboard auth and authenticate first, or define the client in `config.json` instead. The
+  `http://localhost:3001/mcp` example below is one such target. Clients pointed at a public
+  address (like the SSE example that follows) are unaffected either way.
+</Note>
 
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -179,6 +179,14 @@ client:
       pricing can only be set once the tool list is known. For shared-connection
       clients tools are fetched after client creation; for per-user auth types
       they are discovered during the create/verify flow itself.
+
+      Two cases require a genuinely authenticated admin session and are refused
+      with 403 when dashboard authentication is disabled or unconfigured, even
+      though other management endpoints stay reachable in that state:
+      connection_type "stdio" (which runs the supplied command as a gateway
+      subprocess), and connection_type "http"/"sse" whose connection_string
+      resolves to a loopback, private-network, link-local, or CGNAT address.
+      Public http/sse targets are unaffected.
     tags:
       - MCP
     requestBody:
@@ -205,6 +213,12 @@ client:
                 - $ref: '../../schemas/management/oauth.yaml#/OAuthFlowInitiation'
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '403':
+        description: >-
+          The request was not genuinely authenticated (dashboard authentication
+          is disabled or unconfigured) and connection_type is "stdio", or is
+          "http"/"sse" with a connection_string resolving to a loopback,
+          private-network, link-local, or CGNAT address.
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
+	"net/url"
 	"slices"
 	"sort"
 	"strconv"
@@ -19,6 +21,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/mcp"
 	mcputils "github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/network"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -1515,6 +1518,72 @@ func (req *MCPClientUpdateRequest) resolvedAllowByDefault(existing bool) bool {
 	return schemas.ResolveAllowByDefault(req.AllowByDefault, req.AllowOnAllVirtualKeys)
 }
 
+// rejectPrivateMCPTargetIfAuthBypassed refuses to register an HTTP/SSE MCP
+// client whose connection_string resolves to a loopback, private-network,
+// link-local, or CGNAT address when the caller reached this endpoint with no
+// credential check at all (default-open posture, BifrostContextKeyAuthBypassed).
+// A genuinely authenticated admin keeps the documented ability to point an MCP
+// client at a local or private server (see docs/mcp/connecting-to-servers.mdx,
+// whose own HTTP-client example uses http://localhost:3001/mcp) - only the
+// unauthenticated path is restricted, the same scoping used for the STDIO
+// client gate below. Returns true if the request was rejected (the error
+// response has already been written); the caller should return immediately.
+func rejectPrivateMCPTargetIfAuthBypassed(ctx *fasthttp.RequestCtx, connType string, connectionString *schemas.SecretVar) bool {
+	authBypassed, _ := ctx.UserValue(schemas.BifrostContextKeyAuthBypassed).(bool)
+	if !authBypassed {
+		return false
+	}
+	if connType != string(schemas.MCPConnectionTypeHTTP) && connType != string(schemas.MCPConnectionTypeSSE) {
+		return false
+	}
+	if connectionString == nil {
+		return false
+	}
+	parsed, err := url.Parse(connectionString.GetValue())
+	if err != nil || parsed.Hostname() == "" {
+		// Malformed/unresolvable target: let the normal connect path surface
+		// its own error rather than duplicating URL validation here.
+		return false
+	}
+	// A bounded, request-independent context: this lookup is a pre-check, not
+	// a dial, and must not be tied to the request's own (often much longer)
+	// deadline.
+	lookupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ips, err := net.DefaultResolver.LookupIP(lookupCtx, "ip", parsed.Hostname())
+	if err != nil {
+		return false
+	}
+	for _, ip := range ips {
+		if !network.IsPublicIP(ip) {
+			SendError(ctx, fasthttp.StatusForbidden, "unauthenticated callers cannot register MCP clients that connect to loopback, private-network, or link-local addresses; set an admin password to allow this")
+			return true
+		}
+	}
+	return false
+}
+
+// rejectStdioMCPClientIfAuthBypassed refuses to register a stdio MCP client for
+// a caller that was let through because dashboard auth is unconfigured or
+// disabled. A stdio client makes Bifrost exec() an admin-supplied command and
+// args as the gateway process: intentional admin functionality, but only for a
+// caller who actually authenticated. Registering one over this network API with
+// no credential check is equivalent to unauthenticated remote code execution,
+// so it is refused even though the rest of the management API stays open for
+// the zero-config experience. Stdio clients can still be provisioned by an
+// operator with host/filesystem access via config.json. Returns true if the
+// request was rejected (the error response has already been written).
+func rejectStdioMCPClientIfAuthBypassed(ctx *fasthttp.RequestCtx, connType string) bool {
+	if connType != string(schemas.MCPConnectionTypeSTDIO) {
+		return false
+	}
+	if bypassed, _ := ctx.UserValue(schemas.BifrostContextKeyAuthBypassed).(bool); !bypassed {
+		return false
+	}
+	SendError(ctx, fasthttp.StatusForbidden, "Registering a stdio MCP client requires an authenticated admin session; dashboard auth is currently disabled or unconfigured. Enable dashboard authentication, or provision this client via config.json instead.")
+	return true
+}
+
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
 func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	if h.store.ConfigStore == nil {
@@ -1527,6 +1596,16 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	var req MCPClientRequest
 	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
+		return
+	}
+
+	// Both gates run before anything else: registering a client is what makes
+	// Bifrost spawn the subprocess / dial the target, so a refusal has to land
+	// before any of that work is scheduled.
+	if rejectStdioMCPClientIfAuthBypassed(ctx, req.ConnectionType) {
+		return
+	}
+	if rejectPrivateMCPTargetIfAuthBypassed(ctx, req.ConnectionType, req.ConnectionString) {
 		return
 	}
 

--- a/transports/bifrost-http/handlers/mcpregistrationguard_test.go
+++ b/transports/bifrost-http/handlers/mcpregistrationguard_test.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// TestRejectStdioMCPClientIfAuthBypassed_UnauthenticatedRejected proves the
+// reported RCE primitive is closed: registering a stdio client makes Bifrost
+// exec() the supplied command, so a caller let through with no credential
+// check at all must be refused.
+func TestRejectStdioMCPClientIfAuthBypassed_UnauthenticatedRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	if !rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO)) {
+		t.Fatal("expected unauthenticated stdio registration to be rejected")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusForbidden, ctx.Response.StatusCode())
+	}
+}
+
+// TestRejectStdioMCPClientIfAuthBypassed_AuthenticatedAllowed proves stdio
+// registration stays available to a genuinely authenticated admin - the gate
+// is on the credential check, not on the capability.
+func TestRejectStdioMCPClientIfAuthBypassed_AuthenticatedAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	// AuthBypassed intentionally left unset, as it is for an authenticated request.
+
+	if rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO)) {
+		t.Fatal("expected an authenticated admin's stdio registration to be allowed")
+	}
+}
+
+// TestRejectStdioMCPClientIfAuthBypassed_HTTPUnaffected proves this gate is
+// scoped to stdio; HTTP/SSE targets are handled by the separate SSRF check.
+func TestRejectStdioMCPClientIfAuthBypassed_HTTPUnaffected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	if rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP)) {
+		t.Fatal("expected HTTP connection type to be unaffected by the stdio gate")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLoopbackRejected proves
+// the unauthenticated (default-open) path cannot register an HTTP MCP client
+// pointing at loopback - the reproduction target from the reported SSRF.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLoopbackRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP), schemas.NewSecretVar("http://127.0.0.1:8080/health"))
+
+	if !rejected {
+		t.Fatal("expected an unauthenticated loopback target to be rejected")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusForbidden, ctx.Response.StatusCode())
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLinkLocalRejected proves
+// the cloud-metadata target from the report is rejected for an unauthenticated
+// caller.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLinkLocalRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSSE), schemas.NewSecretVar("http://169.254.169.254/latest/meta-data/"))
+
+	if !rejected {
+		t.Fatal("expected an unauthenticated link-local target to be rejected")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_AuthenticatedLoopbackAllowed proves a
+// genuinely authenticated caller keeps the documented ability to register a
+// local MCP server (docs/mcp/connecting-to-servers.mdx uses
+// http://localhost:3001/mcp as its own example) - this fix must not break that
+// flow, only the unauthenticated one.
+func TestRejectPrivateMCPTargetIfAuthBypassed_AuthenticatedLoopbackAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	// AuthBypassed intentionally left unset, as it is for an authenticated request.
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP), schemas.NewSecretVar("http://127.0.0.1:3001/mcp"))
+
+	if rejected {
+		t.Fatal("expected an authenticated caller's loopback target to be allowed")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedPublicTargetAllowed
+// proves an unauthenticated caller can still register a normal internet-hosted
+// MCP server - this fix only restricts private/loopback/link-local targets,
+// not HTTP/SSE clients in general. Uses an IP literal (not a hostname) so the
+// test doesn't depend on DNS being reachable in the test environment.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedPublicTargetAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSSE), schemas.NewSecretVar("https://1.1.1.1/mcp/sse"))
+
+	if rejected {
+		t.Fatal("expected a public target to be allowed even for an unauthenticated caller")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_STDIOUnaffected proves this check is
+// scoped to HTTP/SSE only; stdio registration has its own separate gate.
+func TestRejectPrivateMCPTargetIfAuthBypassed_STDIOUnaffected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO), nil)
+
+	if rejected {
+		t.Fatal("expected STDIO connection type to be unaffected by this check")
+	}
+}


### PR DESCRIPTION
## Summary

Closes two unauthenticated-access primitives in the MCP client registration API: an unauthenticated caller could register a `stdio` MCP client (causing Bifrost to `exec()` an arbitrary command as the gateway process) or an `http`/`sse` MCP client pointed at a loopback or private-network address (enabling SSRF against internal services, including the `169.254.169.254` cloud metadata endpoint). Both are now refused with HTTP 403 when the request reaches the handler without a genuine credential check (`BifrostContextKeyAuthBypassed`). Authenticated admins retain full access to both capabilities, which are the documented primary use cases for the feature.

## Changes

- **`rejectStdioMCPClientIfAuthBypassed`** — new pre-registration gate in `transports/bifrost-http/handlers/mcp.go` that refuses `connection_type: "stdio"` for unauthenticated callers. Stdio clients make Bifrost spawn a subprocess, so allowing this without authentication is equivalent to unauthenticated RCE. Operators can still provision stdio clients via `config.json`.

- **`rejectPrivateMCPTargetIfAuthBypassed`** — new pre-registration gate that resolves the `connection_string` hostname and refuses registration if any resolved IP is non-public (loopback, RFC1918, link-local, CGNAT, unspecified) for unauthenticated callers. Authenticated admins keep the documented ability to point clients at local or private-network MCP servers.

- **`PrivateNetworkDialContext`** — new dial helper in `core/network/ssrf.go`, used by `buildTLSHTTPClient` for all MCP HTTP connections. Unlike `SSRFSafeDialContext`, it permits loopback and private-network targets (the documented primary use case) but still blocks link-local and unspecified addresses at dial time. This is defense-in-depth at the transport layer, not a substitute for the handler-layer auth check above.

- **`buildTLSHTTPClient` always returns a non-nil client** — previously returned `nil` when no TLS config was provided, causing callers to fall back to the mcp-go library's own default HTTP client with no dial guard at all. Now always returns a client routed through `PrivateNetworkDialContext`, with TLS customization layered on top when provided.

- **Docs** — added `<Note>` callouts to `docs/mcp/connecting-to-servers.mdx` and `docs/mcp/auth/none.mdx` explaining the authentication requirement for stdio and private-target HTTP/SSE clients, and documented the new `403` response in the OpenAPI spec.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/network/... ./core/mcp/... ./transports/bifrost-http/handlers/...
```

**Unauthenticated stdio registration (expect 403):**
```sh
curl -X POST http://localhost:8080/api/mcp/client \
  -H "Content-Type: application/json" \
  -d '{"name":"test","connection_type":"stdio","command":"id","args":[]}'
```

**Unauthenticated loopback HTTP registration (expect 403):**
```sh
curl -X POST http://localhost:8080/api/mcp/client \
  -H "Content-Type: application/json" \
  -d '{"name":"test","connection_type":"http","connection_string":"http://127.0.0.1:3001/mcp"}'
```

**Unauthenticated cloud-metadata SSRF (expect 403):**
```sh
curl -X POST http://localhost:8080/api/mcp/client \
  -H "Content-Type: application/json" \
  -d '{"name":"test","connection_type":"sse","connection_string":"http://169.254.169.254/latest/meta-data/"}'
```

**Authenticated admin registering a local MCP server (expect success):**
```sh
curl -X POST http://localhost:8080/api/mcp/client \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <admin-session-token>" \
  -d '{"name":"local","connection_type":"http","connection_string":"http://localhost:3001/mcp"}'
```

## Breaking changes

- [x] No

Unauthenticated callers who were previously able to register stdio or private-target HTTP/SSE clients will now receive a 403. This is intentional — those requests should never have succeeded. Authenticated admins and public HTTP/SSE targets are unaffected.

## Security considerations

- Closes unauthenticated RCE via stdio MCP client registration (`exec()` of arbitrary command).
- Closes unauthenticated SSRF via HTTP/SSE MCP client registration against loopback, RFC1918, link-local (`169.254.169.254`), and CGNAT addresses.
- Defense-in-depth dial-time guard (`PrivateNetworkDialContext`) blocks link-local and unspecified addresses for all MCP HTTP connections regardless of authentication state, including DNS-rebinding scenarios.
- The handler-layer check uses a short, request-independent DNS lookup timeout (5 s) to avoid tying the pre-check to the request's own deadline.
- Authenticated admins retain full capability; the restriction is scoped exclusively to the `BifrostContextKeyAuthBypassed` (default-open, no-credential-check) path.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable