### PR TITLE
require auth for realtime connections when enforced on inference

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -18,8 +18,15 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/network"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+// mcpDialTimeout bounds each dial attempted by the SSRF-safe HTTP client MCP
+// client connections use, matching the timeout convention used by the other
+// SSRF-guarded outbound clients in this codebase (image/document fetch, skill
+// URL sources).
+const mcpDialTimeout = 10 * time.Second
 
 // AcquireClientConn returns a live upstream MCP client connection for the
 // given client state, along with a release function the caller must invoke
@@ -2573,36 +2580,62 @@ func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *s
 	}
 }
 
-// buildTLSHTTPClient constructs an *http.Client with a custom TLS configuration derived
-// from MCPTLSConfig. Returns nil when tlsCfg is nil so callers can use the library default.
+// buildTLSHTTPClient constructs an *http.Client for MCP server connections. The
+// transport is always routed through network.PrivateNetworkDialContext, which
+// blocks link-local and unspecified destinations (including the
+// 169.254.169.254 cloud metadata endpoint) but - unlike the stricter
+// network.SSRFSafeDialContext used for image/document fetch, webhook
+// delivery, and skill URL sources - permits loopback and private-network
+// targets. Loopback/private MCP servers are the documented primary use case
+// for this feature (docs/mcp/connecting-to-servers.mdx's own HTTP-client
+// example is http://localhost:3001/mcp), so this is dial-time defense in
+// depth against the categorically illegitimate ranges, not a substitute for
+// the caller's own authorization check: an unauthenticated caller is refused
+// outright before reaching this code (rejectPrivateMCPTargetIfAuthBypassed in
+// transports/bifrost-http/handlers/mcp.go).
+//
+// Previously this returned nil when tlsCfg was nil, leaving callers to fall
+// back to the mcp-go library's own default client, which carried no guard at
+// all - not even the link-local/metadata block applied here.
+//
+// TLS customization from MCPTLSConfig is layered on top when provided.
 // InsecureSkipVerify takes priority over CACertPEM when both are set.
 func (m *MCPManager) buildTLSHTTPClient(tlsCfg *schemas.MCPTLSConfig) (*http.Client, error) {
-	if tlsCfg == nil {
-		return nil, nil
-	}
-	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
-	if tlsCfg.InsecureSkipVerify {
-		m.logger.Warn("MCP client: skipping TLS verification — do not use in production")
-		tlsConfig.InsecureSkipVerify = true
-	} else if tlsCfg.CACertPEM != nil {
-		caPEM := tlsCfg.CACertPEM.GetValue()
-		if caPEM != "" {
-			rootCAs, err := x509.SystemCertPool()
-			if err != nil {
-				rootCAs = x509.NewCertPool()
-			}
-			if !rootCAs.AppendCertsFromPEM([]byte(caPEM)) {
-				return nil, fmt.Errorf("failed to parse MCP CA certificate PEM")
-			}
-			tlsConfig.RootCAs = rootCAs
-		}
-	}
-	transport, ok := http.DefaultTransport.(*http.Transport)
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
-		transport = &http.Transport{}
+		baseTransport = &http.Transport{}
 	}
-	cloned := transport.Clone()
-	cloned.TLSClientConfig = tlsConfig
+	cloned := baseTransport.Clone()
+	// Clone() preserves DefaultTransport's http.ProxyFromEnvironment. With a
+	// proxy configured, http.Transport hands DialContext the proxy's address
+	// instead of the MCP destination, so the guard below would validate the
+	// proxy and the proxy would forward to the blocked target. Drop it: the
+	// guard is only meaningful when the dialer sees the real destination,
+	// which is also how every other SSRF-guarded client here is built (fresh,
+	// proxy-free transports in fetch.go, webhooks, and skills_serving).
+	cloned.Proxy = nil
+	cloned.DialContext = network.PrivateNetworkDialContext(mcpDialTimeout)
+
+	if tlsCfg != nil {
+		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+		if tlsCfg.InsecureSkipVerify {
+			m.logger.Warn("MCP client: skipping TLS verification — do not use in production")
+			tlsConfig.InsecureSkipVerify = true
+		} else if tlsCfg.CACertPEM != nil {
+			caPEM := tlsCfg.CACertPEM.GetValue()
+			if caPEM != "" {
+				rootCAs, err := x509.SystemCertPool()
+				if err != nil {
+					rootCAs = x509.NewCertPool()
+				}
+				if !rootCAs.AppendCertsFromPEM([]byte(caPEM)) {
+					return nil, fmt.Errorf("failed to parse MCP CA certificate PEM")
+				}
+				tlsConfig.RootCAs = rootCAs
+			}
+		}
+		cloned.TLSClientConfig = tlsConfig
+	}
 	return &http.Client{Transport: cloned}, nil
 }
 

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -3,7 +3,12 @@ package mcp
 import (
 	"context"
 	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -599,4 +604,146 @@ func TestCloseAndMarkNeedsReauth_PerCallSharedOAuth_ReturnsReconnectNotApplicabl
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable))
 	assert.NotContains(t, err.Error(), "per-user", "a genuinely shared client must not be told it's a per-user auth client")
+}
+
+// TestBuildTLSHTTPClientNeverFallsBackToUnguardedDefault proves buildTLSHTTPClient
+// always returns a non-nil client (with or without TLS configured) so callers
+// never fall back to the mcp-go library's own default HTTP client, which
+// carries no dial guard at all.
+func TestBuildTLSHTTPClientNeverFallsBackToUnguardedDefault(t *testing.T) {
+	for _, tlsCfg := range []*schemas.MCPTLSConfig{nil, {InsecureSkipVerify: true}} {
+		httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(tlsCfg)
+		require.NoError(t, err)
+		require.NotNil(t, httpClient)
+
+		transport, ok := httpClient.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.NotNil(t, transport.DialContext)
+	}
+}
+
+// TestBuildTLSHTTPClientBlocksLinkLocal proves the dial-time guard refuses
+// link-local destinations (including the 169.254.169.254 cloud metadata
+// endpoint) - the one class of target with no legitimate MCP use case under
+// any deployment topology, authenticated or not.
+func TestBuildTLSHTTPClientBlocksLinkLocal(t *testing.T) {
+	httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+	require.NoError(t, err)
+	transport := httpClient.Transport.(*http.Transport)
+
+	_, err = transport.DialContext(context.Background(), "tcp", "169.254.169.254:80")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "blocked connection to link-local address")
+}
+
+// TestBuildTLSHTTPClientAllowsLoopback proves loopback MCP servers keep
+// working: connecting to a local MCP tool server on the same host is the
+// documented primary HTTP-client use case
+// (docs/mcp/connecting-to-servers.mdx), so the dial-time guard here must not
+// reject it. The unauthenticated-caller case is refused earlier, at the HTTP
+// handler layer (rejectPrivateMCPTargetIfAuthBypassed), not here.
+func TestBuildTLSHTTPClientAllowsLoopback(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := ln.Close(); err != nil {
+			t.Errorf("failed to close test listener: %v", err)
+		}
+	})
+	// The accepted server side is handed back to the test body so both ends are closed, and
+	// their Close results checked, on the test goroutine rather than after it may have ended.
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		if conn, err := ln.Accept(); err == nil {
+			accepted <- conn
+		}
+	}()
+
+	httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+	require.NoError(t, err)
+	transport := httpClient.Transport.(*http.Transport)
+
+	conn, err := transport.DialContext(context.Background(), "tcp", ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	select {
+	case server := <-accepted:
+		require.NoError(t, server.Close())
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener never accepted the dialed connection")
+	}
+}
+
+// TestBuildTLSHTTPClientNeverRoutesThroughProxy proves the dial-time guard
+// cannot be sidestepped by a proxy. http.DefaultTransport carries
+// http.ProxyFromEnvironment, and Clone() preserves it; when a proxy is
+// configured, http.Transport hands DialContext the proxy's address rather than
+// the MCP destination, so PrivateNetworkDialContext would validate the proxy
+// and let the proxy forward to the blocked link-local target. Every other
+// SSRF-guarded client in this repo (image/document fetch, webhook delivery,
+// skill URL sources) builds a fresh proxy-free transport; the MCP client must
+// end up with the same property despite starting from a clone.
+//
+// The proxy is injected by swapping DefaultTransport.Proxy rather than via
+// HTTP_PROXY, because ProxyFromEnvironment reads the environment once per
+// process and would not see a t.Setenv made after any earlier test used it.
+// This test therefore stays sequential (no t.Parallel) and restores the
+// original Proxy on cleanup.
+func TestBuildTLSHTTPClientNeverRoutesThroughProxy(t *testing.T) {
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := proxyLn.Close(); err != nil {
+			t.Errorf("failed to close proxy listener: %v", err)
+		}
+	})
+	// Any accepted connection is itself the failure; its Close result is passed back to the
+	// test body rather than reported from the goroutine, which may outlive the subtest.
+	var proxyHits atomic.Int32
+	proxyCloseErrs := make(chan error, 8)
+	go func() {
+		for {
+			conn, err := proxyLn.Accept()
+			if err != nil {
+				return
+			}
+			proxyHits.Add(1)
+			if err := conn.Close(); err != nil {
+				select {
+				case proxyCloseErrs <- err:
+				default:
+				}
+			}
+		}
+	}()
+	proxyURL, err := url.Parse("http://" + proxyLn.Addr().String())
+	require.NoError(t, err)
+
+	base, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok)
+	origProxy := base.Proxy
+	base.Proxy = http.ProxyURL(proxyURL)
+	t.Cleanup(func() { base.Proxy = origProxy })
+
+	for _, scheme := range []string{"http", "https"} {
+		t.Run(scheme, func(t *testing.T) {
+			httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+			require.NoError(t, err)
+			httpClient.Timeout = 5 * time.Second
+
+			resp, err := httpClient.Get(scheme + "://169.254.169.254/latest/meta-data/")
+			if resp != nil {
+				require.NoError(t, resp.Body.Close())
+			}
+			require.Error(t, err, "a link-local MCP target must be refused even when a proxy is configured")
+			require.Contains(t, err.Error(), "blocked connection to link-local address",
+				"the refusal must come from the dial-time guard, not from the proxy")
+			require.Zero(t, proxyHits.Load(), "the configured proxy must never be contacted for a guarded MCP request")
+			select {
+			case closeErr := <-proxyCloseErrs:
+				t.Errorf("failed to close a proxy-side connection: %v", closeErr)
+			default:
+			}
+		})
+	}
 }

--- a/core/network/ssrf.go
+++ b/core/network/ssrf.go
@@ -280,3 +280,57 @@ func isValidHostnameLiteral(s string) bool {
 	}
 	return true
 }
+
+// PrivateNetworkDialContext returns a DialContext that, unlike
+// SSRFSafeDialContext, permits loopback, RFC1918/unique-local, and CGNAT
+// destinations. It still blocks link-local addresses (including the
+// 169.254.169.254 cloud metadata endpoint) and unspecified addresses, which
+// have no legitimate destination under any deployment topology. Same
+// DNS-rebinding protection as SSRFSafeDialContext: resolves once and dials
+// the validated IP directly.
+//
+// Use this only for features where connecting to a self-hosted or
+// private-network target is the primary, documented use case (e.g. an MCP
+// server running on the same host or inside the same private network) AND
+// that capability is already gated by genuine authentication elsewhere - this
+// function is a defense-in-depth backstop against link-local/metadata
+// targets, not an authorization check.
+func PrivateNetworkDialContext(dialTimeout time.Duration) func(ctx context.Context, netw, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: dialTimeout}
+	return func(ctx context.Context, netw, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid dial address %q: %w", addr, err)
+		}
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("DNS lookup failed for %s: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("DNS lookup for %s returned no addresses", host)
+		}
+		for _, ip := range ips {
+			if ip.IsUnspecified() {
+				return nil, fmt.Errorf("blocked connection to unspecified address %s (host %s)", ip, host)
+			}
+			if IsLinkLocal(ip) {
+				return nil, fmt.Errorf("blocked connection to link-local address %s (host %s)", ip, host)
+			}
+		}
+		// Every address resolved above passed the policy, so trying them in
+		// turn is no weaker than dialing just the first: nothing outside this
+		// one validated set is ever dialed, which is what defeats rebinding.
+		// Pinning ips[0] instead would break the feature's primary documented
+		// target: "localhost" resolves to [::1, 127.0.0.1] on a dual-stack
+		// host, and an MCP server bound only to IPv4 is unreachable at ::1.
+		var lastErr error
+		for _, ip := range ips {
+			conn, err := dialer.DialContext(ctx, netw, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		return nil, lastErr
+	}
+}

--- a/core/network/ssrf_test.go
+++ b/core/network/ssrf_test.go
@@ -351,3 +351,79 @@ func TestSSRFSafeDialContextWithAllowlist_NilAllowlistMatchesPlainDialContext(t 
 		t.Fatalf("expected blocked-connection error, got %v", err)
 	}
 }
+
+func TestPrivateNetworkDialContextBlocksLinkLocal(t *testing.T) {
+	dial := PrivateNetworkDialContext(time.Second)
+	if _, err := dial(context.Background(), "tcp", "169.254.169.254:80"); err == nil || !strings.Contains(err.Error(), "blocked connection to link-local address") {
+		t.Fatalf("expected blocked link-local error, got %v", err)
+	}
+}
+
+func TestPrivateNetworkDialContextBlocksUnspecified(t *testing.T) {
+	dial := PrivateNetworkDialContext(time.Second)
+	if _, err := dial(context.Background(), "tcp", "0.0.0.0:80"); err == nil || !strings.Contains(err.Error(), "blocked connection to unspecified address") {
+		t.Fatalf("expected blocked unspecified error, got %v", err)
+	}
+}
+
+// TestPrivateNetworkDialContextAllowsLoopback locks in the deliberate
+// difference from SSRFSafeDialContext: a self-hosted MCP server on the same
+// host is the documented primary use case, so loopback must stay dialable.
+func TestPrivateNetworkDialContextAllowsLoopback(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	dial := PrivateNetworkDialContext(time.Second)
+	conn, err := dial(context.Background(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("expected loopback dial to succeed, got %v", err)
+	}
+	conn.Close()
+}
+
+// TestPrivateNetworkDialContextFallsBackAcrossResolvedAddresses locks in the
+// multi-address behavior the MCP feature depends on: "localhost" resolves to
+// [::1, 127.0.0.1] on a dual-stack host, and an MCP server bound only to IPv4
+// must still be reachable. Pinning the first resolved address would make the
+// documented http://localhost:PORT/mcp target undialable.
+func TestPrivateNetworkDialContextFallsBackAcrossResolvedAddresses(t *testing.T) {
+	ips, err := net.DefaultResolver.LookupIP(context.Background(), "ip", "localhost")
+	if err != nil || len(ips) < 2 {
+		t.Skipf("localhost does not resolve to multiple addresses here (%v, err=%v)", ips, err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split listener address: %v", err)
+	}
+
+	dial := PrivateNetworkDialContext(2 * time.Second)
+	conn, err := dial(context.Background(), "tcp", net.JoinHostPort("localhost", port))
+	if err != nil {
+		t.Fatalf("expected dial to fall back to the reachable resolved address, got %v", err)
+	}
+	conn.Close()
+}

--- a/docs/deployment-guides/config-json/client.mdx
+++ b/docs/deployment-guides/config-json/client.mdx
@@ -105,7 +105,7 @@ This setting is also configurable via the UI (**MCP Gateway → MCP Settings**) 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `allowed_origins` | array | `["*"]` | CORS allowed origins (use URIs or `"*"`) |
-| `enforce_auth_on_inference` | boolean | `false` | Require auth (virtual key, API key, or user token) on `/v1/*` inference routes |
+| `enforce_auth_on_inference` | boolean | `false` | Require auth (virtual key, API key, or user token) on `/v1/*` inference routes. Realtime connections (`/v1/realtime`, `/v1/realtime/calls`) are refused with `401` at connect time unless they present one of those, or an ephemeral client secret from `POST /v1/realtime/client_secrets` |
 | `max_request_body_size_mb` | integer | `100` | Maximum allowed request body size in MB |
 | `whitelisted_routes` | array of strings | `[]` | Routes that bypass auth middleware |
 | `allowed_headers` | array of strings | `[]` | Additional headers permitted for CORS and WebSocket |

--- a/docs/mcp/auth/none.mdx
+++ b/docs/mcp/auth/none.mdx
@@ -103,9 +103,16 @@ STDIO connections must use `auth_type: "none"`:
 </Tab>
 <Tab title="API">
 
+<Note>
+  `auth_type: "none"` for a STDIO client is about the upstream connection, not Bifrost's own admin
+  API - creating one still requires an authenticated admin session; see the note in
+  [Connecting to Servers](/mcp/connecting-to-servers#add-stdio-client).
+</Note>
+
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-session-token>" \
   -d '{
     "name": "filesystem",
     "connection_type": "stdio",

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -197,9 +197,17 @@ Here you can:
 
 ### Add STDIO Client
 
+<Note>
+  Registering a stdio client makes Bifrost run the given `command` as a subprocess of the gateway. If [dashboard
+  authentication](/quickstart/gateway/setting-up-auth) is disabled or not yet configured, this call is refused - you
+  must either enable dashboard auth and authenticate first, or define the client in `config.json` instead. This
+  restriction applies only to `connection_type: "stdio"`; HTTP and SSE clients are unaffected.
+</Note>
+
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-session-token>" \
   -d '{
     "name": "filesystem",
     "connection_type": "stdio",
@@ -213,6 +221,15 @@ curl -X POST http://localhost:8080/api/mcp/client \
 ```
 
 ### Add HTTP Client
+
+<Note>
+  If [dashboard authentication](/quickstart/gateway/setting-up-auth) is disabled or not yet
+  configured, an HTTP or SSE client whose `connection_string` resolves to a loopback,
+  private-network, link-local, or carrier-grade-NAT address is refused - you must either enable
+  dashboard auth and authenticate first, or define the client in `config.json` instead. The
+  `http://localhost:3001/mcp` example below is one such target. Clients pointed at a public
+  address (like the SSE example that follows) are unaffected either way.
+</Note>
 
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -179,6 +179,14 @@ client:
       pricing can only be set once the tool list is known. For shared-connection
       clients tools are fetched after client creation; for per-user auth types
       they are discovered during the create/verify flow itself.
+
+      Two cases require a genuinely authenticated admin session and are refused
+      with 403 when dashboard authentication is disabled or unconfigured, even
+      though other management endpoints stay reachable in that state:
+      connection_type "stdio" (which runs the supplied command as a gateway
+      subprocess), and connection_type "http"/"sse" whose connection_string
+      resolves to a loopback, private-network, link-local, or CGNAT address.
+      Public http/sse targets are unaffected.
     tags:
       - MCP
     requestBody:
@@ -205,6 +213,12 @@ client:
                 - $ref: '../../schemas/management/oauth.yaml#/OAuthFlowInitiation'
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '403':
+        description: >-
+          The request was not genuinely authenticated (dashboard authentication
+          is disabled or unconfigured) and connection_type is "stdio", or is
+          "http"/"sse" with a connection_string resolving to a loopback,
+          private-network, link-local, or CGNAT address.
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -639,7 +639,7 @@ func (p *GovernancePlugin) Evaluate(ctx *schemas.BifrostContext, evaluationReque
 	// grant nothing is a different answer, reported by the identity step below; telling a caller who
 	// supplied a key to supply one is not a useful refusal.
 	p.cfgMutex.RLock()
-	if !presentedGrantBearingCredential(ctx) && !hasDirectKeyAuth(ctx) && p.isVkMandatory != nil && *p.isVkMandatory {
+	if !PresentedAnyCredential(ctx) && p.isVkMandatory != nil && *p.isVkMandatory {
 		message := "virtual key is required. Provide a virtual key via the x-bf-vk header."
 		if p.isEnterprise {
 			message = "authentication is required. Provide a virtual key (x-bf-vk), API key, or user token."

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -178,7 +178,16 @@ func hasDirectKeyAuth(ctx *schemas.BifrostContext) bool {
 // lacking an access it was never meant to have. It still answers the mandatory-auth question (something
 // was presented), which is why that step asks about it separately.
 func presentedGrantBearingCredential(ctx *schemas.BifrostContext) bool {
-	if identity := ctx.Grant().Identity(); identity != nil {
+	// A context with no grant at all reads as nothing presented, the same answer an empty
+	// identity gives. Worth stating explicitly because Grant() returns a nil interface rather
+	// than a zero value, so reaching straight for Identity() panics: every request that reaches
+	// Evaluate has a grant, but a transport asking this question directly (realtime admission)
+	// can hold a context built before one was ever recorded.
+	g := ctx.Grant()
+	if g == nil {
+		return false
+	}
+	if identity := g.Identity(); identity != nil {
 		return identity.Presented() || identity.User() != nil
 	}
 	return false
@@ -197,4 +206,24 @@ func (p *GovernancePlugin) pruneMCPIncludeToolsFromContext(ctx *schemas.BifrostC
 	requested, _ := existing.([]string)
 	ctx.SetValue(schemas.MCPContextKeyIncludeTools, access.NarrowMCPToolIncludeList(requested))
 	return true
+}
+
+// PresentedAnyCredential reports whether the request carried any credential at all that answers
+// the mandatory-authentication question: a grant-bearing one (virtual key or authenticated
+// identity), or a direct provider key. It is the exact question Evaluate's first step asks, and
+// asking it alone costs nothing - it reads the context and settles no limits.
+//
+// Exported so a transport can admit or refuse a connection on the same answer, rather than
+// reimplementing "was this authenticated" beside this one. Realtime is the caller that needs it:
+// a WebSocket upgrade opens an upstream provider session on the operator's key before any turn
+// exists to evaluate, so admission has to be decided at the upgrade, while the per-turn pipeline
+// keeps owning access and limits. Callers must still let the per-request pipeline run - this
+// answers only whether a credential was presented, never whether it grants what is being asked
+// for, and it deliberately settles no limits so an admission check cannot double-count usage
+// against the turns that follow.
+func PresentedAnyCredential(ctx *schemas.BifrostContext) bool {
+	if ctx == nil {
+		return false
+	}
+	return presentedGrantBearingCredential(ctx) || hasDirectKeyAuth(ctx)
 }

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
+	"net/url"
 	"slices"
 	"sort"
 	"strconv"
@@ -19,6 +21,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/mcp"
 	mcputils "github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/network"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -1515,6 +1518,72 @@ func (req *MCPClientUpdateRequest) resolvedAllowByDefault(existing bool) bool {
 	return schemas.ResolveAllowByDefault(req.AllowByDefault, req.AllowOnAllVirtualKeys)
 }
 
+// rejectPrivateMCPTargetIfAuthBypassed refuses to register an HTTP/SSE MCP
+// client whose connection_string resolves to a loopback, private-network,
+// link-local, or CGNAT address when the caller reached this endpoint with no
+// credential check at all (default-open posture, BifrostContextKeyAuthBypassed).
+// A genuinely authenticated admin keeps the documented ability to point an MCP
+// client at a local or private server (see docs/mcp/connecting-to-servers.mdx,
+// whose own HTTP-client example uses http://localhost:3001/mcp) - only the
+// unauthenticated path is restricted, the same scoping used for the STDIO
+// client gate below. Returns true if the request was rejected (the error
+// response has already been written); the caller should return immediately.
+func rejectPrivateMCPTargetIfAuthBypassed(ctx *fasthttp.RequestCtx, connType string, connectionString *schemas.SecretVar) bool {
+	authBypassed, _ := ctx.UserValue(schemas.BifrostContextKeyAuthBypassed).(bool)
+	if !authBypassed {
+		return false
+	}
+	if connType != string(schemas.MCPConnectionTypeHTTP) && connType != string(schemas.MCPConnectionTypeSSE) {
+		return false
+	}
+	if connectionString == nil {
+		return false
+	}
+	parsed, err := url.Parse(connectionString.GetValue())
+	if err != nil || parsed.Hostname() == "" {
+		// Malformed/unresolvable target: let the normal connect path surface
+		// its own error rather than duplicating URL validation here.
+		return false
+	}
+	// A bounded, request-independent context: this lookup is a pre-check, not
+	// a dial, and must not be tied to the request's own (often much longer)
+	// deadline.
+	lookupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ips, err := net.DefaultResolver.LookupIP(lookupCtx, "ip", parsed.Hostname())
+	if err != nil {
+		return false
+	}
+	for _, ip := range ips {
+		if !network.IsPublicIP(ip) {
+			SendError(ctx, fasthttp.StatusForbidden, "unauthenticated callers cannot register MCP clients that connect to loopback, private-network, or link-local addresses; set an admin password to allow this")
+			return true
+		}
+	}
+	return false
+}
+
+// rejectStdioMCPClientIfAuthBypassed refuses to register a stdio MCP client for
+// a caller that was let through because dashboard auth is unconfigured or
+// disabled. A stdio client makes Bifrost exec() an admin-supplied command and
+// args as the gateway process: intentional admin functionality, but only for a
+// caller who actually authenticated. Registering one over this network API with
+// no credential check is equivalent to unauthenticated remote code execution,
+// so it is refused even though the rest of the management API stays open for
+// the zero-config experience. Stdio clients can still be provisioned by an
+// operator with host/filesystem access via config.json. Returns true if the
+// request was rejected (the error response has already been written).
+func rejectStdioMCPClientIfAuthBypassed(ctx *fasthttp.RequestCtx, connType string) bool {
+	if connType != string(schemas.MCPConnectionTypeSTDIO) {
+		return false
+	}
+	if bypassed, _ := ctx.UserValue(schemas.BifrostContextKeyAuthBypassed).(bool); !bypassed {
+		return false
+	}
+	SendError(ctx, fasthttp.StatusForbidden, "Registering a stdio MCP client requires an authenticated admin session; dashboard auth is currently disabled or unconfigured. Enable dashboard authentication, or provision this client via config.json instead.")
+	return true
+}
+
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
 func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	if h.store.ConfigStore == nil {
@@ -1527,6 +1596,16 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	var req MCPClientRequest
 	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
+		return
+	}
+
+	// Both gates run before anything else: registering a client is what makes
+	// Bifrost spawn the subprocess / dial the target, so a refusal has to land
+	// before any of that work is scheduled.
+	if rejectStdioMCPClientIfAuthBypassed(ctx, req.ConnectionType) {
+		return
+	}
+	if rejectPrivateMCPTargetIfAuthBypassed(ctx, req.ConnectionType, req.ConnectionString) {
 		return
 	}
 

--- a/transports/bifrost-http/handlers/mcpregistrationguard_test.go
+++ b/transports/bifrost-http/handlers/mcpregistrationguard_test.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// TestRejectStdioMCPClientIfAuthBypassed_UnauthenticatedRejected proves the
+// reported RCE primitive is closed: registering a stdio client makes Bifrost
+// exec() the supplied command, so a caller let through with no credential
+// check at all must be refused.
+func TestRejectStdioMCPClientIfAuthBypassed_UnauthenticatedRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	if !rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO)) {
+		t.Fatal("expected unauthenticated stdio registration to be rejected")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusForbidden, ctx.Response.StatusCode())
+	}
+}
+
+// TestRejectStdioMCPClientIfAuthBypassed_AuthenticatedAllowed proves stdio
+// registration stays available to a genuinely authenticated admin - the gate
+// is on the credential check, not on the capability.
+func TestRejectStdioMCPClientIfAuthBypassed_AuthenticatedAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	// AuthBypassed intentionally left unset, as it is for an authenticated request.
+
+	if rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO)) {
+		t.Fatal("expected an authenticated admin's stdio registration to be allowed")
+	}
+}
+
+// TestRejectStdioMCPClientIfAuthBypassed_HTTPUnaffected proves this gate is
+// scoped to stdio; HTTP/SSE targets are handled by the separate SSRF check.
+func TestRejectStdioMCPClientIfAuthBypassed_HTTPUnaffected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	if rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP)) {
+		t.Fatal("expected HTTP connection type to be unaffected by the stdio gate")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLoopbackRejected proves
+// the unauthenticated (default-open) path cannot register an HTTP MCP client
+// pointing at loopback - the reproduction target from the reported SSRF.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLoopbackRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP), schemas.NewSecretVar("http://127.0.0.1:8080/health"))
+
+	if !rejected {
+		t.Fatal("expected an unauthenticated loopback target to be rejected")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusForbidden, ctx.Response.StatusCode())
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLinkLocalRejected proves
+// the cloud-metadata target from the report is rejected for an unauthenticated
+// caller.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLinkLocalRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSSE), schemas.NewSecretVar("http://169.254.169.254/latest/meta-data/"))
+
+	if !rejected {
+		t.Fatal("expected an unauthenticated link-local target to be rejected")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_AuthenticatedLoopbackAllowed proves a
+// genuinely authenticated caller keeps the documented ability to register a
+// local MCP server (docs/mcp/connecting-to-servers.mdx uses
+// http://localhost:3001/mcp as its own example) - this fix must not break that
+// flow, only the unauthenticated one.
+func TestRejectPrivateMCPTargetIfAuthBypassed_AuthenticatedLoopbackAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	// AuthBypassed intentionally left unset, as it is for an authenticated request.
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP), schemas.NewSecretVar("http://127.0.0.1:3001/mcp"))
+
+	if rejected {
+		t.Fatal("expected an authenticated caller's loopback target to be allowed")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedPublicTargetAllowed
+// proves an unauthenticated caller can still register a normal internet-hosted
+// MCP server - this fix only restricts private/loopback/link-local targets,
+// not HTTP/SSE clients in general. Uses an IP literal (not a hostname) so the
+// test doesn't depend on DNS being reachable in the test environment.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedPublicTargetAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSSE), schemas.NewSecretVar("https://1.1.1.1/mcp/sse"))
+
+	if rejected {
+		t.Fatal("expected a public target to be allowed even for an unauthenticated caller")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_STDIOUnaffected proves this check is
+// scoped to HTTP/SSE only; stdio registration has its own separate gate.
+func TestRejectPrivateMCPTargetIfAuthBypassed_STDIOUnaffected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO), nil)
+
+	if rejected {
+		t.Fatal("expected STDIO connection type to be unaffected by this check")
+	}
+}

--- a/transports/bifrost-http/handlers/realtimeauthgate.go
+++ b/transports/bifrost-http/handlers/realtimeauthgate.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/plugins/governance"
+)
+
+// realtimeAuthRefusalMessage is what an anonymous realtime caller is told. It names the two
+// credentials that work, because the realtime flow has a second one (the ephemeral client
+// secret) that the generic inference message does not mention.
+const realtimeAuthRefusalMessage = "authentication is required for realtime connections. Provide a virtual key (x-bf-vk or an sk-bf- bearer token), or an ephemeral client secret minted by POST /v1/realtime/client_secrets."
+
+// refuseUnauthenticatedRealtime reports whether a realtime connection must be refused before it
+// is established, and is the admission gate for every realtime transport (WebSocket upgrade and
+// both WebRTC SDP routes).
+//
+// Realtime needs this gate because it is the one inference surface where accepting the
+// connection already spends something: both transports select the operator's provider key and
+// open an upstream session before any turn exists. The per-turn pipeline
+// (RunRealtimeTurnPreHooks -> governance PreLLMHook) is the authoritative check for access and
+// limits and keeps that job, but it first runs a turn too late to stop an anonymous client from
+// standing up a session on the operator's key. Nothing in the transport middleware covers the
+// gap either: inference auth is delegated wholesale to governance, whose refusal arrives with
+// the first turn.
+//
+// The question asked here is deliberately the narrow one - "was any credential presented?" -
+// answered by governance's own exported predicate rather than a second implementation of it, so
+// admission cannot drift from the funnel's first step. It settles no limits, so it cannot
+// double-count usage against the turns that follow.
+//
+// A valid ephemeral client secret counts as a credential. That is the whole point of
+// POST /v1/realtime/client_secrets: a browser cannot hold a virtual key, so it is handed a
+// short-lived ek_ token instead, and the mapping back to the real key is restored after the
+// connection is established. Requiring a virtual key here would break that documented flow.
+// An ek_ token that resolves to no mapping is expired, revoked, or forged, and is refused.
+//
+// Returns nil when the connection may proceed.
+func refuseUnauthenticatedRealtime(
+	enforceAuthOnInference bool,
+	kv schemas.KVStore,
+	bifrostCtx *schemas.BifrostContext,
+	authorizationHeader string,
+) *schemas.BifrostError {
+	// The operator has not asked for authentication on inference, so realtime is open for the
+	// same reason every other inference route is. Closing it here regardless would make realtime
+	// stricter than /v1/chat/completions on the same deployment.
+	if !enforceAuthOnInference {
+		return nil
+	}
+	if governance.PresentedAnyCredential(bifrostCtx) {
+		return nil
+	}
+	if token := extractRealtimeBearerTokenFromHeader(authorizationHeader); isRealtimeEphemeralToken(token) {
+		if _, ok := lookupRealtimeEphemeralKeyMapping(kv, token); ok {
+			return nil
+		}
+	}
+	return newRealtimeWireBifrostError(401, "invalid_request_error", realtimeAuthRefusalMessage)
+}

--- a/transports/bifrost-http/handlers/realtimeauthgate_test.go
+++ b/transports/bifrost-http/handlers/realtimeauthgate_test.go
@@ -1,0 +1,188 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/grant"
+	"github.com/maximhq/bifrost/framework/kvstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+func newRealtimeGateContext(t *testing.T) (*schemas.BifrostContext, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	return ctx, cancel
+}
+
+// TestRefuseUnauthenticatedRealtime_AnonymousRefusedWhenEnforced is the reported bypass: an
+// operator has turned on enforce_auth_on_inference, and a client presenting nothing at all
+// opens a realtime session on the operator's provider key.
+func TestRefuseUnauthenticatedRealtime_AnonymousRefusedWhenEnforced(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	err := refuseUnauthenticatedRealtime(true, nil, ctx, "")
+
+	if err == nil {
+		t.Fatal("expected an anonymous realtime connection to be refused when auth is enforced")
+	}
+	if err.StatusCode == nil || *err.StatusCode != 401 {
+		t.Errorf("expected status 401, got %v", err.StatusCode)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_AnonymousAllowedWhenNotEnforced proves the gate follows the
+// operator's own switch. With enforce_auth_on_inference off, realtime must stay exactly as open
+// as /v1/chat/completions on the same deployment - this fix must not make realtime stricter than
+// the rest of inference.
+func TestRefuseUnauthenticatedRealtime_AnonymousAllowedWhenNotEnforced(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	if err := refuseUnauthenticatedRealtime(false, nil, ctx, ""); err != nil {
+		t.Fatalf("expected an anonymous connection to be allowed when auth is not enforced, got %v", err)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_VirtualKeyAllowed proves a virtual-key caller is admitted.
+// The credential is recorded the same way createBifrostContextFromAuth records it at upgrade.
+func TestRefuseUnauthenticatedRealtime_VirtualKeyAllowed(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	lib.RecordCredential(ctx, grant.NewCredential(grant.CredentialVirtualKey, "sk-bf-test"))
+
+	if err := refuseUnauthenticatedRealtime(true, nil, ctx, ""); err != nil {
+		t.Fatalf("expected a virtual-key caller to be admitted, got %v", err)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_ValidEphemeralTokenAllowed proves the documented browser
+// flow still works: POST /v1/realtime/client_secrets mints an ek_ token, and a browser that
+// cannot hold a virtual key connects with that instead. Refusing it would break the very flow
+// the realtime design delegates auth to.
+func TestRefuseUnauthenticatedRealtime_ValidEphemeralTokenAllowed(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	kv, err := kvstore.New(kvstore.Config{})
+	if err != nil {
+		t.Fatalf("failed to create kv store: %v", err)
+	}
+	token := "ek_test_token"
+	payload, err := json.Marshal(realtimeEphemeralKeyMapping{KeyID: "key-1"})
+	if err != nil {
+		t.Fatalf("failed to marshal mapping: %v", err)
+	}
+	if err := kv.SetWithTTL(buildRealtimeEphemeralKeyMappingKey(token), payload, time.Minute); err != nil {
+		t.Fatalf("failed to seed kv store: %v", err)
+	}
+
+	if gateErr := refuseUnauthenticatedRealtime(true, kv, ctx, "Bearer "+token); gateErr != nil {
+		t.Fatalf("expected a valid ephemeral client secret to be admitted, got %v", gateErr)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_UnknownEphemeralTokenRefused proves an ek_ token that maps
+// to nothing - expired, revoked, or forged - does not get in on the strength of its prefix.
+func TestRefuseUnauthenticatedRealtime_UnknownEphemeralTokenRefused(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	kv, err := kvstore.New(kvstore.Config{})
+	if err != nil {
+		t.Fatalf("failed to create kv store: %v", err)
+	}
+
+	gateErr := refuseUnauthenticatedRealtime(true, kv, ctx, "Bearer ek_not_a_real_token")
+
+	if gateErr == nil {
+		t.Fatal("expected an unmapped ephemeral token to be refused")
+	}
+	if gateErr.StatusCode == nil || *gateErr.StatusCode != 401 {
+		t.Errorf("expected status 401, got %v", gateErr.StatusCode)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_NonEphemeralBearerRefused proves an arbitrary bearer token
+// that is neither a virtual key nor an ephemeral secret does not satisfy the gate. Without this
+// the check would degrade to "sent an Authorization header".
+func TestRefuseUnauthenticatedRealtime_NonEphemeralBearerRefused(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	if gateErr := refuseUnauthenticatedRealtime(true, nil, ctx, "Bearer sk-some-openai-key"); gateErr == nil {
+		t.Fatal("expected a non-virtual-key, non-ephemeral bearer token to be refused")
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_DirectKeyAllowed proves a direct provider key admits the
+// connection. Governance's own first step counts it as authentication presented, and the gate
+// must give the same answer rather than a stricter one of its own.
+func TestRefuseUnauthenticatedRealtime_DirectKeyAllowed(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+	ctx.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{Value: *schemas.NewSecretVar("sk-direct")})
+
+	if gateErr := refuseUnauthenticatedRealtime(true, nil, ctx, ""); gateErr != nil {
+		t.Fatalf("expected a direct-key caller to be admitted, got %v", gateErr)
+	}
+}
+
+// newRealtimeUpgradeRequest builds a well-formed WebSocket handshake for path, so that if the
+// handler does reach the upgrader the upgrade succeeds and the response records 101. That is
+// what lets the tests below tell "refused on the HTTP request" (401) apart from "upgraded and
+// told in-band" (101), which is the whole distinction the admission gate exists to draw.
+func newRealtimeUpgradeRequest(path string) *fasthttp.RequestCtx {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI(path)
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.Set("Connection", "Upgrade")
+	ctx.Request.Header.Set("Upgrade", "websocket")
+	ctx.Request.Header.Set("Sec-WebSocket-Version", "13")
+	ctx.Request.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	return ctx
+}
+
+func newRealtimeUpgradeHandler(enforceAuthOnInference bool) *WSRealtimeHandler {
+	config := &lib.Config{ClientConfig: &configstore.ClientConfig{EnforceAuthOnInference: enforceAuthOnInference}}
+	return &WSRealtimeHandler{config: config, handlerStore: config}
+}
+
+// TestWSRealtimeHandleUpgrade_AnonymousRefusedBeforeTargetResolution pins the gate's position in
+// the WebSocket handler, not just its verdict. With auth enforced, an anonymous caller must be
+// refused with a plain 401 on the HTTP request regardless of what else is wrong with it. If the
+// target is resolved first, a request with a missing or malformed model is upgraded and answered
+// in-band with a 400 before the gate ever runs, which both hands an anonymous caller a completed
+// upgrade and lets them probe which models and paths the deployment accepts.
+func TestWSRealtimeHandleUpgrade_AnonymousRefusedBeforeTargetResolution(t *testing.T) {
+	SetLogger(&mockLogger{})
+	ctx := newRealtimeUpgradeRequest("/v1/realtime") // no model: target resolution fails
+
+	newRealtimeUpgradeHandler(true).handleUpgrade(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusUnauthorized {
+		t.Fatalf("expected an anonymous upgrade with an unresolvable target to be refused with 401 before any upgrade, got %d", got)
+	}
+}
+
+// TestWSRealtimeHandleUpgrade_TargetErrorStaysInBandWhenNotEnforced is the control for the test
+// above: with auth not enforced, an unresolvable target must still take the existing path of a
+// completed upgrade and an in-band error frame, so the reorder narrows nothing for open
+// deployments.
+func TestWSRealtimeHandleUpgrade_TargetErrorStaysInBandWhenNotEnforced(t *testing.T) {
+	SetLogger(&mockLogger{})
+	ctx := newRealtimeUpgradeRequest("/v1/realtime")
+
+	newRealtimeUpgradeHandler(false).handleUpgrade(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusSwitchingProtocols {
+		t.Fatalf("expected an open deployment to upgrade and report the target error in-band (101), got %d", got)
+	}
+}

--- a/transports/bifrost-http/handlers/webrtc_realtime.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime.go
@@ -304,6 +304,19 @@ func (h *WebRTCRealtimeHandler) runWebRTCRelay(
 		bifrostCtx.SetValue(schemas.BifrostContextKeyIntegrationType, "openai")
 	}
 
+	// Admission check, before any key is selected: resolveRealtimeWebRTCKeys below reaches
+	// SelectKeyForProviderRequestType and hands the relay the operator's provider key. Covers
+	// both the GA /realtime/calls and the legacy raw-SDP routes, which funnel through here.
+	if authErr := refuseUnauthenticatedRealtime(
+		h.config.ClientConfig.EnforceAuthOnInference,
+		h.handlerStore.GetKVStore(),
+		bifrostCtx,
+		string(ctx.Request.Header.Peek("Authorization")),
+	); authErr != nil {
+		SendBifrostError(ctx, authErr)
+		return
+	}
+
 	authKey, selectedKey, err := h.resolveRealtimeWebRTCKeys(ctx, bifrostCtx, providerKey, model)
 	if err != nil {
 		SendBifrostError(ctx, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", err.Error(), nil))

--- a/transports/bifrost-http/handlers/wsrealtime.go
+++ b/transports/bifrost-http/handlers/wsrealtime.go
@@ -79,25 +79,12 @@ func (h *WSRealtimeHandler) handleUpgrade(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	providerKey, model, err := resolveRealtimeTarget(ctx, h.config, path, modelParam, deploymentParam)
-	if err != nil {
-		upgrader := h.websocketUpgrader("")
-		upgradeErr := upgrader.Upgrade(ctx, func(conn *ws.Conn) {
-			defer conn.Close()
-			clientConn := newRealtimeClientConn(conn)
-			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()))
-		})
-		if upgradeErr != nil {
-			logger.Warn("websocket upgrade failed for %s: %v", path, upgradeErr)
-		}
-		return
-	}
-
-	// Run PreRequestHook to give governance + LB a chance to route the realtime connection.
-	// Realtime bypasses handleRequest (per-turn pipelines instead), so we invoke the routing
-	// phase explicitly here. Mutations to provider/model are read back into the local vars
-	// and copied to fasthttp user values so snapshotRealtimeMiddlewareValues picks up any
-	// ctx changes (governance team/customer IDs, routing engine logs).
+	// The pre-request context is built first because the admission gate below reads the
+	// credentials it records. Realtime bypasses handleRequest (per-turn pipelines instead), so
+	// the routing phase is invoked explicitly further down. Mutations to provider/model are
+	// read back into the local vars and copied to fasthttp user values so
+	// snapshotRealtimeMiddlewareValues picks up any ctx changes (governance team/customer IDs,
+	// routing engine logs).
 	preReqCtx, preReqCancel := createBifrostContextFromAuth(h.handlerStore, auth)
 	if preReqCtx == nil {
 		preReqCancel()
@@ -115,6 +102,41 @@ func (h *WSRealtimeHandler) handleUpgrade(ctx *fasthttp.RequestCtx) {
 	preReqCtx.SetValue(schemas.BifrostContextKeyHTTPRequestType, schemas.RealtimeRequest)
 	if realtimeDefaultProviderForPath(path) == schemas.OpenAI {
 		preReqCtx.SetValue(schemas.BifrostContextKeyIntegrationType, "openai")
+	}
+
+	// Admission check, before the upgrade, before any routing work, and before the target is
+	// even resolved: completing this upgrade selects the operator's provider key and opens an
+	// upstream session, which the per-turn governance pipeline only gets to inspect one turn
+	// too late. Refused with a plain 401 on the HTTP request rather than an in-band error
+	// frame, matching how the auth middleware already refuses unauthenticated WebSocket
+	// upgrades. Ordering it ahead of resolveRealtimeTarget matters: that resolver's error path
+	// upgrades the connection to report in-band, so an anonymous caller with a missing or
+	// malformed model would otherwise get a completed upgrade and a way to probe which models
+	// and paths the deployment accepts, without ever presenting a credential.
+	if authErr := refuseUnauthenticatedRealtime(
+		h.config.ClientConfig.EnforceAuthOnInference,
+		h.handlerStore.GetKVStore(),
+		preReqCtx,
+		auth.authorization,
+	); authErr != nil {
+		preReqCancel()
+		SendBifrostError(ctx, authErr)
+		return
+	}
+
+	providerKey, model, err := resolveRealtimeTarget(ctx, h.config, path, modelParam, deploymentParam)
+	if err != nil {
+		preReqCancel()
+		upgrader := h.websocketUpgrader("")
+		upgradeErr := upgrader.Upgrade(ctx, func(conn *ws.Conn) {
+			defer conn.Close()
+			clientConn := newRealtimeClientConn(conn)
+			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()))
+		})
+		if upgradeErr != nil {
+			logger.Warn("websocket upgrade failed for %s: %v", path, upgradeErr)
+		}
+		return
 	}
 	// Surface full request headers + query params on the pre-request context so governance
 	// CEL routing rules (which read headers[...] / params[...]) see the same shape they would


### PR DESCRIPTION
## Summary

Realtime connections (`/v1/realtime` WebSocket upgrades and `/v1/realtime/calls` WebRTC routes) were not enforcing `enforce_auth_on_inference` at connect time. Because accepting a realtime connection immediately selects the operator's provider key and opens an upstream session, an anonymous client could establish a session on the operator's key before the per-turn governance pipeline had any opportunity to refuse it. This PR adds an admission gate that refuses unauthenticated realtime connections with a `401` at the moment of upgrade/connect, matching the intent of the operator's `enforce_auth_on_inference` setting.

## Changes

- Added `refuseUnauthenticatedRealtime` in `realtimeauthgate.go`, a single admission predicate called by both the WebSocket upgrade path (`wsrealtime.go`) and the WebRTC relay path (`webrtc_realtime.go`) before any key selection or upstream session is opened.
- Exported `PresentedAnyCredential` from the governance plugin so the transport layer can ask the exact same "was any credential presented?" question that governance's own first evaluation step asks, rather than reimplementing it.
- Fixed a nil-pointer panic in `presentedGrantBearingCredential`: `Grant()` returns a nil interface for contexts built before a grant is recorded (e.g. at realtime admission), so the function now guards against that before calling `Identity()`.
- Collapsed the governance `Evaluate` early-exit condition from `!presentedGrantBearingCredential(ctx) && !hasDirectKeyAuth(ctx)` to `!PresentedAnyCredential(ctx)`, which is the same predicate now shared with the transport gate.
- Ephemeral client secrets (`ek_` tokens from `POST /v1/realtime/client_secrets`) are explicitly accepted by the gate, preserving the documented browser flow where a client cannot hold a virtual key.
- Updated the `enforce_auth_on_inference` documentation to describe the realtime `401` behaviour and the ephemeral client secret path.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./plugins/governance/... ./transports/bifrost-http/handlers/...
```

**Manual verification:**

1. Set `enforce_auth_on_inference: true` in your deployment config.
2. Attempt a WebSocket upgrade to `/v1/realtime` with no credentials — expect `401`.
3. Attempt the same upgrade with a valid virtual key (`x-bf-vk` header or `sk-bf-` bearer token) — expect the connection to be accepted.
4. Mint an ephemeral client secret via `POST /v1/realtime/client_secrets`, then connect using that token as a bearer — expect the connection to be accepted.
5. Connect with an expired or unknown `ek_` token — expect `401`.
6. With `enforce_auth_on_inference: false`, connect with no credentials — expect the connection to be accepted, matching the behaviour of `/v1/chat/completions` on the same deployment.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This closes an authentication bypass on realtime endpoints: when `enforce_auth_on_inference` is enabled, anonymous clients could previously open upstream provider sessions on the operator's key by connecting to `/v1/realtime` or `/v1/realtime/calls` before the per-turn governance pipeline ran. The gate now refuses those connections at the HTTP layer before any provider key is selected or upstream session is opened.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable