### PR TITLE
vk allowed models * handling for governance

### DIFF
--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -297,7 +297,8 @@ func (mc *ModelCatalog) computeProvidersForModel(model string) []schemas.ModelPr
 // checks, not by the static keyconfig allow set).
 //
 //   - allowedModels=["*"]: defer to GetProvidersForModel (with custom-provider
-//     fast path when list-models is disabled).
+//     fast path when list-models is disabled), falling back to allow for a
+//     provider the datasheet describes but list-models cannot enumerate.
 //   - allowedModels=[]: deny-by-default.
 //   - explicit allowedModels: direct or provider-prefixed match against the
 //     provider's catalog.
@@ -313,7 +314,22 @@ func (mc *ModelCatalog) IsModelAllowedForProvider(provider schemas.ModelProvider
 		if isCustomProvider && hasListModelsEndpointDisabled {
 			return true
 		}
-		return slices.Contains(mc.GetProvidersForModel(model), provider)
+		if slices.Contains(mc.GetProvidersForModel(model), provider) {
+			return true
+		}
+		// A provider the datasheet describes but list-models cannot enumerate is
+		// known only through the pricing sheet, which lags new releases by weeks.
+		// Refusing on that list makes ["*"] narrower than the provider itself, so
+		// a wildcard denies every model released since the last sync (issue
+		// #6657). Defer to the provider instead: it 404s a model it does not
+		// have, and it is the authority on its own catalog.
+		//
+		// Both other cases are already right and stay untouched. A provider with
+		// no datasheet rows either is handled by computeProvidersForModel's
+		// keyconfig fallback, and a provider whose live list-models did answer is
+		// enumerable, so its catalog is authoritative and still narrows.
+		return len(mc.live.UnfilteredModelsForProvider(provider)) == 0 &&
+			len(mc.datasheet.DatasheetModelsForProvider(provider)) > 0
 	}
 	if allowedModels.IsEmpty() {
 		return false

--- a/framework/modelcatalog/wildcardcatalog_test.go
+++ b/framework/modelcatalog/wildcardcatalog_test.go
@@ -1,0 +1,132 @@
+package modelcatalog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
+	"github.com/maximhq/bifrost/framework/modelcatalog/keyconfig"
+	"github.com/maximhq/bifrost/framework/modelcatalog/live"
+)
+
+// fireworksCatalog builds the catalog shape a Fireworks deployment actually has
+// (issue #6657):
+//
+//   - the datasheet carries Fireworks rows, because the public pricing sheet
+//     ships ~315 "fireworks_ai/..." entries;
+//   - the live store is empty for Fireworks, because Fireworks has no enumerable
+//     OpenAI-style list-models endpoint (see core/providers/fireworks: the
+//     provider builds its list from the key's configured models) and an operator
+//     who only pasted an API key configured none;
+//   - the provider key itself is unrestricted, i.e. an ordinary "just add the
+//     key" setup.
+//
+// The datasheet fixture mirrors the real feed: keys are "<litellm provider>/<model
+// id>" and the row's own "provider" field is "fireworks_ai", which normalizeProvider
+// folds onto schemas.Fireworks.
+func fireworksCatalog(t *testing.T) *ModelCatalog {
+	t.Helper()
+
+	dir := t.TempDir()
+	pricingPath := filepath.Join(dir, "pricing.json")
+	pricingJSON := []byte(`{
+		"fireworks_ai/accounts/fireworks/models/glm-5p2": {
+			"provider": "fireworks_ai",
+			"mode": "chat",
+			"base_model": "glm-5.2",
+			"input_cost_per_token": 0.0000014,
+			"output_cost_per_token": 0.0000044
+		},
+		"fireworks_ai/accounts/fireworks/models/kimi-k2p6": {
+			"provider": "fireworks_ai",
+			"mode": "chat",
+			"base_model": "kimi-k2.6",
+			"input_cost_per_token": 0.0000006,
+			"output_cost_per_token": 0.0000025
+		}
+	}`)
+	if err := os.WriteFile(pricingPath, pricingJSON, 0o600); err != nil {
+		t.Fatalf("write pricing fixture: %v", err)
+	}
+
+	// Point the parameters feed at a local file too, so nothing in this test can
+	// reach the network.
+	paramsPath := filepath.Join(dir, "params.json")
+	if err := os.WriteFile(paramsPath, []byte(`{}`), 0o600); err != nil {
+		t.Fatalf("write params fixture: %v", err)
+	}
+
+	ds := datasheet.New(nil, nil, datasheet.Config{
+		URL:                "file://" + pricingPath,
+		ModelParametersURL: "file://" + paramsPath,
+	})
+	if err := ds.LoadFromURLIntoMemory(t.Context()); err != nil {
+		t.Fatalf("load pricing fixture: %v", err)
+	}
+
+	kc := keyconfig.New(nil)
+	kc.Replace(map[schemas.ModelProvider][]schemas.Key{
+		schemas.Fireworks: {{
+			ID:      "fw-key-1",
+			Enabled: ptrBool(true),
+			Models:  schemas.WhiteList{"*"},
+		}},
+	})
+
+	mc := &ModelCatalog{
+		datasheet: ds,
+		live:      live.New(nil),
+		keyconf:   kc,
+		done:      make(chan struct{}),
+	}
+	mc.initCaches()
+
+	// Sanity: the fixture really did land, so a failure below is about the
+	// wildcard rule and not about an empty datasheet.
+	if got := mc.datasheet.DatasheetModelsForProvider(schemas.Fireworks); len(got) != 2 {
+		t.Fatalf("fixture did not load: DatasheetModelsForProvider(fireworks) = %v, want 2 entries", got)
+	}
+	if got := mc.live.UnfilteredModelsForProvider(schemas.Fireworks); len(got) != 0 {
+		t.Fatalf("live store should be empty for fireworks, got %v", got)
+	}
+	return mc
+}
+
+// TestIsModelAllowedForProvider_WildcardAllowsModelMissingFromCatalog is the
+// regression test for issue #6657.
+//
+// A virtual key scoped to Fireworks with allowed_models ["*"] must permit every
+// Fireworks model. schemas.WhiteList documents "*" as "all values are allowed"
+// (core/schemas/account.go) and framework/configstore/tables/virtualkey.go
+// documents allowed_models ["*"] as "allows all models", but the unrestricted
+// branch of IsModelAllowedForProvider resolves the wildcard against the
+// discovered catalog instead. Fireworks' catalog is the pricing datasheet alone,
+// which lags new releases, so any model newer than the sheet is refused with
+// 403 model_blocked even though the wildcard should not narrow anything.
+func TestIsModelAllowedForProvider_WildcardAllowsModelMissingFromCatalog(t *testing.T) {
+	mc := fireworksCatalog(t)
+	wildcard := schemas.WhiteList{"*"}
+
+	// Control: a model the datasheet knows is permitted today. If this ever
+	// fails the fixture is wrong, not the rule under test.
+	if !mc.IsModelAllowedForProvider(schemas.Fireworks, "accounts/fireworks/models/glm-5p2", nil, wildcard) {
+		t.Fatalf("control failed: a datasheet-known Fireworks model must be allowed under a wildcard")
+	}
+
+	// The defect: glm-5p3 is a real Fireworks model that postdates the pricing
+	// datasheet, so the catalog has never heard of it.
+	const model = "accounts/fireworks/models/glm-5p3"
+	if got := mc.IsModelAllowedForProvider(schemas.Fireworks, model, nil, wildcard); !got {
+		t.Errorf("IsModelAllowedForProvider(fireworks, %q, allowed=[\"*\"]) = false, want true: "+
+			"a wildcard allowlist must permit every model on the provider, not only the ones "+
+			"the discovered catalog happens to list (issue #6657)", model)
+	}
+
+	// The short form the issue also reports failing.
+	const shortForm = "glm-5p3"
+	if got := mc.IsModelAllowedForProvider(schemas.Fireworks, shortForm, nil, wildcard); !got {
+		t.Errorf("IsModelAllowedForProvider(fireworks, %q, allowed=[\"*\"]) = false, want true (issue #6657)", shortForm)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a regression where virtual keys scoped to a provider with `allowed_models: ["*"]` would return `403 model_blocked` for any model not yet present in the pricing datasheet. Because providers like Fireworks have no enumerable list-models endpoint, their catalog is built entirely from the pricing sheet, which can lag new model releases by weeks. This made the wildcard allowlist narrower than the provider itself, blocking legitimate requests.

## Changes

- In `IsModelAllowedForProvider`, when `allowedModels` is `["*"]` and `GetProvidersForModel` does not find the provider in the discovered catalog, the code now falls back to allowing the request if the live store returned no models for that provider but the datasheet has at least one row for it. This means the provider itself (which 404s unknown models) acts as the authority rather than the stale pricing sheet.
- Added `wildcardcatalog_test.go` with a regression test (`TestIsModelAllowedForProvider_WildcardAllowsModelMissingFromCatalog`) that reproduces the exact failure: a Fireworks key with `["*"]` must permit a model that postdates the pricing datasheet, both in full path form and short form.
- Updated a call site in `plugins/governance/store_test.go` to match a changed function signature.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations
- [x] Plugins

## How to test

```sh
go test ./framework/modelcatalog/... -run TestIsModelAllowedForProvider_WildcardAllowsModelMissingFromCatalog -v
go test ./...
```

The regression test sets up a Fireworks catalog with a non-empty datasheet and an empty live store, then asserts that a model absent from the datasheet is still permitted under a `["*"]` allowlist.

## Breaking changes

- [x] No

## Related issues

Closes #6657

## Security considerations

The fallback only activates when the live list-models store is empty for a provider and the datasheet has at least one row, meaning providers with a fully enumerable live catalog are unaffected and still narrowed by that catalog. The provider itself remains the final authority and will 404 any model it does not recognise.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable