### PR TITLE
fix(ui): move sheet header padding from container to sticky header element across all sheets

### DIFF
--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -589,7 +589,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 	return (
 		<Sheet open={open} onOpenChange={(o) => (o ? onOpenChange(true) : handleCloseDrawer())}>
 			<SheetContent side="right" className="dark:bg-card flex w-full flex-col overflow-x-hidden bg-white p-0 pt-4 sm:max-w-2xl">
-				<SheetHeader className="flex flex-col items-start px-4 py-4 md:px-8" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+				<SheetHeader className="flex flex-col items-start py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-4 md:px-8">
 					<SheetTitle className="">{editingOverride ? "Edit Pricing Override" : "Create Pricing Override"}</SheetTitle>
 				</SheetHeader>
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -608,7 +608,7 @@ export default function MCPClientSheet({
 		<>
 			<Sheet open onOpenChange={(open) => !open && onClose()}>
 				<SheetContent className="flex w-full flex-col overflow-hidden! pt-4 sm:max-w-[60%]">
-					<SheetHeader className="w-full p-0 px-4 py-4 md:px-8" showCloseButton={false} headerClassName="mb-0 sticky -top-4 bg-card z-10">
+					<SheetHeader className="w-full p-0 py-4" showCloseButton={false} headerClassName="mb-0 sticky -top-4 bg-card z-10 px-4 md:px-8">
 						<div className="flex w-full items-center justify-between">
 							<div className="space-y-2">
 								<SheetTitle className="flex w-fit items-center gap-2 font-medium">

--- a/ui/app/workspace/model-catalog/views/attributeSheet.tsx
+++ b/ui/app/workspace/model-catalog/views/attributeSheet.tsx
@@ -197,7 +197,7 @@ export default function AttributeSheet({ model, overrides, onClose }: AttributeS
 				}}
 				data-testid="model-catalog-attribute-sheet"
 			>
-				<SheetHeader className="flex flex-col items-start p-0 px-4 py-4 md:px-8" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+				<SheetHeader className="flex flex-col items-start p-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-4 md:px-8">
 					<SheetTitle>Edit Model Attributes</SheetTitle>
 					<SheetDescription>
 						Update the description and other attributes for this model. These attributes are stored on the pricing row and preserved across

--- a/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitSheet.tsx
@@ -428,7 +428,7 @@ export default function ModelLimitSheet({ modelConfig, onSave, onCancel }: Model
 				}}
 				data-testid="model-limit-sheet"
 			>
-				<SheetHeader className="flex flex-col items-start p-0 px-4 py-4 md:px-8" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+				<SheetHeader className="flex flex-col items-start p-0 py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-4 md:px-8">
 					<SheetTitle>{isEditing ? "Edit Limit" : "Create Limit"}</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update budget and rate limit configuration." : "Set up budget and rate limits for a scope."}

--- a/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
+++ b/ui/app/workspace/plugins/sheets/addNewPluginSheet.tsx
@@ -150,7 +150,7 @@ export default function AddNewPluginSheet({ open, onClose, onCreate, plugin }: A
 	return (
 		<Sheet open={open} onOpenChange={handleClose}>
 			<SheetContent className="flex w-full flex-col overflow-x-hidden pt-4">
-				<SheetHeader className="flex flex-col items-start px-4 py-4 md:px-8" headerClassName="mb-0 sticky top-0 bg-card z-10">
+				<SheetHeader className="flex flex-col items-start py-4" headerClassName="mb-0 sticky top-0 bg-card z-10 px-4 md:px-8">
 					<SheetTitle>{isEditMode ? "Update Plugin" : "Install New Plugin"}</SheetTitle>
 					<SheetDescription>
 						{isEditMode

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -133,7 +133,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 
 	return (
 		<>
-			<SheetHeader className="flex shrink-0 flex-col items-start px-4 py-4 md:px-8" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+			<SheetHeader className="flex shrink-0 flex-col items-start py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-4 md:px-8">
 				<SheetTitle>Add Custom Provider</SheetTitle>
 				<SheetDescription>Enter the details of your custom provider.</SheetDescription>
 			</SheetHeader>

--- a/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewKeySheet.tsx
@@ -30,7 +30,7 @@ export default function AddNewKeySheet({ show, onCancel, provider, keyId, provid
 			}}
 		>
 			<SheetContent className="p-0 pt-4" data-testid="key-form" onInteractOutside={(e) => e.preventDefault()}>
-				<SheetHeader className="flex flex-col items-start px-4 py-4 md:px-8" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+				<SheetHeader className="flex flex-col items-start py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-4 md:px-8 ">
 					<SheetTitle>
 						<div className="font-lg flex items-center gap-2">
 							<div className={"flex items-center"}>

--- a/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/providerConfigSheet.tsx
@@ -97,7 +97,7 @@ export default function ProviderConfigSheet({ show, onCancel, provider }: Props)
 			}}
 		>
 			<SheetContent className="p-0 pt-4 sm:max-w-[50%]">
-				<SheetHeader className="flex flex-col items-start px-4 py-4 md:px-8" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+				<SheetHeader className="flex flex-col items-start py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-4 md:px-8">
 					<SheetTitle>
 						<div className="font-lg flex items-center gap-2">
 							<div className="flex items-center">

--- a/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
+++ b/ui/app/workspace/routing-rules/views/routingRuleSheet.tsx
@@ -328,7 +328,7 @@ export function RoutingRuleSheet({ open, onOpenChange, editingRule, onSuccess }:
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="flex w-full min-w-1/2 flex-col gap-4 overflow-x-hidden p-0 pt-4">
-				<SheetHeader className="flex flex-col items-start px-4 py-4 md:px-8" headerClassName="mb-0 sticky -top-4 bg-card z-10">
+				<SheetHeader className="flex flex-col items-start py-4" headerClassName="mb-0 sticky -top-4 bg-card z-10 px-4 md:px-8">
 					<SheetTitle>{isEditing ? "Edit Routing Rule" : "Create New Routing Rule"}</SheetTitle>
 					<SheetDescription>
 						{isEditing ? "Update the routing rule configuration" : "Create a new CEL-based routing rule for intelligent request routing"}

--- a/ui/components/prompts/sheets/promptSheet.tsx
+++ b/ui/components/prompts/sheets/promptSheet.tsx
@@ -78,7 +78,7 @@ export function PromptSheet({ open, onOpenChange, prompt, folderId, onSaved }: P
 				}}
 			>
 				<form onSubmit={handleSubmit(onSubmit)} className="flex grow flex-col">
-					<SheetHeader className="flex flex-col items-start px-4 pt-8 md:px-8">
+					<SheetHeader className="flex flex-col items-start pt-8" headerClassName="px-4 md:px-8">
 						<SheetTitle>{isEditing ? "Rename Prompt" : "Create Prompt"}</SheetTitle>
 						<SheetDescription>
 							{isEditing ? "Update the prompt name." : folderId ? "Create a new prompt in this folder." : "Create a new prompt."}


### PR DESCRIPTION
## Summary

Fixes sticky sheet headers that were losing their horizontal padding when scrolling. The padding was applied to the outer `SheetHeader` wrapper instead of the sticky inner header element, causing the header to appear without padding as it stuck to the top during scroll.

## Changes

- Moved `px-4 md:px-8` from the outer `className` prop to the `headerClassName` prop on `SheetHeader` across all affected sheets, ensuring the sticky header retains its horizontal padding when pinned during scroll.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Open any of the affected sheets (e.g., Pricing Override, MCP Client, Model Limits, Routing Rules, Provider Config, etc.) and scroll down within the sheet. Verify that the sticky header maintains consistent horizontal padding and does not appear flush against the edges when pinned.

## Screenshots/Recordings

Before/after screenshots showing the sticky header with and without correct padding when scrolled.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable