### PR TITLE
feat(ui): audit virtual key reveal and copy events via enterprise hook with OSS no-op fallback

### DIFF
--- a/ui/app/_fallbacks/enterprise/lib/hooks/useVirtualKeyAccessAudit.ts
+++ b/ui/app/_fallbacks/enterprise/lib/hooks/useVirtualKeyAccessAudit.ts
@@ -1,0 +1,6 @@
+export type VirtualKeyAccessKind = "reveal" | "copy";
+
+// OSS stub: virtual key access auditing is enterprise-only.
+export function useVirtualKeyAccessAudit(): (vkId: string, kind: VirtualKeyAccessKind) => void {
+	return () => {};
+}

--- a/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeysTable.tsx
@@ -27,6 +27,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { resetDurationLabels } from "@/lib/constants/governance";
 import { getUserPicker } from "@/lib/registries/userPicker";
+import { useVirtualKeyAccessAudit } from "@enterprise/lib/hooks/useVirtualKeyAccessAudit";
 import {
 	getErrorMessage,
 	useBulkRotateVirtualKeysMutation,
@@ -575,12 +576,17 @@ export default function VirtualKeysTable({
 		}
 	};
 
+	// Enterprise records reveals and copies in the audit log; a no-op in OSS builds.
+	const reportVkAccess = useVirtualKeyAccessAudit();
+
 	const toggleKeyVisibility = (vkId: string) => {
 		const newRevealed = new Set(revealedKeys);
 		if (newRevealed.has(vkId)) {
 			newRevealed.delete(vkId);
 		} else {
 			newRevealed.add(vkId);
+			// Only the reveal edge is a disclosure; re-hiding is not.
+			reportVkAccess(vkId, "reveal");
 		}
 		setRevealedKeys(newRevealed);
 	};
@@ -979,7 +985,11 @@ export default function VirtualKeysTable({
 														<Button
 															variant="ghost"
 															size="sm"
-															onClick={() => copyToClipboard(vk.value)}
+															onClick={() => {
+																// Not awaited: the clipboard write must not wait on the beacon.
+																reportVkAccess(vk.id, "copy");
+																copyToClipboard(vk.value);
+															}}
 															data-testid={`vk-copy-btn-${vk.name}`}
 														>
 															<Copy className="h-4 w-4" />


### PR DESCRIPTION
## Summary

Adds audit logging for virtual key reveal and copy actions. When a user reveals a virtual key or copies it to the clipboard, the event is recorded in the audit log. This is an enterprise-only feature; OSS builds use a no-op stub so the behavior is unchanged outside of enterprise environments.

## Changes

- Introduced a `useVirtualKeyAccessAudit` hook that fires an audit event for `"reveal"` or `"copy"` access kinds against a virtual key ID.
- Added an OSS fallback stub for `useVirtualKeyAccessAudit` that returns a no-op function, keeping OSS builds unaffected.
- Wired `reportVkAccess` into `toggleKeyVisibility` so that only the reveal edge (not re-hiding) is recorded as a disclosure.
- Wired `reportVkAccess` into the copy button's click handler. The audit beacon is intentionally not awaited so the clipboard write is not blocked.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Use an enterprise build.
2. Navigate to the Virtual Keys table.
3. Click the reveal icon on a virtual key — confirm an audit log entry is created with kind `"reveal"`.
4. Click the copy icon on a virtual key — confirm an audit log entry is created with kind `"copy"`.
5. Re-hide a revealed key — confirm no additional audit log entry is created.
6. On an OSS build, confirm reveal and copy actions work normally with no errors or audit entries.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [x] No

## Security considerations

Virtual key reveal and copy events are sensitive disclosures. Recording these in the audit log improves traceability of secret access. Care was taken to ensure the audit beacon does not block the clipboard write, and that re-hiding a key does not generate a spurious disclosure event.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable