### PR TITLE
fix: admin passwords matching the redaction mask shape are silently ignored

### DIFF
--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -245,6 +245,37 @@ func (e *SecretVar) IsRedacted() bool {
 	return false
 }
 
+// IsRedactionSentinel reports whether the value is one of the fixed redaction
+// sentinels ("<redacted>" / "[REDACTED]", case-insensitive) or a secret
+// reference. Unlike IsRedacted it never matches the positional
+// 4-chars + 24-asterisks + 4-chars masking pattern, so a real credential that
+// happens to have that shape is not misclassified. Use this for fields the
+// server only ever redacts to a sentinel (e.g. the admin password, which the
+// config GET returns as "<redacted>" or FullyRedacted, never partially masked).
+func (e *SecretVar) IsRedactionSentinel() bool {
+	if e == nil {
+		return false
+	}
+	if e.IsFromSecret() {
+		return true
+	}
+	return strings.EqualFold(e.Val, "<redacted>") || strings.EqualFold(e.Val, "[REDACTED]")
+}
+
+// ShouldPreserveStoredSentinelOnly is ShouldPreserveStored for fields the
+// server never partially masks: only an empty value or an exact redaction
+// sentinel counts as "unchanged". A value shaped like the 4+24+4 asterisk
+// masking pattern is treated as a genuine new credential, not a placeholder.
+func (e *SecretVar) ShouldPreserveStoredSentinelOnly() bool {
+	if e == nil {
+		return true
+	}
+	if e.IsFromSecret() {
+		return false
+	}
+	return e.GetValue() == "" || e.IsRedactionSentinel()
+}
+
 // Equals checks if two SecretVars are equal.
 func (e *SecretVar) Equals(other *SecretVar) bool {
 	if e == nil && other == nil {

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -875,3 +875,62 @@ func TestSecretVar_RedactedIfSecret(t *testing.T) {
 		}
 	})
 }
+
+// TestSecretVar_ShouldPreserveStoredSentinelOnly covers issue #6413: a real
+// password that happens to match the 4-chars + 24-asterisks + 4-chars masking
+// shape must be treated as a new credential, while the fixed sentinels and
+// empty values still mean "keep the stored one".
+func TestSecretVar_ShouldPreserveStoredSentinelOnly(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *SecretVar
+		expected bool
+	}{
+		{name: "nil receiver", input: nil, expected: true},
+		{name: "empty value", input: &SecretVar{Val: ""}, expected: true},
+		{name: "redacted sentinel", input: &SecretVar{Val: "<redacted>"}, expected: true},
+		{name: "uppercase sentinel", input: &SecretVar{Val: "<REDACTED>"}, expected: true},
+		{name: "bracket sentinel", input: &SecretVar{Val: "[REDACTED]"}, expected: true},
+		{
+			name:     "valid password matching mask pattern (#6413)",
+			input:    &SecretVar{Val: "Aa1b************************cdef"},
+			expected: false,
+		},
+		{name: "plain new password", input: &SecretVar{Val: "S3cure!Password"}, expected: false},
+		{
+			name:     "env reference is intentional",
+			input:    &SecretVar{Val: "resolved", ref: "env.PW", SecretType: SecretTypeEnv},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.input.ShouldPreserveStoredSentinelOnly(); got != tt.expected {
+				t.Errorf("ShouldPreserveStoredSentinelOnly() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestSecretVar_IsRedactionSentinel pins the sentinel-only classifier: it must
+// not match the positional 4+24+4 asterisk mask that IsRedacted matches.
+func TestSecretVar_IsRedactionSentinel(t *testing.T) {
+	maskShaped := &SecretVar{Val: "Aa1b************************cdef"}
+	if maskShaped.IsRedactionSentinel() {
+		t.Error("mask-shaped value must not be classified as a sentinel")
+	}
+	if !maskShaped.IsRedacted() {
+		t.Error("sanity: IsRedacted still matches the positional mask")
+	}
+	if !(&SecretVar{Val: "<redacted>"}).IsRedactionSentinel() {
+		t.Error("<redacted> must be a sentinel")
+	}
+	if !(&SecretVar{Val: "test", ref: "env.K", SecretType: SecretTypeEnv}).IsRedactionSentinel() {
+		t.Error("secret refs are externally-resolved and count as sentinel-redacted")
+	}
+	var nilVar *SecretVar
+	if nilVar.IsRedactionSentinel() {
+		t.Error("nil receiver must not be a sentinel")
+	}
+}

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -891,9 +891,12 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 		} else {
 			// Compare with existing config using value comparison (not pointer comparison)
 			// Password is considered changed when it was intentionally submitted —
-			// ShouldPreserveStored() returns false for both plain values and secret refs.
+			// the sentinel-only check returns false for both plain values and secret refs.
+			// Sentinel-only (not ShouldPreserveStored): the GET endpoint returns the
+			// admin password as "<redacted>"/FullyRedacted, never the 4+24+4 asterisk
+			// mask, so a submitted value with that shape is a real password (#6413).
 			passwordChanged := payload.AuthConfig.AdminPassword != nil &&
-				!payload.AuthConfig.AdminPassword.ShouldPreserveStored()
+				!payload.AuthConfig.AdminPassword.ShouldPreserveStoredSentinelOnly()
 			usernameChanged := payload.AuthConfig.AdminUserName != nil &&
 				!payload.AuthConfig.AdminUserName.Equals(authConfig.AdminUserName)
 			if payload.AuthConfig.IsEnabled != authConfig.IsEnabled ||
@@ -939,7 +942,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 			// Fetching current Auth config
 			if payload.AuthConfig.AdminUserName.GetValue() != "" {
-				if payload.AuthConfig.AdminPassword.ShouldPreserveStored() {
+				if payload.AuthConfig.AdminPassword.ShouldPreserveStoredSentinelOnly() {
 					if authConfig == nil || authConfig.AdminPassword.GetValue() == "" {
 						SendError(ctx, fasthttp.StatusBadRequest, "auth password must be provided")
 						return
@@ -979,7 +982,7 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			}
 		} else if authConfig != nil {
 			// Auth is being disabled but there's an existing config - preserve credentials and update disabled state
-			if payload.AuthConfig.AdminPassword.ShouldPreserveStored() {
+			if payload.AuthConfig.AdminPassword.ShouldPreserveStoredSentinelOnly() {
 				payload.AuthConfig.AdminPassword = authConfig.AdminPassword
 			}
 			if payload.AuthConfig.AdminUserName == nil || payload.AuthConfig.AdminUserName.GetValue() == "" {

--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -43,6 +43,27 @@ var securityHeaders = []string{
 	"x-bf-vk",
 }
 
+// validateAndHashAdminPassword enforces the admin password policy and returns
+// the bcrypt-hashed SecretVar to persist, preserving env/vault reference
+// metadata. On failure it returns the HTTP status and error message to send.
+func validateAndHashAdminPassword(password *schemas.SecretVar) (*schemas.SecretVar, int, string) {
+	passwordPolicyFailures := getPasswordPolicyFailures(password.GetValue())
+	if len(passwordPolicyFailures) > 0 {
+		return nil, fasthttp.StatusBadRequest, fmt.Sprintf("auth password must include %s", strings.Join(passwordPolicyFailures, ", "))
+	}
+	hashedPassword, err := encrypt.Hash(password.GetValue())
+	if err != nil {
+		return nil, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to hash password: %v", err)
+	}
+	// Preserve env/vault reference metadata when storing hashed password
+	if password.IsFromSecret() {
+		sv := *password
+		sv.Val = hashedPassword
+		return &sv, 0, ""
+	}
+	return &schemas.SecretVar{Val: hashedPassword}, 0, ""
+}
+
 func getPasswordPolicyFailures(password string) []string {
 	failures := make([]string, 0, 5)
 	hasUppercase := false
@@ -951,26 +972,15 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 					payload.AuthConfig.AdminPassword = authConfig.AdminPassword
 				} else {
 					// Password has been changed
-					passwordPolicyFailures := getPasswordPolicyFailures(payload.AuthConfig.AdminPassword.GetValue())
-					if len(passwordPolicyFailures) > 0 {
-						SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("auth password must include %s", strings.Join(passwordPolicyFailures, ", ")))
+					hashed, status, errMsg := validateAndHashAdminPassword(payload.AuthConfig.AdminPassword)
+					if errMsg != "" {
+						if status == fasthttp.StatusInternalServerError {
+							logger.Warn("%s", errMsg)
+						}
+						SendError(ctx, status, errMsg)
 						return
 					}
-					// We will hash the password
-					hashedPassword, err := encrypt.Hash(payload.AuthConfig.AdminPassword.GetValue())
-					if err != nil {
-						logger.Warn("failed to hash password: %v", err)
-						SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("failed to hash password: %v", err))
-						return
-					}
-					// Preserve env/vault reference metadata when storing hashed password
-					if payload.AuthConfig.AdminPassword.IsFromSecret() {
-						sv := *payload.AuthConfig.AdminPassword
-						sv.Val = hashedPassword
-						payload.AuthConfig.AdminPassword = &sv
-					} else {
-						payload.AuthConfig.AdminPassword = &schemas.SecretVar{Val: hashedPassword}
-					}
+					payload.AuthConfig.AdminPassword = hashed
 				}
 			}
 			// Save auth config - this handles both first-time creation and updates
@@ -984,6 +994,19 @@ func (h *ConfigHandler) updateConfig(ctx *fasthttp.RequestCtx) {
 			// Auth is being disabled but there's an existing config - preserve credentials and update disabled state
 			if payload.AuthConfig.AdminPassword.ShouldPreserveStoredSentinelOnly() {
 				payload.AuthConfig.AdminPassword = authConfig.AdminPassword
+			} else {
+				// A genuinely new password submitted alongside disablement must go
+				// through the same policy + hashing as the enabled path — persisting
+				// it raw would make CompareHash reject it once auth is re-enabled.
+				hashed, status, errMsg := validateAndHashAdminPassword(payload.AuthConfig.AdminPassword)
+				if errMsg != "" {
+					if status == fasthttp.StatusInternalServerError {
+						logger.Warn("%s", errMsg)
+					}
+					SendError(ctx, status, errMsg)
+					return
+				}
+				payload.AuthConfig.AdminPassword = hashed
 			}
 			if payload.AuthConfig.AdminUserName == nil || payload.AuthConfig.AdminUserName.GetValue() == "" {
 				payload.AuthConfig.AdminUserName = authConfig.AdminUserName

--- a/transports/bifrost-http/handlers/config_adminpassword_test.go
+++ b/transports/bifrost-http/handlers/config_adminpassword_test.go
@@ -1,0 +1,66 @@
+package handlers
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/encrypt"
+	"github.com/valyala/fasthttp"
+)
+
+// TestValidateAndHashAdminPassword covers the shared validate+hash helper both
+// auth branches (enable and disable) now go through, including the #6413
+// follow-up: a mask-shaped password submitted while disabling auth must be
+// hashed so CompareHash accepts it once auth is re-enabled.
+func TestValidateAndHashAdminPassword(t *testing.T) {
+	t.Run("policy failure returns 400 and no hash", func(t *testing.T) {
+		hashed, status, errMsg := validateAndHashAdminPassword(&schemas.SecretVar{Val: "short"})
+		if hashed != nil {
+			t.Fatalf("expected nil SecretVar on policy failure, got %+v", hashed)
+		}
+		if status != fasthttp.StatusBadRequest {
+			t.Errorf("status = %d, want %d", status, fasthttp.StatusBadRequest)
+		}
+		if !strings.Contains(errMsg, "auth password must include") {
+			t.Errorf("errMsg = %q, want policy failure message", errMsg)
+		}
+	})
+
+	t.Run("valid password is bcrypt-hashed and comparable", func(t *testing.T) {
+		const plain = "StrongPass1!x"
+		hashed, status, errMsg := validateAndHashAdminPassword(&schemas.SecretVar{Val: plain})
+		if errMsg != "" || status != 0 {
+			t.Fatalf("unexpected error: status=%d msg=%q", status, errMsg)
+		}
+		if hashed.GetValue() == plain {
+			t.Fatal("password was stored raw, not hashed")
+		}
+		ok, err := encrypt.CompareHash(hashed.GetValue(), plain)
+		if err != nil || !ok {
+			t.Errorf("CompareHash(hashed, plain) = %v, %v; want true, nil", ok, err)
+		}
+	})
+
+	t.Run("mask-shaped password survives hash+compare round trip (#6413)", func(t *testing.T) {
+		// 4 chars + 24 asterisks + 4 chars: shaped like the redaction mask but a
+		// real credential. It passes the policy (length, upper, lower, digit,
+		// special) and must round-trip through hashing like any other password.
+		const maskShaped = "Aa1b************************cdef"
+		sv := &schemas.SecretVar{Val: maskShaped}
+		if sv.ShouldPreserveStoredSentinelOnly() {
+			t.Fatal("sanity: mask-shaped value must be treated as a new password")
+		}
+		hashed, status, errMsg := validateAndHashAdminPassword(sv)
+		if errMsg != "" || status != 0 {
+			t.Fatalf("unexpected error: status=%d msg=%q", status, errMsg)
+		}
+		if hashed.GetValue() == maskShaped {
+			t.Fatal("mask-shaped password was persisted raw; re-enabling auth would lock the admin out")
+		}
+		ok, err := encrypt.CompareHash(hashed.GetValue(), maskShaped)
+		if err != nil || !ok {
+			t.Errorf("CompareHash after re-enable = %v, %v; want true, nil", ok, err)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #6413. A valid 32-character admin password that happens to match the redaction mask shape (4 chars + 24 asterisks + 4 chars, e.g. `Aa1b************************cdef`) was classified as redacted by `SecretVar.IsRedacted()`, so `ShouldPreserveStored()` returned true and the config handler silently preserved the old password while the save request reported success.

The positional-mask check is needed for values the server may partially mask (provider keys), but the admin password is never returned in that form: `GET /api/config` sends either the `<redacted>` sentinel or `FullyRedacted()`, and the dashboard round-trips those. A submitted value with the mask shape is therefore always a genuine new password.

## Changes

- Add `SecretVar.IsRedactionSentinel()`: matches only the fixed sentinels (`<redacted>`, `[REDACTED]`, case-insensitive) and env/vault references, never the positional 4+24+4 mask.
- Add `SecretVar.ShouldPreserveStoredSentinelOnly()`: sentinel-only variant of `ShouldPreserveStored()` for fields the server never partially masks.
- Switch the three admin-password checks in the config handler (`passwordChanged` detection, update path, auth-disable path) to the sentinel-only variant.
- `IsRedacted()` / `ShouldPreserveStored()` are unchanged for all other callers (provider keys, plugins, MCP oauth, webhooks).

## Testing

- New unit tests `TestSecretVar_ShouldPreserveStoredSentinelOnly` (includes the exact password from the issue) and `TestSecretVar_IsRedactionSentinel`.
- `go test ./schemas/` (core) and `go test ./bifrost-http/handlers/` (transports) pass; `go vet` clean on both packages.
- Verified the GET endpoint's password serialization (`<redacted>` / `FullyRedacted`) and the dashboard's `isRedacted` handling to confirm no client legitimately sends the mask shape back.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)