### PR TITLE
fix(ui): fix logs page layout on small screens with scrolling fallback and header wrap fixes

### DIFF
--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -731,16 +731,20 @@ export default function LogsPage() {
 	);
 
 	return (
-		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))]">
+		// Below lg the strip, the volume chart and the table cannot all share one
+		// viewport-height column - the table collapses to a couple of rows. There the
+		// page itself scrolls and each section keeps its natural height; from lg up
+		// the fixed-height, inner-scrolling layout is untouched.
+		<div className="dark:bg-card no-padding-parent no-border-parent h-[calc(var(--app-content-viewport)_-_var(--app-bottom-padding))] overflow-y-auto lg:overflow-y-visible">
 			{showEmptyState ? (
 				<EmptyState error={error ?? (logsError ? getErrorMessage(logsError as Parameters<typeof getErrorMessage>[0]) : null)} />
 			) : (
-				<div className="bg-background flex h-full w-full grow gap-3">
+				<div className="bg-background flex min-h-full w-full grow gap-3 lg:h-full">
 					{/* Sidebar Filters */}
 					<LogsFilterSidebar filters={filters} onFiltersChange={setFilters} />
 
 					{/* Main Content */}
-					<div className="bg-card flex min-w-0 flex-1 flex-col gap-2 overflow-hidden rounded-md border p-4 pb-2">
+					<div className="bg-card flex min-w-0 flex-1 flex-col gap-2 rounded-md border p-4 pb-2 lg:overflow-hidden">
 						<div className="shrink-0">
 							<LogsHeaderView
 								filters={filters}
@@ -806,7 +810,10 @@ export default function LogsPage() {
 							</Alert>
 						)}
 
-						<div className="min-h-0 flex-1">
+						{/* The min-height is what makes the table usable on a scrolling page:
+						    without it the flex child shrinks to its content and the strip plus
+						    the chart leave it a few rows tall. */}
+						<div className="min-h-[28rem] flex-1 lg:min-h-0">
 							<LogsDataTable
 								columns={columns}
 								data={displayLogs}

--- a/ui/app/workspace/logs/views/logsHeaderView.tsx
+++ b/ui/app/workspace/logs/views/logsHeaderView.tsx
@@ -275,7 +275,10 @@ export function LogsHeaderView({
 	const isIdSearch = isLogIdSearch(localSearch);
 
 	return (
-		<div className="flex grow flex-wrap items-center justify-between gap-2">
+		// justify-between only once the row can hold everything: while the controls
+		// wrap, spreading them pushes the last row's two icon buttons to opposite
+		// edges of the card and burns a whole row on two buttons.
+		<div className="flex grow flex-wrap lg:flex-nowrap items-center justify-start gap-2 lg:justify-between">
 			<Button
 				data-testid="logs-refresh-btn"
 				variant="outline"
@@ -321,7 +324,9 @@ export function LogsHeaderView({
 					This grouped view may load more slowly than the flat view for very large log tables.
 				</TooltipContent>
 			</Tooltip>
-			<div className="border-input flex h-7.5 min-w-[12rem] flex-1 items-center gap-2 rounded-sm border">
+			{/* Full width while the row wraps, so the search field owns its own line
+			    instead of squeezing to its 12rem minimum beside the date picker. */}
+			<div className="border-input flex h-7.5 min-w-[12rem] flex-1 basis-full items-center gap-2 rounded-sm border lg:basis-auto">
 				<Search className="mr-0.5 ml-2 size-4" />
 				<Input
 					type="text"
@@ -346,7 +351,7 @@ export function LogsHeaderView({
 			</div>
 
 			<DateTimePickerWithRange
-				buttonClassName="w-full sm:w-auto"
+				buttonClassName="w-auto"
 				triggerTestId="filter-date-range"
 				dateTime={{ from: startTime, to: endTime }}
 				predefinedPeriod={period || undefined}


### PR DESCRIPTION
## Summary

The Logs page layout breaks on smaller viewports (below `lg`) because the fixed-height, inner-scrolling column causes the data table to collapse to only a few visible rows. This PR fixes the responsive behaviour so that below `lg` the page itself scrolls and each section takes its natural height, while the existing fixed-height layout is preserved at `lg` and above.

## Changes

- The outer page container now allows vertical scrolling below `lg` (`overflow-y-auto lg:overflow-y-visible`) and uses `min-h-full` instead of `h-full` on the inner flex container below `lg` so the card stretches to fill the page.
- The main content card removes `overflow-hidden` below `lg` so content is not clipped when the page scrolls.
- The table wrapper gets a `min-h-[28rem]` floor below `lg` so the table remains usable rather than shrinking to a handful of rows behind the strip and volume chart.
- In `LogsHeaderView`, the header row switches to `flex-nowrap` at `md` and defers `justify-between` until `lg`, preventing the two icon buttons from being spread to opposite edges of the card when controls wrap onto multiple lines.
- The search field gains `basis-full` below `lg` so it occupies its own line instead of squeezing to its 12rem minimum beside the date picker, reverting to `basis-auto` at `lg`.
- The date picker button's `w-full sm:w-auto` is simplified to `w-auto` since the search field now handles its own line independently.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the Logs page in a browser.
2. Resize the viewport below the `lg` breakpoint (~1024px).
3. Verify the page scrolls vertically and the data table is at least `28rem` tall and fully usable.
4. Verify the header controls wrap cleanly — the search field takes its own line and the icon buttons do not spread to opposite edges.
5. Resize back above `lg` and confirm the fixed-height, inner-scrolling layout is unchanged.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots at a viewport narrower than `lg` recommended to confirm the table height and header wrapping behaviour.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable