### PR TITLE
fix(ui): replace hard-coded metric strip colours with theme tokens and stabilise strip height across loading states

### DIFF
--- a/ui/app/workspace/logs/views/metricStrip.tsx
+++ b/ui/app/workspace/logs/views/metricStrip.tsx
@@ -30,12 +30,15 @@ import {
 const positive = "text-[#16794f] dark:text-[#3fbd85]";
 const negative = "text-[#c0392b] dark:text-[#e8705f]";
 const warning = "text-[#d98324] dark:text-[#eaa14f]";
-const muted = "text-[#6f6f6a] dark:text-[#a5a5a0]";
-const label = "text-[#8b8b85] dark:text-[#9a9a94]";
-const value = "text-[#1a1a19] dark:text-[#f2f2f0]";
-const track = "bg-[#ededea] dark:bg-[#33332f]";
-const divider = "bg-[#ededea] dark:bg-[#33332f]";
-const surface = "bg-white dark:bg-[#1a1a19]";
+// The neutrals come from the theme tokens rather than the mock's own greys: the
+// strip sits inside a `bg-card` panel, and a hard-coded warm near-black surface
+// read as a foreign block against the app's cooler card colour in dark mode.
+const muted = "text-muted-foreground";
+const label = "text-muted-foreground";
+const value = "text-foreground";
+const track = "bg-muted";
+const divider = "bg-border";
+const surface = "bg-card";
 const fill = "bg-[#16794f] dark:bg-[#3fbd85]";
 const tokensIn = "bg-[#4c6fdc] dark:bg-[#7f9bf0]";
 const tokensOut = "bg-[#a8bcf2] dark:bg-[#c3d2f7]";
@@ -241,10 +244,15 @@ function Segment({
 			{/* NumberFlow reserves 0.25em above and below its digits for the mask that
 			    fades a rolling number in and out, which left 16px of dead space in a
 			    row whose line-height is already the type size. A shorter mask still
-			    fades the roll and gives the segment back that height. */}
+			    fades the roll and gives the segment back that height.
+
+			    The row is pinned to 1.5em - tall enough for the shortened mask and the
+			    trailing unit - so the placeholder dash occupies exactly the height the
+			    rendered figure will, and the strip does not resize when data lands. It
+			    stays a block (not a flex row) so `truncate` keeps working. */}
 			<div
 				className={cn(
-					"truncate font-mono text-[28px] leading-none font-medium tracking-[-0.02em]",
+					"h-[1.5em] truncate font-mono text-xl leading-[1.5em] font-medium tracking-[-0.02em] sm:text-2xl",
 					"[--number-flow-mask-height:0.15em]",
 					ready ? value : muted,
 				)}
@@ -254,14 +262,17 @@ function Segment({
 			</div>
 			{/* min-w-0 lets the trailing figure shrink rather than push past the
 			    segment's padding and collide with the divider. */}
-			<div className="flex min-w-0 items-center gap-2">{ready ? footer : null}</div>
+			{/* Fixed height so the strip does not grow when the footer shapes arrive -
+			    the placeholder state renders nothing here but must reserve the same
+			    row the sparklines and meters occupy. */}
+			<div className="flex h-4 min-w-0 items-center gap-2">{ready ? footer : null}</div>
 		</div>
 	);
 }
 
 /** The small unit that trails a value, e.g. the % in "68.27%". */
 function Unit({ children }: { children: React.ReactNode }) {
-	return <span className={cn("text-[18px]", label)}>{children}</span>;
+	return <span className={cn("text-base", label)}>{children}</span>;
 }
 
 function Trailing({ children, className }: { children: React.ReactNode; className: string }) {
@@ -367,7 +378,7 @@ export function MetricStrip({ stats, requestHistogram, latencyHistogram, costHis
 	return (
 		<Card
 			className={cn(
-				"shrink-0 overflow-hidden rounded-sm border-[#e4e4e0] py-0 shadow-[0_1px_2px_rgba(0,0,0,.03)] dark:border-[#33332f]",
+				"shrink-0 overflow-hidden rounded-sm py-0 shadow-none",
 				// gap-px over a divider-coloured surface renders the hairlines, so they
 				// stay correct at every breakpoint instead of relying on nth-child math.
 				"grid grid-cols-2 gap-px md:grid-cols-3 lg:grid-cols-6",

--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -251,15 +251,14 @@ const SidebarItemView = ({
 
 	const isHighlighted = !hasSubItems && highlightedUrl === item.url;
 
-	const buttonClassName = `group/nav-item relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${
-		isHighlighted
+	const buttonClassName = `group/nav-item relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${isHighlighted
 			? "bg-sidebar-accent text-accent-foreground border-primary/20"
 			: isActive || isAnySubItemActive
 				? "bg-sidebar-accent text-primary border-primary/20"
 				: item.hasAccess
 					? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
 					: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-	} `;
+		} `;
 
 	const innerContent = (
 		<div className="flex w-full items-center justify-between">
@@ -410,15 +409,14 @@ const SidebarItemView = ({
 						const isSubItemActive = subItem.queryParam ? pathname === subItem.url : isRouteMatch(subItem.url);
 						const isSubItemHighlighted = highlightedUrl ? subItemHref.startsWith(highlightedUrl) : false;
 						const SubItemIcon = subItem.icon;
-						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${
-							isSubItemHighlighted
+						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${isSubItemHighlighted
 								? "bg-sidebar-accent text-accent-foreground"
 								: isSubItemActive
 									? "bg-sidebar-accent text-primary font-medium"
 									: subItem.hasAccess === false
 										? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
 										: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
-						}`;
+							}`;
 						const subInner = (
 							<div className="flex w-full items-center gap-2">
 								{SubItemIcon && <SubItemIcon className={`h-3.5 w-3.5 ${isSubItemActive ? "text-primary" : "text-muted-foreground"}`} />}
@@ -960,21 +958,21 @@ export default function AppSidebar() {
 			},
 			...(isDbConnected
 				? [
-						{
-							title: "Prompt Repository",
-							url: "/workspace/prompt-repo",
-							icon: FolderGit,
-							description: "Prompt repository",
-							hasAccess: hasPromptRepositoryAccess,
-						},
-						{
-							title: "Skills Repository",
-							url: "/workspace/skills-repo",
-							icon: BookOpenText,
-							description: "Skills repository",
-							hasAccess: hasSkillsRepositoryAccess,
-						},
-					]
+					{
+						title: "Prompt Repository",
+						url: "/workspace/prompt-repo",
+						icon: FolderGit,
+						description: "Prompt repository",
+						hasAccess: hasPromptRepositoryAccess,
+					},
+					{
+						title: "Skills Repository",
+						url: "/workspace/skills-repo",
+						icon: BookOpenText,
+						description: "Skills repository",
+						hasAccess: hasSkillsRepositoryAccess,
+					},
+				]
 				: []),
 			{
 				title: "Settings",
@@ -1013,14 +1011,14 @@ export default function AppSidebar() {
 					},
 					...(IS_ENTERPRISE
 						? [
-								{
-									title: "Proxy",
-									url: "/workspace/config/proxy",
-									icon: Globe,
-									description: "Proxy configuration",
-									hasAccess: hasSettingsAccess,
-								},
-							]
+							{
+								title: "Proxy",
+								url: "/workspace/config/proxy",
+								icon: Globe,
+								description: "Proxy configuration",
+								hasAccess: hasSettingsAccess,
+							},
+						]
 						: []),
 					{
 						title: "API Keys",
@@ -1045,21 +1043,21 @@ export default function AppSidebar() {
 					},
 					...(IS_ENTERPRISE
 						? [
-								{
-									title: "Branding",
-									url: "/workspace/config/branding",
-									icon: Palette,
-									description: "Custom logo and icon",
-									hasAccess: hasSettingsAccess,
-								},
-								{
-									title: "License Info",
-									url: "/workspace/config/license",
-									icon: BadgeInfo,
-									description: "Enterprise license information",
-									hasAccess: hasSettingsAccess,
-								},
-							]
+							{
+								title: "Branding",
+								url: "/workspace/config/branding",
+								icon: Palette,
+								description: "Custom logo and icon",
+								hasAccess: hasSettingsAccess,
+							},
+							{
+								title: "License Info",
+								url: "/workspace/config/license",
+								icon: BadgeInfo,
+								description: "Enterprise license information",
+								hasAccess: hasSettingsAccess,
+							},
+						]
 						: []),
 				],
 			},
@@ -1500,7 +1498,7 @@ export default function AppSidebar() {
 				</div>
 			</div>
 			<SidebarContent className="overflow-hidden">
-				<SidebarGroup className="custom-scrollbar min-h-0 flex-1 overflow-y-auto pr-3">
+				<SidebarGroup className="custom-scrollbar min-h-0 flex-1 overflow-y-auto pr-3 pt-0.5">
 					<SidebarGroupContent>
 						<SidebarMenu className="space-y-0.5">
 							{filteredItems.map((item) => {


### PR DESCRIPTION
## Summary

Fixes visual inconsistencies in the metric strip component where hard-coded colour values caused the strip to appear as a foreign block against the app's card background in dark mode, and stabilises the strip's layout so it does not resize when data loads.

## Changes

- Replaced hard-coded warm neutral colours in `metricStrip.tsx` with theme tokens (`bg-card`, `bg-muted`, `bg-border`, `text-foreground`, `text-muted-foreground`) so the strip inherits the app's colour system correctly in both light and dark mode.
- Switched the `Card` wrapper from a custom border and shadow to `shadow-none`, letting the gap-based divider approach handle hairlines consistently.
- Pinned the value row to `h-[1.5em]` with `leading-[1.5em]` and made the font size responsive (`text-xl` / `sm:text-2xl`) so the strip does not shift in height when data arrives to replace the placeholder dash.
- Fixed the footer row to `h-4` so the strip does not grow when sparklines and meters render in place of the empty placeholder state.
- Changed the `Unit` trailing label from a fixed `text-[18px]` to `text-base` to stay consistent with the responsive value size.
- Added `pt-0.5` to the sidebar scroll group to give the top item a small breathing gap.
- Reformatted indentation in `sidebar.tsx` for conditional array spreads and template literal class name strings (no behaviour change).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

1. Open the workspace logs view.
2. Toggle between light and dark mode and confirm the metric strip background matches the surrounding card — no warm near-black block visible in dark mode.
3. Load the page before stats arrive and confirm the strip height does not change once data populates the segments.
4. Verify the sidebar top item is not clipped at the scroll boundary.

## Screenshots/Recordings

Before/after screenshots showing the metric strip in dark mode and the stable height behaviour when data loads are recommended.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable