### PR TITLE
scope prompt child reads and writes to their parent prompt

### DIFF
--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -18,8 +18,15 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/network"
 	"github.com/maximhq/bifrost/core/schemas"
 )
+
+// mcpDialTimeout bounds each dial attempted by the SSRF-safe HTTP client MCP
+// client connections use, matching the timeout convention used by the other
+// SSRF-guarded outbound clients in this codebase (image/document fetch, skill
+// URL sources).
+const mcpDialTimeout = 10 * time.Second
 
 // AcquireClientConn returns a live upstream MCP client connection for the
 // given client state, along with a release function the caller must invoke
@@ -2573,36 +2580,62 @@ func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *s
 	}
 }
 
-// buildTLSHTTPClient constructs an *http.Client with a custom TLS configuration derived
-// from MCPTLSConfig. Returns nil when tlsCfg is nil so callers can use the library default.
+// buildTLSHTTPClient constructs an *http.Client for MCP server connections. The
+// transport is always routed through network.PrivateNetworkDialContext, which
+// blocks link-local and unspecified destinations (including the
+// 169.254.169.254 cloud metadata endpoint) but - unlike the stricter
+// network.SSRFSafeDialContext used for image/document fetch, webhook
+// delivery, and skill URL sources - permits loopback and private-network
+// targets. Loopback/private MCP servers are the documented primary use case
+// for this feature (docs/mcp/connecting-to-servers.mdx's own HTTP-client
+// example is http://localhost:3001/mcp), so this is dial-time defense in
+// depth against the categorically illegitimate ranges, not a substitute for
+// the caller's own authorization check: an unauthenticated caller is refused
+// outright before reaching this code (rejectPrivateMCPTargetIfAuthBypassed in
+// transports/bifrost-http/handlers/mcp.go).
+//
+// Previously this returned nil when tlsCfg was nil, leaving callers to fall
+// back to the mcp-go library's own default client, which carried no guard at
+// all - not even the link-local/metadata block applied here.
+//
+// TLS customization from MCPTLSConfig is layered on top when provided.
 // InsecureSkipVerify takes priority over CACertPEM when both are set.
 func (m *MCPManager) buildTLSHTTPClient(tlsCfg *schemas.MCPTLSConfig) (*http.Client, error) {
-	if tlsCfg == nil {
-		return nil, nil
-	}
-	tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
-	if tlsCfg.InsecureSkipVerify {
-		m.logger.Warn("MCP client: skipping TLS verification — do not use in production")
-		tlsConfig.InsecureSkipVerify = true
-	} else if tlsCfg.CACertPEM != nil {
-		caPEM := tlsCfg.CACertPEM.GetValue()
-		if caPEM != "" {
-			rootCAs, err := x509.SystemCertPool()
-			if err != nil {
-				rootCAs = x509.NewCertPool()
-			}
-			if !rootCAs.AppendCertsFromPEM([]byte(caPEM)) {
-				return nil, fmt.Errorf("failed to parse MCP CA certificate PEM")
-			}
-			tlsConfig.RootCAs = rootCAs
-		}
-	}
-	transport, ok := http.DefaultTransport.(*http.Transport)
+	baseTransport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
-		transport = &http.Transport{}
+		baseTransport = &http.Transport{}
 	}
-	cloned := transport.Clone()
-	cloned.TLSClientConfig = tlsConfig
+	cloned := baseTransport.Clone()
+	// Clone() preserves DefaultTransport's http.ProxyFromEnvironment. With a
+	// proxy configured, http.Transport hands DialContext the proxy's address
+	// instead of the MCP destination, so the guard below would validate the
+	// proxy and the proxy would forward to the blocked target. Drop it: the
+	// guard is only meaningful when the dialer sees the real destination,
+	// which is also how every other SSRF-guarded client here is built (fresh,
+	// proxy-free transports in fetch.go, webhooks, and skills_serving).
+	cloned.Proxy = nil
+	cloned.DialContext = network.PrivateNetworkDialContext(mcpDialTimeout)
+
+	if tlsCfg != nil {
+		tlsConfig := &tls.Config{MinVersion: tls.VersionTLS12}
+		if tlsCfg.InsecureSkipVerify {
+			m.logger.Warn("MCP client: skipping TLS verification — do not use in production")
+			tlsConfig.InsecureSkipVerify = true
+		} else if tlsCfg.CACertPEM != nil {
+			caPEM := tlsCfg.CACertPEM.GetValue()
+			if caPEM != "" {
+				rootCAs, err := x509.SystemCertPool()
+				if err != nil {
+					rootCAs = x509.NewCertPool()
+				}
+				if !rootCAs.AppendCertsFromPEM([]byte(caPEM)) {
+					return nil, fmt.Errorf("failed to parse MCP CA certificate PEM")
+				}
+				tlsConfig.RootCAs = rootCAs
+			}
+		}
+		cloned.TLSClientConfig = tlsConfig
+	}
 	return &http.Client{Transport: cloned}, nil
 }
 

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -3,7 +3,12 @@ package mcp
 import (
 	"context"
 	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
@@ -599,4 +604,146 @@ func TestCloseAndMarkNeedsReauth_PerCallSharedOAuth_ReturnsReconnectNotApplicabl
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, schemas.ErrMCPReconnectNotApplicable))
 	assert.NotContains(t, err.Error(), "per-user", "a genuinely shared client must not be told it's a per-user auth client")
+}
+
+// TestBuildTLSHTTPClientNeverFallsBackToUnguardedDefault proves buildTLSHTTPClient
+// always returns a non-nil client (with or without TLS configured) so callers
+// never fall back to the mcp-go library's own default HTTP client, which
+// carries no dial guard at all.
+func TestBuildTLSHTTPClientNeverFallsBackToUnguardedDefault(t *testing.T) {
+	for _, tlsCfg := range []*schemas.MCPTLSConfig{nil, {InsecureSkipVerify: true}} {
+		httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(tlsCfg)
+		require.NoError(t, err)
+		require.NotNil(t, httpClient)
+
+		transport, ok := httpClient.Transport.(*http.Transport)
+		require.True(t, ok)
+		require.NotNil(t, transport.DialContext)
+	}
+}
+
+// TestBuildTLSHTTPClientBlocksLinkLocal proves the dial-time guard refuses
+// link-local destinations (including the 169.254.169.254 cloud metadata
+// endpoint) - the one class of target with no legitimate MCP use case under
+// any deployment topology, authenticated or not.
+func TestBuildTLSHTTPClientBlocksLinkLocal(t *testing.T) {
+	httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+	require.NoError(t, err)
+	transport := httpClient.Transport.(*http.Transport)
+
+	_, err = transport.DialContext(context.Background(), "tcp", "169.254.169.254:80")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "blocked connection to link-local address")
+}
+
+// TestBuildTLSHTTPClientAllowsLoopback proves loopback MCP servers keep
+// working: connecting to a local MCP tool server on the same host is the
+// documented primary HTTP-client use case
+// (docs/mcp/connecting-to-servers.mdx), so the dial-time guard here must not
+// reject it. The unauthenticated-caller case is refused earlier, at the HTTP
+// handler layer (rejectPrivateMCPTargetIfAuthBypassed), not here.
+func TestBuildTLSHTTPClientAllowsLoopback(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := ln.Close(); err != nil {
+			t.Errorf("failed to close test listener: %v", err)
+		}
+	})
+	// The accepted server side is handed back to the test body so both ends are closed, and
+	// their Close results checked, on the test goroutine rather than after it may have ended.
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		if conn, err := ln.Accept(); err == nil {
+			accepted <- conn
+		}
+	}()
+
+	httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+	require.NoError(t, err)
+	transport := httpClient.Transport.(*http.Transport)
+
+	conn, err := transport.DialContext(context.Background(), "tcp", ln.Addr().String())
+	require.NoError(t, err)
+	require.NoError(t, conn.Close())
+	select {
+	case server := <-accepted:
+		require.NoError(t, server.Close())
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener never accepted the dialed connection")
+	}
+}
+
+// TestBuildTLSHTTPClientNeverRoutesThroughProxy proves the dial-time guard
+// cannot be sidestepped by a proxy. http.DefaultTransport carries
+// http.ProxyFromEnvironment, and Clone() preserves it; when a proxy is
+// configured, http.Transport hands DialContext the proxy's address rather than
+// the MCP destination, so PrivateNetworkDialContext would validate the proxy
+// and let the proxy forward to the blocked link-local target. Every other
+// SSRF-guarded client in this repo (image/document fetch, webhook delivery,
+// skill URL sources) builds a fresh proxy-free transport; the MCP client must
+// end up with the same property despite starting from a clone.
+//
+// The proxy is injected by swapping DefaultTransport.Proxy rather than via
+// HTTP_PROXY, because ProxyFromEnvironment reads the environment once per
+// process and would not see a t.Setenv made after any earlier test used it.
+// This test therefore stays sequential (no t.Parallel) and restores the
+// original Proxy on cleanup.
+func TestBuildTLSHTTPClientNeverRoutesThroughProxy(t *testing.T) {
+	proxyLn, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		if err := proxyLn.Close(); err != nil {
+			t.Errorf("failed to close proxy listener: %v", err)
+		}
+	})
+	// Any accepted connection is itself the failure; its Close result is passed back to the
+	// test body rather than reported from the goroutine, which may outlive the subtest.
+	var proxyHits atomic.Int32
+	proxyCloseErrs := make(chan error, 8)
+	go func() {
+		for {
+			conn, err := proxyLn.Accept()
+			if err != nil {
+				return
+			}
+			proxyHits.Add(1)
+			if err := conn.Close(); err != nil {
+				select {
+				case proxyCloseErrs <- err:
+				default:
+				}
+			}
+		}
+	}()
+	proxyURL, err := url.Parse("http://" + proxyLn.Addr().String())
+	require.NoError(t, err)
+
+	base, ok := http.DefaultTransport.(*http.Transport)
+	require.True(t, ok)
+	origProxy := base.Proxy
+	base.Proxy = http.ProxyURL(proxyURL)
+	t.Cleanup(func() { base.Proxy = origProxy })
+
+	for _, scheme := range []string{"http", "https"} {
+		t.Run(scheme, func(t *testing.T) {
+			httpClient, err := (&MCPManager{logger: defaultLogger}).buildTLSHTTPClient(nil)
+			require.NoError(t, err)
+			httpClient.Timeout = 5 * time.Second
+
+			resp, err := httpClient.Get(scheme + "://169.254.169.254/latest/meta-data/")
+			if resp != nil {
+				require.NoError(t, resp.Body.Close())
+			}
+			require.Error(t, err, "a link-local MCP target must be refused even when a proxy is configured")
+			require.Contains(t, err.Error(), "blocked connection to link-local address",
+				"the refusal must come from the dial-time guard, not from the proxy")
+			require.Zero(t, proxyHits.Load(), "the configured proxy must never be contacted for a guarded MCP request")
+			select {
+			case closeErr := <-proxyCloseErrs:
+				t.Errorf("failed to close a proxy-side connection: %v", closeErr)
+			default:
+			}
+		})
+	}
 }

--- a/core/network/ssrf.go
+++ b/core/network/ssrf.go
@@ -280,3 +280,57 @@ func isValidHostnameLiteral(s string) bool {
 	}
 	return true
 }
+
+// PrivateNetworkDialContext returns a DialContext that, unlike
+// SSRFSafeDialContext, permits loopback, RFC1918/unique-local, and CGNAT
+// destinations. It still blocks link-local addresses (including the
+// 169.254.169.254 cloud metadata endpoint) and unspecified addresses, which
+// have no legitimate destination under any deployment topology. Same
+// DNS-rebinding protection as SSRFSafeDialContext: resolves once and dials
+// the validated IP directly.
+//
+// Use this only for features where connecting to a self-hosted or
+// private-network target is the primary, documented use case (e.g. an MCP
+// server running on the same host or inside the same private network) AND
+// that capability is already gated by genuine authentication elsewhere - this
+// function is a defense-in-depth backstop against link-local/metadata
+// targets, not an authorization check.
+func PrivateNetworkDialContext(dialTimeout time.Duration) func(ctx context.Context, netw, addr string) (net.Conn, error) {
+	dialer := &net.Dialer{Timeout: dialTimeout}
+	return func(ctx context.Context, netw, addr string) (net.Conn, error) {
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil {
+			return nil, fmt.Errorf("invalid dial address %q: %w", addr, err)
+		}
+		ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("DNS lookup failed for %s: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("DNS lookup for %s returned no addresses", host)
+		}
+		for _, ip := range ips {
+			if ip.IsUnspecified() {
+				return nil, fmt.Errorf("blocked connection to unspecified address %s (host %s)", ip, host)
+			}
+			if IsLinkLocal(ip) {
+				return nil, fmt.Errorf("blocked connection to link-local address %s (host %s)", ip, host)
+			}
+		}
+		// Every address resolved above passed the policy, so trying them in
+		// turn is no weaker than dialing just the first: nothing outside this
+		// one validated set is ever dialed, which is what defeats rebinding.
+		// Pinning ips[0] instead would break the feature's primary documented
+		// target: "localhost" resolves to [::1, 127.0.0.1] on a dual-stack
+		// host, and an MCP server bound only to IPv4 is unreachable at ::1.
+		var lastErr error
+		for _, ip := range ips {
+			conn, err := dialer.DialContext(ctx, netw, net.JoinHostPort(ip.String(), port))
+			if err == nil {
+				return conn, nil
+			}
+			lastErr = err
+		}
+		return nil, lastErr
+	}
+}

--- a/core/network/ssrf.go
+++ b/core/network/ssrf.go
@@ -15,6 +15,19 @@ import (
 // IsPrivate() does not cover it.
 var cgnat = netip.MustParsePrefix("100.64.0.0/10")
 
+// teredo is the RFC 4380 Teredo tunnelling prefix. Note the /32: only
+// 2001:0000::/32 is Teredo, so ordinary global unicast under 2001::/16 (e.g.
+// 2001:4860::/32) is untouched.
+//
+// Rejected wholesale rather than unwrapped-and-reclassified the way 6to4 and
+// NAT64 are, for two reasons. Teredo carries two IPv4 addresses - the client's
+// in bits 96-127 (obfuscated by XOR with 0xFFFFFFFF) and the relay server's in
+// bits 32-63 - so reclassifying on one still leaves the other attacker-chosen.
+// And unlike 6to4, Teredo has no legitimate server-to-server use: it is a
+// consumer NAT-traversal mechanism, deprecated and off by default on modern
+// systems, so nothing is lost by refusing the range outright.
+var teredo = netip.MustParsePrefix("2001:0000::/32")
+
 // IsPublicIP reports whether ip is safe to dial from server-side code that
 // fetches user-controlled URLs: not loopback, private, CGNAT, link-local,
 // unique-local, site-local, multicast, broadcast, or unspecified. IPv6 forms
@@ -53,6 +66,13 @@ func IsPublicIP(ip net.IP) bool {
 	if addr.Is6() {
 		b := addr.As16()
 		if b[0] == 0xfe && (b[1]&0xc0) == 0xc0 {
+			return false
+		}
+		// Teredo. Checked after the transition unwrap above so a Teredo address
+		// is judged as itself: none of the stdlib predicates match it, and its
+		// embedded IPv4 is obfuscated, so without this an internal target
+		// wrapped as 2001:0000:...:5601:5601 reads as ordinary global unicast.
+		if teredo.Contains(addr) {
 			return false
 		}
 	}

--- a/core/network/ssrf_test.go
+++ b/core/network/ssrf_test.go
@@ -54,6 +54,20 @@ func TestIsPublicIP(t *testing.T) {
 
 		// Deprecated IPv6 site-local (RFC 3879).
 		{"site-local fec0::/10", "fec0::1", false},
+
+		// Teredo (RFC 4380). The whole 2001:0000::/32 prefix is refused: the
+		// embedded client IPv4 is XOR-obfuscated so none of the stdlib
+		// predicates see through it, and the address carries a second,
+		// separately attacker-chosen relay IPv4 in bits 32-63.
+		// 2001:0000:4136:e378:8000:63bf:5601:5601 obfuscates 169.254.169.254
+		// (0xa9fea9fe ^ 0xffffffff = 0x56015601) as the client address.
+		{"teredo-wrapped IMDS", "2001:0000:4136:e378:8000:63bf:5601:5601", false},
+		{"teredo prefix low", "2001:0::1", false},
+		{"teredo prefix high", "2001:0:ffff:ffff:ffff:ffff:ffff:ffff", false},
+		// The block is a /32, not a /16: ordinary global unicast that merely
+		// starts with 2001: must stay reachable.
+		{"global unicast 2001:4860 (Google) stays public", "2001:4860:4860::8888", true},
+		{"global unicast 2001:1:: stays public", "2001:1::1", true},
 	}
 
 	for _, tt := range tests {

--- a/core/network/ssrf_test.go
+++ b/core/network/ssrf_test.go
@@ -351,3 +351,79 @@ func TestSSRFSafeDialContextWithAllowlist_NilAllowlistMatchesPlainDialContext(t 
 		t.Fatalf("expected blocked-connection error, got %v", err)
 	}
 }
+
+func TestPrivateNetworkDialContextBlocksLinkLocal(t *testing.T) {
+	dial := PrivateNetworkDialContext(time.Second)
+	if _, err := dial(context.Background(), "tcp", "169.254.169.254:80"); err == nil || !strings.Contains(err.Error(), "blocked connection to link-local address") {
+		t.Fatalf("expected blocked link-local error, got %v", err)
+	}
+}
+
+func TestPrivateNetworkDialContextBlocksUnspecified(t *testing.T) {
+	dial := PrivateNetworkDialContext(time.Second)
+	if _, err := dial(context.Background(), "tcp", "0.0.0.0:80"); err == nil || !strings.Contains(err.Error(), "blocked connection to unspecified address") {
+		t.Fatalf("expected blocked unspecified error, got %v", err)
+	}
+}
+
+// TestPrivateNetworkDialContextAllowsLoopback locks in the deliberate
+// difference from SSRFSafeDialContext: a self-hosted MCP server on the same
+// host is the documented primary use case, so loopback must stay dialable.
+func TestPrivateNetworkDialContextAllowsLoopback(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		conn, err := ln.Accept()
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	dial := PrivateNetworkDialContext(time.Second)
+	conn, err := dial(context.Background(), "tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("expected loopback dial to succeed, got %v", err)
+	}
+	conn.Close()
+}
+
+// TestPrivateNetworkDialContextFallsBackAcrossResolvedAddresses locks in the
+// multi-address behavior the MCP feature depends on: "localhost" resolves to
+// [::1, 127.0.0.1] on a dual-stack host, and an MCP server bound only to IPv4
+// must still be reachable. Pinning the first resolved address would make the
+// documented http://localhost:PORT/mcp target undialable.
+func TestPrivateNetworkDialContextFallsBackAcrossResolvedAddresses(t *testing.T) {
+	ips, err := net.DefaultResolver.LookupIP(context.Background(), "ip", "localhost")
+	if err != nil || len(ips) < 2 {
+		t.Skipf("localhost does not resolve to multiple addresses here (%v, err=%v)", ips, err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start test listener: %v", err)
+	}
+	defer ln.Close()
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	if err != nil {
+		t.Fatalf("failed to split listener address: %v", err)
+	}
+
+	dial := PrivateNetworkDialContext(2 * time.Second)
+	conn, err := dial(context.Background(), "tcp", net.JoinHostPort("localhost", port))
+	if err != nil {
+		t.Fatalf("expected dial to fall back to the reachable resolved address, got %v", err)
+	}
+	conn.Close()
+}

--- a/docs/deployment-guides/config-json/client.mdx
+++ b/docs/deployment-guides/config-json/client.mdx
@@ -105,7 +105,7 @@ This setting is also configurable via the UI (**MCP Gateway → MCP Settings**) 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `allowed_origins` | array | `["*"]` | CORS allowed origins (use URIs or `"*"`) |
-| `enforce_auth_on_inference` | boolean | `false` | Require auth (virtual key, API key, or user token) on `/v1/*` inference routes |
+| `enforce_auth_on_inference` | boolean | `false` | Require auth (virtual key, API key, or user token) on `/v1/*` inference routes. Realtime connections (`/v1/realtime`, `/v1/realtime/calls`) are refused with `401` at connect time unless they present one of those, or an ephemeral client secret from `POST /v1/realtime/client_secrets` |
 | `max_request_body_size_mb` | integer | `100` | Maximum allowed request body size in MB |
 | `whitelisted_routes` | array of strings | `[]` | Routes that bypass auth middleware |
 | `allowed_headers` | array of strings | `[]` | Additional headers permitted for CORS and WebSocket |

--- a/docs/mcp/auth/none.mdx
+++ b/docs/mcp/auth/none.mdx
@@ -103,9 +103,16 @@ STDIO connections must use `auth_type: "none"`:
 </Tab>
 <Tab title="API">
 
+<Note>
+  `auth_type: "none"` for a STDIO client is about the upstream connection, not Bifrost's own admin
+  API - creating one still requires an authenticated admin session; see the note in
+  [Connecting to Servers](/mcp/connecting-to-servers#add-stdio-client).
+</Note>
+
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-session-token>" \
   -d '{
     "name": "filesystem",
     "connection_type": "stdio",

--- a/docs/mcp/connecting-to-servers.mdx
+++ b/docs/mcp/connecting-to-servers.mdx
@@ -197,9 +197,17 @@ Here you can:
 
 ### Add STDIO Client
 
+<Note>
+  Registering a stdio client makes Bifrost run the given `command` as a subprocess of the gateway. If [dashboard
+  authentication](/quickstart/gateway/setting-up-auth) is disabled or not yet configured, this call is refused - you
+  must either enable dashboard auth and authenticate first, or define the client in `config.json` instead. This
+  restriction applies only to `connection_type: "stdio"`; HTTP and SSE clients are unaffected.
+</Note>
+
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \
   -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <admin-session-token>" \
   -d '{
     "name": "filesystem",
     "connection_type": "stdio",
@@ -213,6 +221,15 @@ curl -X POST http://localhost:8080/api/mcp/client \
 ```
 
 ### Add HTTP Client
+
+<Note>
+  If [dashboard authentication](/quickstart/gateway/setting-up-auth) is disabled or not yet
+  configured, an HTTP or SSE client whose `connection_string` resolves to a loopback,
+  private-network, link-local, or carrier-grade-NAT address is refused - you must either enable
+  dashboard auth and authenticate first, or define the client in `config.json` instead. The
+  `http://localhost:3001/mcp` example below is one such target. Clients pointed at a public
+  address (like the SSE example that follows) are unaffected either way.
+</Note>
 
 ```bash
 curl -X POST http://localhost:8080/api/mcp/client \

--- a/docs/openapi/paths/management/mcp.yaml
+++ b/docs/openapi/paths/management/mcp.yaml
@@ -179,6 +179,14 @@ client:
       pricing can only be set once the tool list is known. For shared-connection
       clients tools are fetched after client creation; for per-user auth types
       they are discovered during the create/verify flow itself.
+
+      Two cases require a genuinely authenticated admin session and are refused
+      with 403 when dashboard authentication is disabled or unconfigured, even
+      though other management endpoints stay reachable in that state:
+      connection_type "stdio" (which runs the supplied command as a gateway
+      subprocess), and connection_type "http"/"sse" whose connection_string
+      resolves to a loopback, private-network, link-local, or CGNAT address.
+      Public http/sse targets are unaffected.
     tags:
       - MCP
     requestBody:
@@ -205,6 +213,12 @@ client:
                 - $ref: '../../schemas/management/oauth.yaml#/OAuthFlowInitiation'
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '403':
+        description: >-
+          The request was not genuinely authenticated (dashboard authentication
+          is disabled or unconfigured) and connection_type is "stdio", or is
+          "http"/"sse" with a connection_string resolving to a loopback,
+          private-network, link-local, or CGNAT address.
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/framework/configstore/prompts.go
+++ b/framework/configstore/prompts.go
@@ -212,6 +212,9 @@ func (s *RDBConfigStore) CreatePrompt(ctx context.Context, prompt *tables.TableP
 
 // UpdatePrompt updates a prompt
 func (s *RDBConfigStore) UpdatePrompt(ctx context.Context, prompt *tables.TablePrompt) error {
+	if err := s.assertPromptInScope(ctx, prompt.ID); err != nil {
+		return err
+	}
 	// Use Select to explicitly include FolderID so GORM writes NULL when it's nil
 	res := s.DB().WithContext(ctx).
 		Model(prompt).
@@ -231,6 +234,11 @@ func (s *RDBConfigStore) UpdatePrompt(ctx context.Context, prompt *tables.TableP
 // PostgreSQL uses native ON DELETE CASCADE; SQLite requires manual cascade because it cannot
 // alter foreign key constraints after table creation.
 func (s *RDBConfigStore) DeletePrompt(ctx context.Context, id string) error {
+	// Gated before the transaction: deleting a prompt the caller cannot see is a worse
+	// outcome than reading one, and the handler for this route resolves no parent first.
+	if err := s.assertPromptInScope(ctx, id); err != nil {
+		return err
+	}
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Check prompt exists
 		var prompt tables.TablePrompt
@@ -267,7 +275,43 @@ func (s *RDBConfigStore) DeletePrompt(ctx context.Context, id string) error {
 // Prompt Repository - Versions
 // ============================================================================
 
+// assertPromptInScope reports whether promptID names a prompt the caller may see, returning
+// ErrNotFound when it does not - the same answer GetPromptByID gives, so a caller probing child
+// collections cannot distinguish "hidden" from "absent" any more than it can on the parent.
+//
+// Child rows carry no scope columns of their own, and a QueryScope is written against the
+// prompts table (GetPromptByID's own query is table-qualified, "prompts.id = ?"), so ScopedDB
+// cannot be applied to a prompt_versions or prompt_sessions query directly - it would reference
+// columns that query does not select. Reaching the parent through the scope and gating on the
+// answer is what makes the child reads honour it, and it mirrors what the version-creation path
+// already does before inserting a child.
+//
+// Note this deliberately re-reads the parent per call rather than trusting a scope filter to
+// have been applied upstream: attaching a scope to a context does not retroactively restrict a
+// query built from the unscoped handle, which is exactly how these reads came to leak.
+func (s *RDBConfigStore) assertPromptInScope(ctx context.Context, promptID string) error {
+	if promptID == "" {
+		return ErrNotFound
+	}
+	// Existence is all that is needed, and a scope is a WHERE predicate on prompts columns,
+	// which SQL evaluates independently of the SELECT list, so the projection can be narrowed
+	// to the key without affecting what any scope can filter on.
+	var prompt tables.TablePrompt
+	if err := s.ScopedDB(ctx).Select("prompts.id").First(&prompt, "prompts.id = ?", promptID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
 // GetAllPromptVersions returns every version across all prompts in a single query.
+//
+// Deliberately unscoped: its only caller is the prompts plugin, which loads every version at
+// startup to serve prompt injection for the whole deployment and runs on a background context
+// that carries no scope. It is not reachable from any HTTP route, so no caller-supplied
+// identifier reaches it. Do not wire it to a request-scoped path without adding a scope filter.
 func (s *RDBConfigStore) GetAllPromptVersions(ctx context.Context) ([]tables.TablePromptVersion, error) {
 	var versions []tables.TablePromptVersion
 	if err := s.DB().WithContext(ctx).
@@ -279,8 +323,14 @@ func (s *RDBConfigStore) GetAllPromptVersions(ctx context.Context) ([]tables.Tab
 	return versions, nil
 }
 
-// GetPromptVersions gets all versions for a prompt
+// GetPromptVersions gets all versions for a prompt.
+//
+// Returns ErrNotFound when the parent prompt is outside the caller's scope, matching
+// GetPromptByID rather than returning the versions of a prompt the caller cannot see.
 func (s *RDBConfigStore) GetPromptVersions(ctx context.Context, promptID string) ([]tables.TablePromptVersion, error) {
+	if err := s.assertPromptInScope(ctx, promptID); err != nil {
+		return nil, err
+	}
 	var versions []tables.TablePromptVersion
 	if err := s.DB().WithContext(ctx).
 		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
@@ -292,7 +342,12 @@ func (s *RDBConfigStore) GetPromptVersions(ctx context.Context, promptID string)
 	return versions, nil
 }
 
-// GetPromptVersionByID gets a version by ID
+// GetPromptVersionByID gets a version by ID.
+//
+// The row is fetched first because the version's own ID is all the caller supplies - which
+// prompt it belongs to is only known once it is read - and the parent is then checked. A version
+// whose prompt is outside the caller's scope reports ErrNotFound, the same answer an absent ID
+// gets, so nothing distinguishes the two.
 func (s *RDBConfigStore) GetPromptVersionByID(ctx context.Context, id uint) (*tables.TablePromptVersion, error) {
 	var version tables.TablePromptVersion
 	if err := s.DB().WithContext(ctx).
@@ -304,11 +359,19 @@ func (s *RDBConfigStore) GetPromptVersionByID(ctx context.Context, id uint) (*ta
 		}
 		return nil, err
 	}
+	if err := s.assertPromptInScope(ctx, version.PromptID); err != nil {
+		return nil, err
+	}
 	return &version, nil
 }
 
-// GetLatestPromptVersion gets the latest version for a prompt
+// GetLatestPromptVersion gets the latest version for a prompt.
+//
+// Scoped on the parent for the same reason as GetPromptVersions.
 func (s *RDBConfigStore) GetLatestPromptVersion(ctx context.Context, promptID string) (*tables.TablePromptVersion, error) {
+	if err := s.assertPromptInScope(ctx, promptID); err != nil {
+		return nil, err
+	}
 	var version tables.TablePromptVersion
 	if err := s.DB().WithContext(ctx).
 		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
@@ -324,7 +387,14 @@ func (s *RDBConfigStore) GetLatestPromptVersion(ctx context.Context, promptID st
 
 // CreatePromptVersion creates a new version and marks it as latest.
 // Retries on unique constraint conflict (concurrent version_number allocation).
+//
+// The parent is checked through the scope before the transaction opens, for the reason given
+// on DeletePromptVersion: creating a child is a write against the parent, and a scoped caller
+// must not be able to attach one to a prompt it cannot see, however the handler reached here.
 func (s *RDBConfigStore) CreatePromptVersion(ctx context.Context, version *tables.TablePromptVersion) error {
+	if err := s.assertPromptInScope(ctx, version.PromptID); err != nil {
+		return err
+	}
 	const maxRetries = 3
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
@@ -376,6 +446,20 @@ func (s *RDBConfigStore) CreatePromptVersion(ctx context.Context, version *table
 // DeletePromptVersion deletes a version and promotes the previous version to latest if needed.
 // PostgreSQL uses native ON DELETE CASCADE for messages; SQLite requires manual cascade.
 func (s *RDBConfigStore) DeletePromptVersion(ctx context.Context, id uint) error {
+	// Resolved and checked before the transaction opens, not inside it: assertPromptInScope
+	// queries through s.DB(), a different handle from tx, so asking inside the transaction
+	// reads outside its snapshot - and on SQLite does not see the transaction's database at
+	// all. The parent is only knowable once the child is read, hence the extra lookup.
+	var version tables.TablePromptVersion
+	if err := s.DB().WithContext(ctx).Select("prompt_id").First(&version, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	if err := s.assertPromptInScope(ctx, version.PromptID); err != nil {
+		return err
+	}
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Get the version to check if it's latest
 		var version tables.TablePromptVersion
@@ -422,8 +506,14 @@ func (s *RDBConfigStore) DeletePromptVersion(ctx context.Context, id uint) error
 // Prompt Repository - Sessions
 // ============================================================================
 
-// GetPromptSessions gets all sessions for a prompt
+// GetPromptSessions gets all sessions for a prompt.
+//
+// Scoped on the parent for the same reason as GetPromptVersions. Sessions carry the prompt's
+// message contents, so they leak the same data the versions do.
 func (s *RDBConfigStore) GetPromptSessions(ctx context.Context, promptID string) ([]tables.TablePromptSession, error) {
+	if err := s.assertPromptInScope(ctx, promptID); err != nil {
+		return nil, err
+	}
 	var sessions []tables.TablePromptSession
 	if err := s.DB().WithContext(ctx).
 		Preload("Messages", func(db *gorm.DB) *gorm.DB { return db.Order("order_index ASC") }).
@@ -436,7 +526,12 @@ func (s *RDBConfigStore) GetPromptSessions(ctx context.Context, promptID string)
 	return sessions, nil
 }
 
-// GetPromptSessionByID gets a session by ID
+// GetPromptSessionByID gets a session by ID.
+//
+// Fetched then checked against its parent, for the same reason as GetPromptVersionByID. This is
+// the widest-reaching of these reads: four handlers resolve a session from a caller-supplied ID,
+// including the ones that then update or delete it, so the check belongs here rather than at any
+// one of them.
 func (s *RDBConfigStore) GetPromptSessionByID(ctx context.Context, id uint) (*tables.TablePromptSession, error) {
 	var session tables.TablePromptSession
 	if err := s.DB().WithContext(ctx).
@@ -449,11 +544,19 @@ func (s *RDBConfigStore) GetPromptSessionByID(ctx context.Context, id uint) (*ta
 		}
 		return nil, err
 	}
+	if err := s.assertPromptInScope(ctx, session.PromptID); err != nil {
+		return nil, err
+	}
 	return &session, nil
 }
 
-// CreatePromptSession creates a new session
+// CreatePromptSession creates a new session.
+//
+// The parent is scoped before the transaction opens, as on CreatePromptVersion.
 func (s *RDBConfigStore) CreatePromptSession(ctx context.Context, session *tables.TablePromptSession) error {
+	if err := s.assertPromptInScope(ctx, session.PromptID); err != nil {
+		return err
+	}
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Verify version belongs to the same prompt if set
 		if session.VersionID != nil {
@@ -494,8 +597,30 @@ func (s *RDBConfigStore) CreatePromptSession(ctx context.Context, session *table
 	})
 }
 
-// UpdatePromptSession updates a session and its messages
+// UpdatePromptSession updates a session and its messages.
+//
+// The parent it scopes is the one already stored under session.ID, not the one the caller
+// supplies: the update carries the whole row, so trusting session.PromptID would let a caller
+// who can see one prompt pair it with a hidden session's ID, pass the scope check on the
+// visible parent, and have Save overwrite the hidden session and re-parent it. A session cannot
+// be moved between prompts through an update at all, so a stored parent that differs from the
+// supplied one is rejected outright. Its HTTP handler resolves the session through the scoped
+// GetPromptSessionByID first, so as with RenamePromptSession this is defence in depth, but the
+// store must not depend on a caller having looked the parent up in the right order.
 func (s *RDBConfigStore) UpdatePromptSession(ctx context.Context, session *tables.TablePromptSession) error {
+	var stored tables.TablePromptSession
+	if err := s.DB().WithContext(ctx).Select("prompt_id").First(&stored, "id = ?", session.ID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	if err := s.assertPromptInScope(ctx, stored.PromptID); err != nil {
+		return err
+	}
+	if stored.PromptID != session.PromptID {
+		return fmt.Errorf("session does not belong to the specified prompt")
+	}
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		// Verify version belongs to the same prompt if set
 		if session.VersionID != nil {
@@ -540,8 +665,22 @@ func (s *RDBConfigStore) UpdatePromptSession(ctx context.Context, session *table
 	})
 }
 
-// RenamePromptSession updates only the name of a session
+// RenamePromptSession updates only the name of a session.
+//
+// Its own handler resolves the session through GetPromptSessionByID first, which is scoped, so
+// this is defence in depth rather than the only gate - but the store should not depend on a
+// caller having looked the parent up in the right order.
 func (s *RDBConfigStore) RenamePromptSession(ctx context.Context, id uint, name string) error {
+	var session tables.TablePromptSession
+	if err := s.DB().WithContext(ctx).First(&session, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	if err := s.assertPromptInScope(ctx, session.PromptID); err != nil {
+		return err
+	}
 	result := s.DB().WithContext(ctx).Model(&tables.TablePromptSession{}).Where("id = ?", id).Update("name", name)
 	if result.Error != nil {
 		return result.Error
@@ -555,6 +694,17 @@ func (s *RDBConfigStore) RenamePromptSession(ctx context.Context, id uint, name 
 // DeletePromptSession deletes a session and its messages.
 // PostgreSQL uses native ON DELETE CASCADE for messages; SQLite requires manual cascade.
 func (s *RDBConfigStore) DeletePromptSession(ctx context.Context, id uint) error {
+	// Checked before the transaction, for the reason given on DeletePromptVersion.
+	var owner tables.TablePromptSession
+	if err := s.DB().WithContext(ctx).Select("prompt_id").First(&owner, "id = ?", id).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return ErrNotFound
+		}
+		return err
+	}
+	if err := s.assertPromptInScope(ctx, owner.PromptID); err != nil {
+		return err
+	}
 	return s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		var session tables.TablePromptSession
 		if err := tx.First(&session, "id = ?", id).Error; err != nil {

--- a/framework/configstore/scopeddb_test.go
+++ b/framework/configstore/scopeddb_test.go
@@ -6,6 +6,7 @@ import (
 
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/queryscope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -136,4 +137,147 @@ func TestRoutingRuleReads_HonorQueryScope(t *testing.T) {
 	unscoped, err := store.GetRoutingRules(ctx)
 	require.NoError(t, err)
 	assert.Len(t, unscoped, 2, "a ctx without a scope keeps full visibility")
+}
+
+// promptFixture builds a minimal prompt row for the scope tests below.
+func promptFixture(id, name string) *tables.TablePrompt {
+	return &tables.TablePrompt{ID: id, Name: name}
+}
+
+// TestPromptChildReads_HonorQueryScope is the regression for the prompt child-read family
+// ignoring the row-visibility QueryScope: GetPromptByID correctly treated a scoped-out prompt as
+// absent, but every read of that prompt's children built its query from DB() and returned the
+// child rows - version metadata and preloaded message contents - using only the caller-supplied
+// ID. The parent was hidden and the children were not.
+//
+// The scope predicate is written against the prompts table, so these reads reach the parent
+// through the scope and gate on that answer rather than trying to scope the child query itself.
+func TestPromptChildReads_HonorQueryScope(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreatePrompt(ctx, promptFixture("prompt-visible", "Visible")))
+	require.NoError(t, store.CreatePrompt(ctx, promptFixture("prompt-hidden", "Hidden")))
+	require.NoError(t, store.CreatePromptVersion(ctx, &tables.TablePromptVersion{
+		PromptID: "prompt-hidden", VersionNumber: 1, CommitMessage: "hidden-secret", IsLatest: true,
+	}))
+	require.NoError(t, store.CreatePromptVersion(ctx, &tables.TablePromptVersion{
+		PromptID: "prompt-visible", VersionNumber: 1, CommitMessage: "visible", IsLatest: true,
+	}))
+	require.NoError(t, store.CreatePromptSession(ctx, &tables.TablePromptSession{PromptID: "prompt-hidden"}))
+
+	hiddenVersions, err := store.GetPromptVersions(ctx, "prompt-hidden")
+	require.NoError(t, err)
+	require.Len(t, hiddenVersions, 1, "fixture sanity: the hidden prompt has a version to leak")
+	hiddenVersionID := hiddenVersions[0].ID
+
+	hiddenSessions, err := store.GetPromptSessions(ctx, "prompt-hidden")
+	require.NoError(t, err)
+	require.Len(t, hiddenSessions, 1, "fixture sanity: the hidden prompt has a session to leak")
+	hiddenSessionID := hiddenSessions[0].ID
+
+	scoped := queryscope.WithQueryScope(ctx, func(db *gorm.DB) *gorm.DB {
+		return db.Where("prompts.id <> ?", "prompt-hidden")
+	})
+
+	// The negative control the reported issue relies on: the parent is already correctly hidden.
+	_, err = store.GetPromptByID(scoped, "prompt-hidden")
+	require.ErrorIs(t, err, ErrNotFound, "negative control: the parent must already be hidden")
+
+	// Reads keyed by the parent ID.
+	_, err = store.GetPromptVersions(scoped, "prompt-hidden")
+	assert.ErrorIs(t, err, ErrNotFound, "GetPromptVersions must hide a scoped-out prompt's versions")
+	_, err = store.GetLatestPromptVersion(scoped, "prompt-hidden")
+	assert.ErrorIs(t, err, ErrNotFound, "GetLatestPromptVersion must hide a scoped-out prompt's version")
+	_, err = store.GetPromptSessions(scoped, "prompt-hidden")
+	assert.ErrorIs(t, err, ErrNotFound, "GetPromptSessions must hide a scoped-out prompt's sessions")
+
+	// Reads keyed by the child's own ID, where the parent is only known after the row is read.
+	_, err = store.GetPromptVersionByID(scoped, hiddenVersionID)
+	assert.ErrorIs(t, err, ErrNotFound, "GetPromptVersionByID must hide a version whose prompt is scoped out")
+	_, err = store.GetPromptSessionByID(scoped, hiddenSessionID)
+	assert.ErrorIs(t, err, ErrNotFound, "GetPromptSessionByID must hide a session whose prompt is scoped out")
+
+	// The visible prompt is unaffected: this narrows visibility, it does not break the feature.
+	visibleVersions, err := store.GetPromptVersions(scoped, "prompt-visible")
+	require.NoError(t, err)
+	assert.Len(t, visibleVersions, 1, "an in-scope prompt's versions stay readable")
+
+	// A ctx with no scope keeps full visibility, as everywhere else in this store.
+	unscoped, err := store.GetPromptVersions(ctx, "prompt-hidden")
+	require.NoError(t, err)
+	assert.Len(t, unscoped, 1, "a ctx without a scope keeps full visibility")
+}
+
+// TestPromptWrites_HonorQueryScope covers the mutating half of the same defect. Cross-tenant
+// modification is a worse outcome than disclosure, and deletePrompt / deletePromptVersion reach
+// the store with no scoped parent lookup at all, so the gate has to live in the store.
+func TestPromptWrites_HonorQueryScope(t *testing.T) {
+	store := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	require.NoError(t, store.CreatePrompt(ctx, promptFixture("prompt-hidden", "Hidden")))
+	require.NoError(t, store.CreatePrompt(ctx, promptFixture("prompt-visible", "Visible")))
+	require.NoError(t, store.CreatePromptVersion(ctx, &tables.TablePromptVersion{
+		PromptID: "prompt-hidden", VersionNumber: 1, IsLatest: true,
+	}))
+	require.NoError(t, store.CreatePromptSession(ctx, &tables.TablePromptSession{PromptID: "prompt-hidden", Name: "original"}))
+
+	hiddenVersions, err := store.GetPromptVersions(ctx, "prompt-hidden")
+	require.NoError(t, err)
+	require.Len(t, hiddenVersions, 1)
+	hiddenSessions, err := store.GetPromptSessions(ctx, "prompt-hidden")
+	require.NoError(t, err)
+	require.Len(t, hiddenSessions, 1)
+
+	scoped := queryscope.WithQueryScope(ctx, func(db *gorm.DB) *gorm.DB {
+		return db.Where("prompts.id <> ?", "prompt-hidden")
+	})
+
+	assert.ErrorIs(t, store.DeletePrompt(scoped, "prompt-hidden"), ErrNotFound,
+		"DeletePrompt must refuse a scoped-out prompt")
+	assert.ErrorIs(t, store.UpdatePrompt(scoped, promptFixture("prompt-hidden", "Renamed")), ErrNotFound,
+		"UpdatePrompt must refuse a scoped-out prompt")
+	assert.ErrorIs(t, store.DeletePromptVersion(scoped, hiddenVersions[0].ID), ErrNotFound,
+		"DeletePromptVersion must refuse a version whose prompt is scoped out")
+	assert.ErrorIs(t, store.DeletePromptSession(scoped, hiddenSessions[0].ID), ErrNotFound,
+		"DeletePromptSession must refuse a session whose prompt is scoped out")
+	assert.ErrorIs(t, store.RenamePromptSession(scoped, hiddenSessions[0].ID, "renamed"), ErrNotFound,
+		"RenamePromptSession must refuse a session whose prompt is scoped out")
+
+	// UpdatePromptSession takes the whole row, parent included, so the parent it must scope is
+	// the one already stored under session.ID, not the one the caller supplies. Otherwise a
+	// caller who can see prompt-visible pairs it with a hidden session's ID, passes the scope
+	// check on the visible parent, and Save overwrites the hidden session and re-parents it.
+	assert.ErrorIs(t, store.UpdatePromptSession(scoped, &tables.TablePromptSession{
+		ID: hiddenSessions[0].ID, PromptID: "prompt-visible", Name: "stolen",
+	}), ErrNotFound, "UpdatePromptSession must scope the stored parent, not the supplied one")
+	// Even with full visibility a session cannot be moved between prompts through an update.
+	assert.ErrorContains(t, store.UpdatePromptSession(ctx, &tables.TablePromptSession{
+		ID: hiddenSessions[0].ID, PromptID: "prompt-visible", Name: "moved",
+	}), "session does not belong to the specified prompt", "UpdatePromptSession must reject a parent change")
+
+	// Creation is a write too: a scoped caller must not be able to attach a new version or
+	// session to a prompt it cannot see, even though the handlers look the parent up first.
+	assert.ErrorIs(t, store.CreatePromptVersion(scoped, &tables.TablePromptVersion{
+		PromptID: "prompt-hidden", CommitMessage: "planted",
+	}), ErrNotFound, "CreatePromptVersion must refuse a scoped-out parent")
+	assert.ErrorIs(t, store.CreatePromptSession(scoped, &tables.TablePromptSession{
+		PromptID: "prompt-hidden", Name: "planted",
+	}), ErrNotFound, "CreatePromptSession must refuse a scoped-out parent")
+	versionsAfter, err := store.GetPromptVersions(ctx, "prompt-hidden")
+	require.NoError(t, err)
+	assert.Len(t, versionsAfter, 1, "a refused version creation must not persist a row")
+	sessionsAfter, err := store.GetPromptSessions(ctx, "prompt-hidden")
+	require.NoError(t, err)
+	assert.Len(t, sessionsAfter, 1, "a refused session creation must not persist a row")
+
+	// Nothing was actually removed or rewritten by any of the refused calls.
+	stillThere, err := store.GetPromptByID(ctx, "prompt-hidden")
+	require.NoError(t, err)
+	assert.Equal(t, "Hidden", stillThere.Name, "a refused write must not have taken effect")
+	untouched, err := store.GetPromptSessionByID(ctx, hiddenSessions[0].ID)
+	require.NoError(t, err)
+	assert.Equal(t, "prompt-hidden", untouched.PromptID, "a refused update must not re-parent the session")
+	assert.Equal(t, "original", untouched.Name, "a refused update must not overwrite the session")
 }

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -639,7 +639,7 @@ func (p *GovernancePlugin) Evaluate(ctx *schemas.BifrostContext, evaluationReque
 	// grant nothing is a different answer, reported by the identity step below; telling a caller who
 	// supplied a key to supply one is not a useful refusal.
 	p.cfgMutex.RLock()
-	if !presentedGrantBearingCredential(ctx) && !hasDirectKeyAuth(ctx) && p.isVkMandatory != nil && *p.isVkMandatory {
+	if !PresentedAnyCredential(ctx) && p.isVkMandatory != nil && *p.isVkMandatory {
 		message := "virtual key is required. Provide a virtual key via the x-bf-vk header."
 		if p.isEnterprise {
 			message = "authentication is required. Provide a virtual key (x-bf-vk), API key, or user token."

--- a/plugins/governance/utils.go
+++ b/plugins/governance/utils.go
@@ -178,7 +178,16 @@ func hasDirectKeyAuth(ctx *schemas.BifrostContext) bool {
 // lacking an access it was never meant to have. It still answers the mandatory-auth question (something
 // was presented), which is why that step asks about it separately.
 func presentedGrantBearingCredential(ctx *schemas.BifrostContext) bool {
-	if identity := ctx.Grant().Identity(); identity != nil {
+	// A context with no grant at all reads as nothing presented, the same answer an empty
+	// identity gives. Worth stating explicitly because Grant() returns a nil interface rather
+	// than a zero value, so reaching straight for Identity() panics: every request that reaches
+	// Evaluate has a grant, but a transport asking this question directly (realtime admission)
+	// can hold a context built before one was ever recorded.
+	g := ctx.Grant()
+	if g == nil {
+		return false
+	}
+	if identity := g.Identity(); identity != nil {
 		return identity.Presented() || identity.User() != nil
 	}
 	return false
@@ -197,4 +206,24 @@ func (p *GovernancePlugin) pruneMCPIncludeToolsFromContext(ctx *schemas.BifrostC
 	requested, _ := existing.([]string)
 	ctx.SetValue(schemas.MCPContextKeyIncludeTools, access.NarrowMCPToolIncludeList(requested))
 	return true
+}
+
+// PresentedAnyCredential reports whether the request carried any credential at all that answers
+// the mandatory-authentication question: a grant-bearing one (virtual key or authenticated
+// identity), or a direct provider key. It is the exact question Evaluate's first step asks, and
+// asking it alone costs nothing - it reads the context and settles no limits.
+//
+// Exported so a transport can admit or refuse a connection on the same answer, rather than
+// reimplementing "was this authenticated" beside this one. Realtime is the caller that needs it:
+// a WebSocket upgrade opens an upstream provider session on the operator's key before any turn
+// exists to evaluate, so admission has to be decided at the upgrade, while the per-turn pipeline
+// keeps owning access and limits. Callers must still let the per-request pipeline run - this
+// answers only whether a credential was presented, never whether it grants what is being asked
+// for, and it deliberately settles no limits so an admission check cannot double-count usage
+// against the turns that follow.
+func PresentedAnyCredential(ctx *schemas.BifrostContext) bool {
+	if ctx == nil {
+		return false
+	}
+	return presentedGrantBearingCredential(ctx) || hasDirectKeyAuth(ctx)
 }

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
+	"net/url"
 	"slices"
 	"sort"
 	"strconv"
@@ -19,6 +21,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/mcp"
 	mcputils "github.com/maximhq/bifrost/core/mcp/utils"
+	"github.com/maximhq/bifrost/core/network"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -1515,6 +1518,72 @@ func (req *MCPClientUpdateRequest) resolvedAllowByDefault(existing bool) bool {
 	return schemas.ResolveAllowByDefault(req.AllowByDefault, req.AllowOnAllVirtualKeys)
 }
 
+// rejectPrivateMCPTargetIfAuthBypassed refuses to register an HTTP/SSE MCP
+// client whose connection_string resolves to a loopback, private-network,
+// link-local, or CGNAT address when the caller reached this endpoint with no
+// credential check at all (default-open posture, BifrostContextKeyAuthBypassed).
+// A genuinely authenticated admin keeps the documented ability to point an MCP
+// client at a local or private server (see docs/mcp/connecting-to-servers.mdx,
+// whose own HTTP-client example uses http://localhost:3001/mcp) - only the
+// unauthenticated path is restricted, the same scoping used for the STDIO
+// client gate below. Returns true if the request was rejected (the error
+// response has already been written); the caller should return immediately.
+func rejectPrivateMCPTargetIfAuthBypassed(ctx *fasthttp.RequestCtx, connType string, connectionString *schemas.SecretVar) bool {
+	authBypassed, _ := ctx.UserValue(schemas.BifrostContextKeyAuthBypassed).(bool)
+	if !authBypassed {
+		return false
+	}
+	if connType != string(schemas.MCPConnectionTypeHTTP) && connType != string(schemas.MCPConnectionTypeSSE) {
+		return false
+	}
+	if connectionString == nil {
+		return false
+	}
+	parsed, err := url.Parse(connectionString.GetValue())
+	if err != nil || parsed.Hostname() == "" {
+		// Malformed/unresolvable target: let the normal connect path surface
+		// its own error rather than duplicating URL validation here.
+		return false
+	}
+	// A bounded, request-independent context: this lookup is a pre-check, not
+	// a dial, and must not be tied to the request's own (often much longer)
+	// deadline.
+	lookupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	ips, err := net.DefaultResolver.LookupIP(lookupCtx, "ip", parsed.Hostname())
+	if err != nil {
+		return false
+	}
+	for _, ip := range ips {
+		if !network.IsPublicIP(ip) {
+			SendError(ctx, fasthttp.StatusForbidden, "unauthenticated callers cannot register MCP clients that connect to loopback, private-network, or link-local addresses; set an admin password to allow this")
+			return true
+		}
+	}
+	return false
+}
+
+// rejectStdioMCPClientIfAuthBypassed refuses to register a stdio MCP client for
+// a caller that was let through because dashboard auth is unconfigured or
+// disabled. A stdio client makes Bifrost exec() an admin-supplied command and
+// args as the gateway process: intentional admin functionality, but only for a
+// caller who actually authenticated. Registering one over this network API with
+// no credential check is equivalent to unauthenticated remote code execution,
+// so it is refused even though the rest of the management API stays open for
+// the zero-config experience. Stdio clients can still be provisioned by an
+// operator with host/filesystem access via config.json. Returns true if the
+// request was rejected (the error response has already been written).
+func rejectStdioMCPClientIfAuthBypassed(ctx *fasthttp.RequestCtx, connType string) bool {
+	if connType != string(schemas.MCPConnectionTypeSTDIO) {
+		return false
+	}
+	if bypassed, _ := ctx.UserValue(schemas.BifrostContextKeyAuthBypassed).(bool); !bypassed {
+		return false
+	}
+	SendError(ctx, fasthttp.StatusForbidden, "Registering a stdio MCP client requires an authenticated admin session; dashboard auth is currently disabled or unconfigured. Enable dashboard authentication, or provision this client via config.json instead.")
+	return true
+}
+
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
 func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	if h.store.ConfigStore == nil {
@@ -1527,6 +1596,16 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	var req MCPClientRequest
 	if err := json.Unmarshal(ctx.PostBody(), &req); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, "Invalid request payload")
+		return
+	}
+
+	// Both gates run before anything else: registering a client is what makes
+	// Bifrost spawn the subprocess / dial the target, so a refusal has to land
+	// before any of that work is scheduled.
+	if rejectStdioMCPClientIfAuthBypassed(ctx, req.ConnectionType) {
+		return
+	}
+	if rejectPrivateMCPTargetIfAuthBypassed(ctx, req.ConnectionType, req.ConnectionString) {
 		return
 	}
 

--- a/transports/bifrost-http/handlers/mcpregistrationguard_test.go
+++ b/transports/bifrost-http/handlers/mcpregistrationguard_test.go
@@ -1,0 +1,123 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// TestRejectStdioMCPClientIfAuthBypassed_UnauthenticatedRejected proves the
+// reported RCE primitive is closed: registering a stdio client makes Bifrost
+// exec() the supplied command, so a caller let through with no credential
+// check at all must be refused.
+func TestRejectStdioMCPClientIfAuthBypassed_UnauthenticatedRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	if !rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO)) {
+		t.Fatal("expected unauthenticated stdio registration to be rejected")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusForbidden, ctx.Response.StatusCode())
+	}
+}
+
+// TestRejectStdioMCPClientIfAuthBypassed_AuthenticatedAllowed proves stdio
+// registration stays available to a genuinely authenticated admin - the gate
+// is on the credential check, not on the capability.
+func TestRejectStdioMCPClientIfAuthBypassed_AuthenticatedAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	// AuthBypassed intentionally left unset, as it is for an authenticated request.
+
+	if rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO)) {
+		t.Fatal("expected an authenticated admin's stdio registration to be allowed")
+	}
+}
+
+// TestRejectStdioMCPClientIfAuthBypassed_HTTPUnaffected proves this gate is
+// scoped to stdio; HTTP/SSE targets are handled by the separate SSRF check.
+func TestRejectStdioMCPClientIfAuthBypassed_HTTPUnaffected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	if rejectStdioMCPClientIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP)) {
+		t.Fatal("expected HTTP connection type to be unaffected by the stdio gate")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLoopbackRejected proves
+// the unauthenticated (default-open) path cannot register an HTTP MCP client
+// pointing at loopback - the reproduction target from the reported SSRF.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLoopbackRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP), schemas.NewSecretVar("http://127.0.0.1:8080/health"))
+
+	if !rejected {
+		t.Fatal("expected an unauthenticated loopback target to be rejected")
+	}
+	if ctx.Response.StatusCode() != fasthttp.StatusForbidden {
+		t.Errorf("expected status %d, got %d", fasthttp.StatusForbidden, ctx.Response.StatusCode())
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLinkLocalRejected proves
+// the cloud-metadata target from the report is rejected for an unauthenticated
+// caller.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedLinkLocalRejected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSSE), schemas.NewSecretVar("http://169.254.169.254/latest/meta-data/"))
+
+	if !rejected {
+		t.Fatal("expected an unauthenticated link-local target to be rejected")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_AuthenticatedLoopbackAllowed proves a
+// genuinely authenticated caller keeps the documented ability to register a
+// local MCP server (docs/mcp/connecting-to-servers.mdx uses
+// http://localhost:3001/mcp as its own example) - this fix must not break that
+// flow, only the unauthenticated one.
+func TestRejectPrivateMCPTargetIfAuthBypassed_AuthenticatedLoopbackAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	// AuthBypassed intentionally left unset, as it is for an authenticated request.
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeHTTP), schemas.NewSecretVar("http://127.0.0.1:3001/mcp"))
+
+	if rejected {
+		t.Fatal("expected an authenticated caller's loopback target to be allowed")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedPublicTargetAllowed
+// proves an unauthenticated caller can still register a normal internet-hosted
+// MCP server - this fix only restricts private/loopback/link-local targets,
+// not HTTP/SSE clients in general. Uses an IP literal (not a hostname) so the
+// test doesn't depend on DNS being reachable in the test environment.
+func TestRejectPrivateMCPTargetIfAuthBypassed_UnauthenticatedPublicTargetAllowed(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSSE), schemas.NewSecretVar("https://1.1.1.1/mcp/sse"))
+
+	if rejected {
+		t.Fatal("expected a public target to be allowed even for an unauthenticated caller")
+	}
+}
+
+// TestRejectPrivateMCPTargetIfAuthBypassed_STDIOUnaffected proves this check is
+// scoped to HTTP/SSE only; stdio registration has its own separate gate.
+func TestRejectPrivateMCPTargetIfAuthBypassed_STDIOUnaffected(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyAuthBypassed, true)
+
+	rejected := rejectPrivateMCPTargetIfAuthBypassed(ctx, string(schemas.MCPConnectionTypeSTDIO), nil)
+
+	if rejected {
+		t.Fatal("expected STDIO connection type to be unaffected by this check")
+	}
+}

--- a/transports/bifrost-http/handlers/realtimeauthgate.go
+++ b/transports/bifrost-http/handlers/realtimeauthgate.go
@@ -1,0 +1,59 @@
+package handlers
+
+import (
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/plugins/governance"
+)
+
+// realtimeAuthRefusalMessage is what an anonymous realtime caller is told. It names the two
+// credentials that work, because the realtime flow has a second one (the ephemeral client
+// secret) that the generic inference message does not mention.
+const realtimeAuthRefusalMessage = "authentication is required for realtime connections. Provide a virtual key (x-bf-vk or an sk-bf- bearer token), or an ephemeral client secret minted by POST /v1/realtime/client_secrets."
+
+// refuseUnauthenticatedRealtime reports whether a realtime connection must be refused before it
+// is established, and is the admission gate for every realtime transport (WebSocket upgrade and
+// both WebRTC SDP routes).
+//
+// Realtime needs this gate because it is the one inference surface where accepting the
+// connection already spends something: both transports select the operator's provider key and
+// open an upstream session before any turn exists. The per-turn pipeline
+// (RunRealtimeTurnPreHooks -> governance PreLLMHook) is the authoritative check for access and
+// limits and keeps that job, but it first runs a turn too late to stop an anonymous client from
+// standing up a session on the operator's key. Nothing in the transport middleware covers the
+// gap either: inference auth is delegated wholesale to governance, whose refusal arrives with
+// the first turn.
+//
+// The question asked here is deliberately the narrow one - "was any credential presented?" -
+// answered by governance's own exported predicate rather than a second implementation of it, so
+// admission cannot drift from the funnel's first step. It settles no limits, so it cannot
+// double-count usage against the turns that follow.
+//
+// A valid ephemeral client secret counts as a credential. That is the whole point of
+// POST /v1/realtime/client_secrets: a browser cannot hold a virtual key, so it is handed a
+// short-lived ek_ token instead, and the mapping back to the real key is restored after the
+// connection is established. Requiring a virtual key here would break that documented flow.
+// An ek_ token that resolves to no mapping is expired, revoked, or forged, and is refused.
+//
+// Returns nil when the connection may proceed.
+func refuseUnauthenticatedRealtime(
+	enforceAuthOnInference bool,
+	kv schemas.KVStore,
+	bifrostCtx *schemas.BifrostContext,
+	authorizationHeader string,
+) *schemas.BifrostError {
+	// The operator has not asked for authentication on inference, so realtime is open for the
+	// same reason every other inference route is. Closing it here regardless would make realtime
+	// stricter than /v1/chat/completions on the same deployment.
+	if !enforceAuthOnInference {
+		return nil
+	}
+	if governance.PresentedAnyCredential(bifrostCtx) {
+		return nil
+	}
+	if token := extractRealtimeBearerTokenFromHeader(authorizationHeader); isRealtimeEphemeralToken(token) {
+		if _, ok := lookupRealtimeEphemeralKeyMapping(kv, token); ok {
+			return nil
+		}
+	}
+	return newRealtimeWireBifrostError(401, "invalid_request_error", realtimeAuthRefusalMessage)
+}

--- a/transports/bifrost-http/handlers/realtimeauthgate_test.go
+++ b/transports/bifrost-http/handlers/realtimeauthgate_test.go
@@ -1,0 +1,188 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/grant"
+	"github.com/maximhq/bifrost/framework/kvstore"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/valyala/fasthttp"
+)
+
+func newRealtimeGateContext(t *testing.T) (*schemas.BifrostContext, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	return ctx, cancel
+}
+
+// TestRefuseUnauthenticatedRealtime_AnonymousRefusedWhenEnforced is the reported bypass: an
+// operator has turned on enforce_auth_on_inference, and a client presenting nothing at all
+// opens a realtime session on the operator's provider key.
+func TestRefuseUnauthenticatedRealtime_AnonymousRefusedWhenEnforced(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	err := refuseUnauthenticatedRealtime(true, nil, ctx, "")
+
+	if err == nil {
+		t.Fatal("expected an anonymous realtime connection to be refused when auth is enforced")
+	}
+	if err.StatusCode == nil || *err.StatusCode != 401 {
+		t.Errorf("expected status 401, got %v", err.StatusCode)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_AnonymousAllowedWhenNotEnforced proves the gate follows the
+// operator's own switch. With enforce_auth_on_inference off, realtime must stay exactly as open
+// as /v1/chat/completions on the same deployment - this fix must not make realtime stricter than
+// the rest of inference.
+func TestRefuseUnauthenticatedRealtime_AnonymousAllowedWhenNotEnforced(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	if err := refuseUnauthenticatedRealtime(false, nil, ctx, ""); err != nil {
+		t.Fatalf("expected an anonymous connection to be allowed when auth is not enforced, got %v", err)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_VirtualKeyAllowed proves a virtual-key caller is admitted.
+// The credential is recorded the same way createBifrostContextFromAuth records it at upgrade.
+func TestRefuseUnauthenticatedRealtime_VirtualKeyAllowed(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+	ctx.SetValue(schemas.BifrostContextKeyVirtualKey, "sk-bf-test")
+	lib.RecordCredential(ctx, grant.NewCredential(grant.CredentialVirtualKey, "sk-bf-test"))
+
+	if err := refuseUnauthenticatedRealtime(true, nil, ctx, ""); err != nil {
+		t.Fatalf("expected a virtual-key caller to be admitted, got %v", err)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_ValidEphemeralTokenAllowed proves the documented browser
+// flow still works: POST /v1/realtime/client_secrets mints an ek_ token, and a browser that
+// cannot hold a virtual key connects with that instead. Refusing it would break the very flow
+// the realtime design delegates auth to.
+func TestRefuseUnauthenticatedRealtime_ValidEphemeralTokenAllowed(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	kv, err := kvstore.New(kvstore.Config{})
+	if err != nil {
+		t.Fatalf("failed to create kv store: %v", err)
+	}
+	token := "ek_test_token"
+	payload, err := json.Marshal(realtimeEphemeralKeyMapping{KeyID: "key-1"})
+	if err != nil {
+		t.Fatalf("failed to marshal mapping: %v", err)
+	}
+	if err := kv.SetWithTTL(buildRealtimeEphemeralKeyMappingKey(token), payload, time.Minute); err != nil {
+		t.Fatalf("failed to seed kv store: %v", err)
+	}
+
+	if gateErr := refuseUnauthenticatedRealtime(true, kv, ctx, "Bearer "+token); gateErr != nil {
+		t.Fatalf("expected a valid ephemeral client secret to be admitted, got %v", gateErr)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_UnknownEphemeralTokenRefused proves an ek_ token that maps
+// to nothing - expired, revoked, or forged - does not get in on the strength of its prefix.
+func TestRefuseUnauthenticatedRealtime_UnknownEphemeralTokenRefused(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	kv, err := kvstore.New(kvstore.Config{})
+	if err != nil {
+		t.Fatalf("failed to create kv store: %v", err)
+	}
+
+	gateErr := refuseUnauthenticatedRealtime(true, kv, ctx, "Bearer ek_not_a_real_token")
+
+	if gateErr == nil {
+		t.Fatal("expected an unmapped ephemeral token to be refused")
+	}
+	if gateErr.StatusCode == nil || *gateErr.StatusCode != 401 {
+		t.Errorf("expected status 401, got %v", gateErr.StatusCode)
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_NonEphemeralBearerRefused proves an arbitrary bearer token
+// that is neither a virtual key nor an ephemeral secret does not satisfy the gate. Without this
+// the check would degrade to "sent an Authorization header".
+func TestRefuseUnauthenticatedRealtime_NonEphemeralBearerRefused(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+
+	if gateErr := refuseUnauthenticatedRealtime(true, nil, ctx, "Bearer sk-some-openai-key"); gateErr == nil {
+		t.Fatal("expected a non-virtual-key, non-ephemeral bearer token to be refused")
+	}
+}
+
+// TestRefuseUnauthenticatedRealtime_DirectKeyAllowed proves a direct provider key admits the
+// connection. Governance's own first step counts it as authentication presented, and the gate
+// must give the same answer rather than a stricter one of its own.
+func TestRefuseUnauthenticatedRealtime_DirectKeyAllowed(t *testing.T) {
+	ctx, cancel := newRealtimeGateContext(t)
+	defer cancel()
+	ctx.SetValue(schemas.BifrostContextKeyDirectKey, schemas.Key{Value: *schemas.NewSecretVar("sk-direct")})
+
+	if gateErr := refuseUnauthenticatedRealtime(true, nil, ctx, ""); gateErr != nil {
+		t.Fatalf("expected a direct-key caller to be admitted, got %v", gateErr)
+	}
+}
+
+// newRealtimeUpgradeRequest builds a well-formed WebSocket handshake for path, so that if the
+// handler does reach the upgrader the upgrade succeeds and the response records 101. That is
+// what lets the tests below tell "refused on the HTTP request" (401) apart from "upgraded and
+// told in-band" (101), which is the whole distinction the admission gate exists to draw.
+func newRealtimeUpgradeRequest(path string) *fasthttp.RequestCtx {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.Request.SetRequestURI(path)
+	ctx.Request.Header.SetMethod(fasthttp.MethodGet)
+	ctx.Request.Header.Set("Connection", "Upgrade")
+	ctx.Request.Header.Set("Upgrade", "websocket")
+	ctx.Request.Header.Set("Sec-WebSocket-Version", "13")
+	ctx.Request.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	return ctx
+}
+
+func newRealtimeUpgradeHandler(enforceAuthOnInference bool) *WSRealtimeHandler {
+	config := &lib.Config{ClientConfig: &configstore.ClientConfig{EnforceAuthOnInference: enforceAuthOnInference}}
+	return &WSRealtimeHandler{config: config, handlerStore: config}
+}
+
+// TestWSRealtimeHandleUpgrade_AnonymousRefusedBeforeTargetResolution pins the gate's position in
+// the WebSocket handler, not just its verdict. With auth enforced, an anonymous caller must be
+// refused with a plain 401 on the HTTP request regardless of what else is wrong with it. If the
+// target is resolved first, a request with a missing or malformed model is upgraded and answered
+// in-band with a 400 before the gate ever runs, which both hands an anonymous caller a completed
+// upgrade and lets them probe which models and paths the deployment accepts.
+func TestWSRealtimeHandleUpgrade_AnonymousRefusedBeforeTargetResolution(t *testing.T) {
+	SetLogger(&mockLogger{})
+	ctx := newRealtimeUpgradeRequest("/v1/realtime") // no model: target resolution fails
+
+	newRealtimeUpgradeHandler(true).handleUpgrade(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusUnauthorized {
+		t.Fatalf("expected an anonymous upgrade with an unresolvable target to be refused with 401 before any upgrade, got %d", got)
+	}
+}
+
+// TestWSRealtimeHandleUpgrade_TargetErrorStaysInBandWhenNotEnforced is the control for the test
+// above: with auth not enforced, an unresolvable target must still take the existing path of a
+// completed upgrade and an in-band error frame, so the reorder narrows nothing for open
+// deployments.
+func TestWSRealtimeHandleUpgrade_TargetErrorStaysInBandWhenNotEnforced(t *testing.T) {
+	SetLogger(&mockLogger{})
+	ctx := newRealtimeUpgradeRequest("/v1/realtime")
+
+	newRealtimeUpgradeHandler(false).handleUpgrade(ctx)
+
+	if got := ctx.Response.StatusCode(); got != fasthttp.StatusSwitchingProtocols {
+		t.Fatalf("expected an open deployment to upgrade and report the target error in-band (101), got %d", got)
+	}
+}

--- a/transports/bifrost-http/handlers/webrtc_realtime.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime.go
@@ -304,6 +304,19 @@ func (h *WebRTCRealtimeHandler) runWebRTCRelay(
 		bifrostCtx.SetValue(schemas.BifrostContextKeyIntegrationType, "openai")
 	}
 
+	// Admission check, before any key is selected: resolveRealtimeWebRTCKeys below reaches
+	// SelectKeyForProviderRequestType and hands the relay the operator's provider key. Covers
+	// both the GA /realtime/calls and the legacy raw-SDP routes, which funnel through here.
+	if authErr := refuseUnauthenticatedRealtime(
+		h.config.ClientConfig.EnforceAuthOnInference,
+		h.handlerStore.GetKVStore(),
+		bifrostCtx,
+		string(ctx.Request.Header.Peek("Authorization")),
+	); authErr != nil {
+		SendBifrostError(ctx, authErr)
+		return
+	}
+
 	authKey, selectedKey, err := h.resolveRealtimeWebRTCKeys(ctx, bifrostCtx, providerKey, model)
 	if err != nil {
 		SendBifrostError(ctx, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", err.Error(), nil))

--- a/transports/bifrost-http/handlers/wsrealtime.go
+++ b/transports/bifrost-http/handlers/wsrealtime.go
@@ -79,25 +79,12 @@ func (h *WSRealtimeHandler) handleUpgrade(ctx *fasthttp.RequestCtx) {
 		}
 	}
 
-	providerKey, model, err := resolveRealtimeTarget(ctx, h.config, path, modelParam, deploymentParam)
-	if err != nil {
-		upgrader := h.websocketUpgrader("")
-		upgradeErr := upgrader.Upgrade(ctx, func(conn *ws.Conn) {
-			defer conn.Close()
-			clientConn := newRealtimeClientConn(conn)
-			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()))
-		})
-		if upgradeErr != nil {
-			logger.Warn("websocket upgrade failed for %s: %v", path, upgradeErr)
-		}
-		return
-	}
-
-	// Run PreRequestHook to give governance + LB a chance to route the realtime connection.
-	// Realtime bypasses handleRequest (per-turn pipelines instead), so we invoke the routing
-	// phase explicitly here. Mutations to provider/model are read back into the local vars
-	// and copied to fasthttp user values so snapshotRealtimeMiddlewareValues picks up any
-	// ctx changes (governance team/customer IDs, routing engine logs).
+	// The pre-request context is built first because the admission gate below reads the
+	// credentials it records. Realtime bypasses handleRequest (per-turn pipelines instead), so
+	// the routing phase is invoked explicitly further down. Mutations to provider/model are
+	// read back into the local vars and copied to fasthttp user values so
+	// snapshotRealtimeMiddlewareValues picks up any ctx changes (governance team/customer IDs,
+	// routing engine logs).
 	preReqCtx, preReqCancel := createBifrostContextFromAuth(h.handlerStore, auth)
 	if preReqCtx == nil {
 		preReqCancel()
@@ -115,6 +102,41 @@ func (h *WSRealtimeHandler) handleUpgrade(ctx *fasthttp.RequestCtx) {
 	preReqCtx.SetValue(schemas.BifrostContextKeyHTTPRequestType, schemas.RealtimeRequest)
 	if realtimeDefaultProviderForPath(path) == schemas.OpenAI {
 		preReqCtx.SetValue(schemas.BifrostContextKeyIntegrationType, "openai")
+	}
+
+	// Admission check, before the upgrade, before any routing work, and before the target is
+	// even resolved: completing this upgrade selects the operator's provider key and opens an
+	// upstream session, which the per-turn governance pipeline only gets to inspect one turn
+	// too late. Refused with a plain 401 on the HTTP request rather than an in-band error
+	// frame, matching how the auth middleware already refuses unauthenticated WebSocket
+	// upgrades. Ordering it ahead of resolveRealtimeTarget matters: that resolver's error path
+	// upgrades the connection to report in-band, so an anonymous caller with a missing or
+	// malformed model would otherwise get a completed upgrade and a way to probe which models
+	// and paths the deployment accepts, without ever presenting a credential.
+	if authErr := refuseUnauthenticatedRealtime(
+		h.config.ClientConfig.EnforceAuthOnInference,
+		h.handlerStore.GetKVStore(),
+		preReqCtx,
+		auth.authorization,
+	); authErr != nil {
+		preReqCancel()
+		SendBifrostError(ctx, authErr)
+		return
+	}
+
+	providerKey, model, err := resolveRealtimeTarget(ctx, h.config, path, modelParam, deploymentParam)
+	if err != nil {
+		preReqCancel()
+		upgrader := h.websocketUpgrader("")
+		upgradeErr := upgrader.Upgrade(ctx, func(conn *ws.Conn) {
+			defer conn.Close()
+			clientConn := newRealtimeClientConn(conn)
+			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()))
+		})
+		if upgradeErr != nil {
+			logger.Warn("websocket upgrade failed for %s: %v", path, upgradeErr)
+		}
+		return
 	}
 	// Surface full request headers + query params on the pre-request context so governance
 	// CEL routing rules (which read headers[...] / params[...]) see the same shape they would


### PR DESCRIPTION
## Summary

Prompt child reads (versions and sessions) were not honouring the row-visibility `QueryScope`. `GetPromptByID` correctly treated a scoped-out prompt as absent, but every read of that prompt's children queried through the unscoped `DB()` handle and returned child rows — including version metadata and preloaded message contents — using only the caller-supplied ID. The parent was hidden; the children were not. Mutating operations (`DeletePrompt`, `DeletePromptVersion`, `DeletePromptSession`, `RenamePromptSession`) had the same gap, with cross-tenant modification being a worse outcome than disclosure.

## Changes

- Introduced `assertPromptInScope`, a shared helper that re-reads the parent prompt through `ScopedDB` and returns `ErrNotFound` when it is outside the caller's scope — the same answer `GetPromptByID` gives, so a caller cannot distinguish "hidden" from "absent".
- Added scope gates to all child reads keyed by parent ID (`GetPromptVersions`, `GetLatestPromptVersion`, `GetPromptSessions`) before the child query runs.
- Added scope gates to child reads keyed by the child's own ID (`GetPromptVersionByID`, `GetPromptSessionByID`) after the row is fetched, since the parent ID is only known once the row is read.
- Added scope gates to all mutating operations (`UpdatePrompt`, `DeletePrompt`, `DeletePromptVersion`, `UpdatePromptSession`, `RenamePromptSession`, `DeletePromptSession`). For delete operations the scope check is placed before the transaction opens, because `assertPromptInScope` queries through a different handle than `tx` and on SQLite cannot see the transaction's database at all.
- Added a comment to `GetAllPromptVersions` documenting that it is intentionally unscoped — it is only called at startup on a background context with no caller-supplied identifier and must not be wired to a request-scoped path without adding a scope filter.
- Added two regression test suites: `TestPromptChildReads_HonorQueryScope` covering all read paths, and `TestPromptWrites_HonorQueryScope` covering all mutating paths, both verifying that scoped-out prompts and their children are indistinguishable from absent ones, and that unscoped contexts retain full visibility.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/configstore/... -run TestPromptChildReads_HonorQueryScope
go test ./framework/configstore/... -run TestPromptWrites_HonorQueryScope
go test ./...
```

Both new test suites should pass. The read suite verifies that versions and sessions belonging to a scoped-out prompt return `ErrNotFound`, and that the visible prompt's children remain readable. The write suite verifies that all mutating operations are refused and that no state change takes effect.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This closes a data-visibility defect where a caller with a restricted `QueryScope` could read version metadata, preloaded message contents, and session data belonging to prompts outside their scope, and could also modify or delete those prompts and their children. All affected paths now return `ErrNotFound` for out-of-scope resources, matching the behaviour of the parent read, so no information about the existence or contents of hidden prompts is disclosed.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable