### PR TITLE
feat(databricks): gate optional parameters on datasheet capabilities per model and drop Anthropic-native fields unconditionally

### DIFF
--- a/core/providers/databricks/databricks_test.go
+++ b/core/providers/databricks/databricks_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -394,6 +395,338 @@ func TestDatabricksChatStreamStripsUnsupportedFields(t *testing.T) {
 
 	if len(request.Params.ContextManagement) == 0 || request.Params.Reasoning == nil || request.Params.Reasoning.Effort == nil ||
 		request.Params.ExtraParams["context_management"] == nil || request.Params.ExtraParams["reasoning_effort"] == nil {
+		t.Error("sanitizing the wire request mutated the original request")
+	}
+}
+
+// TestDatabricksReasoningEffortFollowsDatasheet pins the model-parameter wiring: whether
+// reasoning_effort reaches Databricks is decided by the datasheet record for the endpoint's
+// model, not by a hardcoded provider-wide rule. Resolution order is unsupported_fields →
+// supports_reasoning_effort / the effort ladder → supports_reasoning, and a model with no row
+// keeps the conservative drop.
+func TestDatabricksReasoningEffortFollowsDatasheet(t *testing.T) {
+	tests := []struct {
+		name       string
+		model      string
+		caps       *schemas.ModelCapabilities
+		wantEffort any
+	}{
+		{
+			name:       "no datasheet row drops the effort",
+			model:      "databricks-unknown-endpoint",
+			wantEffort: nil,
+		},
+		{
+			name:       "supports_reasoning keeps the effort",
+			model:      "databricks-reasoning-endpoint",
+			caps:       &schemas.ModelCapabilities{SupportsReasoning: schemas.Ptr(true)},
+			wantEffort: "medium",
+		},
+		{
+			// The shape of the real databricks/databricks-claude-opus-5 row: the model
+			// reasons, but through Claude's thinking budget rather than an effort label.
+			name:       "anthropic-family model drops the effort even when it reasons",
+			model:      "databricks-claude-opus-5",
+			caps:       &schemas.ModelCapabilities{SupportsReasoning: schemas.Ptr(true)},
+			wantEffort: nil,
+		},
+		{
+			// The shape of the real databricks/databricks-gpt-oss-120b row.
+			name:  "a published reasoning_effort parameter keeps the effort",
+			model: "databricks-gpt-oss-120b",
+			caps: &schemas.ModelCapabilities{
+				SupportsReasoning: schemas.Ptr(true),
+				ModelParameters:   []schemas.ModelParameterDescriptor{{ID: "temperature"}, {ID: "reasoning_effort"}},
+			},
+			wantEffort: "medium",
+		},
+		{
+			name:       "supports_reasoning_effort false drops the effort",
+			model:      "databricks-budget-only-endpoint",
+			caps:       &schemas.ModelCapabilities{SupportsReasoning: schemas.Ptr(true), SupportsReasoningEffort: schemas.Ptr(false)},
+			wantEffort: nil,
+		},
+		{
+			name:       "effort ladder keeps the effort and clamps it to a published rung",
+			model:      "databricks-ladder-endpoint",
+			caps:       &schemas.ModelCapabilities{ReasoningEffortLevels: []string{"low", "high"}},
+			wantEffort: "high",
+		},
+		{
+			name:  "unsupported_fields wins over the reasoning flags",
+			model: "databricks-rejects-effort-endpoint",
+			caps: &schemas.ModelCapabilities{
+				SupportsReasoning:       schemas.Ptr(true),
+				SupportsReasoningEffort: schemas.Ptr(true),
+				UnsupportedFields:       map[string]bool{schemas.FieldReasoningEffort: true},
+			},
+			wantEffort: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// The resolver is process-global, so answer only for this case's model and
+			// leave every other lookup on the name-based fallbacks.
+			schemas.SetCapabilityResolver(func(provider schemas.ModelProvider, model string) *schemas.ModelCapabilities {
+				if provider == schemas.Databricks && model == tt.model {
+					return tt.caps
+				}
+				return nil
+			})
+			t.Cleanup(func() { schemas.SetCapabilityResolver(nil) })
+
+			var mu sync.Mutex
+			var gotBody map[string]any
+			provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+				mu.Lock()
+				gotBody = body
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(stubChatResponse))
+			})
+
+			key := schemas.Key{
+				Models: []string{"*"},
+				Value:  *schemas.NewSecretVar("dapi-test"),
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+					WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+				},
+			}
+			request := &schemas.BifrostChatRequest{
+				Provider: schemas.Databricks,
+				Model:    tt.model,
+				Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hey")}}},
+				Params: &schemas.ChatParameters{
+					Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("medium")},
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if _, bErr := provider.ChatCompletion(ctx, key, request); bErr != nil {
+				t.Fatalf("ChatCompletion returned an error: %v", bErr)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if got := gotBody["reasoning_effort"]; got != tt.wantEffort {
+				t.Errorf("reasoning_effort on the wire: got %#v, want %#v", got, tt.wantEffort)
+			}
+		})
+	}
+}
+
+// TestDatabricksChatParamsFollowDatasheet covers the rest of the parameter wiring. Bifrost's
+// neutral parameter set is wider than any single Databricks endpoint accepts, so each
+// optional field is gated on the datasheet record for the model rather than on a
+// provider-wide rule. A model the datasheet does not describe keeps every field.
+func TestDatabricksChatParamsFollowDatasheet(t *testing.T) {
+	sent := []string{
+		"temperature", "top_p", "top_k", "tool_choice", "parallel_tool_calls",
+		"response_format", "stop", "presence_penalty", "frequency_penalty",
+	}
+
+	tests := []struct {
+		name        string
+		model       string
+		caps        *schemas.ModelCapabilities
+		wantDropped []string
+	}{
+		{
+			name:  "no datasheet row keeps every field",
+			model: "databricks-unknown-endpoint",
+		},
+		{
+			// The shape of the real databricks/databricks-claude-opus-5 row: adaptive-only
+			// thinking, which rejects the sampling knobs with a 400.
+			name:        "supports_sampling_params false drops temperature, top_p and top_k",
+			model:       "databricks-adaptive-endpoint",
+			caps:        &schemas.ModelCapabilities{SupportsSamplingParams: schemas.Ptr(false)},
+			wantDropped: []string{"temperature", "top_p", "top_k"},
+		},
+		{
+			name:        "supports_tool_choice false drops the tool_choice pin",
+			model:       "databricks-no-tool-choice-endpoint",
+			caps:        &schemas.ModelCapabilities{SupportsToolChoice: schemas.Ptr(false)},
+			wantDropped: []string{"tool_choice"},
+		},
+		{
+			name:        "supports_parallel_function_calling false drops parallel_tool_calls",
+			model:       "databricks-serial-tools-endpoint",
+			caps:        &schemas.ModelCapabilities{SupportsParallelFunctionCalling: schemas.Ptr(false)},
+			wantDropped: []string{"parallel_tool_calls"},
+		},
+		{
+			name:        "supports_response_schema false drops response_format",
+			model:       "databricks-no-schema-endpoint",
+			caps:        &schemas.ModelCapabilities{SupportsResponseSchema: schemas.Ptr(false)},
+			wantDropped: []string{"response_format"},
+		},
+		{
+			name:  "unsupported_fields drops stop and the penalties",
+			model: "databricks-narrow-endpoint",
+			caps: &schemas.ModelCapabilities{UnsupportedFields: map[string]bool{
+				schemas.FieldStop:             true,
+				schemas.FieldPresencePenalty:  true,
+				schemas.FieldFrequencyPenalty: true,
+			}},
+			wantDropped: []string{"stop", "presence_penalty", "frequency_penalty"},
+		},
+		{
+			name:        "unsupported_fields top_p drops the sampling knobs",
+			model:       "databricks-no-top-p-endpoint",
+			caps:        &schemas.ModelCapabilities{UnsupportedFields: map[string]bool{schemas.FieldTopP: true}},
+			wantDropped: []string{"temperature", "top_p", "top_k"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schemas.SetCapabilityResolver(func(provider schemas.ModelProvider, model string) *schemas.ModelCapabilities {
+				if provider == schemas.Databricks && model == tt.model {
+					return tt.caps
+				}
+				return nil
+			})
+			t.Cleanup(func() { schemas.SetCapabilityResolver(nil) })
+
+			var mu sync.Mutex
+			var gotBody map[string]any
+			provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+				mu.Lock()
+				gotBody = body
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(stubChatResponse))
+			})
+
+			key := schemas.Key{
+				Models: []string{"*"},
+				Value:  *schemas.NewSecretVar("dapi-test"),
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+					WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+				},
+			}
+			responseFormat := any(map[string]any{"type": "json_object"})
+			request := &schemas.BifrostChatRequest{
+				Provider: schemas.Databricks,
+				Model:    tt.model,
+				Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hey")}}},
+				Params: &schemas.ChatParameters{
+					Temperature:       schemas.Ptr(0.5),
+					TopP:              schemas.Ptr(0.9),
+					TopK:              schemas.Ptr(40),
+					ToolChoice:        &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("auto")},
+					ParallelToolCalls: schemas.Ptr(true),
+					ResponseFormat:    &responseFormat,
+					Stop:              []string{"stop"},
+					PresencePenalty:   schemas.Ptr(0.1),
+					FrequencyPenalty:  schemas.Ptr(0.2),
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if _, bErr := provider.ChatCompletion(ctx, key, request); bErr != nil {
+				t.Fatalf("ChatCompletion returned an error: %v", bErr)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			for _, field := range sent {
+				_, onWire := gotBody[field]
+				wantDropped := slices.Contains(tt.wantDropped, field)
+				if wantDropped && onWire {
+					t.Errorf("%s reached Databricks: %#v", field, gotBody[field])
+				}
+				if !wantDropped && !onWire {
+					t.Errorf("%s was dropped, but the datasheet does not reject it", field)
+				}
+			}
+			// Dropping is a wire-level fixup; the caller's request must survive it intact
+			// for fallbacks and post-hooks.
+			if request.Params.Temperature == nil || request.Params.ToolChoice == nil || len(request.Params.Stop) == 0 {
+				t.Error("sanitizing the wire request mutated the original request")
+			}
+		})
+	}
+}
+
+// TestDatabricksChatStripsAnthropicOnlyFields pins the fields that are dropped whatever the
+// datasheet says. They ride on the neutral chat parameters and serialize straight onto the
+// wire, but both Databricks surfaces are OpenAI-shaped and reject them regardless of which
+// model backs the endpoint — so this is a fact about the surface, not a model capability.
+// The datasheet marks Claude-on-Databricks as supporting prompt caching and context editing,
+// which would otherwise forward Anthropic-native fields onto an OpenAI-shaped request.
+func TestDatabricksChatStripsAnthropicOnlyFields(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var gotBody map[string]any
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		mu.Lock()
+		gotBody = body
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stubChatResponse))
+	})
+
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+	request := &schemas.BifrostChatRequest{
+		Provider: schemas.Databricks,
+		Model:    "databricks-claude-sonnet-4-5",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hey")}}},
+		Params: &schemas.ChatParameters{
+			ContextManagement: json.RawMessage(`{"edits":[{"type":"clear_thinking_20251015","keep":"all"}]}`),
+			CacheControl:      &schemas.CacheControl{Type: "ephemeral"},
+			Speed:             schemas.Ptr("fast"),
+			InferenceGeo:      schemas.Ptr("us"),
+			TaskBudget:        &schemas.ChatTaskBudget{},
+			Container:         &schemas.ChatContainer{},
+			MCPServers:        []schemas.ChatMCPServer{{Name: "docs"}},
+			ExtraParams:       map[string]any{"databricks_test_param": "kept"},
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if _, bErr := provider.ChatCompletion(ctx, key, request); bErr != nil {
+		t.Fatalf("ChatCompletion returned an error: %v", bErr)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, field := range []string{
+		"context_management", "cache_control", "speed", "inference_geo",
+		"task_budget", "container", "mcp_servers",
+	} {
+		if _, exists := gotBody[field]; exists {
+			t.Errorf("%s reached Databricks: %#v", field, gotBody[field])
+		}
+	}
+	if gotBody["databricks_test_param"] != "kept" {
+		t.Errorf("unrelated extra param: got %#v, want %q", gotBody["databricks_test_param"], "kept")
+	}
+	if request.Params.CacheControl == nil || request.Params.Speed == nil || len(request.Params.MCPServers) == 0 {
 		t.Error("sanitizing the wire request mutated the original request")
 	}
 }

--- a/core/providers/databricks/inference.go
+++ b/core/providers/databricks/inference.go
@@ -11,26 +11,110 @@ import (
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
-// stripUnsupportedChatFields removes request extensions that Databricks'
-// OpenAI-compatible Chat Completions surfaces reject. Work on a
-// copy because the original request may be reused by fallbacks and post-hooks.
-func stripUnsupportedChatFields(request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
+// paramSupport records which optional wire fields the resolved model accepts. Bifrost's
+// neutral parameter set is broader than any single Databricks endpoint takes, and both
+// surfaces answer a field they do not know with a 400 rather than ignoring it, so every
+// optional field is resolved against the datasheet row for the model before the request is
+// converted.
+//
+// Every fallback is "keep the field": a workspace can serve a model the datasheet has never
+// heard of, and a silent drop is worse than an upstream error the caller can read.
+// reasoning_effort is the exception — see resolveParamSupport.
+type paramSupport struct {
+	reasoningEffort   bool // reasoning_effort
+	samplingParams    bool // temperature, top_p, top_k
+	toolChoice        bool // tool_choice
+	parallelToolCalls bool // parallel_tool_calls
+	responseSchema    bool // response_format (chat), text.format (responses)
+	stop              bool // stop
+	presencePenalty   bool // presence_penalty
+	frequencyPenalty  bool // frequency_penalty
+}
+
+// resolveParamSupport reads the datasheet record for the model behind a Databricks endpoint
+// and answers, per field, whether Bifrost may send it.
+//
+// reasoning_effort resolves through: an explicit unsupported_fields entry →
+// supports_reasoning_effort (or a published effort ladder) → a reasoning_effort entry in the
+// row's model_parameters → the model reasons and is not Anthropic-family. The last clause is
+// what makes Claude-on-Databricks correct: those endpoints reason through Claude's thinking
+// budget and reject an effort label, which is the 400 Claude Code requests hit. A model with
+// no row drops the field, since Databricks endpoint names are workspace-defined and there is
+// nothing else to go on.
+func resolveParamSupport(ctx *schemas.BifrostContext, model string) paramSupport {
+	canonicalModel := schemas.ResolveCanonicalModel(ctx, model)
+	caps := schemas.ResolveModelCaps(schemas.Databricks, canonicalModel)
+
+	effortFallback := caps.PublishesParameter(schemas.FieldReasoningEffort) ||
+		(caps.SupportsReasoning(false) && !schemas.IsAnthropicModelFamily(ctx, canonicalModel))
+
+	return paramSupport{
+		reasoningEffort: !caps.FieldUnsupported(schemas.FieldReasoningEffort,
+			!caps.SupportsReasoningEffort(effortFallback)),
+		// supports_sampling_params is false on the adaptive-only Claude models
+		// (Opus 4.7+, Sonnet 5+, Fable), which 400 on temperature/top_p/top_k.
+		samplingParams:    caps.SupportsSamplingParams(!caps.FieldUnsupported(schemas.FieldTopP, false)),
+		toolChoice:        caps.SupportsToolChoice(true),
+		parallelToolCalls: caps.SupportsParallelFunctionCalling(true),
+		responseSchema:    caps.SupportsResponseSchema(true),
+		stop:              !caps.FieldUnsupported(schemas.FieldStop, false),
+		presencePenalty:   !caps.FieldUnsupported(schemas.FieldPresencePenalty, false),
+		frequencyPenalty:  !caps.FieldUnsupported(schemas.FieldFrequencyPenalty, false),
+	}
+}
+
+// stripUnsupportedChatFields removes request fields the resolved Databricks model rejects.
+// Work on a copy because the original request may be reused by fallbacks and post-hooks.
+//
+// The Anthropic-native knobs are dropped unconditionally rather than per model. They are
+// carried on the neutral chat parameters and serialize straight onto the wire, but both
+// Databricks surfaces speak OpenAI shapes that reject them whichever model backs the
+// endpoint — a fact about the surface, not a model capability. context_management is the one
+// that surfaced first, as a 400 on Claude Code requests.
+func stripUnsupportedChatFields(ctx *schemas.BifrostContext, request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
 	if request == nil || request.Params == nil {
 		return request
 	}
-	_, hasExtraContextManagement := request.Params.ExtraParams["context_management"]
-	_, hasExtraReasoningEffort := request.Params.ExtraParams["reasoning_effort"]
-	hasReasoningEffort := request.Params.Reasoning != nil &&
-		(request.Params.Reasoning.Effort != nil || request.Params.Reasoning.MaxTokens != nil)
-	if len(request.Params.ContextManagement) == 0 && !hasExtraContextManagement &&
-		!hasReasoningEffort && !hasExtraReasoningEffort {
+	params := request.Params
+	support := resolveParamSupport(ctx, request.Model)
+
+	_, hasExtraContextManagement := params.ExtraParams["context_management"]
+	dropAnthropicFields := len(params.ContextManagement) > 0 || hasExtraContextManagement ||
+		params.CacheControl != nil || params.Speed != nil || params.InferenceGeo != nil ||
+		params.TaskBudget != nil || params.Container != nil || len(params.MCPServers) > 0
+
+	_, hasExtraReasoningEffort := params.ExtraParams["reasoning_effort"]
+	hasReasoningEffort := hasExtraReasoningEffort || (params.Reasoning != nil &&
+		(params.Reasoning.Effort != nil || params.Reasoning.MaxTokens != nil))
+
+	dropReasoningEffort := hasReasoningEffort && !support.reasoningEffort
+	dropSamplingParams := !support.samplingParams &&
+		(params.Temperature != nil || params.TopP != nil || params.TopK != nil)
+	dropToolChoice := !support.toolChoice && params.ToolChoice != nil
+	dropParallelToolCalls := !support.parallelToolCalls && params.ParallelToolCalls != nil
+	dropResponseFormat := !support.responseSchema && params.ResponseFormat != nil
+	dropStop := !support.stop && len(params.Stop) > 0
+	dropPresencePenalty := !support.presencePenalty && params.PresencePenalty != nil
+	dropFrequencyPenalty := !support.frequencyPenalty && params.FrequencyPenalty != nil
+
+	if !dropAnthropicFields && !dropReasoningEffort && !dropSamplingParams && !dropToolChoice &&
+		!dropParallelToolCalls && !dropResponseFormat && !dropStop && !dropPresencePenalty &&
+		!dropFrequencyPenalty {
 		return request
 	}
 
 	requestCopy := *request
-	paramsCopy := *request.Params
-	paramsCopy.ContextManagement = nil
-	if paramsCopy.Reasoning != nil {
+	paramsCopy := *params
+	if dropAnthropicFields {
+		paramsCopy.ContextManagement = nil
+		paramsCopy.CacheControl = nil
+		paramsCopy.Speed = nil
+		paramsCopy.InferenceGeo = nil
+		paramsCopy.TaskBudget = nil
+		paramsCopy.Container = nil
+		paramsCopy.MCPServers = nil
+	}
+	if dropReasoningEffort && paramsCopy.Reasoning != nil {
 		reasoningCopy := *paramsCopy.Reasoning
 		reasoningCopy.Effort = nil
 		// The shared OpenAI converter derives reasoning_effort from MaxTokens
@@ -38,10 +122,109 @@ func stripUnsupportedChatFields(request *schemas.BifrostChatRequest) *schemas.Bi
 		reasoningCopy.MaxTokens = nil
 		paramsCopy.Reasoning = &reasoningCopy
 	}
-	if paramsCopy.ExtraParams != nil {
+	if dropSamplingParams {
+		paramsCopy.Temperature = nil
+		paramsCopy.TopP = nil
+		paramsCopy.TopK = nil
+	}
+	if dropToolChoice {
+		paramsCopy.ToolChoice = nil
+	}
+	if dropParallelToolCalls {
+		paramsCopy.ParallelToolCalls = nil
+	}
+	if dropResponseFormat {
+		paramsCopy.ResponseFormat = nil
+	}
+	if dropStop {
+		paramsCopy.Stop = nil
+	}
+	if dropPresencePenalty {
+		paramsCopy.PresencePenalty = nil
+	}
+	if dropFrequencyPenalty {
+		paramsCopy.FrequencyPenalty = nil
+	}
+	// Only the extra-param spellings of fields dropped above are removed. Everything else in
+	// ExtraParams is the documented passthrough for endpoint-specific knobs Bifrost does not
+	// model, so it is forwarded untouched.
+	if paramsCopy.ExtraParams != nil && (dropAnthropicFields || dropReasoningEffort) {
 		paramsCopy.ExtraParams = maps.Clone(paramsCopy.ExtraParams)
-		delete(paramsCopy.ExtraParams, "context_management")
-		delete(paramsCopy.ExtraParams, "reasoning_effort")
+		if dropAnthropicFields {
+			delete(paramsCopy.ExtraParams, "context_management")
+		}
+		if dropReasoningEffort {
+			delete(paramsCopy.ExtraParams, "reasoning_effort")
+		}
+	}
+	requestCopy.Params = &paramsCopy
+	return &requestCopy
+}
+
+// stripUnsupportedResponsesFields is stripUnsupportedChatFields for the Model Serving
+// Responses surface, which carries the same fields through a different params struct — minus
+// the chat-only knobs (stop, the penalties, top_k) and the Anthropic betas, which the
+// neutral Responses parameters do not model at all. The AI Gateway surface has no native
+// Responses endpoint and is emulated through ChatCompletion, so it is sanitized by the chat
+// path instead.
+func stripUnsupportedResponsesFields(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
+	if request == nil || request.Params == nil {
+		return request
+	}
+	params := request.Params
+	support := resolveParamSupport(ctx, request.Model)
+
+	_, hasExtraContextManagement := params.ExtraParams["context_management"]
+	dropContextManagement := len(params.ContextManagement) > 0 || hasExtraContextManagement
+
+	_, hasExtraReasoningEffort := params.ExtraParams["reasoning_effort"]
+	hasReasoningEffort := hasExtraReasoningEffort || (params.Reasoning != nil &&
+		(params.Reasoning.Effort != nil || params.Reasoning.MaxTokens != nil))
+
+	dropReasoningEffort := hasReasoningEffort && !support.reasoningEffort
+	dropSamplingParams := !support.samplingParams && (params.Temperature != nil || params.TopP != nil)
+	dropToolChoice := !support.toolChoice && params.ToolChoice != nil
+	dropParallelToolCalls := !support.parallelToolCalls && params.ParallelToolCalls != nil
+	dropTextFormat := !support.responseSchema && params.Text != nil && params.Text.Format != nil
+
+	if !dropContextManagement && !dropReasoningEffort && !dropSamplingParams && !dropToolChoice &&
+		!dropParallelToolCalls && !dropTextFormat {
+		return request
+	}
+
+	requestCopy := *request
+	paramsCopy := *params
+	paramsCopy.ContextManagement = nil
+	if dropReasoningEffort && paramsCopy.Reasoning != nil {
+		reasoningCopy := *paramsCopy.Reasoning
+		reasoningCopy.Effort = nil
+		reasoningCopy.MaxTokens = nil
+		paramsCopy.Reasoning = &reasoningCopy
+	}
+	if dropSamplingParams {
+		paramsCopy.Temperature = nil
+		paramsCopy.TopP = nil
+	}
+	if dropToolChoice {
+		paramsCopy.ToolChoice = nil
+	}
+	if dropParallelToolCalls {
+		paramsCopy.ParallelToolCalls = nil
+	}
+	if dropTextFormat {
+		// text also carries verbosity, so only the schema is cleared.
+		textCopy := *paramsCopy.Text
+		textCopy.Format = nil
+		paramsCopy.Text = &textCopy
+	}
+	if paramsCopy.ExtraParams != nil && (dropContextManagement || dropReasoningEffort) {
+		paramsCopy.ExtraParams = maps.Clone(paramsCopy.ExtraParams)
+		if dropContextManagement {
+			delete(paramsCopy.ExtraParams, "context_management")
+		}
+		if dropReasoningEffort {
+			delete(paramsCopy.ExtraParams, "reasoning_effort")
+		}
 	}
 	requestCopy.Params = &paramsCopy
 	return &requestCopy
@@ -49,7 +232,7 @@ func stripUnsupportedChatFields(request *schemas.BifrostChatRequest) *schemas.Bi
 
 // ChatCompletion performs a chat completion request against the resolved Databricks surface.
 func (provider *DatabricksProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
-	request = stripUnsupportedChatFields(request)
+	request = stripUnsupportedChatFields(ctx, request)
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/chat/completions")
 	if bErr != nil {
 		return nil, bErr
@@ -74,7 +257,7 @@ func (provider *DatabricksProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 // ChatCompletionStream performs a streaming chat completion request against the resolved
 // Databricks surface. Both surfaces emit OpenAI-shaped Server-Sent Events.
 func (provider *DatabricksProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	request = stripUnsupportedChatFields(request)
+	request = stripUnsupportedChatFields(ctx, request)
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/chat/completions")
 	if bErr != nil {
 		return nil, bErr
@@ -136,6 +319,7 @@ func (provider *DatabricksProvider) Responses(ctx *schemas.BifrostContext, key s
 		return chatResponse.ToBifrostResponsesResponse(), nil
 	}
 
+	request = stripUnsupportedResponsesFields(ctx, request)
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/responses")
 	if bErr != nil {
 		return nil, bErr
@@ -165,6 +349,7 @@ func (provider *DatabricksProvider) ResponsesStream(ctx *schemas.BifrostContext,
 		return provider.ChatCompletionStream(ctx, postHookRunner, postHookSpanFinalizer, key, request.ToChatRequest())
 	}
 
+	request = stripUnsupportedResponsesFields(ctx, request)
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/responses")
 	if bErr != nil {
 		return nil, bErr

--- a/core/schemas/modelcaps.go
+++ b/core/schemas/modelcaps.go
@@ -166,6 +166,64 @@ func (c ModelCaps) FieldName(logical string, fallback string) string {
 	return fallback
 }
 
+// PublishesParameter reports whether the datasheet row lists a request parameter
+// under model_parameters, matched on the descriptor's id ("reasoning_effort",
+// "top_p", ...).
+//
+// Positive signal only: the list is the datasheet's prompt-playground surface and
+// rows populate it to varying depth, so a hit means the model takes the parameter
+// while a miss only means the row does not say. Callers pass it as the fallback to
+// a supports_* check rather than treating it as an allowlist.
+func (c ModelCaps) PublishesParameter(id string) bool {
+	if c.record == nil || id == "" {
+		return false
+	}
+	for _, param := range c.record.ModelParameters {
+		if param.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// SupportsSamplingParams reports whether the model accepts the sampling knobs —
+// temperature, top_p, top_k. False on the adaptive-only thinking models (Claude
+// Opus 4.7+, Sonnet 5+, the Fable/Mythos family), which reject them with a 400.
+func (c ModelCaps) SupportsSamplingParams(fallback bool) bool {
+	if c.record != nil && c.record.SupportsSamplingParams != nil {
+		return *c.record.SupportsSamplingParams
+	}
+	return fallback
+}
+
+// SupportsToolChoice reports whether the model accepts a tool_choice pin.
+func (c ModelCaps) SupportsToolChoice(fallback bool) bool {
+	if c.record != nil && c.record.SupportsToolChoice != nil {
+		return *c.record.SupportsToolChoice
+	}
+	return fallback
+}
+
+// SupportsParallelFunctionCalling reports whether the model accepts
+// parallel_tool_calls.
+func (c ModelCaps) SupportsParallelFunctionCalling(fallback bool) bool {
+	if c.record != nil && c.record.SupportsParallelFunctionCalling != nil {
+		return *c.record.SupportsParallelFunctionCalling
+	}
+	return fallback
+}
+
+// SupportsResponseSchema reports whether the model accepts a structured-output
+// schema — response_format on the chat surface, text.format on Responses.
+// Distinct from SupportsResponseSchemaWithTools, which gates the combination
+// with function tools.
+func (c ModelCaps) SupportsResponseSchema(fallback bool) bool {
+	if c.record != nil && c.record.SupportsResponseSchema != nil {
+		return *c.record.SupportsResponseSchema
+	}
+	return fallback
+}
+
 // SupportsSystemMessages reports whether the (provider, model) pair accepts a
 // system message. Providers differ in how they carry one — Replicate exposes a
 // system_prompt input field per model — so callers that must reroute the text

--- a/docs/providers/supported-providers/databricks.mdx
+++ b/docs/providers/supported-providers/databricks.mdx
@@ -215,7 +215,7 @@ The Responses API is native on Model Serving. On the Unity AI Gateway, which is 
 
 ### Provider-specific parameters
 
-Databricks accepts fields Bifrost does not model canonically, such as `service_tier` for priority pay-per-token inference and `reasoning_effort` for reasoning models. Send them as top-level fields and Bifrost forwards them:
+Databricks accepts fields Bifrost does not model canonically, such as `service_tier` for priority pay-per-token inference. Send them as top-level fields and Bifrost forwards them:
 
 ```bash
 curl -X POST http://localhost:8080/v1/chat/completions \
@@ -226,6 +226,25 @@ curl -X POST http://localhost:8080/v1/chat/completions \
     "service_tier": "priority"
   }'
 ```
+
+### Parameter support per model
+
+Bifrost's parameter set is wider than any single Databricks endpoint accepts, and both surfaces answer an unknown field with a 400 rather than ignoring it. Each optional parameter is therefore checked against the Bifrost datasheet record for the model behind the endpoint before the request goes out:
+
+| Parameter | Dropped when the datasheet says |
+| --- | --- |
+| `reasoning_effort` | the model does not take an effort label |
+| `temperature`, `top_p`, `top_k` | `supports_sampling_params: false` — the adaptive-thinking Claude endpoints reject them |
+| `tool_choice` | `supports_tool_choice: false` |
+| `parallel_tool_calls` | `supports_parallel_function_calling: false` |
+| `response_format` (`text.format` on Responses) | `supports_response_schema: false` |
+| `stop`, `presence_penalty`, `frequency_penalty` | the field is listed in `unsupported_fields` |
+
+A model the datasheet does not describe keeps every field except `reasoning_effort` — Databricks endpoint names are workspace-defined, so there is nothing to identify an unknown endpoint by, and a silent drop is worse than an upstream error you can read.
+
+`reasoning_effort` resolves through `unsupported_fields` → `supports_reasoning_effort` (or a published effort ladder) → a `reasoning_effort` entry in the row's parameters → the model reasons and is not Claude-family. Claude endpoints on Databricks reason through a thinking budget and reject an effort label, so it is dropped there. A requested effort is clamped onto the levels the model publishes.
+
+Anthropic-native fields — `context_management`, `cache_control`, `speed`, `inference_geo`, `task_budget`, `container`, `mcp_servers` — are always dropped, whatever the model. Both Databricks surfaces are OpenAI-shaped and reject them even on Claude endpoints.
 
 ### Provisioned throughput
 


### PR DESCRIPTION
## Summary

Databricks endpoints answer unknown or unsupported request fields with a 400 rather than ignoring them. Previously, only `context_management` and `reasoning_effort` were stripped before the request went out. This PR extends that sanitization to cover the full set of optional parameters — sampling knobs, tool choice, parallel tool calls, response format, stop sequences, and the penalty fields — and makes every decision driven by the datasheet record for the model behind the endpoint rather than by hardcoded provider-wide rules.

## Changes

- `resolveParamSupport` reads the datasheet capabilities for the resolved model and returns a `paramSupport` struct that records, per field, whether Bifrost may send it to Databricks.
- `stripUnsupportedChatFields` is extended to act on all fields in `paramSupport`, not just `context_management` and `reasoning_effort`. Anthropic-native fields (`cache_control`, `speed`, `inference_geo`, `task_budget`, `container`, `mcp_servers`) are dropped unconditionally because both Databricks surfaces are OpenAI-shaped and reject them regardless of which model backs the endpoint.
- `stripUnsupportedResponsesFields` is added as the equivalent sanitizer for the Model Serving Responses surface, covering the fields that surface exposes (`text.format`, `temperature`, `top_p`, `tool_choice`, `parallel_tool_calls`, `context_management`, `reasoning_effort`).
- `reasoning_effort` resolution follows: `unsupported_fields` → `supports_reasoning_effort` / effort ladder → a published `reasoning_effort` model parameter → the model reasons and is not Anthropic-family. Claude endpoints on Databricks reason through a thinking budget and reject an effort label.
- A model with no datasheet row keeps every field except `reasoning_effort`, since a silent drop is worse than an upstream error the caller can read.
- `ModelCaps` gains `PublishesParameter`, `SupportsSamplingParams`, `SupportsToolChoice`, `SupportsParallelFunctionCalling`, and `SupportsResponseSchema` accessors.
- Tests pin the full wiring: `TestDatabricksReasoningEffortFollowsDatasheet` covers all resolution paths for `reasoning_effort`; `TestDatabricksChatParamsFollowDatasheet` covers the remaining optional fields; `TestDatabricksChatStripsAnthropicOnlyFields` pins the unconditional Anthropic-native field drops. All tests verify that sanitizing the wire request does not mutate the original request.
- Documentation is updated to describe per-model parameter gating and the `reasoning_effort` resolution order, and removes `reasoning_effort` from the `extra_params` passthrough example since it is now a first-class canonical parameter.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/providers/databricks/... -run TestDatabricksReasoningEffortFollowsDatasheet
go test ./core/providers/databricks/... -run TestDatabricksChatParamsFollowDatasheet
go test ./core/providers/databricks/... -run TestDatabricksChatStripsAnthropicOnlyFields
go test ./core/...
```

Send a chat completion request to a Databricks endpoint backed by a Claude model with `reasoning.effort` set and confirm no 400 is returned and `reasoning_effort` does not appear in the upstream request. Repeat with a model that publishes `reasoning_effort` in its parameters and confirm the field is forwarded.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII changes. The sanitization operates on outbound request fields only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable