### PR TITLE
feat: add `governance.projects` to config.json schema and docs with reconciliation semantics, budget/rate-limit fields, and enterprise-only exclusion in OSS tests

### DIFF
--- a/docs/deployment-guides/config-json/governance.mdx
+++ b/docs/deployment-guides/config-json/governance.mdx
@@ -311,6 +311,90 @@ Define organizational entities and attach rate limits directly. Team budgets ref
 
 ---
 
+## Projects
+
+Declare projects that requests opt into for access and accounting. A project composes with what the caller already holds, spends against its own budgets, the calling principal's, or both as `accounting_mode` directs, and can divide every budget and rate limit it holds equally between its members.
+
+<Note>
+`governance.projects` is an enterprise capability. Members are added from the dashboard: a project declared here starts with none, and membership cannot be declared in the file. The schema rejects a `members` key.
+</Note>
+
+```json
+{
+  "governance": {
+    "projects": [
+      {
+        "name": "atlas",
+        "description": "Atlas research",
+        "access_rule": "union",
+        "split_policy": "equal",
+        "calendar_aligned": true,
+        "budgets": [{ "max_limit": 1000.00, "reset_duration": "1M" }],
+        "rate_limit": { "request_max_limit": 600, "request_reset_duration": "1m" },
+        "provider_configs": [
+          {
+            "provider_name": "openai",
+            "all_models_allowed": false,
+            "allowed_models": ["gpt-4o", "gpt-4o-mini"],
+            "budgets": [{ "max_limit": 400.00, "reset_duration": "1M" }],
+            "model_budgets": [
+              { "model_name": "gpt-4o", "budgets": [{ "max_limit": 100.00, "reset_duration": "1d" }] }
+            ]
+          }
+        ],
+        "mcp_configs": [{ "mcp_client_name": "github", "tools_to_execute": ["*"] }]
+      }
+    ]
+  }
+}
+```
+
+Requests reference a project by name with the `x-bf-project-name` header.
+
+### Project Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Unique project name. Declarations are matched to stored projects by name |
+| `description` | No | Free-form description |
+| `is_active` | No | Defaults to `true` |
+| `expires_at` | No | RFC 3339 timestamp after which the project grants nothing |
+| `access_rule` | Yes | `union` leaves the caller's own access untouched (a project with no provider or MCP config then only accounts for spend); `intersect` permits only what both the caller and the project allow |
+| `membership_mode` | No | `explicit` (default) consults the membership rows; `open` lets any caller opt in. An open project cannot use `split_policy: equal` |
+| `accounting_mode` | No | Which ledgers spend lands on: `both` (default), `project_only`, or `principal_only` |
+| `split_policy` | No | `none` (default) shares every cap the project holds; `equal` gives every member an equal slice of every budget and rate limit at every tier: the project's own, each provider's, and each model's |
+| `calendar_aligned` | No | Snap reset windows to calendar boundaries instead of rolling from first use |
+| `budgets` | No | Project-level spend caps, each with `max_limit` and `reset_duration` |
+| `rate_limit` | No | Request and token limits: `request_max_limit`, `request_reset_duration`, `token_max_limit`, `token_reset_duration` |
+| `provider_configs` | No | One entry per provider, see below |
+| `mcp_configs` | No | One entry per MCP client: `mcp_client_name` (as declared under `mcp.client_configs`) and `tools_to_execute` (`["*"]` grants every tool; empty or omitted grants none, regardless of the top-level `version`) |
+
+Budgets and rate limits inside a project are declared without ids.
+
+### Project Provider Config Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `provider_name` | Yes | Provider this entry grants. A project names each provider at most once |
+| `all_models_allowed` | No | Allow every model of the provider |
+| `allowed_models` | No | Allowed model names, ignored when `all_models_allowed` is true |
+| `blacklisted_models` | No | Models blocked even if allowed; `["*"]` blocks all |
+| `key_ids` | No | Keys that may serve the request; `["*"]` allows all, empty or omitted allows none, regardless of the top-level `version`. Each id must belong to this provider |
+| `weight` | No | Load-balancer seed weight; omit to leave the caller's own preference standing |
+| `budgets` | No | Spend caps on this provider inside the project |
+| `rate_limit` | No | Request and token limits on this provider inside the project |
+| `model_budgets` | No | Per-model caps under this provider: `model_name`, `budgets`, and an optional `rate_limit`. The `*` tier is not accepted here |
+
+### How projects are reconciled
+
+- **Matched by name.** A name not in the database creates the project; a name already stored updates it when the declaration's hash differs from the one recorded at the last sync, and leaves it alone otherwise, so dashboard edits survive until the file changes.
+- **Edits keep spend.** Budgets are paired with their stored rows by `reset_duration` (in declared order when a duration appears twice), provider configs by `provider_name`, model budgets by `model_name`, and MCP configs by client. A paired row is updated in place, so raising a cap does not forgive what was already spent against it. A budget, provider, or client the file stops declaring is removed.
+- **Equal splits redivide in the background.** Changing a cap or the split policy of a project with `split_policy: equal` queues a recalculation of every member's share, which runs shortly after startup.
+- **Members are never touched.** The file cannot add or remove members; the schema rejects a `members` key on a project.
+- **With `source_of_truth: "config.json"`** and `governance.projects` present, declarations always overwrite the database and projects the file does not declare are deleted, members included.
+
+---
+
 ## Full Governance Example
 
 ```json

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -40,7 +40,7 @@ This page is a concise reference for every top-level key in `config.json`. Click
 
 ## `version`
 
-Controls how empty arrays in allow-list fields (`models`, `allowed_models`, `key_ids`, `tools_to_execute`) are interpreted:
+Controls how empty arrays in the allow-list fields of provider keys (`models`) and virtual keys (`allowed_models`, `key_ids`, `tools_to_execute`) are interpreted:
 
 | Value | Behaviour |
 |-------|-----------|
@@ -48,6 +48,8 @@ Controls how empty arrays in allow-list fields (`models`, `allowed_models`, `key
 | `1` *(v1.4.x compat)* | Empty array = **allow all** |
 
 Omitting `version` uses v2 semantics. Set `"version": 1` only if you are migrating from v1.4.x and need the old behaviour temporarily.
+
+Projects declared under `governance.projects` are not covered by this switch: their `key_ids` and `tools_to_execute` always treat an empty or omitted array as granting nothing, under either value.
 
 ---
 
@@ -133,6 +135,7 @@ Seeds governance resources at startup. All sub-keys are optional arrays.
 | `routing_rules` | CEL-based dynamic provider/model routing |
 | `pricing_overrides` | Scoped per-model pricing overrides |
 | `model_configs` | Per-model rate limit and budget configurations |
+| `projects` | Projects: access gates and accounting scopes that requests opt into, with budgets divisible between members *(enterprise only)* |
 
 Full documentation: [Governance](/deployment-guides/config-json/governance).
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -18232,6 +18232,7 @@ var excludedSchemaFields = map[string]map[string]bool{
 	"governance": {
 		"business_units": true, // Enterprise feature; not in OSS GovernanceConfig
 		"roles":          true, // Enterprise RBAC role bootstrap; not in OSS GovernanceConfig
+		"projects":       true, // Enterprise projects bootstrap; not in OSS GovernanceConfig
 	},
 	"auth_config": {
 		"disable_auth_on_inference": true, // Deprecated and ignored; kept in schema for backward-compatible config.json validation. Use enforce_auth_on_inference.

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -30,7 +30,7 @@
     },
     "version": {
       "type": "integer",
-      "description": "Controls how empty arrays in allow-list fields (models, allowed_models, key_ids, tools_to_execute) are interpreted. Omit or set to 2 for v1.5.0+ semantics: empty = deny all, [\"*\"] = allow all. Set to 1 to restore v1.4.x semantics: empty = allow all.",
+      "description": "Controls how empty arrays in the allow-list fields of provider keys (models) and virtual keys (allowed_models, key_ids, tools_to_execute) are interpreted. Omit or set to 2 for v1.5.0+ semantics: empty = deny all, [\"*\"] = allow all. Set to 1 to restore v1.4.x semantics: empty = allow all. Projects under governance.projects are not affected: their allow-lists always treat empty or omitted as granting nothing, whatever this is set to.",
       "enum": [1, 2],
       "default": 2
     },
@@ -894,6 +894,13 @@
             },
             "required": ["name"],
             "additionalProperties": false
+          }
+        },
+        "projects": {
+          "type": "array",
+          "description": "Projects: per-request access gates and accounting scopes that requests opt into. Matched by name and created or updated on startup when the config hash changes; membership is managed from the dashboard and is never declared here.",
+          "items": {
+            "$ref": "#/$defs/project"
           }
         },
         "virtual_keys": {
@@ -7192,6 +7199,289 @@
         }
       },
       "required": ["model_name"],
+      "additionalProperties": false
+    },
+    "project": {
+      "type": "object",
+      "description": "A project declared under governance.projects: what it grants, what it may spend, and how that is divided between its members. Members themselves are added from the dashboard.",
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "membership_mode": {
+                "const": "open"
+              }
+            },
+            "required": ["membership_mode"]
+          },
+          "then": {
+            "properties": {
+              "split_policy": {
+                "const": "none"
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique project name. Requests reference it with the x-bf-project-name header; the reconciler matches the declaration to the stored project by this name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Optional project description"
+        },
+        "is_active": {
+          "type": "boolean",
+          "description": "Whether the project grants and accounts for anything",
+          "default": true
+        },
+        "expires_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "When the project stops granting anything; omit to never expire"
+        },
+        "access_rule": {
+          "type": "string",
+          "description": "How the project's grants compose with the grants a caller already holds: union leaves the caller's own access untouched (a project with no provider or MCP config then only accounts for spend), intersect permits only what both allow.",
+          "enum": ["union", "intersect"]
+        },
+        "membership_mode": {
+          "type": "string",
+          "description": "explicit consults the membership rows; open lets any caller opt in. An open project cannot divide its budget between members.",
+          "enum": ["explicit", "open"],
+          "default": "explicit"
+        },
+        "accounting_mode": {
+          "type": "string",
+          "description": "Which ledgers a request's spend lands on: the project's, the calling principal's, or both",
+          "enum": ["both", "project_only", "principal_only"],
+          "default": "both"
+        },
+        "split_policy": {
+          "type": "string",
+          "description": "How the budgets and rate limits the project holds, at every tier (its own, each provider's, and each model's), are divided between members: none leaves them shared, equal gives every member an equal share of each. A change to an equal split's roster or caps recomputes every share in the background.",
+          "enum": ["none", "equal"],
+          "default": "none"
+        },
+        "calendar_aligned": {
+          "type": "boolean",
+          "description": "Snap the project's budget and rate-limit reset windows to calendar boundaries (day, week, month, year) instead of rolling from first use",
+          "default": false
+        },
+        "budgets": {
+          "type": "array",
+          "description": "Project-level spend caps. Declared without ids: on a change, a budget is matched to its stored row by reset_duration so its accumulated spend and window carry over.",
+          "items": {
+            "$ref": "#/$defs/project_budget"
+          }
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/project_rate_limit"
+        },
+        "provider_configs": {
+          "type": "array",
+          "description": "Per-provider grants and accounting, one entry per provider",
+          "items": {
+            "$ref": "#/$defs/project_provider_config"
+          }
+        },
+        "mcp_configs": {
+          "type": "array",
+          "description": "MCP clients the project grants, one entry per client",
+          "items": {
+            "$ref": "#/$defs/project_mcp_config"
+          }
+        }
+      },
+      "required": ["name", "access_rule"],
+      "additionalProperties": false
+    },
+    "project_budget": {
+      "type": "object",
+      "description": "A spend cap on a project, a provider inside it, or a model under that provider",
+      "allOf": [
+        {
+          "if": {
+            "required": ["reset_config"]
+          },
+          "then": {
+            "required": ["reset_duration"],
+            "properties": {
+              "reset_duration": {
+                "const": "1Q"
+              }
+            }
+          }
+        }
+      ],
+      "properties": {
+        "max_limit": {
+          "type": "number",
+          "minimum": 0,
+          "description": "Maximum spend limit in USD"
+        },
+        "reset_duration": {
+          "type": "string",
+          "description": "Reset window, e.g. \"1M\", \"1h\", \"1Q\". Also what pairs a declared budget with its stored row on a change."
+        },
+        "reset_config": {
+          "type": "object",
+          "description": "Window settings the reset duration cannot express. Only valid when reset_duration is quarterly (\"1Q\").",
+          "properties": {
+            "quarter_start_month": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 12,
+              "description": "First month of Q1 as 1-12. Omitted or 0 means January."
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["max_limit", "reset_duration"],
+      "additionalProperties": false
+    },
+    "project_rate_limit": {
+      "type": "object",
+      "description": "A request and token rate limit on a project, a provider inside it, or a model under that provider. A cap is enforced only with its window, and a limit with neither pair enforces nothing, so at least one complete pair is required.",
+      "properties": {
+        "token_max_limit": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum number of tokens allowed in the reset window"
+        },
+        "token_reset_duration": {
+          "type": "string",
+          "description": "Token reset window, e.g. \"1M\", \"1h\""
+        },
+        "request_max_limit": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum number of requests allowed in the reset window"
+        },
+        "request_reset_duration": {
+          "type": "string",
+          "description": "Request reset window, e.g. \"1M\", \"1h\""
+        }
+      },
+      "dependentRequired": {
+        "token_max_limit": ["token_reset_duration"],
+        "token_reset_duration": ["token_max_limit"],
+        "request_max_limit": ["request_reset_duration"],
+        "request_reset_duration": ["request_max_limit"]
+      },
+      "anyOf": [
+        {
+          "required": ["token_max_limit"]
+        },
+        {
+          "required": ["request_max_limit"]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "project_provider_config": {
+      "type": "object",
+      "properties": {
+        "provider_name": {
+          "type": "string",
+          "description": "Provider name. A project names each provider at most once; on a change the entry is matched to its stored row by this name."
+        },
+        "all_models_allowed": {
+          "type": "boolean",
+          "description": "Whether all models under this provider are allowed",
+          "default": false
+        },
+        "allowed_models": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowed model names (ignored when all_models_allowed is true)"
+        },
+        "blacklisted_models": {
+          "type": "array",
+          "description": "Models blocked for this provider even if matched by allowed_models (denylist wins). Use [\"*\"] to block all; empty array or omitted blocks none.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "key_ids": {
+          "type": "array",
+          "description": "Key IDs allowed for this provider. Use [\"*\"] to allow all keys; empty array or omitted allows none, regardless of the top-level version. Specific IDs restrict access to those keys only, and each must belong to this provider.",
+          "items": {
+            "type": "string"
+          }
+        },
+        "weight": {
+          "type": ["number", "null"],
+          "description": "Load-balancer seed weight for this provider (null opts out of weighted routing / no override)",
+          "default": null
+        },
+        "budgets": {
+          "type": "array",
+          "description": "Spend caps on this provider inside the project",
+          "items": {
+            "$ref": "#/$defs/project_budget"
+          }
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/project_rate_limit"
+        },
+        "model_budgets": {
+          "type": "array",
+          "description": "Per-model budgets and rate limits under this provider, at most one entry per model",
+          "items": {
+            "$ref": "#/$defs/project_provider_model_budget"
+          }
+        }
+      },
+      "required": ["provider_name"],
+      "additionalProperties": false
+    },
+    "project_provider_model_budget": {
+      "type": "object",
+      "description": "Per-model budget group under a project provider config, with optional per-model rate limit",
+      "properties": {
+        "model_name": {
+          "type": "string",
+          "not": {
+            "const": "*"
+          },
+          "description": "Model this budget group applies to (scoped to the parent provider). The \"*\" tier is not accepted here; the provider's own budgets cover it."
+        },
+        "budgets": {
+          "type": "array",
+          "description": "Spend caps for this model",
+          "items": {
+            "$ref": "#/$defs/project_budget"
+          }
+        },
+        "rate_limit": {
+          "$ref": "#/$defs/project_rate_limit"
+        }
+      },
+      "required": ["model_name"],
+      "additionalProperties": false
+    },
+    "project_mcp_config": {
+      "type": "object",
+      "properties": {
+        "mcp_client_name": {
+          "type": "string",
+          "description": "Name of the MCP client (as declared under mcp.client_configs) the project grants. Resolved to the stored client on startup; a name that matches no client is refused."
+        },
+        "tools_to_execute": {
+          "type": "array",
+          "description": "Tools of the client the project grants. Use [\"*\"] to grant every tool; empty array or omitted grants none, regardless of the top-level version.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["mcp_client_name"],
       "additionalProperties": false
     },
     "access_profile_mcp_tool_group": {

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -1320,3 +1320,55 @@ func TestSchemaResetConfigRequiresQuarterlyDuration(t *testing.T) {
 		})
 	}
 }
+
+// TestSchemaGovernanceProjectsValidation pins the constraints a governance.projects declaration
+// has to satisfy before the reconciler sees it: the two policies that cannot combine, the model
+// tier the provider's own budget already covers, a rate limit that would enforce nothing, negative
+// caps, and a members list the file cannot declare.
+func TestSchemaGovernanceProjectsValidation(t *testing.T) {
+	compiled := compileSchema(t)
+
+	tests := []struct {
+		name      string
+		project   string
+		wantError bool
+	}{
+		{
+			name: "a full declaration is valid",
+			project: `{
+				"name": "atlas", "access_rule": "union", "split_policy": "equal",
+				"budgets": [{"max_limit": 100, "reset_duration": "1M"}],
+				"rate_limit": {"request_max_limit": 10, "request_reset_duration": "1m"},
+				"provider_configs": [{"provider_name": "openai", "allowed_models": ["gpt-4o"],
+					"budgets": [{"max_limit": 40, "reset_duration": "1d"}],
+					"model_budgets": [{"model_name": "gpt-4o", "budgets": [{"max_limit": 5, "reset_duration": "1d"}]}]}],
+				"mcp_configs": [{"mcp_client_name": "github", "tools_to_execute": ["*"]}]
+			}`,
+		},
+		{name: "an open project cannot split equally", project: `{"name": "p", "access_rule": "union", "membership_mode": "open", "split_policy": "equal"}`, wantError: true},
+		{name: "an open project with no split is valid", project: `{"name": "p", "access_rule": "union", "membership_mode": "open", "split_policy": "none"}`},
+		{name: "an open project with the default split is valid", project: `{"name": "p", "access_rule": "union", "membership_mode": "open"}`},
+		{name: "the wildcard model tier is rejected", project: `{"name": "p", "access_rule": "union", "provider_configs": [{"provider_name": "openai", "model_budgets": [{"model_name": "*"}]}]}`, wantError: true},
+		{name: "an empty rate limit is rejected", project: `{"name": "p", "access_rule": "union", "rate_limit": {}}`, wantError: true},
+		{name: "a token cap without its window is rejected", project: `{"name": "p", "access_rule": "union", "rate_limit": {"token_max_limit": 1000}}`, wantError: true},
+		{name: "a request cap without its window is rejected", project: `{"name": "p", "access_rule": "union", "rate_limit": {"request_max_limit": 10, "token_reset_duration": "1h"}}`, wantError: true},
+		{name: "one complete pair is a valid rate limit", project: `{"name": "p", "access_rule": "union", "rate_limit": {"token_max_limit": 1000, "token_reset_duration": "1h"}}`},
+		{name: "a negative budget cap is rejected", project: `{"name": "p", "access_rule": "union", "budgets": [{"max_limit": -1, "reset_duration": "1M"}]}`, wantError: true},
+		{name: "a negative token cap is rejected", project: `{"name": "p", "access_rule": "union", "rate_limit": {"token_max_limit": -1, "token_reset_duration": "1h"}}`, wantError: true},
+		{name: "a negative request cap is rejected", project: `{"name": "p", "access_rule": "union", "rate_limit": {"request_max_limit": -1, "request_reset_duration": "1m"}}`, wantError: true},
+		{name: "a members list cannot be declared", project: `{"name": "p", "access_rule": "union", "members": [{"user_id": "u-1"}]}`, wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := fmt.Sprintf(`{"governance": {"projects": [%s]}}`, tt.project)
+			err := validateConfig(t, compiled, config)
+			if tt.wantError && err == nil {
+				t.Fatal("config should be invalid")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("config should be valid, got: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `governance.projects` as a declarable config.json section, enabling enterprise users to define projects—access gates and accounting scopes that requests opt into via the `x-bf-project-name` header—directly in the configuration file rather than exclusively through the dashboard.

## Changes

- Added a `projects` section to the governance documentation with a full field reference covering `access_rule`, `membership_mode`, `accounting_mode`, `split_policy`, `calendar_aligned`, budgets, rate limits, provider configs, and MCP configs.
- Documented reconciliation behavior: projects are matched by name, budgets are paired by `reset_duration`, provider configs by `provider_name`, and MCP configs by client name. Members are never touched by the file.
- Added `projects` to the schema reference table as an enterprise-only governance sub-key.
- Defined `project`, `project_budget`, `project_rate_limit`, `project_provider_config`, `project_provider_model_budget`, and `project_mcp_config` definitions in `config.schema.json`, with full property descriptions, required fields, and `additionalProperties: false` constraints.
- Added `projects` to the `governance` array under `excludedSchemaFields` in the config test, since it is an enterprise capability not present in the OSS `GovernanceConfig`.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./transports/bifrost-http/lib/...
```

Validate that the schema correctly accepts a `governance.projects` declaration matching the documented structure and rejects unknown fields or missing required fields (`name`, `access_rule`, `provider_name`, `mcp_client_name`, `model_name`).

## Breaking changes

- [x] No

## Security considerations

Projects are an enterprise-only feature. The `membership_mode: open` variant allows any caller to opt into a project without explicit membership, which should be used with care when budgets or access grants are attached. Members can only be managed from the dashboard; the config file cannot add or remove them, limiting the blast radius of a misconfigured file.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable