### PR TITLE
feat: add `credential` block to `MCPClientResponse` with scopes and refresh-token presence, surface in server sheet and sessions table

### DIFF
--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -810,6 +810,103 @@ type MCPClientResponse struct {
 	// self-reported state). Only ever populated by a configured
 	// MCPClusterStateAggregator; nil in a single-instance deployment.
 	NodeStates map[string]string `json:"node_states,omitempty"`
+	// Credential is the read-only view of the credential the client holds on
+	// its own behalf (see MCPClientCredentialResponse). Nil when the client's
+	// auth type has no such credential (none, headers) or when none has been
+	// issued yet (a client still pending its one-time authorization).
+	Credential *MCPClientCredentialResponse `json:"credential,omitempty"`
+}
+
+// MCPClientCredentialResponse describes the credential a client holds on its
+// own behalf, as opposed to the per-caller credentials listed under
+// /api/mcp/sessions: the single shared token for an oauth client, the
+// retained admin token for per_user_oauth and token_exchange clients (used
+// only to refresh the tool list), or the retained admin header values for a
+// per_user_headers client. Secret material never appears here: the refresh
+// token is reported as present or absent, and header values only by name.
+type MCPClientCredentialResponse struct {
+	Kind   string `json:"kind"`   // "oauth" | "headers"
+	Status string `json:"status"` // oauth: active | orphaned | needs_reauth. headers: active | orphaned | needs_update.
+	// ExpiresAt is the access token's expiry on oauth credentials; nil when
+	// the provider did not report one. Always nil for headers credentials.
+	ExpiresAt *string `json:"expires_at,omitempty"`
+	// LastRefreshedAt is set on oauth credentials once the access token has
+	// been refreshed or the credential re-authorized at least once.
+	LastRefreshedAt *string `json:"last_refreshed_at,omitempty"`
+	// HasRefreshToken reports whether the provider issued a refresh token, so
+	// the access token can be renewed without another consent. Always false
+	// for headers credentials.
+	HasRefreshToken bool `json:"has_refresh_token"`
+	// Scopes are the scopes the provider reported at consent time. Empty when
+	// the provider omitted them from its token response.
+	Scopes []string `json:"scopes,omitempty"`
+	// HeaderKeys are the names of the headers the stored admin values cover,
+	// sorted. Compared against the client's per_user_header_keys, a key
+	// present there but missing here is one the stored values predate.
+	HeaderKeys []string `json:"header_keys,omitempty"`
+	CreatedAt  string   `json:"created_at"`
+	UpdatedAt  string   `json:"updated_at"`
+}
+
+// mcpClientCredentialResponse picks the credential row a client of the given
+// auth type depends on and projects it to the wire shape. Mirrors the row
+// selection in projectMCPCredentialState so the sheet's credential block and
+// the client's state badge always describe the same row. Returns nil when
+// the auth type holds no such credential or the row does not exist.
+func mcpClientCredentialResponse(
+	authType schemas.MCPAuthType,
+	adminToken *configstoreTables.TableMCPOauthToken,
+	adminCred *configstoreTables.TableMCPPerUserHeaderCredential,
+	sharedToken *configstoreTables.TableMCPOauthToken,
+) *MCPClientCredentialResponse {
+	oauthCredential := func(t *configstoreTables.TableMCPOauthToken) *MCPClientCredentialResponse {
+		if t == nil {
+			return nil
+		}
+		resp := &MCPClientCredentialResponse{
+			Kind:            "oauth",
+			Status:          t.Status,
+			HasRefreshToken: t.RefreshToken != "",
+			Scopes:          parseOauthScopesJSON(t.Scopes),
+			CreatedAt:       t.CreatedAt.UTC().Format(rfc3339Nano),
+			UpdatedAt:       t.UpdatedAt.UTC().Format(rfc3339Nano),
+		}
+		if t.ExpiresAt != nil {
+			resp.ExpiresAt = bifrost.Ptr(t.ExpiresAt.UTC().Format(rfc3339Nano))
+		}
+		if t.LastRefreshedAt != nil {
+			resp.LastRefreshedAt = bifrost.Ptr(t.LastRefreshedAt.UTC().Format(rfc3339Nano))
+		}
+		return resp
+	}
+	switch authType {
+	case schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypeTokenExchange:
+		return oauthCredential(adminToken)
+	case schemas.MCPAuthTypeOauth:
+		return oauthCredential(sharedToken)
+	case schemas.MCPAuthTypePerUserHeaders:
+		if adminCred == nil {
+			return nil
+		}
+		resp := &MCPClientCredentialResponse{
+			Kind:      "headers",
+			Status:    adminCred.Status,
+			CreatedAt: adminCred.CreatedAt.UTC().Format(rfc3339Nano),
+			UpdatedAt: adminCred.UpdatedAt.UTC().Format(rfc3339Nano),
+		}
+		// Names only. A decode failure (a row written before encryption was
+		// configured and read after, say) leaves the key list empty rather
+		// than hiding the row: status and timestamps are still accurate.
+		if headers, err := adminCred.GetHeaders(); err == nil && len(headers) > 0 {
+			resp.HeaderKeys = make([]string, 0, len(headers))
+			for name := range headers {
+				resp.HeaderKeys = append(resp.HeaderKeys, name)
+			}
+			sort.Strings(resp.HeaderKeys)
+		}
+		return resp
+	}
+	return nil
 }
 
 // MCPClusterStateAggregator is an optional capability the configured
@@ -1122,6 +1219,23 @@ func projectMCPCredentialState(
 	return runtimeState
 }
 
+// oauthTokenStatus and headerCredentialStatus read the status off a possibly
+// absent credential row, so projectMCPCredentialState's "" (no row) input
+// falls out of a plain map miss.
+func oauthTokenStatus(t *configstoreTables.TableMCPOauthToken) string {
+	if t == nil {
+		return ""
+	}
+	return t.Status
+}
+
+func headerCredentialStatus(c *configstoreTables.TableMCPPerUserHeaderCredential) string {
+	if c == nil {
+		return ""
+	}
+	return c.Status
+}
+
 func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params configstore.MCPClientsQueryParams, states []string) {
 	// Get connected clients from Bifrost engine — used both to resolve the
 	// runtime state filter and to merge live state/tools onto each row below.
@@ -1219,15 +1333,18 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 		}
 	}
 
-	// Batch-fetch the retained admin discovery credentials for this page's
-	// per-user clients so their registry state can carry the needs_reauth
-	// projection (see projectPerUserAdminCredentialState). Best-effort: a
-	// batch-read failure only means the projection is skipped and runtime
-	// states pass through untouched. Debug, not Error, because this runs on
-	// every registry list.
-	adminTokenStatusByClientID := make(map[string]string)
-	adminCredStatusByClientID := make(map[string]string)
-	sharedTokenStatusByClientID := make(map[string]string)
+	// Batch-fetch the credential row each of this page's clients holds on its
+	// own behalf (the retained admin discovery credential for per-user
+	// clients, the shared token for oauth ones). Each row feeds two things:
+	// the needs_reauth state projection (see projectMCPCredentialState) and
+	// the read-only credential block on the response (see
+	// mcpClientCredentialResponse). Best-effort: a batch-read failure only
+	// means the projection is skipped, runtime states pass through untouched,
+	// and the credential block is absent. Debug, not Error, because this runs
+	// on every registry list.
+	adminTokenByClientID := make(map[string]*configstoreTables.TableMCPOauthToken)
+	adminCredByClientID := make(map[string]*configstoreTables.TableMCPPerUserHeaderCredential)
+	sharedTokenByClientID := make(map[string]*configstoreTables.TableMCPOauthToken)
 	if h.store.ConfigStore != nil {
 		adminTokenClientIDs := make([]string, 0)
 		perUserHeaderClientIDs := make([]string, 0)
@@ -1253,7 +1370,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 		if len(adminTokenClientIDs) > 0 {
 			if adminTokens, err := h.store.ConfigStore.GetAdminOauthTokensByMCPClientIDs(ctx, adminTokenClientIDs); err == nil {
 				for clientID, token := range adminTokens {
-					adminTokenStatusByClientID[clientID] = token.Status
+					adminTokenByClientID[clientID] = token
 				}
 			} else {
 				logger.Debug("failed to batch-get admin oauth tokens for MCP registry state projection: %v", err)
@@ -1262,7 +1379,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 		if len(perUserHeaderClientIDs) > 0 {
 			if adminCreds, err := h.store.ConfigStore.GetAdminMCPPerUserHeaderCredentialsByClientIDs(ctx, perUserHeaderClientIDs); err == nil {
 				for clientID, cred := range adminCreds {
-					adminCredStatusByClientID[clientID] = cred.Status
+					adminCredByClientID[clientID] = cred
 				}
 			} else {
 				logger.Debug("failed to batch-get admin header credentials for MCP registry state projection: %v", err)
@@ -1272,7 +1389,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			if sharedTokens, err := h.store.ConfigStore.GetSharedOauthTokensByConfigIDs(ctx, sharedOauthConfigIDs); err == nil {
 				for oauthConfigID, token := range sharedTokens {
 					for _, clientID := range clientIDsByOauthConfigID[oauthConfigID] {
-						sharedTokenStatusByClientID[clientID] = token.Status
+						sharedTokenByClientID[clientID] = token
 					}
 				}
 			} else {
@@ -1338,6 +1455,10 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			})
 		}
 		redactedConfig := h.store.RedactMCPClientConfig(clientConfig)
+		adminToken := adminTokenByClientID[dbClient.ClientID]
+		adminCred := adminCredByClientID[dbClient.ClientID]
+		sharedToken := sharedTokenByClientID[dbClient.ClientID]
+		credential := mcpClientCredentialResponse(clientConfig.AuthType, adminToken, adminCred, sharedToken)
 		if connectedClient, exists := connectedClientsMap[clientConfig.ID]; exists {
 			sortedTools := make([]schemas.ChatToolFunction, len(connectedClient.Tools))
 			copy(sortedTools, connectedClient.Tools)
@@ -1347,15 +1468,16 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			resolvedState := projectMCPCredentialState(
 				clientConfig.AuthType,
 				connectedClient.State,
-				adminTokenStatusByClientID[dbClient.ClientID],
-				adminCredStatusByClientID[dbClient.ClientID],
-				sharedTokenStatusByClientID[dbClient.ClientID],
+				oauthTokenStatus(adminToken),
+				headerCredentialStatus(adminCred),
+				oauthTokenStatus(sharedToken),
 			)
 			resp := MCPClientResponse{
-				Config:    redactedConfig,
-				Tools:     sortedTools,
-				State:     resolvedState,
-				VKConfigs: vkConfigs,
+				Config:     redactedConfig,
+				Tools:      sortedTools,
+				State:      resolvedState,
+				VKConfigs:  vkConfigs,
+				Credential: credential,
 			}
 			if aggregator, ok := h.mcpManager.(MCPClusterStateAggregator); ok {
 				if aggState, nodeStates := aggregator.AggregateMCPClientState(clientConfig.ID, resolvedState); aggState == schemas.MCPConnectionStateDegraded {
@@ -1366,10 +1488,11 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 			clients = append(clients, resp)
 		} else {
 			clients = append(clients, MCPClientResponse{
-				Config:    redactedConfig,
-				Tools:     []schemas.ChatToolFunction{},
-				State:     schemas.MCPConnectionStateError,
-				VKConfigs: vkConfigs,
+				Config:     redactedConfig,
+				Tools:      []schemas.ChatToolFunction{},
+				State:      schemas.MCPConnectionStateError,
+				VKConfigs:  vkConfigs,
+				Credential: credential,
 			})
 		}
 	}

--- a/transports/bifrost-http/handlers/mcp_client_credential_test.go
+++ b/transports/bifrost-http/handlers/mcp_client_credential_test.go
@@ -1,0 +1,142 @@
+package handlers
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+func TestParseOauthScopesJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{name: "empty string", raw: "", want: nil},
+		{name: "whitespace only", raw: "   ", want: nil},
+		{name: "json null (provider omitted scope)", raw: "null", want: nil},
+		{name: "empty array", raw: "[]", want: nil},
+		{name: "malformed", raw: "[repo", want: nil},
+		{name: "wrong shape", raw: `{"scope":"repo"}`, want: nil},
+		{name: "list", raw: `["repo","read:org"]`, want: []string{"repo", "read:org"}},
+		{name: "drops blank entries", raw: `["repo",""," "]`, want: []string{"repo"}},
+		{name: "trims entries", raw: `[" openid "]`, want: []string{"openid"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseOauthScopesJSON(tc.raw); !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("parseOauthScopesJSON(%q) = %#v, want %#v", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTokenRow_TokenOnlyFields(t *testing.T) {
+	row := tokenRow(configstoreTables.TableMCPOauthToken{ID: "t1", AuthMode: "user", Scopes: `["repo","read:org"]`, RefreshToken: "r"})
+	if want := []string{"repo", "read:org"}; !reflect.DeepEqual(row.Scopes, want) {
+		t.Fatalf("scopes = %#v, want %#v", row.Scopes, want)
+	}
+	if row.HasRefreshToken == nil || !*row.HasRefreshToken {
+		t.Fatalf("has_refresh_token = %v, want true", row.HasRefreshToken)
+	}
+	empty := tokenRow(configstoreTables.TableMCPOauthToken{ID: "t2", AuthMode: "vk", Scopes: "null"})
+	if empty.Scopes != nil {
+		t.Fatalf("scopes for a null column = %#v, want nil so the wire field is omitted", empty.Scopes)
+	}
+	// False, not omitted: a token row always answers the question, only
+	// header and flow rows leave it out.
+	if empty.HasRefreshToken == nil || *empty.HasRefreshToken {
+		t.Fatalf("has_refresh_token = %v, want false", empty.HasRefreshToken)
+	}
+	if flow := flowRow(configstoreTables.TableMCPOauthFlow{ID: "f1", FlowMode: "user"}); flow.HasRefreshToken != nil || flow.Scopes != nil {
+		t.Fatalf("flow rows must omit token-only fields, got scopes=%#v has_refresh_token=%v", flow.Scopes, flow.HasRefreshToken)
+	}
+}
+
+// TestMCPClientCredentialResponse checks that the sheet's credential block is
+// projected from the same row projectMCPCredentialState reads for each auth
+// type, that secret material is reduced to presence or names, and that a
+// missing row or an auth type without a self-held credential yields no block.
+func TestMCPClientCredentialResponse(t *testing.T) {
+	created := time.Date(2026, 8, 12, 10, 0, 0, 0, time.UTC)
+	updated := created.Add(time.Hour)
+	expires := updated.Add(30 * time.Minute)
+	refreshed := updated
+
+	adminToken := &configstoreTables.TableMCPOauthToken{
+		ID: "admin", AuthMode: "admin", Status: "needs_reauth",
+		AccessToken: "secret", RefreshToken: "",
+		Scopes: "null", CreatedAt: created, UpdatedAt: updated,
+	}
+	sharedToken := &configstoreTables.TableMCPOauthToken{
+		ID: "shared", AuthMode: "shared", Status: "active",
+		AccessToken: "secret", RefreshToken: "refresh-secret",
+		ExpiresAt: &expires, LastRefreshedAt: &refreshed,
+		Scopes: `["repo","read:org"]`, CreatedAt: created, UpdatedAt: updated,
+	}
+	adminCred := &configstoreTables.TableMCPPerUserHeaderCredential{
+		ID: "cred", AuthMode: "admin", Status: "needs_update", CreatedAt: created, UpdatedAt: updated,
+	}
+	if err := adminCred.SetHeaders(map[string]string{"X-Tenant-ID": "acme", "X-API-Key": "k"}); err != nil {
+		t.Fatal(err)
+	}
+
+	sharedWant := &MCPClientCredentialResponse{
+		Kind: "oauth", Status: "active", HasRefreshToken: true,
+		ExpiresAt:       ptrString("2026-08-12T11:30:00Z"),
+		LastRefreshedAt: ptrString("2026-08-12T11:00:00Z"),
+		Scopes:          []string{"repo", "read:org"},
+		CreatedAt:       "2026-08-12T10:00:00Z", UpdatedAt: "2026-08-12T11:00:00Z",
+	}
+	adminWant := &MCPClientCredentialResponse{
+		Kind: "oauth", Status: "needs_reauth", HasRefreshToken: false,
+		CreatedAt: "2026-08-12T10:00:00Z", UpdatedAt: "2026-08-12T11:00:00Z",
+	}
+	headersWant := &MCPClientCredentialResponse{
+		Kind: "headers", Status: "needs_update",
+		HeaderKeys: []string{"X-API-Key", "X-Tenant-ID"},
+		CreatedAt:  "2026-08-12T10:00:00Z", UpdatedAt: "2026-08-12T11:00:00Z",
+	}
+
+	tests := []struct {
+		name     string
+		authType schemas.MCPAuthType
+		want     *MCPClientCredentialResponse
+	}{
+		{name: "oauth reads the shared token, not the admin one", authType: schemas.MCPAuthTypeOauth, want: sharedWant},
+		{name: "per_user_oauth reads the admin token, not the shared one", authType: schemas.MCPAuthTypePerUserOauth, want: adminWant},
+		{name: "token_exchange reads the admin token", authType: schemas.MCPAuthTypeTokenExchange, want: adminWant},
+		{name: "per_user_headers reads the admin header credential with sorted key names", authType: schemas.MCPAuthTypePerUserHeaders, want: headersWant},
+		{name: "none has no self-held credential", authType: schemas.MCPAuthTypeNone, want: nil},
+		{name: "headers has no self-held credential", authType: schemas.MCPAuthTypeHeaders, want: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mcpClientCredentialResponse(tc.authType, adminToken, adminCred, sharedToken)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Fatalf("got %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+
+	t.Run("missing rows yield no block", func(t *testing.T) {
+		for _, at := range []schemas.MCPAuthType{schemas.MCPAuthTypeOauth, schemas.MCPAuthTypePerUserOauth, schemas.MCPAuthTypeTokenExchange, schemas.MCPAuthTypePerUserHeaders} {
+			if got := mcpClientCredentialResponse(at, nil, nil, nil); got != nil {
+				t.Fatalf("%s: got %+v, want nil", at, got)
+			}
+		}
+	})
+
+	t.Run("unreadable header values still project status and timestamps", func(t *testing.T) {
+		broken := &configstoreTables.TableMCPPerUserHeaderCredential{Status: "active", HeadersJSON: "not-json", CreatedAt: created, UpdatedAt: updated}
+		got := mcpClientCredentialResponse(schemas.MCPAuthTypePerUserHeaders, nil, broken, nil)
+		if got == nil || got.Status != "active" || got.HeaderKeys != nil {
+			t.Fatalf("got %+v, want active block with no header keys", got)
+		}
+	})
+}
+
+func ptrString(s string) *string { return &s }

--- a/transports/bifrost-http/handlers/mcpsessions.go
+++ b/transports/bifrost-http/handlers/mcpsessions.go
@@ -10,6 +10,7 @@ package handlers
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sort"
 	"strconv"
@@ -102,6 +103,14 @@ type mcpSessionRow struct {
 	LastRefreshedAt *string            `json:"last_refreshed_at,omitempty"` // OAuth token rows only; nil if never refreshed
 	UpdatedAt       *string            `json:"updated_at,omitempty"`        // Headers rows: timestamp of last submission/edit
 	OauthConfigID   string             `json:"oauth_config_id,omitempty"`   // OAuth rows only
+	// Scopes are the scopes the provider reported when it issued the token.
+	// Token rows only; empty when the provider omitted them from its token
+	// response, which many do when granted equals requested.
+	Scopes []string `json:"scopes,omitempty"`
+	// HasRefreshToken reports whether the provider issued a refresh token for
+	// this credential. Token rows only. Without one the access token cannot be
+	// renewed at use time, so the row must be re-authenticated once it expires.
+	HasRefreshToken *bool `json:"has_refresh_token,omitempty"`
 	// CanReauth mirrors the server-side identity gate on POST /reauth: user-mode
 	// rows are only reauthable by the bound user (admin DAC scope is enough to
 	// see the row, but reauthing mints credentials for whoever clicks the URL).
@@ -939,7 +948,37 @@ func tokenRow(t tables.TableMCPOauthToken) mcpSessionRow {
 		s := t.LastRefreshedAt.UTC().Format(rfc3339Nano)
 		row.LastRefreshedAt = &s
 	}
+	row.Scopes = parseOauthScopesJSON(t.Scopes)
+	hasRefreshToken := t.RefreshToken != ""
+	row.HasRefreshToken = &hasRefreshToken
 	return row
+}
+
+// parseOauthScopesJSON decodes the JSON scope list stored on an oauth token
+// row. The column holds a JSON array of strings, but a token issued by a
+// provider that omitted the scope field is stored as "null", and rows created
+// before scopes were captured may hold "". Every such shape, along with
+// malformed content, decodes to nil rather than an error: the scope list is
+// display-only and an unreadable one must not fail a listing.
+func parseOauthScopesJSON(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "null" {
+		return nil
+	}
+	var scopes []string
+	if err := json.Unmarshal([]byte(raw), &scopes); err != nil {
+		return nil
+	}
+	out := scopes[:0]
+	for _, s := range scopes {
+		if s = strings.TrimSpace(s); s != "" {
+			out = append(out, s)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // flowRow maps an oauth_user_sessions (pending flow) row to the wire shape.

--- a/ui/app/workspace/mcp-registry/views/mcpClientCredentialSection.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientCredentialSection.tsx
@@ -1,0 +1,321 @@
+// Read-only view of the credential an MCP server holds on its own behalf,
+// rendered in the sheet's Authentication tab, plus the row that links to the
+// per-user sessions stored for it. Everything comes from MCPClient.credential
+// and the client config: nothing here is editable, and no secret material is
+// ever present (the refresh token as presence only, header values by name).
+
+import { RefreshTokenStatus } from "@/components/refreshTokenStatus";
+import { ScopeChips } from "@/components/scopeChips";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useGetMCPSessionsQuery } from "@/lib/store";
+import { MCPClient, MCPClientCredential } from "@/lib/types/mcp";
+import {
+	formatAbsoluteDate,
+	formatAbsoluteDateTime,
+	formatRelativePast,
+	formatTokenExpiry,
+	missingHeaderKeys,
+} from "@/lib/utils/mcpCredential";
+import { Link } from "@tanstack/react-router";
+import { ArrowUpRight } from "lucide-react";
+import { ReactNode } from "react";
+import { SectionHeader } from "./sectionHeader";
+
+interface Props {
+	mcpClient: MCPClient;
+}
+
+/**
+ * MCPClientCredentialSection renders the credential block for the server's
+ * auth type: the shared token (oauth), the retained admin token
+ * (per_user_oauth, token_exchange), or the retained admin header values
+ * (per_user_headers). Renders nothing for auth types without a self-held
+ * credential.
+ */
+export function MCPClientCredentialSection({ mcpClient }: Props) {
+	switch (mcpClient.config.auth_type) {
+		case "oauth":
+		case "per_user_oauth":
+		case "token_exchange":
+			return <OAuthCredentialBlock mcpClient={mcpClient} />;
+		case "per_user_headers":
+			return <HeaderCredentialBlock mcpClient={mcpClient} />;
+		default:
+			return null;
+	}
+}
+
+/**
+ * MCPClientSessionsSection is the "User Sessions" / "User Submissions" row:
+ * how many per-user credentials are stored for this server and a link to
+ * the MCP sessions page pre-filtered to it. Only per-user auth types store
+ * such rows, so it renders nothing for the others.
+ */
+export function MCPClientSessionsSection({ mcpClient }: Props) {
+	const authType = mcpClient.config.auth_type;
+	if (authType !== "per_user_oauth" && authType !== "per_user_headers") return null;
+	return <SessionsRow clientId={mcpClient.config.client_id} kind={authType === "per_user_oauth" ? "token" : "header"} />;
+}
+
+function OAuthCredentialBlock({ mcpClient }: Props) {
+	const copy = oauthCredentialCopy(mcpClient.config.auth_type);
+	const credential = mcpClient.credential?.kind === "oauth" ? mcpClient.credential : undefined;
+
+	return (
+		<div className="space-y-4" data-testid="mcpclient-credential-section">
+			<SectionHeader title={copy.title} description={copy.description} testId="mcpclient-credential-heading" />
+			{!credential ? (
+				<EmptyCredential>{copy.empty}</EmptyCredential>
+			) : (
+				<DefinitionList>
+					<Row label="Status">
+						<CredentialStatusBadge status={credential.status} />
+						{credential.status === "needs_reauth" && <Hint>{copy.needsReauth}</Hint>}
+					</Row>
+					<Row label="Access token expires">
+						{credential.expires_at ? (
+							<>
+								{formatTokenExpiry(credential.expires_at, credential.status, credential.has_refresh_token)}
+								<Sub>
+									{formatAbsoluteDateTime(credential.expires_at)}
+									{credential.last_refreshed_at && ` · refreshed ${formatRelativePast(credential.last_refreshed_at)}`}
+								</Sub>
+							</>
+						) : (
+							<>
+								<span className="text-muted-foreground">No expiry reported</span>
+								{credential.last_refreshed_at && <Sub>refreshed {formatRelativePast(credential.last_refreshed_at)}</Sub>}
+							</>
+						)}
+					</Row>
+					<Row label="Refresh token">
+						<RefreshTokenValue credential={credential} notIssuedHint={copy.notIssued} />
+					</Row>
+					<Row label="Granted scopes">
+						{credential.scopes?.length ? (
+							<ScopeChips scopes={credential.scopes} max={credential.scopes.length} />
+						) : (
+							<span className="text-muted-foreground">Not reported by the provider</span>
+						)}
+					</Row>
+					<Row label="Authorized">{formatAbsoluteDate(credential.created_at)}</Row>
+				</DefinitionList>
+			)}
+		</div>
+	);
+}
+
+// Copy for the three auth types that hold an OAuth credential of their own.
+// The repair action named in each string matches the label of the
+// actions-menu item that replaces that credential.
+function oauthCredentialCopy(authType: MCPClient["config"]["auth_type"]) {
+	switch (authType) {
+		case "per_user_oauth": {
+			const repairAction = "Refresh admin credential";
+			return {
+				title: "Admin Credential",
+				description:
+					"Kept on file only to refresh this server's tool list. End users sign in individually; their tokens are listed under MCP sessions.",
+				empty: `No admin credential on file, so the tool list is not refreshed automatically. Use ${repairAction} from the server's actions menu to add one.`,
+				needsReauth: `The provider rejected the refresh token. Use ${repairAction} from the actions menu. User sessions are not affected.`,
+				notIssued: `This provider did not return a refresh token. Use ${repairAction} once the access token expires.`,
+			};
+		}
+		case "token_exchange": {
+			const repairAction = "Re-verify as me";
+			return {
+				title: "Admin Credential",
+				description:
+					"The token exchanged from the admin's own sign-in at verification, kept on file only to refresh this server's tool list. Callers have their own identity tokens exchanged on every tool call.",
+				empty: `No admin credential on file, so the tool list is not refreshed automatically. Use ${repairAction} from the server's actions menu to add one.`,
+				needsReauth: `The identity provider rejected the refresh token. Use ${repairAction} from the actions menu. Callers' tool calls are not affected.`,
+				notIssued: `The identity provider did not return a refresh token. Add offline_access to the exchange scopes where it is supported so the credential renews itself, then use ${repairAction}.`,
+			};
+		}
+		default: {
+			const repairAction = "Reauthorize";
+			return {
+				title: "OAuth Credential",
+				description: `The shared token every caller of this server uses. Read-only. Use ${repairAction} from the server's actions menu to replace it.`,
+				empty: "No credential yet. Complete the one-time authorization from the server's actions menu to connect this server.",
+				needsReauth: `The provider rejected the refresh token. Use ${repairAction} from the server's actions menu.`,
+				notIssued: `This provider did not return a refresh token. Use ${repairAction} once the access token expires.`,
+			};
+		}
+	}
+}
+
+// Same reading as the sessions table's Refresh token column, plus the hint
+// that tells the admin what it means for this server. The needs_reauth case
+// is already explained under Status, so it carries no second hint.
+function RefreshTokenValue({ credential, notIssuedHint }: { credential: MCPClientCredential; notIssuedHint: string }) {
+	return (
+		<>
+			<RefreshTokenStatus hasRefreshToken={credential.has_refresh_token} status={credential.status} />
+			{credential.status !== "needs_reauth" &&
+				(credential.has_refresh_token ? (
+					<Hint>Bifrost renews the access token automatically on the next request after expiry.</Hint>
+				) : (
+					<Hint>{notIssuedHint}</Hint>
+				))}
+		</>
+	);
+}
+
+function HeaderCredentialBlock({ mcpClient }: Props) {
+	const credential = mcpClient.credential?.kind === "headers" ? mcpClient.credential : undefined;
+	const covered = credential?.header_keys ?? [];
+	const missing = credential ? missingHeaderKeys(mcpClient.config.per_user_header_keys, covered) : [];
+
+	return (
+		<div className="space-y-4" data-testid="mcpclient-credential-section">
+			<SectionHeader
+				title="Admin Verification Values"
+				description="Sample values supplied at verification. Bifrost uses them only to refresh the tool list. They are stored encrypted and never shown."
+				testId="mcpclient-credential-heading"
+			/>
+			{!credential ? (
+				<EmptyCredential>
+					No admin values on file, so the tool list is not refreshed automatically. Run Verify headers from the server's actions menu to add
+					them.
+				</EmptyCredential>
+			) : (
+				<DefinitionList>
+					<Row label="Status">
+						<CredentialStatusBadge status={credential.status} />
+						{credential.status === "needs_update" && (
+							<Hint>
+								Required headers changed after these values were submitted. Run Verify headers from the actions menu to refresh tool
+								discovery.
+							</Hint>
+						)}
+					</Row>
+					<Row label="Covers headers">
+						{covered.length === 0 && missing.length === 0 ? (
+							<span className="text-muted-foreground">-</span>
+						) : (
+							<div className="flex flex-wrap items-center gap-1">
+								{covered.map((key) => (
+									<Badge key={key} variant="outline" className="font-mono text-xs font-normal">
+										{key}
+									</Badge>
+								))}
+								{missing.map((key) => (
+									<Badge
+										key={`missing-${key}`}
+										variant="outline"
+										className="text-muted-foreground border-dashed bg-transparent font-mono text-xs font-normal"
+									>
+										{key}
+									</Badge>
+								))}
+								{missing.length > 0 && (
+									<span className="text-muted-foreground rounded-sm border px-1 font-mono text-[10px] tracking-wider uppercase">
+										missing
+									</span>
+								)}
+							</div>
+						)}
+					</Row>
+					<Row label="Submitted">{formatAbsoluteDate(credential.created_at)}</Row>
+					<Row label="Last updated">{formatRelativePast(credential.updated_at)}</Row>
+				</DefinitionList>
+			)}
+		</div>
+	);
+}
+
+function SessionsRow({ clientId, kind }: { clientId: string; kind: "token" | "header" }) {
+	// One-row page: only total_count is used. Shares the MCPSessions cache tag,
+	// so a revoke on the sessions page refreshes this count too.
+	const { data } = useGetMCPSessionsQuery({ mcp_client_id: [clientId], kind: [kind], limit: 1 });
+	const total = data?.total_count;
+	const oauth = kind === "token";
+	const noun = oauth ? "session" : "submission";
+
+	return (
+		<div className="space-y-4" data-testid="mcpclient-sessions-section">
+			<SectionHeader
+				title={oauth ? "User Sessions" : "User Submissions"}
+				description={
+					oauth
+						? "Per-user OAuth tokens stored for this server, plus any sign-ins still pending."
+						: "Header values submitted by individual callers, plus any submissions still pending."
+				}
+				testId="mcpclient-sessions-heading"
+				action={
+					<div className="flex shrink-0 items-center gap-3">
+						{typeof total === "number" && (
+							<span className="text-muted-foreground text-sm" data-testid="mcpclient-sessions-count">
+								<span className="text-foreground font-medium tabular-nums">{total}</span> {total === 1 ? noun : `${noun}s`}
+							</span>
+						)}
+						<Button variant="outline" size="sm" asChild>
+							<Link
+								to="/workspace/mcp-sessions"
+								search={{ mcp_client_id: [clientId], kind: [kind] }}
+								data-testid="mcpclient-view-sessions-link"
+							>
+								{oauth ? "View sessions" : "View submissions"}
+								<ArrowUpRight className="size-3.5" />
+							</Link>
+						</Button>
+					</div>
+				}
+			/>
+		</div>
+	);
+}
+
+// Status vocabulary and colors mirror the sessions table's StatusBadge so a
+// credential reads the same in both places.
+function CredentialStatusBadge({ status }: { status: MCPClientCredential["status"] }) {
+	switch (status) {
+		case "orphaned":
+			return (
+				<Badge variant="outline" className="border-amber-500 bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
+					Orphaned
+				</Badge>
+			);
+		case "needs_reauth":
+			return <Badge variant="destructive">Needs re-auth</Badge>;
+		case "needs_update":
+			return (
+				<Badge variant="outline" className="border-red-500 bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200">
+					Needs update
+				</Badge>
+			);
+		default:
+			return <Badge>Active</Badge>;
+	}
+}
+
+function DefinitionList({ children }: { children: ReactNode }) {
+	return <dl className="grid grid-cols-1 gap-x-4 gap-y-3.5 rounded-md border p-4 text-sm sm:grid-cols-[168px_1fr]">{children}</dl>;
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+	return (
+		<>
+			<dt className="text-muted-foreground pt-0.5">{label}</dt>
+			<dd className="m-0 min-w-0">{children}</dd>
+		</>
+	);
+}
+
+function Sub({ children }: { children: ReactNode }) {
+	return <span className="text-muted-foreground mt-0.5 block text-xs">{children}</span>;
+}
+
+function Hint({ children }: { children: ReactNode }) {
+	return <span className="text-muted-foreground mt-1 block max-w-prose text-xs">{children}</span>;
+}
+
+function EmptyCredential({ children }: { children: ReactNode }) {
+	return (
+		<div className="text-muted-foreground rounded-md border border-dashed p-4 text-sm" data-testid="mcpclient-credential-empty">
+			{children}
+		</div>
+	);
+}

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -43,6 +43,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { OAuthAdvancedFields } from "./oauthAdvancedFields";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
+import { MCPClientCredentialSection, MCPClientSessionsSection } from "./mcpClientCredentialSection";
 import { SectionHeader } from "./sectionHeader";
 import { TLSConfigFields } from "./tlsConfigFields";
 import { TokenExchangeFields } from "./tokenExchangeFields";
@@ -112,6 +113,12 @@ export default function MCPClientSheet({
 	const isPerUserAuth =
 		mcpClient.config.auth_type === "per_user_oauth" ||
 		mcpClient.config.auth_type === "per_user_headers" ||
+		mcpClient.config.auth_type === "token_exchange";
+	// Auth types whose server holds an OAuth credential of its own: the shared
+	// token, or the retained admin token used to refresh the tool list.
+	const holdsOwnOauthCredential =
+		mcpClient.config.auth_type === "oauth" ||
+		mcpClient.config.auth_type === "per_user_oauth" ||
 		mcpClient.config.auth_type === "token_exchange";
 	const [updateMCPClient, { isLoading: isUpdating }] = useUpdateMCPClientMutation();
 
@@ -1077,6 +1084,13 @@ export default function MCPClientSheet({
 											</>
 										)}
 
+										{mcpClient.config.auth_type === "per_user_headers" && (
+											<>
+												<DottedSeparator />
+												<MCPClientCredentialSection mcpClient={mcpClient} />
+											</>
+										)}
+
 										<DottedSeparator />
 										<div className="space-y-4">
 											<SectionHeader
@@ -1115,6 +1129,20 @@ export default function MCPClientSheet({
 												)}
 											/>
 										</div>
+
+										{holdsOwnOauthCredential && (
+											<>
+												<DottedSeparator />
+												<MCPClientCredentialSection mcpClient={mcpClient} />
+											</>
+										)}
+
+										{(mcpClient.config.auth_type === "per_user_oauth" || mcpClient.config.auth_type === "per_user_headers") && (
+											<>
+												<DottedSeparator />
+												<MCPClientSessionsSection mcpClient={mcpClient} />
+											</>
+										)}
 
 										{(() => {
 											const showTLS = mcpClient.config.connection_type === "http" || mcpClient.config.connection_type === "sse";

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -39,6 +39,9 @@ import { ChevronLeft, ChevronRight, Info, Search } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { getErrorMessage, useReauthMCPSessionMutation, useRevokeMCPSessionMutation } from "@/lib/store";
 import { MCPSessionRow } from "@/lib/types/mcpSessions";
+import { formatRelativePast, formatTokenExpiry } from "@/lib/utils/mcpCredential";
+import { RefreshTokenStatus } from "@/components/refreshTokenStatus";
+import { ScopeChips } from "@/components/scopeChips";
 import { ExternalLink, Fingerprint, KeyRound, Loader2, MoreHorizontal, Pencil, RefreshCcw, Trash2, UserRound } from "lucide-react";
 import { useState } from "react";
 
@@ -179,8 +182,20 @@ export default function SessionsTable({
 								</TableHead>
 								<TableHead>
 									<HeaderWithTooltip
+										label="Scopes"
+										tooltip="Scopes the provider granted at sign-in, as reported in its token response. Shown as a dash when the provider did not report them. Header submissions and pending sign-ins have no scopes."
+									/>
+								</TableHead>
+								<TableHead>
+									<HeaderWithTooltip
 										label="Access token expiry"
-										tooltip="When the current access token expires. Bifrost auto-refreshes using the refresh token on the next request, so an active row past its expiry will silently mint a new token at use time. Header rows do not have an upstream expiry; their values stay valid until revoked or the schema changes."
+										tooltip="When the current access token expires. With a refresh token, Bifrost renews it on the next request, so an active row past its expiry silently mints a new token at use time. Without one, a past expiry means the row must be re-authenticated. Header rows do not have an upstream expiry; their values stay valid until revoked or the schema changes."
+									/>
+								</TableHead>
+								<TableHead>
+									<HeaderWithTooltip
+										label="Refresh token"
+										tooltip="Whether the provider issued a refresh token. Present: Bifrost renews the access token automatically at use time. Not issued: the row must be re-authenticated once the access token expires. Rejected upstream: the provider refused the last refresh, so the row needs re-auth. Header rows and pending sign-ins have no token."
 									/>
 								</TableHead>
 								<TableHead>Created</TableHead>
@@ -190,7 +205,7 @@ export default function SessionsTable({
 						<TableBody>
 							{sessions.length === 0 ? (
 								<TableRow>
-									<TableCell colSpan={7} className="h-24 text-center">
+									<TableCell colSpan={9} className="h-24 text-center">
 										{hasActiveFilters ? (
 											<div className="text-muted-foreground text-sm">No sessions match these filters.</div>
 										) : (
@@ -214,11 +229,17 @@ export default function SessionsTable({
 										<TableCell>
 											<StatusBadge status={row.status} />
 										</TableCell>
+										<TableCell>
+											<ScopesCell row={row} />
+										</TableCell>
 										<TableCell className="text-muted-foreground text-sm">
 											<div className="flex flex-col">
 												<span>{formatAccessExpiry(row)}</span>
 												{row.last_refreshed_at && <span className="text-xs">refreshed {formatRelativePast(row.last_refreshed_at)}</span>}
 											</div>
+										</TableCell>
+										<TableCell className="text-sm">
+											<RefreshTokenCell row={row} />
 										</TableCell>
 										<TableCell className="text-muted-foreground text-sm">{formatRelativePast(row.created_at)}</TableCell>
 										<TableCell
@@ -326,6 +347,24 @@ function BindingCell({ row }: { row: MCPSessionRow }) {
 		);
 	}
 	return <span className="text-muted-foreground text-sm">Session-bound</span>;
+}
+
+// Granted scopes on token rows. A dash when the provider reported none, and
+// for header rows and pending sign-ins, which have no token.
+function ScopesCell({ row }: { row: MCPSessionRow }) {
+	if (row.kind !== "token" || !row.scopes?.length) {
+		return <span className="text-muted-foreground text-sm">-</span>;
+	}
+	return <ScopeChips scopes={row.scopes} />;
+}
+
+// Refresh token presence on token rows; a dash for header rows and pending
+// sign-ins, which have no token.
+function RefreshTokenCell({ row }: { row: MCPSessionRow }) {
+	if (row.kind !== "token" || row.has_refresh_token === undefined) {
+		return <span className="text-muted-foreground text-sm">-</span>;
+	}
+	return <RefreshTokenStatus hasRefreshToken={row.has_refresh_token} status={row.status} />;
 }
 
 function TypeBadge({ authKind }: { authKind: string }) {
@@ -496,23 +535,6 @@ function RowActions({ row, reauthing, revoking, isPendingRow, onReauth, onRevoke
 	);
 }
 
-function formatRelativePast(iso: string): string {
-	try {
-		const t = new Date(iso).getTime();
-		if (Number.isNaN(t)) return iso;
-		const diffMs = Date.now() - t;
-		if (diffMs < 60_000) return "just now";
-		const mins = Math.floor(diffMs / 60_000);
-		if (mins < 60) return `${mins} min ago`;
-		const hours = Math.floor(diffMs / 3_600_000);
-		if (hours < 48) return `${hours}h ago`;
-		const days = Math.floor(diffMs / 86_400_000);
-		return `${days}d ago`;
-	} catch {
-		return iso;
-	}
-}
-
 function formatAccessExpiry(row: MCPSessionRow): string {
 	// Header rows don't have an upstream-side expiry — the submitted values
 	// are durable until the user revokes or the schema changes. The status
@@ -521,33 +543,5 @@ function formatAccessExpiry(row: MCPSessionRow): string {
 	if (row.kind === "header") {
 		return "-";
 	}
-	if (!row.expires_at) return "-";
-	try {
-		const t = new Date(row.expires_at).getTime();
-		if (Number.isNaN(t)) return row.expires_at;
-		const diffMs = t - Date.now();
-		if (diffMs < 0) {
-			// Active rows auto-refresh on next use via the refresh token.
-			// Orphaned rows still hold a valid upstream credential — the past
-			// expiry just means the cached access token is stale; if access
-			// is restored, refresh kicks in. Only 'needs_reauth' is genuinely
-			// expired (the refresh token itself is dead).
-			switch (row.status) {
-				case "active":
-					return "Refreshes on next use";
-				case "orphaned":
-					return "Refreshes when access is restored";
-				default:
-					return "expired";
-			}
-		}
-		const days = Math.floor(diffMs / 86_400_000);
-		if (days > 1) return `in ${days} days`;
-		const hours = Math.floor(diffMs / 3_600_000);
-		if (hours > 1) return `in ${hours} hours`;
-		const mins = Math.floor(diffMs / 60_000);
-		return `in ${Math.max(mins, 1)} min`;
-	} catch {
-		return row.expires_at;
-	}
+	return formatTokenExpiry(row.expires_at, row.status, row.has_refresh_token);
 }

--- a/ui/components/refreshTokenStatus.tsx
+++ b/ui/components/refreshTokenStatus.tsx
@@ -1,0 +1,41 @@
+// RefreshTokenStatus is the shared one-line reading of an OAuth credential's
+// refresh token, used by the MCP sessions table and the MCP server sheet so
+// both describe the same row with the same words. Present: Bifrost renews
+// the access token at use time. Not issued: the provider returned none, so
+// the credential must be re-authenticated once the access token expires.
+// Rejected upstream: the provider refused the last refresh (the row is in
+// needs_reauth), whether or not a refresh token string is still stored.
+
+import { cn } from "@/lib/utils";
+import { Check, X } from "lucide-react";
+
+interface RefreshTokenStatusProps {
+	hasRefreshToken: boolean;
+	status: string;
+	className?: string;
+}
+
+export function RefreshTokenStatus({ hasRefreshToken, status, className }: RefreshTokenStatusProps) {
+	if (status === "needs_reauth") {
+		return (
+			<span className={cn("inline-flex items-center gap-1.5 text-red-700 dark:text-red-300", className)}>
+				<X className="size-3.5 shrink-0" />
+				Rejected upstream
+			</span>
+		);
+	}
+	if (hasRefreshToken) {
+		return (
+			<span className={cn("inline-flex items-center gap-1.5 text-green-700 dark:text-green-300", className)}>
+				<Check className="size-3.5 shrink-0" />
+				Present
+			</span>
+		);
+	}
+	return (
+		<span className={cn("inline-flex items-center gap-1.5", className)}>
+			<X className="text-muted-foreground size-3.5 shrink-0" />
+			Not issued
+		</span>
+	);
+}

--- a/ui/components/scopeChips.tsx
+++ b/ui/components/scopeChips.tsx
@@ -1,0 +1,56 @@
+// ScopeChips renders an OAuth scope list as compact monospace chips: the
+// first few inline, the rest behind a "+N" that reveals the full list on
+// hover or focus.
+
+import { Badge } from "@/components/ui/badge";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hoverCard";
+import { cn } from "@/lib/utils";
+
+interface ScopeChipsProps {
+	scopes: string[];
+	// Chips shown inline before the "+N" overflow. Pass scopes.length to
+	// show every scope inline (the sheet does; the table keeps rows short).
+	max?: number;
+	className?: string;
+}
+
+export function ScopeChips({ scopes, max = 2, className }: ScopeChipsProps) {
+	if (scopes.length === 0) {
+		return <span className="text-muted-foreground text-sm">-</span>;
+	}
+	const visible = scopes.slice(0, max);
+	const hidden = scopes.length - visible.length;
+
+	return (
+		<div className={cn("flex flex-wrap items-center gap-1", className)}>
+			{visible.map((scope) => (
+				<Badge key={scope} variant="outline" className="font-mono text-xs font-normal">
+					{scope}
+				</Badge>
+			))}
+			{hidden > 0 && (
+				<HoverCard openDelay={100} closeDelay={100}>
+					<HoverCardTrigger asChild>
+						<button
+							type="button"
+							className="text-muted-foreground hover:text-foreground focus-visible:ring-ring/50 cursor-default rounded-sm px-1 text-xs focus-visible:ring-[3px] focus-visible:outline-none"
+							aria-label={`Show all ${scopes.length} scopes`}
+						>
+							+{hidden}
+						</button>
+					</HoverCardTrigger>
+					<HoverCardContent align="start" className="w-auto max-w-sm p-3">
+						<div className="text-muted-foreground mb-2 font-mono text-[10px] tracking-wider uppercase">Granted scopes</div>
+						<div className="flex flex-col items-start gap-1">
+							{scopes.map((scope) => (
+								<Badge key={scope} variant="outline" className="max-w-full font-mono text-xs font-normal break-all whitespace-normal">
+									{scope}
+								</Badge>
+							))}
+						</div>
+					</HoverCardContent>
+				</HoverCard>
+			)}
+		</div>
+	);
+}

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -150,6 +150,33 @@ export interface MCPVKConfigResponse {
 	tools_to_execute: string[];
 }
 
+// MCPClientCredential is the read-only view of the credential a server holds
+// on its own behalf, as opposed to the per-caller credentials listed under
+// MCP sessions: the single shared token for an oauth server, the retained
+// admin token for per_user_oauth and token_exchange servers (used only to
+// refresh the tool list), or the retained admin header values for a
+// per_user_headers server. Never carries secret material: the refresh token
+// is reported as present or absent, and header values only by name.
+export interface MCPClientCredential {
+	kind: "oauth" | "headers";
+	// oauth: active | orphaned | needs_reauth. headers: active | orphaned | needs_update.
+	status: "active" | "orphaned" | "needs_reauth" | "needs_update";
+	// oauth only: access token expiry; absent when the provider did not report one.
+	expires_at?: string | null;
+	// oauth only: set once the access token has been refreshed or the
+	// credential re-authorized at least once.
+	last_refreshed_at?: string | null;
+	// oauth only: whether the provider issued a refresh token. Always false for headers.
+	has_refresh_token: boolean;
+	// oauth only: scopes the provider reported at consent. Empty when the
+	// provider omitted them from its token response.
+	scopes?: string[];
+	// headers only: names of the headers the stored admin values cover, sorted.
+	header_keys?: string[];
+	created_at: string;
+	updated_at: string;
+}
+
 export interface MCPClient {
 	config: MCPClientConfig;
 	tools: ToolFunction[];
@@ -159,6 +186,10 @@ export interface MCPClient {
 	// -> that instance's own self-reported state). Only ever present in a
 	// distributed deployment; absent otherwise.
 	node_states?: Record<string, string>;
+	// The credential this server holds on its own behalf. Absent for auth
+	// types without one (none, headers) and for servers that have not
+	// completed their one-time authorization yet.
+	credential?: MCPClientCredential;
 }
 
 export interface CreateMCPClientRequest {

--- a/ui/lib/types/mcpSessions.ts
+++ b/ui/lib/types/mcpSessions.ts
@@ -64,6 +64,14 @@ export interface MCPSessionRow {
 	// last submission/edit. OAuth rows omit this field.
 	updated_at?: string | null;
 	oauth_config_id?: string;
+	// scopes: token rows only. What the provider reported when it issued the
+	// token; absent when the provider omitted scopes from its token response,
+	// which many do when granted equals requested.
+	scopes?: string[];
+	// has_refresh_token: token rows only. Whether the provider issued a
+	// refresh token; without one the access token cannot be renewed at use
+	// time and the row needs re-auth once it expires.
+	has_refresh_token?: boolean;
 	// can_reauth mirrors the server-side identity gate on POST /reauth. For
 	// user-bound rows it's true only when the calling user matches the row's
 	// bound user; for vk/session rows it's always true. The UI hides the

--- a/ui/lib/utils/mcpCredential.test.ts
+++ b/ui/lib/utils/mcpCredential.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { formatTokenExpiry, missingHeaderKeys } from "./mcpCredential";
+
+describe("formatTokenExpiry", () => {
+	const now = new Date("2026-09-03T12:00:00Z");
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test("missing expiry renders a dash", () => {
+		expect(formatTokenExpiry(undefined, "active")).toBe("-");
+		expect(formatTokenExpiry(null, "active")).toBe("-");
+		expect(formatTokenExpiry("", "active")).toBe("-");
+	});
+
+	test("future expiry is relative", () => {
+		expect(formatTokenExpiry("2026-09-03T12:42:00Z", "active")).toBe("in 42 min");
+		expect(formatTokenExpiry("2026-09-03T15:30:00Z", "active")).toBe("in 3 hours");
+		expect(formatTokenExpiry("2026-09-10T12:00:00Z", "active")).toBe("in 7 days");
+	});
+
+	test("a past expiry only reads as expired when the credential is dead", () => {
+		const past = "2026-09-01T12:00:00Z";
+		expect(formatTokenExpiry(past, "active")).toBe("Refreshes on next use");
+		expect(formatTokenExpiry(past, "active", true)).toBe("Refreshes on next use");
+		expect(formatTokenExpiry(past, "orphaned")).toBe("Refreshes when access is restored");
+		expect(formatTokenExpiry(past, "needs_reauth")).toBe("expired");
+	});
+
+	test("the exact expiry instant counts as expired", () => {
+		const exact = "2026-09-03T12:00:00Z";
+		expect(formatTokenExpiry(exact, "needs_reauth")).toBe("expired");
+		expect(formatTokenExpiry(exact, "active", false)).toBe("expired");
+		expect(formatTokenExpiry(exact, "active", true)).toBe("Refreshes on next use");
+	});
+
+	test("a past expiry without a refresh token is expired whatever the status", () => {
+		const past = "2026-09-01T12:00:00Z";
+		expect(formatTokenExpiry(past, "active", false)).toBe("expired");
+		expect(formatTokenExpiry(past, "orphaned", false)).toBe("expired");
+		// Still in the future: the refresh token only matters once it lapses.
+		expect(formatTokenExpiry("2026-09-03T12:42:00Z", "active", false)).toBe("in 42 min");
+	});
+
+	test("unparseable input passes through", () => {
+		expect(formatTokenExpiry("not-a-date", "active")).toBe("not-a-date");
+	});
+});
+
+describe("missingHeaderKeys", () => {
+	test("empty required list has nothing missing", () => {
+		expect(missingHeaderKeys(undefined, ["X-API-Key"])).toEqual([]);
+		expect(missingHeaderKeys([], undefined)).toEqual([]);
+	});
+
+	test("everything is missing when nothing is covered", () => {
+		expect(missingHeaderKeys(["X-API-Key", "X-Tenant-ID"], undefined)).toEqual(["X-API-Key", "X-Tenant-ID"]);
+	});
+
+	test("compares header names case-insensitively and ignores blanks", () => {
+		expect(missingHeaderKeys(["X-API-Key", " X-Tenant-ID ", "", "X-Region"], ["x-api-key", "X-Tenant-Id"])).toEqual(["X-Region"]);
+	});
+});

--- a/ui/lib/utils/mcpCredential.ts
+++ b/ui/lib/utils/mcpCredential.ts
@@ -1,0 +1,80 @@
+// Formatting helpers shared by the MCP auth sessions table and the MCP
+// server sheet's credential block, so both surfaces describe the same
+// token row with the same words.
+
+export function formatRelativePast(iso: string): string {
+	try {
+		const t = new Date(iso).getTime();
+		if (Number.isNaN(t)) return iso;
+		const diffMs = Date.now() - t;
+		if (diffMs < 60_000) return "just now";
+		const mins = Math.floor(diffMs / 60_000);
+		if (mins < 60) return `${mins} min ago`;
+		const hours = Math.floor(diffMs / 3_600_000);
+		if (hours < 48) return `${hours}h ago`;
+		const days = Math.floor(diffMs / 86_400_000);
+		return `${days}d ago`;
+	} catch {
+		return iso;
+	}
+}
+
+/**
+ * formatTokenExpiry describes an OAuth access token's expiry relative to now.
+ * A past expiry only reads as "expired" when nothing can renew the token:
+ * needs_reauth (refresh token rejected), or no refresh token at all. With
+ * one, an active row refreshes on next use, and an orphaned row still holds
+ * a valid upstream credential that refreshes once access is restored. An
+ * unknown hasRefreshToken (older rows on the wire) keeps the status reading.
+ */
+export function formatTokenExpiry(expiresAt: string | null | undefined, status: string, hasRefreshToken?: boolean): string {
+	if (!expiresAt) return "-";
+	try {
+		const t = new Date(expiresAt).getTime();
+		if (Number.isNaN(t)) return expiresAt;
+		const diffMs = t - Date.now();
+		if (diffMs <= 0) {
+			if (hasRefreshToken === false) return "expired";
+			switch (status) {
+				case "active":
+					return "Refreshes on next use";
+				case "orphaned":
+					return "Refreshes when access is restored";
+				default:
+					return "expired";
+			}
+		}
+		const days = Math.floor(diffMs / 86_400_000);
+		if (days > 1) return `in ${days} days`;
+		const hours = Math.floor(diffMs / 3_600_000);
+		if (hours > 1) return `in ${hours} hours`;
+		const mins = Math.floor(diffMs / 60_000);
+		return `in ${Math.max(mins, 1)} min`;
+	} catch {
+		return expiresAt;
+	}
+}
+
+export function formatAbsoluteDateTime(iso: string): string {
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
+}
+
+export function formatAbsoluteDate(iso: string): string {
+	const d = new Date(iso);
+	if (Number.isNaN(d.getTime())) return iso;
+	return d.toLocaleDateString(undefined, { dateStyle: "medium" });
+}
+
+/**
+ * missingHeaderKeys lists the required header names the stored admin values
+ * do not cover: keys added to the required list after the values were
+ * submitted. Header names compare case-insensitively, since the stored keys
+ * are canonicalized on submission while the required list is typed by hand.
+ */
+export function missingHeaderKeys(required: readonly string[] | undefined, covered: readonly string[] | undefined): string[] {
+	if (!required?.length) return [];
+	const have = new Set((covered ?? []).map((k) => k.trim().toLowerCase()));
+	return required.map((k) => k.trim()).filter((k) => k && !have.has(k.toLowerCase()));
+}


### PR DESCRIPTION
## Summary

The MCP registry's server sheet and sessions table were missing key OAuth credential details that admins need to understand the health of a server's authentication state. This PR surfaces the credential each MCP server holds on its own behalf directly in the server sheet, and adds granted scopes and refresh token presence to the sessions table.

## Changes

- **API**: `MCPClientResponse` now includes a `credential` field (`MCPClientCredentialResponse`) carrying the read-only view of the credential a server holds on its own behalf — the shared token for `oauth` servers, the retained admin token for `per_user_oauth`/`token_exchange` servers, or the retained admin header values for `per_user_headers` servers. Secret material is never exposed: the refresh token is reported as present or absent, and header values only by name.
- **API**: The batch credential fetches in `getMCPClientsPaginated` now retain full row pointers instead of just status strings, so the same fetch feeds both the existing state projection and the new credential block without additional queries.
- **API**: `mcpSessionRow` gains `scopes` and `has_refresh_token` fields, populated by a new `parseOauthScopesJSON` helper that tolerates `null`, empty, and malformed column values without failing the listing.
- **UI – server sheet**: A new `MCPClientCredentialSection` renders the credential block in the Authentication tab for `oauth`, `per_user_oauth`, and `per_user_headers` servers. A new `MCPClientSessionsSection` renders a "User Sessions" / "User Submissions" row with a live count and a link to the sessions page pre-filtered to that server.
- **UI – sessions table**: Added "Scopes" and "Refresh token" columns. The access token expiry column's tooltip and logic are updated to account for whether a refresh token is present, since a past expiry without one is genuinely expired rather than auto-renewable.
- **UI – shared utilities**: `formatRelativePast`, `formatTokenExpiry`, `formatAbsoluteDate`, `formatAbsoluteDateTime`, and `missingHeaderKeys` are extracted to `ui/lib/utils/mcpCredential.ts` so the sessions table and server sheet describe the same row with the same words. `RefreshTokenStatus` and `ScopeChips` are extracted as shared components for the same reason.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Open the MCP registry, select a server with `oauth`, `per_user_oauth`, or `per_user_headers` auth, and verify the Authentication tab shows the credential block with status, expiry, refresh token presence, and scopes (or header key names). Open the MCP sessions table and verify the new Scopes and Refresh token columns appear and are populated for token rows and show a dash for header and pending rows.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

No secret material is exposed. The refresh token is reported only as a boolean presence flag. Header credential values are reported only by key name, not value. The `parseOauthScopesJSON` helper treats malformed or missing scope columns as nil rather than an error, so a corrupt row cannot fail a listing.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable