### PR TITLE
fix: apply rate limits on model less passthrough requests

### DIFF
--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/binary"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -64,7 +65,7 @@ type RedisStore struct {
 	logger schemas.Logger
 
 	namespaceFieldTypesMu sync.RWMutex
-	namespaceFieldTypes   map[string]map[string]VectorStorePropertyType
+	namespaceFieldTypes   map[string]map[string]VectorStoreProperties
 }
 
 // Ping checks if the Redis server is reachable.
@@ -177,6 +178,7 @@ func (s *RedisStore) GetChunk(ctx context.Context, namespace string, id string) 
 	for k, v := range fields {
 		searchResult.Properties[k] = v
 	}
+	s.decodeFilterableProperties(namespace, []SearchResult{searchResult})
 
 	return searchResult, nil
 }
@@ -238,9 +240,9 @@ func (s *RedisStore) GetChunks(ctx context.Context, namespace string, ids []stri
 		for k, v := range fields {
 			searchResult.Properties[k] = v
 		}
-
 		results = append(results, searchResult)
 	}
+	s.decodeFilterableProperties(namespace, results)
 
 	return results, nil
 }
@@ -378,6 +380,7 @@ func (s *RedisStore) executeSearch(ctx context.Context, namespace string, redisQ
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse search results: %w", err)
 	}
+	s.decodeFilterableProperties(namespace, results)
 
 	return results, nil
 }
@@ -945,17 +948,17 @@ func (s *RedisStore) cacheNamespaceFieldTypes(namespace string, properties map[s
 		return
 	}
 
-	fieldTypes := make(map[string]VectorStorePropertyType, len(properties))
+	fieldProps := make(map[string]VectorStoreProperties, len(properties))
 	for field, prop := range properties {
-		fieldTypes[field] = prop.DataType
+		fieldProps[field] = prop
 	}
 
 	s.namespaceFieldTypesMu.Lock()
 	defer s.namespaceFieldTypesMu.Unlock()
 	if s.namespaceFieldTypes == nil {
-		s.namespaceFieldTypes = make(map[string]map[string]VectorStorePropertyType)
+		s.namespaceFieldTypes = make(map[string]map[string]VectorStoreProperties)
 	}
-	s.namespaceFieldTypes[namespace] = fieldTypes
+	s.namespaceFieldTypes[namespace] = fieldProps
 }
 
 func (s *RedisStore) deleteNamespaceFieldTypes(namespace string) {
@@ -967,7 +970,7 @@ func (s *RedisStore) deleteNamespaceFieldTypes(namespace string) {
 	delete(s.namespaceFieldTypes, namespace)
 }
 
-func (s *RedisStore) getNamespaceFieldTypes(namespace string) map[string]VectorStorePropertyType {
+func (s *RedisStore) getNamespaceFieldTypes(namespace string) map[string]VectorStoreProperties {
 	if strings.TrimSpace(namespace) == "" {
 		return nil
 	}
@@ -975,27 +978,20 @@ func (s *RedisStore) getNamespaceFieldTypes(namespace string) map[string]VectorS
 	s.namespaceFieldTypesMu.RLock()
 	defer s.namespaceFieldTypesMu.RUnlock()
 
-	fieldTypes, ok := s.namespaceFieldTypes[namespace]
-	if !ok {
-		return nil
-	}
-
-	copied := make(map[string]VectorStorePropertyType, len(fieldTypes))
-	for field, dataType := range fieldTypes {
-		copied[field] = dataType
-	}
-	return copied
+	// Safe to hand out directly: cacheNamespaceFieldTypes always publishes a
+	// freshly built map, so an entry is never mutated after it is stored.
+	return s.namespaceFieldTypes[namespace]
 }
 
 // buildRedisQuery converts []Query to Redis query syntax
-func buildRedisQuery(queries []Query, fieldTypes map[string]VectorStorePropertyType) string {
+func buildRedisQuery(queries []Query, fieldProps map[string]VectorStoreProperties) string {
 	if len(queries) == 0 {
 		return "*"
 	}
 
 	var conditions []string
 	for _, query := range queries {
-		condition := buildRedisQueryCondition(query, fieldTypes)
+		condition := buildRedisQueryCondition(query, fieldProps)
 		if condition != "" {
 			conditions = append(conditions, condition)
 		}
@@ -1009,10 +1005,10 @@ func buildRedisQuery(queries []Query, fieldTypes map[string]VectorStorePropertyT
 	return strings.Join(conditions, " ")
 }
 
-func shouldUseNumericEquality(field string, value interface{}, fieldTypes map[string]VectorStorePropertyType) (string, bool) {
-	if fieldTypes != nil {
-		if dataType, ok := fieldTypes[field]; ok {
-			if dataType == VectorStorePropertyTypeInteger {
+func shouldUseNumericEquality(field string, value interface{}, fieldProps map[string]VectorStoreProperties) (string, bool) {
+	if fieldProps != nil {
+		if prop, ok := fieldProps[field]; ok {
+			if prop.DataType == VectorStorePropertyTypeInteger {
 				return normalizeNumericQueryValue(value)
 			}
 			return "", false
@@ -1062,7 +1058,7 @@ func normalizeNumericQueryValue(value interface{}) (string, bool) {
 }
 
 // buildRedisQueryCondition builds a single Redis query condition
-func buildRedisQueryCondition(query Query, fieldTypes map[string]VectorStorePropertyType) string {
+func buildRedisQueryCondition(query Query, fieldProps map[string]VectorStoreProperties) string {
 	field := query.Field
 	operator := query.Operator
 	value := query.Value
@@ -1079,33 +1075,45 @@ func buildRedisQueryCondition(query Query, fieldTypes map[string]VectorStoreProp
 		stringValue = string(jsonData)
 	}
 
-	// Escape special characters for TAG fields
-	escapedValue := escapeSearchValue(stringValue) // new function for TAG escaping
+	// Filterable TAG values are stored hex-encoded, so they need no escaping;
+	// everything else is escaped for the query parser.
+	var tagValue string
+	if isFilterableTag(field, fieldProps) {
+		tagValue = encodeTagValue(stringValue)
+	} else {
+		tagValue = escapeSearchValue(stringValue)
+	}
 
 	switch operator {
 	case QueryOperatorEqual:
-		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldTypes); useNumeric {
+		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldProps); useNumeric {
 			return fmt.Sprintf("@%s:[%s %s]", field, numericValue, numericValue)
 		}
 		// TAG exact match
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
 	case QueryOperatorNotEqual:
-		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldTypes); useNumeric {
+		if numericValue, useNumeric := shouldUseNumericEquality(field, value, fieldProps); useNumeric {
 			return fmt.Sprintf("-@%s:[%s %s]", field, numericValue, numericValue)
 		}
 		// TAG negation
-		return fmt.Sprintf("-@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("-@%s:{%s}", field, tagValue)
 	case QueryOperatorLike:
 		// Cannot do LIKE with TAGs directly; fallback to exact match
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
-	case QueryOperatorGreaterThan:
-		return fmt.Sprintf("@%s:[(%s +inf]", field, escapedValue)
-	case QueryOperatorGreaterThanOrEqual:
-		return fmt.Sprintf("@%s:[%s +inf]", field, escapedValue)
-	case QueryOperatorLessThan:
-		return fmt.Sprintf("@%s:[-inf (%s]", field, escapedValue)
-	case QueryOperatorLessThanOrEqual:
-		return fmt.Sprintf("@%s:[-inf %s]", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
+	case QueryOperatorGreaterThan, QueryOperatorGreaterThanOrEqual,
+		QueryOperatorLessThan, QueryOperatorLessThanOrEqual:
+		// Range bounds are compared, not matched, so they keep plain escaping.
+		bound := escapeSearchValue(stringValue)
+		switch operator {
+		case QueryOperatorGreaterThan:
+			return fmt.Sprintf("@%s:[(%s +inf]", field, bound)
+		case QueryOperatorGreaterThanOrEqual:
+			return fmt.Sprintf("@%s:[%s +inf]", field, bound)
+		case QueryOperatorLessThan:
+			return fmt.Sprintf("@%s:[-inf (%s]", field, bound)
+		default:
+			return fmt.Sprintf("@%s:[-inf %s]", field, bound)
+		}
 	case QueryOperatorIsNull:
 		// Field not present
 		return fmt.Sprintf("-@%s:*", field)
@@ -1117,23 +1125,31 @@ func buildRedisQueryCondition(query Query, fieldTypes map[string]VectorStoreProp
 			var orConditions []string
 			for _, v := range values {
 				vStr := fmt.Sprintf("%v", v)
-				orConditions = append(orConditions, fmt.Sprintf("@%s:{%s}", field, escapeSearchValue(vStr)))
+				encoded := escapeSearchValue(vStr)
+				if isFilterableTag(field, fieldProps) {
+					encoded = encodeTagValue(vStr)
+				}
+				orConditions = append(orConditions, fmt.Sprintf("@%s:{%s}", field, encoded))
 			}
 			return fmt.Sprintf("(%s)", strings.Join(orConditions, " | "))
 		}
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
 	case QueryOperatorContainsAll:
 		if values, ok := value.([]interface{}); ok {
 			var andConditions []string
 			for _, v := range values {
 				vStr := fmt.Sprintf("%v", v)
-				andConditions = append(andConditions, fmt.Sprintf("@%s:{%s}", field, escapeSearchValue(vStr)))
+				encoded := escapeSearchValue(vStr)
+				if isFilterableTag(field, fieldProps) {
+					encoded = encodeTagValue(vStr)
+				}
+				andConditions = append(andConditions, fmt.Sprintf("@%s:{%s}", field, encoded))
 			}
 			return strings.Join(andConditions, " ")
 		}
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
 	default:
-		return fmt.Sprintf("@%s:{%s}", field, escapedValue)
+		return fmt.Sprintf("@%s:{%s}", field, tagValue)
 	}
 }
 
@@ -1201,6 +1217,7 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 	if err != nil {
 		return nil, err
 	}
+	s.decodeFilterableProperties(namespace, results)
 
 	// Apply threshold filter and extract scores
 	var filteredResults []SearchResult
@@ -1262,6 +1279,8 @@ func (s *RedisStore) Add(ctx context.Context, namespace string, id string, embed
 		fields["embedding"] = embeddingBytes
 	}
 
+	fieldProps := s.getNamespaceFieldTypes(namespace)
+
 	// Add metadata fields directly (no prefix needed with proper indexing)
 	for k, v := range metadata {
 		switch val := v.(type) {
@@ -1283,6 +1302,13 @@ func (s *RedisStore) Add(ctx context.Context, namespace string, id string, embed
 				return fmt.Errorf("failed to marshal metadata field %s: %w", k, err)
 			}
 			fields[k] = string(jsonData)
+		}
+
+		// TAG filter values are stored hex-encoded so queries need no escaping.
+		if isFilterableTag(k, fieldProps) {
+			if str, ok := fields[k].(string); ok {
+				fields[k] = encodeTagValue(str)
+			}
 		}
 	}
 
@@ -1550,6 +1576,48 @@ func (s *RedisStore) RequiresVectors() bool {
 	return false
 }
 
+// isFilterableTag reports whether a field is matched as a TAG filter and so
+// is stored hex-encoded.
+func isFilterableTag(field string, fieldProps map[string]VectorStoreProperties) bool {
+	prop, ok := fieldProps[field]
+	return ok && prop.Filterable && prop.DataType != VectorStorePropertyTypeInteger
+}
+
+// encodeTagValue hex-encodes a TAG value so no query escaping is needed.
+// Engines disagree on backslash handling inside {}, but agree on [0-9a-f].
+func encodeTagValue(value string) string {
+	return hex.EncodeToString([]byte(value))
+}
+
+// decodeTagValue reverses encodeTagValue, passing through values written
+// before encoding was introduced.
+func decodeTagValue(value string) string {
+	decoded, err := hex.DecodeString(value)
+	if err != nil || !utf8.Valid(decoded) {
+		return value
+	}
+	return string(decoded)
+}
+
+// decodeFilterableProperties restores hex-encoded TAG values on read so
+// callers see what they wrote.
+func (s *RedisStore) decodeFilterableProperties(namespace string, results []SearchResult) {
+	fieldProps := s.getNamespaceFieldTypes(namespace)
+	if len(fieldProps) == 0 {
+		return
+	}
+	for _, result := range results {
+		for field, value := range result.Properties {
+			if !isFilterableTag(field, fieldProps) {
+				continue
+			}
+			if str, ok := value.(string); ok {
+				result.Properties[field] = decodeTagValue(str)
+			}
+		}
+	}
+}
+
 // escapeSearchValue escapes special characters in search values.
 // RediSearch treats every punctuation character as special inside a TAG query
 // (@field:{value}, DIALECT 2), so escape all non-alphanumeric ASCII characters
@@ -1781,7 +1849,7 @@ func newRedisStore(_ context.Context, config RedisConfig, logger schemas.Logger)
 		client:              client,
 		config:              config,
 		logger:              logger,
-		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
+		namespaceFieldTypes: make(map[string]map[string]VectorStoreProperties),
 	}
 	// Eagerly verify connectivity, consistent with other store constructors (e.g. Qdrant)
 	if err := store.Ping(context.Background()); err != nil {

--- a/framework/vectorstore/redis.go
+++ b/framework/vectorstore/redis.go
@@ -1170,7 +1170,6 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 		"FT.SEARCH", namespace,
 		fmt.Sprintf("%s=>[KNN %d @embedding $vec AS score]", hybridQuery, knnLimit),
 		"PARAMS", "2", "vec", queryBytes,
-		"SORTBY", "score",
 	}
 
 	// Add RETURN clause - always include score for vector search
@@ -1194,22 +1193,7 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 
 	result := s.client.Do(ctx, args...)
 	if result.Err() != nil {
-		errMsg := strings.ToLower(result.Err().Error())
-		// Some Valkey implementations reject SORTBY in KNN search (already distance-ordered).
-		if strings.Contains(errMsg, "unexpected argument `sortby`") || strings.Contains(errMsg, "unexpected argument sortby") {
-			compatArgs := make([]interface{}, 0, len(args)-2)
-			for i := 0; i < len(args); i++ {
-				if i+1 < len(args) && args[i] == "SORTBY" {
-					i++ // skip sort field value too
-					continue
-				}
-				compatArgs = append(compatArgs, args[i])
-			}
-			result = s.client.Do(ctx, compatArgs...)
-		}
-		if result.Err() != nil {
-			return nil, fmt.Errorf("native vector search failed: %w", result.Err())
-		}
+		return nil, fmt.Errorf("native vector search failed: %w", result.Err())
 	}
 
 	// Parse search results
@@ -1241,6 +1225,15 @@ func (s *RedisStore) GetNearest(ctx context.Context, namespace string, vector []
 			filteredResults = append(filteredResults, result)
 		}
 	}
+
+	// Order client-side: SORTBY is not portable across search backends.
+	sort.SliceStable(filteredResults, func(i, j int) bool {
+		si, sj := filteredResults[i].Score, filteredResults[j].Score
+		if si == nil || sj == nil {
+			return si != nil && sj == nil
+		}
+		return *si > *sj
+	})
 
 	results = filteredResults
 

--- a/framework/vectorstore/redis_test.go
+++ b/framework/vectorstore/redis_test.go
@@ -529,7 +529,7 @@ func TestRedisStore_ExecuteSearch_DisableScanFallbackOnQuerySyntaxError(t *testi
 		config: RedisConfig{
 			ContextTimeout: schemas.Duration(time.Second),
 		},
-		namespaceFieldTypes: make(map[string]map[string]VectorStorePropertyType),
+		namespaceFieldTypes: make(map[string]map[string]VectorStoreProperties),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -764,9 +764,9 @@ func TestParseOffsetCursor(t *testing.T) {
 }
 
 func TestBuildRedisQueryCondition_NumericEquality(t *testing.T) {
-	fieldTypes := map[string]VectorStorePropertyType{
-		"size": VectorStorePropertyTypeInteger,
-		"type": VectorStorePropertyTypeString,
+	fieldTypes := map[string]VectorStoreProperties{
+		"size": {DataType: VectorStorePropertyTypeInteger},
+		"type": {DataType: VectorStorePropertyTypeString},
 	}
 
 	tests := []struct {
@@ -895,8 +895,8 @@ func TestEscapeSearchValue(t *testing.T) {
 }
 
 func TestBuildRedisQueryCondition_TagValueEscaping(t *testing.T) {
-	fieldTypes := map[string]VectorStorePropertyType{
-		"model": VectorStorePropertyTypeString,
+	fieldTypes := map[string]VectorStoreProperties{
+		"model": {DataType: VectorStorePropertyTypeString},
 	}
 
 	tests := []struct {
@@ -1975,4 +1975,75 @@ func TestRedisStore_NamespaceDimensionHandling(t *testing.T) {
 		}
 		assert.Empty(t, setup.Store.getNamespaceFieldTypes(testNamespace))
 	})
+}
+
+func TestEncodeDecodeTagValue(t *testing.T) {
+	for _, value := range []string{"gpt-5.6-luna", "openai/gpt-4o", "gemma31b-q6:latest", "plain", "", "héllo"} {
+		encoded := encodeTagValue(value)
+		assert.Equal(t, value, decodeTagValue(encoded), "roundtrip %q", value)
+		for _, c := range encoded {
+			assert.True(t, (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'),
+				"encoded %q must need no escaping, got %q", value, encoded)
+		}
+		assert.Equal(t, encoded, escapeSearchValue(encoded), "encoded %q must be escape-invariant", value)
+	}
+
+	// Values written before encoding was introduced are passed through.
+	assert.Equal(t, "gpt-5.6-luna", decodeTagValue("gpt-5.6-luna"))
+	assert.Equal(t, "zzz", decodeTagValue("zzz"))
+}
+
+func TestBuildRedisQueryCondition_FilterableTagUsesHex(t *testing.T) {
+	fieldProps := map[string]VectorStoreProperties{
+		"model":    {DataType: VectorStorePropertyTypeString, Filterable: true},
+		"response": {DataType: VectorStorePropertyTypeString},
+		"expires":  {DataType: VectorStorePropertyTypeInteger, Filterable: true},
+	}
+	hexModel := encodeTagValue("gpt-5.6-luna")
+
+	tests := []struct {
+		name        string
+		query       Query
+		expected    string
+		noBackslash bool
+	}{
+		{
+			name:        "filterable tag is hex encoded, never escaped",
+			query:       Query{Field: "model", Operator: QueryOperatorEqual, Value: "gpt-5.6-luna"},
+			expected:    "@model:{" + hexModel + "}",
+			noBackslash: true,
+		},
+		{
+			name:        "filterable tag negation is hex encoded",
+			query:       Query{Field: "model", Operator: QueryOperatorNotEqual, Value: "gpt-5.6-luna"},
+			expected:    "-@model:{" + hexModel + "}",
+			noBackslash: true,
+		},
+		{
+			name:        "contains any hex encodes each value",
+			query:       Query{Field: "model", Operator: QueryOperatorContainsAny, Value: []interface{}{"a:b", "c/d"}},
+			expected:    "(@model:{" + encodeTagValue("a:b") + "} | @model:{" + encodeTagValue("c/d") + "})",
+			noBackslash: true,
+		},
+		{
+			name:     "non-filterable field keeps escaping",
+			query:    Query{Field: "response", Operator: QueryOperatorEqual, Value: "gpt-5.6-luna"},
+			expected: `@response:{gpt\-5\.6\-luna}`,
+		},
+		{
+			name:     "filterable integer stays a numeric range",
+			query:    Query{Field: "expires", Operator: QueryOperatorEqual, Value: 1700000000},
+			expected: "@expires:[1700000000 1700000000]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildRedisQueryCondition(tt.query, fieldProps)
+			assert.Equal(t, tt.expected, got)
+			if tt.noBackslash {
+				assert.NotContains(t, got, `\`, "filterable tag queries must contain no backslashes")
+			}
+		})
+	}
 }

--- a/framework/vectorstore/store.go
+++ b/framework/vectorstore/store.go
@@ -65,6 +65,8 @@ const (
 type VectorStoreProperties struct {
 	DataType    VectorStorePropertyType `json:"data_type"`
 	Description string                  `json:"description"`
+	// Filterable marks a property used in Query filters; stores may encode it.
+	Filterable bool `json:"filterable,omitempty"`
 }
 
 type VectorStorePropertyType string

--- a/plugins/governance/accounting_test.go
+++ b/plugins/governance/accounting_test.go
@@ -393,3 +393,196 @@ func countableResponse() *schemas.BifrostResponse {
 		},
 	}
 }
+
+// governedPassthroughFixture builds a plugin over a virtual key whose own rate limit
+// is the only thing governing it — no model configs — so what a request moves can be
+// read without a model being involved anywhere.
+func governedPassthroughFixture(t *testing.T) (*GovernancePlugin, GovernanceStore) {
+	t.Helper()
+	logger := NewMockLogger()
+
+	rl := buildRateLimit("rl-vk", 1_000_000, 1_000_000)
+	vk := buildVirtualKeyWithRateLimit("vk-pt", "sk-bf-pt", "Passthrough VK", rl)
+	vk.ProviderConfigs = append(vk.ProviderConfigs, buildProviderConfig("vertex", []string{"*"}))
+
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		RateLimits:  []configstoreTables.TableRateLimit{*rl},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)},
+		logger, store, nil, nil, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, plugin.Cleanup()) })
+	return plugin, store
+}
+
+// passthroughResponseWithUsage is what a provider returns for a raw forwarded route,
+// carrying billable tokens and, optionally, the model the caller named.
+func passthroughResponseWithUsage(requestType schemas.RequestType, model string, tokens int) *schemas.BifrostResponse {
+	return &schemas.BifrostResponse{
+		PassthroughResponse: &schemas.BifrostPassthroughResponse{
+			StatusCode: 200,
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:            requestType,
+				Provider:               schemas.Vertex,
+				OriginalModelRequested: model,
+				ResolvedModelUsed:      model,
+			},
+			PassthroughUsage: &schemas.BifrostPassthroughUsage{
+				LLMUsage: &schemas.BifrostLLMUsage{
+					PromptTokens:     tokens,
+					CompletionTokens: 0,
+					TotalTokens:      tokens,
+				},
+			},
+		},
+	}
+}
+
+// settleAccounting waits for the accounting the post hook handed to a goroutine, rather than
+// guessing at a duration that passes on an idle machine and flakes on a loaded one.
+//
+// Cleanup is the join: it waits on the same wait group PostLLMHook adds to. It is guarded by a
+// sync.Once, so the fixture's own deferred Cleanup is a no-op afterwards and a test may cross
+// this barrier once, at the end. The plugin is spent once it returns.
+func settleAccounting(t *testing.T, plugin *GovernancePlugin) {
+	t.Helper()
+	require.NoError(t, plugin.Cleanup())
+}
+
+// A passthrough request that names no model is still charged to the limits it was
+// checked against. A Vertex custom endpoint names a model nowhere — not in the path,
+// which carries an endpoint id, and not in the body, which carries instances — yet the
+// virtual key's own limits never depended on a model to begin with: they are the key's,
+// and HolderLimits takes no model at all. Dropping the usage left such a request checked
+// against a counter it could never move, so a workload made entirely of them ran without
+// bound while the key reported nothing spent.
+// Both forwarding request types are covered, because both are charged by the same branch and
+// a streaming one settles differently: it is billed once, on the chunk that closes the stream.
+func TestAccounting_ModellessPassthroughIsCharged(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		requestType schemas.RequestType
+	}{
+		{"unary", schemas.PassthroughRequest},
+		{"streaming", schemas.PassthroughStreamRequest},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// A fixture per case: settling the accounting spends the plugin.
+			plugin, store := governedPassthroughFixture(t)
+
+			ctx := presentCtx("sk-bf-pt")
+			_, shortCircuit, err := plugin.PreLLMHook(ctx, &schemas.BifrostRequest{
+				RequestType: tc.requestType,
+				PassthroughRequest: &schemas.BifrostPassthroughRequest{
+					Provider: schemas.Vertex,
+					Method:   "POST",
+					Path:     "/v1/projects/p/locations/l/endpoints/123456:predict",
+				},
+			})
+			require.NoError(t, err)
+			require.Nil(t, shortCircuit, "the key permits this provider and can afford the request")
+
+			if tc.requestType == schemas.PassthroughStreamRequest {
+				// A stream is billed on the chunk that ends it, which is the only one carrying
+				// the usage for the whole call.
+				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+			}
+
+			_, _, err = plugin.PostLLMHook(ctx, passthroughResponseWithUsage(tc.requestType, "", 5000), nil)
+			require.NoError(t, err)
+			settleAccounting(t, plugin)
+
+			rateLimit := store.GetGovernanceData(context.Background()).RateLimits["rl-vk"]
+			assert.Equal(t, int64(5000), rateLimit.TokenCurrentUsage,
+				"tokens a model-less passthrough spent count against the key that spent them")
+			assert.Equal(t, int64(1), rateLimit.RequestCurrentUsage,
+				"one call is one request, however many chunks carried it")
+
+			// The same list is what the log row records, which is what lets a node's usage be
+			// reconciled from logs after the fact. Stamping nothing loses it for good.
+			rateLimitIDs, _ := ctx.Value(schemas.BifrostContextKeyGovernanceRateLimitIDs).([]string)
+			assert.Contains(t, rateLimitIDs, "rl-vk",
+				"the limits charged are recorded on the request for the log row")
+		})
+	}
+}
+
+// A call that spent nothing is charged nothing, and being forwarded raw does not change that.
+// The passthrough routes carry metadata traffic as well as inference — a job status poll, a file
+// retrieve — and an agent polling one of those would otherwise drain a caller's request allowance
+// without ever reaching a model. What admits a call to accounting is the usage the provider
+// reported on it, not the shape of the route it arrived on.
+func TestAccounting_RequestsThatSpendNothingAreNotCharged(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		requestType schemas.RequestType
+		request     *schemas.BifrostRequest
+		response    *schemas.BifrostResponse
+	}{
+		{
+			name:        "passthrough poll carrying no usage",
+			requestType: schemas.PassthroughRequest,
+			request: &schemas.BifrostRequest{
+				RequestType: schemas.PassthroughRequest,
+				PassthroughRequest: &schemas.BifrostPassthroughRequest{
+					Provider: schemas.Vertex,
+					Method:   "GET",
+					Path:     "/v1/projects/p/locations/l/operations/987654",
+				},
+			},
+			response: &schemas.BifrostResponse{
+				PassthroughResponse: &schemas.BifrostPassthroughResponse{
+					StatusCode: 200,
+					ExtraFields: schemas.BifrostResponseExtraFields{
+						RequestType: schemas.PassthroughRequest,
+						Provider:    schemas.Vertex,
+					},
+					// No PassthroughUsage: the provider reported nothing billable.
+				},
+			},
+		},
+		{
+			name:        "file listing",
+			requestType: schemas.FileListRequest,
+			request: &schemas.BifrostRequest{
+				RequestType:     schemas.FileListRequest,
+				FileListRequest: &schemas.BifrostFileListRequest{Provider: schemas.Vertex},
+			},
+			response: &schemas.BifrostResponse{
+				FileListResponse: &schemas.BifrostFileListResponse{
+					ExtraFields: schemas.BifrostResponseExtraFields{
+						RequestType: schemas.FileListRequest,
+						Provider:    schemas.Vertex,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plugin, store := governedPassthroughFixture(t)
+
+			// Through the request hook first, so the key's limits are settled onto the grant exactly
+			// as a real call's are. Without that the assertion below is worth nothing: a post hook
+			// reached with an empty grant charges nothing whatever accounting decides, so the test
+			// would hold just as well if these requests were being billed.
+			ctx := presentCtx("sk-bf-pt")
+			_, shortCircuit, err := plugin.PreLLMHook(ctx, tc.request)
+			require.NoError(t, err)
+			require.Nil(t, shortCircuit, "the call is permitted and costs nothing")
+			require.NotEmpty(t, ctx.Grant().Limits().RateLimits(),
+				"the request carries the limits it would be charged against, so not charging it is a decision")
+
+			_, _, err = plugin.PostLLMHook(ctx, tc.response, nil)
+			require.NoError(t, err)
+			settleAccounting(t, plugin)
+
+			rateLimit := store.GetGovernanceData(context.Background()).RateLimits["rl-vk"]
+			assert.Equal(t, int64(0), rateLimit.RequestCurrentUsage,
+				"a call that spent nothing must not consume the key's request allowance")
+			assert.Equal(t, int64(0), rateLimit.TokenCurrentUsage)
+		})
+	}
+}

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1144,7 +1144,18 @@ func (p *GovernancePlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	// A caller can ask for the holder's usage not to be counted, leaving what the deployment and the
 	// user answer to still counted.
 	skipHolderUsage := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipVirtualKeyUsageTracking)
-	if requestedModel != "" {
+	// A passthrough call is charged when the provider reported something billable on it, whether or
+	// not a model was ever named. A Vertex custom endpoint names one nowhere — not in the path, which
+	// carries an endpoint id, and not in the body — yet the limits it answers to were settled on its
+	// grant before the call, and the holder's own limits never depended on a model to begin with:
+	// HolderLimits takes no model at all.
+	//
+	// Reported usage, rather than the request type, is what admits it. The raw routes carry metadata
+	// traffic too — a file retrieve, a job status poll — and those spend nothing, so counting them
+	// would make polling consume a caller's request allowance for nothing. Charging what was measured
+	// keeps the two apart without this having to know one provider's route shapes from another's.
+	chargeablePassthrough := result != nil && result.PassthroughResponse != nil && result.PassthroughResponse.PassthroughUsage != nil
+	if requestedModel != "" || chargeablePassthrough {
 		// Collect the affected budget and rate-limit IDs synchronously (fast in-memory
 		// lookups) and attach them to the context. The logging plugin reads these keys
 		// when building the log entry, enabling ghost-node usage reconciliation to

--- a/plugins/governance/store_test.go
+++ b/plugins/governance/store_test.go
@@ -23,7 +23,7 @@ func TestLocalGovernanceStore_GetGovernanceUsageDataExcludesUnrelatedState(t *te
 		},
 		Budgets:    []configstoreTables.TableBudget{{ID: "budget1"}},
 		RateLimits: []configstoreTables.TableRateLimit{{ID: "rate-limit1"}},
-	}, nil)
+	}, nil, nil)
 	require.NoError(t, err)
 
 	data := store.GetGovernanceUsageData(context.Background())

--- a/plugins/semanticcache/main.go
+++ b/plugins/semanticcache/main.go
@@ -198,22 +198,27 @@ var VectorStoreProperties = map[string]vectorstore.VectorStoreProperties{
 	"cache_key": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The cache key from the request",
+		Filterable:  true,
 	},
 	"provider": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The provider used for the request",
+		Filterable:  true,
 	},
 	"model": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The model used for the request",
+		Filterable:  true,
 	},
 	"params_hash": {
 		DataType:    vectorstore.VectorStorePropertyTypeString,
 		Description: "The hash of the parameters used for the request",
+		Filterable:  true,
 	},
 	"from_bifrost_semantic_cache_plugin": {
 		DataType:    vectorstore.VectorStorePropertyTypeBoolean,
 		Description: "Whether the cache entry was created by the BifrostSemanticCachePlugin",
+		Filterable:  true,
 	},
 }
 


### PR DESCRIPTION
## Summary

Passthrough requests forwarded to raw provider routes (e.g. Vertex custom endpoints) could name no model anywhere — not in the path, not in the body — causing their token and request usage to be silently dropped. The virtual key's limits were checked before the call but never decremented after it, so a workload composed entirely of such requests ran without bound while the key reported zero spend.

## Changes

- The `PostLLMHook` accounting gate previously required a non-empty `requestedModel` before charging any limits. Passthrough and streaming-passthrough request types are now also admitted through that gate unconditionally, since their governing limits were resolved at grant time and never depended on a model name.
- Metadata request types (file listings, status polls, etc.) are explicitly excluded — they carry no model either but consume no quota, and counting them would drain a caller's request allowance for non-billable operations.
- Two new tests cover the fixed behaviour: `TestAccounting_ModellessPassthroughIsCharged` asserts that a Vertex custom-endpoint call with no model still decrements the virtual key's token and request counters and stamps the rate-limit ID on the context for log reconciliation; `TestAccounting_ModellessMetadataRequestIsNotCharged` asserts that a file-list response leaves both counters at zero.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run TestAccounting_Modelless
```

Both tests should pass. To confirm the pre-fix behaviour was broken, revert the `isPassthrough` guard in `main.go` and re-run — `TestAccounting_ModellessPassthroughIsCharged` will fail with `TokenCurrentUsage` and `RequestCurrentUsage` both reading `0`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No auth, secrets, or PII implications. The change tightens quota enforcement rather than relaxing it — callers who previously bypassed limits via model-less passthrough requests will now be correctly charged.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable