### PR TITLE
[fix]: ui - declare VKCreationPolicyResponse in the OSS access-profile fallback

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/types/accessProfile.ts
+++ b/ui/app/_fallbacks/enterprise/lib/types/accessProfile.ts
@@ -42,3 +42,8 @@ export interface UserAccessProfile {
 export interface GetUserAccessProfilesResponse {
 	access_profiles: UserAccessProfile[];
 }
+
+export interface VKCreationPolicyResponse {
+	governed: boolean;
+	profile_name?: string;
+}


### PR DESCRIPTION
## Summary

Declares `VKCreationPolicyResponse` in the OSS fallback `accessProfile.ts` so `tsc --noEmit` passes on an OSS checkout again. #6618 added `useGetMyVKCreationPolicyQuery` to the fallback API importing the type, but only the enterprise checkout defines it. Closes #6775.

## Changes

- `ui/app/_fallbacks/enterprise/lib/types/accessProfile.ts`: add the interface with the two fields the create form reads (`governed`, `profile_name`). The fallback query never returns data, so nothing else is needed.

## Type of change

- [x] Bug fix

## Affected areas

- [x] UI (React)

## How to test

```sh
cd ui && npm ci && npx tsc --noEmit
make build-ui
```

Both fail on `dev` today with TS2305 on `accessProfileApi.ts` and pass with this change.

## Breaking changes

- [x] No

## Related issues

Closes #6775

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I verified builds succeed (Go and UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)