### PR TITLE
fix: hex value fields in redis store

### DIFF
--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -64,7 +65,7 @@ type RedisStore struct {
 	logger schemas.Logger
 
 	namespaceFieldTypesMu sync.RWMutex
-	namespaceFieldTypes   map[string]map[string]VectorStorePropertyType
+	namespaceFieldTypes   map[string]map[string]VectorStoreProperties
 }
 
 // Ping checks if the Redis server is reachable.
@@ -177,6 +178,7 @@ func (s *RedisStore) GetChunk(ctx context.Context, namespace string, id string) 
 	for k, v := range fields {
 		searchResult.Properties[k] = v
 	}
+	s.decodeFilterableProperties(namespace, []SearchResult{searchResult})
 
 	return searchResult, nil
 }
@@ -238,9 +240,9 @@ func (s *RedisStore) GetChunks(ctx context.Context, namespace string, ids []stri
 		for k, v := range fields {
 			searchResult.Properties[k] = v
 		}
-
 		results = append(results, searchResult)
 	}
+	s.decodeFilterableProperties(namespace, results)
 
 	return results, nil
 }
@@ -378,6 +380,7 @@ func (s *RedisStore) executeSearch(ctx context.Context, namespace string, redisQ
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse search results: %w", err)
 	}
+	s.decodeFilterableProperties(namespace, results)
 
 	return results, nil
 }
@@ -945,17 +948,17 @@ func (s *RedisStore) cacheNamespaceFieldTypes(namespace string, properties map[s
 		return
 	}
 
-	fieldTypes := make(map[string]VectorStorePropertyType, len(properties))
+	fieldProps := make(map[string]VectorStoreProperties, len(properties))
 	for field, prop := range properties {
-		fieldTypes[field] = prop.DataType
+		fieldProps[field] = prop
 	}
 
 	s.namespaceFieldTypesMu.Lock()
 	defer s.namespaceFieldTypesMu.Unlock()
 	if s.namespaceFieldTypes == nil {
-		s.namespaceFieldTypes = make(map[string]map[string]VectorStorePropertyType)
+		s.namespaceFieldTypes = make(map[string]map[string]VectorStoreProperties)
 	}
-	s.namespaceFieldTypes[namespace] = fieldTypes
+	s.namespaceFieldTypes[namespace] = fieldProps
 }
 
 func (s *RedisStore) deleteNamespaceFieldTypes(namespace string) {
@@ -967,7 +970,7 @@ func (s *RedisStore) deleteNamespaceFieldTypes(namespace string) {
 	delete(s.namespaceFieldTypes, namespace)
 }
 
-func (s *RedisStore) getNamespaceFieldTypes(namespace string) map[string]VectorStorePropertyType {
+func (s *RedisStore) getNamespaceFieldTypes(namespace string) map[string]VectorStoreProperties {
 	if strings.TrimSpace(namespace) == "" {
 		return nil
 	}
@@ -975,27 +978,20 @@ func (s *RedisStore) getNamespaceFieldTypes(namespace string) map[string]VectorS
 	s.namespaceFieldTypesMu.RLock()
 	defer s.namespaceFieldTypesMu.RUnlock()
 
-	fieldTypes, ok := s.namespaceFieldTypes[namespace]
-	if !ok {
-		return nil
-	}
-
-	copied := make(map[string]VectorStorePropertyType, len(fieldTypes))
-	for field, dataType := range fieldTypes {
-		copied[field] = dataType
-	}
-	return copied
+	// Safe to hand out directly: cacheNamespaceFieldTypes always publishes a
+	// freshly built map, so an entry is never mutated after it is stored.
+	return s.namespaceFieldTypes[namespace]
 }
 
 // buildRedisQuery converts []Query to Redis query syntax
-func buildRedisQuery(queries []Query, fieldTypes map[string]VectorStorePropertyType) string {
+func buildRedisQuery(queries []Query, fieldProps map[string]VectorStoreProperties) string {
 	if len(queries) == 0 {
 		return "*"
 	}
 
 	var conditions []string
 	for _, query := range queries {
-		condition := buildRedisQueryCondition(query, fieldTypes)
+		condition := buildRedisQueryCondition(query, fieldProps)
 		if condition != "" {
 			conditions = append(conditions, condition)
 		}
@@ -1009,10 +1005,10 @@ func buildRedisQuery(queries []Query, fieldTypes map[string]VectorStorePropertyT
 	return strings.Join(conditions, " ")
 }
 
-func shouldUseNumericEquality(field string, value interface{}, fieldTypes map[string]VectorStorePropertyType) (string, bool) {
-	if fieldTypes != nil {
-		if dataType, ok := fieldTypes[field]; ok {
-			if dataType == VectorStorePropertyTypeInteger {
+func shouldUseNumericEquality(field string, value interface{}, fieldProps map[string]VectorStoreProperties) (string, bool) {
+	if fieldProps != nil {
+		if prop, ok := fieldProps[field]; ok {
+			if prop.DataType == VectorStorePropertyTypeInteger {
 				return normalizeNumericQueryValue(value)
 			}
 			return "", false
@@ -1062,7 +1058,7 @@ func normalizeNumericQueryValue(value interface{}) (string, bool) {
 }
 
 // buildRedisQueryCondition builds a single Redis query condition
-func buildRedisQueryCondition(query Query, fieldTypes map[string]VectorStorePropertyType) string {
+func buildRedisQueryCondition(query Query, fieldProps map[string]VectorStoreProperties) string {
 	field := query.Field
 	operator := query.Operator
 	value := query.Value
@@ -1079,33 +1075,45 @@ func buildRedisQueryCondition(query Query, fieldTypes map[string]VectorStoreProp
 		stringValue = string(jsonData)
 	}
 
-	// Escape special characters for TAG fields
-	escapedValue := escapeSearchValue(stringValue) // new function for TAG escaping
+	// Filterable TAG values are stored hex-encoded, so they need no escaping;
+	// everything else is escaped for the query parser.
+	var tagValue string
+	if isFilterableTag(field, fieldProps) {
+		tagValue = encodeTagValue(stringValue)
+	} else {
+		tagValue = escapeSearchValue(stringValue)
+	}
 
 	switch operator {
 	case QueryOperatorEqual:
-		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldTypes); useNumeric {
+		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldProps); useNumeric {
 			return fmt.Sprintf("@%s:[%s %s]", field, numericValue, numericValue)
 		}
 		// TAG exact match
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
 	case QueryOperatorNotEqual:
-		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldTypes); useNumeric {
+		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldProps); useNumeric {
 			return fmt.Sprintf("-@%s:[%s %s]", field, numericValue, numericValue)
 		}
 		// TAG negation
-		return fmt.Sprintf("-@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("-@%s:{%s}", field, tagValue)
 	case QueryOperatorLike:
 		// Cannot do LIKE with TAGs directly; fallback to exact match
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
-	case QueryOperatorGreaterThan:
-		return fmt.Sprintf("@%s:[(%s +inf]", field, escapedValue)
-	case QueryOperatorGreaterThanOrEqual:
-		return fmt.Sprintf("@%s:[%s +inf]", field, escapedValue)
-	case QueryOperatorLessThan:
-		return fmt.Sprintf("@%s:[-inf (%s]", field, escapedValue)
-	case QueryOperatorLessThanOrEqual:
-		return fmt.Sprintf("@%s:[-inf %s]", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
+	case QueryOperatorGreaterThan, QueryOperatorGreaterThanOrEqual,
+		QueryOperatorLessThan, QueryOperatorLessThanOrEqual:
+		// Range bounds are compared, not matched, so they keep plain escaping.
+		bound := escapeSearchValue(stringValue)
+		switch operator {
+		case QueryOperatorGreaterThan:
+			return fmt.Sprintf("@%s:[(%s +inf]", field, bound)
+		case QueryOperatorGreaterThanOrEqual:
+			return fmt.Sprintf("@%s:[%s +inf]", field, bound)
+		case QueryOperatorLessThan:
+			return fmt.Sprintf("@%s:[-inf (%s]", field, bound)
+		default:
+			return fmt.Sprintf("@%s:[-inf %s]", field, bound)
+		}
 	case QueryOperatorIsNull:
 		// Field not present
 		return fmt.Sprintf("-@%s:*", field)
@@ -1117,23 +1125,31 @@ func buildRedisQueryCondition(query Query, fieldTypes map[string]VectorStoreProp
 			var orConditions []string
 			for _, v := range values {
 				vStr := fmt.Sprintf("%v", v)
-				orConditions = append(orConditions, fmt.Sprintf("@%s:{%s}", field, escapeSearchValue(vStr)))
+				encoded := escapeSearchValue(vStr)
+				if isFilterableTag(field, fieldProps) {
+					encoded = encodeTagValue(vStr)
+				}
+				orConditions = append(orConditions, fmt.Sprintf("@%s:{%s}", field, encoded))
 			}
 			return fmt.Sprintf("(%s)", strings.Join(orConditions, " | "))
 		}
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
 	case QueryOperatorContainsAll:
 		if values, ok := value.([]interface{}); ok {
 			var andConditions []string
 			for _, v := range values {
 				vStr := fmt.Sprintf("%v", v)
-				andConditions = append(andConditions, fmt.Sprintf("@%s:{%s}", field, escapeSearchValue(vStr)))
+				encoded := escapeSearchValue(vStr)
+				if isFilterableTag(field, fieldProps) {
+					encoded = encodeTagValue(vStr)
+				}
+				andConditions = append(andConditions, fmt.Sprintf("@%s:{%s}", field, encoded))
 			}
 			return strings.Join(andConditions, " ")
 		}
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
 	default:
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
 	}
 }
 
@@ -1201,6 +1217,7 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 	if err != nil {
 		return nil, err
 	}
+	s.decodeFilterableProperties(namespace, results)
 
 	// Apply threshold filter and extract scores
 	var filteredResults []SearchResult
@@ -1262,6 +1279,8 @@ func (s *RedisStore) Add(ctx context.Context, namespace string, id string, embed
 		fields["embedding"] = embeddingBytes
 	}
 
+	fieldProps := s.getNamespaceFieldTypes(namespace)
+
 	// Add metadata fields directly (no prefix needed with proper indexing)
 	for k, v := range metadata {
 		switch val := v.(type) {
@@ -1283,6 +1302,13 @@ func (s *RedisStore) Add(ctx context.Context, namespace string, id string, embed
 				return fmt.Errorf("failed to marshal metadata field %s: %w", k, err)
 			}
 			fields[k] = string(jsonData)
+		}
+
+		// TAG filter values are stored hex-encoded so queries need no escaping.
+		if isFilterableTag(k, fieldProps) {
+			if str, ok := fields[k].(string); ok {
+				fields[k] = encodeTagValue(str)
+			}
 		}
 	}
 
@@ -1550,6 +1576,48 @@ func (s *RedisStore) RequiresVectors() bool {
 	return false
 }
 
+// isFilterableTag reports whether a field is matched as a TAG filter and so
+// is stored hex-encoded.
+func isFilterableTag(field string, fieldProps map[string]VectorStoreProperties) bool {
+	prop, ok := fieldProps[field]
+	return ok && prop.Filterable && prop.DataType != VectorStorePropertyTypeInteger
+}
+
+// encodeTagValue hex-encodes a TAG value so no query escaping is needed.
+// Engines disagree on backslash handling inside {}, but agree on [0-9a-f].
+func encodeTagValue(value string) string {
+	return hex.EncodeToString([]byte(value))
+}
+
+// decodeTagValue reverses encodeTagValue, passing through values written
+// before encoding was introduced.
+func decodeTagValue(value string) string {
+	decoded, err := hex.DecodeString(value)
+	if err != nil || !utf8.Valid(decoded) {
+		return value
+	}
+	return string(decoded)
+}
+
+// decodeFilterableProperties restores hex-encoded TAG values on read so
+// callers see what they wrote.
+func (s *RedisStore) decodeFilterableProperties(namespace string, results []SearchResult) {
+	fieldProps := s.getNamespaceFieldTypes(namespace)
+	if len(fieldProps) == 0 {
+		return
+	}
+	for _, result := range results {
+		for field, value := range result.Properties {
+			if !isFilterableTag(field, fieldProps) {
+				continue
+			}
+			if str, ok := value.(string); ok {
+				result.Properties[field] = decodeTagValue(str)
+			}
+		}
+	}
+}
+
 // escapeSearchValue escapes special characters in search values.
 // RediSearch treats every punctuation character as special inside a TAG query
 // (@field:{value}, DIALECT 2), so escape all non-alphanumeric ASCII characters
@@ -1781,7 +1849,7 @@ func newRedisStore(_ context.Context, config RedisConfig, logger schemas.Logger)
 		client:              client,
 		config:              config,
 		logger:              logger,
-		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
+		namespaceFieldTypes: make(map[string]map[string]VectorStoreProperties),
 	}
 	// Eagerly verify connectivity, consistent with other store constructors (e.g. Qdrant)
 	if err := store.Ping(context.Background()); err != nil {

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -529,7 +529,7 @@ func TestRedisStore_ExecuteSearch_DisableScanFallbackOnQuerySyntaxError(t *testi
 		config: RedisConfig{
 			ContextTimeout: schemas.Duration(time.Second),
 		},
-		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
+		namespaceFieldTypes: make(map[string]map[string]VectorStoreProperties),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -764,9 +764,9 @@ func TestParseOffsetCursor(t *testing.T) {
 }
 
 func TestBuildRedisQueryCondition_NumericEquality(t *testing.T) {
-	fieldTypes := map[string]VectorStorePropertyType{
-		"size": VectorStorePropertyTypeInteger,
-		"type": VectorStorePropertyTypeString,
+	fieldTypes := map[string]VectorStoreProperties{
+		"size": {DataType: VectorStorePropertyTypeInteger},
+		"type": {DataType: VectorStorePropertyTypeString},
 	}
 
 	tests := []struct {
@@ -895,8 +895,8 @@ func TestEscapeSearchValue(t *testing.T) {
 }
 
 func TestBuildRedisQueryCondition_TagValueEscaping(t *testing.T) {
-	fieldTypes := map[string]VectorStorePropertyType{
-		"model": VectorStorePropertyTypeString,
+	fieldTypes := map[string]VectorStoreProperties{
+		"model": {DataType: VectorStorePropertyTypeString},
 	}
 
 	tests := []struct {
@@ -1975,4 +1975,75 @@ func TestRedisStore_NamespaceDimensionHandling(t *testing.T) {
 		}
 		assert.Empty(t, setup.Store.getNamespaceFieldTypes(testNamespace))
 	})
+}
+
+func TestEncodeDecodeTagValue(t *testing.T) {
+	for _, value := range []string{"gpt-5.6-luna", "openai/gpt-4o", "gemma31b-q6:latest", "plain", "", "héllo"} {
+		encoded := encodeTagValue(value)
+		assert.Equal(t, value, decodeTagValue(encoded), "roundtrip %q", value)
+		for _, c := range encoded {
+			assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+				"encoded %q must need no escaping, got %q", value, encoded)
+		}
+		assert.Equal(t, encoded, escapeSearchValue(encoded), "encoded %q must be escape-invariant", value)
+	}
+
+	// Values written before encoding was introduced are passed through.
+	assert.Equal(t, "gpt-5.6-luna", decodeTagValue("gpt-5.6-luna"))
+	assert.Equal(t, "zzz", decodeTagValue("zzz"))
+}
+
+func TestBuildRedisQueryCondition_FilterableTagUsesHex(t *testing.T) {
+	fieldProps := map[string]VectorStoreProperties{
+		"model":    {DataType: VectorStorePropertyTypeString, Filterable: true},
+		"response": {DataType: VectorStorePropertyTypeString},
+		"expires":  {DataType: VectorStorePropertyTypeInteger, Filterable: true},
+	}
+	hexModel := encodeTagValue("gpt-5.6-luna")
+
+	tests := []struct {
+		name        string
+		query       Query
+		expected    string
+		noBackslash bool
+	}{
+		{
+			name:        "filterable tag is hex encoded, never escaped",
+			query:       Query{Field: "model", Operator: QueryOperatorEqual, Value: "gpt-5.6-luna"},
+			expected:    "@model:{" + hexModel + "}",
+			noBackslash: true,
+		},
+		{
+			name:        "filterable tag negation is hex encoded",
+			query:       Query{Field: "model", Operator: QueryOperatorNotEqual, Value: "gpt-5.6-luna"},
+			expected:    "-@model:{" + hexModel + "}",
+			noBackslash: true,
+		},
+		{
+			name:        "contains any hex encodes each value",
+			query:       Query{Field: "model", Operator: QueryOperatorContainsAny, Value: []interface{}{"a:b", "c/d"}},
+			expected:    "(@model:{" + encodeTagValue("a:b") + "} | @model:{" + encodeTagValue("c/d") + "})",
+			noBackslash: true,
+		},
+		{
+			name:     "non-filterable field keeps escaping",
+			query:    Query{Field: "response", Operator: QueryOperatorEqual, Value: "gpt-5.6-luna"},
+			expected: `@response:{gpt\-5\.6\-luna}`,
+		},
+		{
+			name:     "filterable integer stays a numeric range",
+			query:    Query{Field: "expires", Operator: QueryOperatorEqual, Value: 1700000000},
+			expected: "@expires:[1700000000 1700000000]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRedisQueryCondition(tt.query, fieldProps)
+			assert.Equal(t, tt.expected, got)
+			if tt.noBackslash {
+				assert.NotContains(t, got, `\`, "filterable tag queries must contain no backslashes")
+			}
+		})
+	}
 }

--- a/framework/vectorstore/store.go
+++ b/framework/vectorstore/store.go
@@ -65,6 +65,8 @@ const (
 type VectorStoreProperties struct {
 	DataType    VectorStorePropertyType `json:"data_type"`
 	Description string                  `json:"description"`
+	// Filterable marks a property used in Query filters; stores may encode it.
+	Filterable bool `json:"filterable,omitempty"`
 }
 
 type VectorStorePropertyType string

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -198,22 +198,27 @@ var VectorStoreProperties = map[string]vectorstore.VectorStoreProperties{
 	"cache_key": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The cache key from the request",
+		Filterable:  true,
 	},
 	"provider": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The provider used for the request",
+		Filterable:  true,
 	},
 	"model": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The model used for the request",
+		Filterable:  true,
 	},
 	"params_hash": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The hash of the parameters used for the request",
+		Filterable:  true,
 	},
 	"from_bifrost_semantic_cache_plugin": {
 		DataType:    vectorstore.VectorStorePropertyTypeBoolean,
 		Description: "Whether the cache entry was created by the BifrostSemanticCachePlugin",
+		Filterable:  true,
 	},
 }
 


### PR DESCRIPTION
## Summary

Redis TAG field queries were failing or returning incorrect results when values contained special characters (e.g. `gpt-5.6-luna`, `openai/gpt-4o`, `gemma31b-q6:latest`). RediSearch treats punctuation as special inside `{}` TAG queries, and backslash escaping is inconsistently handled across Redis versions and dialects. This PR eliminates the escaping problem entirely for filterable TAG fields by hex-encoding their values at write time and decoding them at read time, so queries always contain only `[0-9a-f]` characters that need no escaping.

## Changes

- Added a `Filterable` flag to `VectorStoreProperties` to mark fields used in query filters.
- Filterable non-integer TAG fields are now stored hex-encoded via `encodeTagValue` and decoded on retrieval via `decodeTagValue`/`decodeFilterableProperties`.
- `decodeFilterableProperties` is called after every read path (`GetChunk`, `GetChunks`, `executeSearch`, `GetNearest`) so callers always see the original unencoded values.
- The namespace field type cache was upgraded from storing only `VectorStorePropertyType` to storing the full `VectorStoreProperties` struct, giving query builders access to the `Filterable` flag.
- Range operators (`>`, `>=`, `<`, `<=`) continue to use plain escaping since their bounds are compared numerically, not matched as TAG values.
- `decodeTagValue` passes through values written before encoding was introduced (non-hex strings), preserving backward compatibility.
- Semantic cache plugin properties (`cache_key`, `provider`, `model`, `params_hash`, `from_bifrost_semantic_cache_plugin`) are marked `Filterable: true` since they are used as query filters.
- The internal `getNamespaceFieldTypes` copy-on-read was removed; the map is safe to hand out directly because it is never mutated after being stored.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/vectorstore/... ./plugins/semanticcache/...
```

Key scenarios to validate:
- Querying a filterable TAG field whose value contains `-`, `.`, `/`, `:` returns the correct results.
- Values written before this change (non-hex strings) are passed through unchanged on read.
- Integer filterable fields continue to use numeric range queries.
- Non-filterable fields continue to use backslash escaping.

## Breaking changes

- [x] Yes
- [ ] No

Existing Redis entries for filterable TAG fields written before this change will be stored in plain text. On read, `decodeTagValue` detects non-hex strings and passes them through, so old entries remain readable. However, new writes will store hex-encoded values, meaning queries issued after this change will not match old plain-text entries for those fields. A one-time re-index or cache flush may be required for affected namespaces (e.g. the semantic cache).

## Security considerations

Hex encoding removes any possibility of query injection through TAG field values, since the encoded form contains only `[0-9a-f]` characters.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable