### PR TITLE
fix: remove score filter from redis

### DIFF
--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -1170,7 +1170,6 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 		"FT.SEARCH", namespace,
 		fmt.Sprintf("%s=>[KNN %d @embedding $vec AS score]", hybridQuery, knnLimit),
 		"PARAMS", "2", "vec", queryBytes,
-		"SORTBY", "score",
 	}
 
 	// Add RETURN clause - always include score for vector search
@@ -1194,22 +1193,7 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 
 	result := s.client.Do(ctx, args...)
 	if result.Err() != nil {
-		errMsg := strings.ToLower(result.Err().Error())
-		// Some Valkey implementations reject SORTBY in KNN search (already distance-ordered).
-		if strings.Contains(errMsg, "unexpected argument `sortby`") || strings.Contains(errMsg, "unexpected argument sortby") {
-			compatArgs := make([]interface{}, 0, len(args)-2)
-			for i := 0; i < len(args); i++ {
-				if i+1 < len(args) && args[i] == "SORTBY" {
-					i++ // skip sort field value too
-					continue
-				}
-				compatArgs = append(compatArgs, args[i])
-			}
-			result = s.client.Do(ctx, compatArgs...)
-		}
-		if result.Err() != nil {
-			return nil, fmt.Errorf("native vector search failed: %w", result.Err())
-		}
+		return nil, fmt.Errorf("native vector search failed: %w", result.Err())
 	}
 
 	// Parse search results
@@ -1241,6 +1225,15 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 			filteredResults = append(filteredResults, result)
 		}
 	}
+
+	// Order client-side: SORTBY is not portable across search backends.
+	sort.SliceStable(filteredResults, func(i, j int) bool {
+		si, sj := filteredResults[i].Score, filteredResults[j].Score
+		if si == nil || sj == nil {
+			return si != nil && sj == nil
+		}
+		return *si > *sj
+	})
 
 	results = filteredResults
 


### PR DESCRIPTION
## Summary

Removes the `SORTBY` clause from the Redis KNN vector search command and replaces it with client-side sorting, resolving compatibility issues across different Redis/Valkey backends that do not uniformly support `SORTBY` in KNN queries.

## Changes

- Removed `SORTBY score` from the `FT.SEARCH` KNN query arguments, as it is not portable across search backends (e.g., some Valkey implementations reject it outright).
- Removed the error-handling fallback that detected `SORTBY`-related errors and retried the query without it — this retry logic is no longer needed.
- Added client-side `sort.SliceStable` on the filtered results, ordering by descending score to preserve the expected nearest-neighbor ordering.

The trade-off here is a minor shift of sorting responsibility from the server to the client, which is acceptable given that KNN result sets are already small and bounded by the `knnLimit` parameter.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/vectorstore/...
```

Validate that vector similarity search returns results ordered by descending score when using both Redis and Valkey backends. Confirm no errors are returned from `GetNearest` on either backend.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable