### PR TITLE
feat: wire in endpoint support in direct MCP servers

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -439,6 +439,7 @@ func (c *MCPTokenExchangeConfig) DiffersFrom(resolved *MCPTokenExchangeConfig) b
 type MCPClientConfig struct {
 	ID                string            `json:"client_id"`                     // Client ID
 	Name              string            `json:"name"`                          // Client name
+	EndpointSlug      string            `json:"endpoint_slug"`                 // URL-safe, immutable; serves /mcp/<slug>
 	IsCodeModeClient  bool              `json:"is_code_mode_client"`           // Whether the client is a code mode client
 	ConnectionType    MCPConnectionType `json:"connection_type"`               // How to connect (HTTP, STDIO, SSE, or InProcess)
 	ConnectionString  *SecretVar        `json:"connection_string,omitempty"`   // HTTP or SSE URL (required for HTTP or SSE connections)

--- a/framework/configstore/errors.go
+++ b/framework/configstore/errors.go
@@ -9,10 +9,16 @@ import (
 var ErrNotFound = errors.New("not found")
 var ErrAlreadyExists = errors.New("already exists")
 
-// ErrVirtualMCPEndpointExists is returned by CreateVirtualMCP when the resolved endpoint slug is
-// already taken, so callers can answer with a clear message and a 409. (Name uniqueness is left to
-// the table's own unique index and surfaces as a generic unique-constraint error.)
-var ErrVirtualMCPEndpointExists = errors.New("a virtual MCP with this endpoint already exists")
+// ErrMCPEndpointSlugExists is returned when a create resolves an endpoint slug already used by a
+// Virtual MCP or an MCP client. Both serve at /mcp/<slug>, so the slug namespace is shared; callers
+// answer with a clear message and a 409. (Name uniqueness is left to each table's own unique index
+// and surfaces as a generic unique-constraint error.)
+var ErrMCPEndpointSlugExists = errors.New("an MCP endpoint with this slug already exists")
+
+// ErrMCPEndpointSlugInvalid is returned when a create cannot derive an endpoint slug (the name
+// slugifies to empty and no endpoint_slug was supplied). It is caller input, so handlers map it
+// to a 400 rather than a 500.
+var ErrMCPEndpointSlugInvalid = errors.New("could not derive an MCP endpoint slug; provide an endpoint_slug")
 
 // ErrVirtualKeyAccessProfileManaged is returned by AttachVirtualMCPToVirtualKey (enterprise) when the
 // target virtual key is managed by an access profile: its MCP access is governed by the profile, so it

--- a/framework/configstore/mcpclient_endpoint_slug_test.go
+++ b/framework/configstore/mcpclient_endpoint_slug_test.go
@@ -1,0 +1,100 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateMCPClientConfig_WritesBackDerivedSlug pins that CreateMCPClientConfig sets the derived slug
+// on the caller's config, so the in-memory registration (which reuses that pointer) serves /mcp/<slug>
+// immediately rather than only after a restart.
+func TestCreateMCPClientConfig_WritesBackDerivedSlug(t *testing.T) {
+	s := setupRDBTestStore(t)
+	cfg := &schemas.MCPClientConfig{
+		ID: "c1", Name: "My Client", ConnectionType: schemas.MCPConnectionTypeHTTP,
+		ConnectionString: schemas.NewSecretVar("https://example.invalid/mcp"),
+	}
+	require.NoError(t, s.CreateMCPClientConfig(context.Background(), cfg))
+	assert.Equal(t, "my-client", cfg.EndpointSlug, "the derived slug is written back to the caller's config")
+}
+
+// TestCreateMCPClientConfig_RejectsUnderivableSlug pins that a name slugifying to empty (with no
+// endpoint_slug) is rejected with a typed error, so handlers can map invalid input to a 400.
+func TestCreateMCPClientConfig_RejectsUnderivableSlug(t *testing.T) {
+	s := setupRDBTestStore(t)
+	err := s.CreateMCPClientConfig(context.Background(), &schemas.MCPClientConfig{
+		ID: "c1", Name: "***",
+		ConnectionType: schemas.MCPConnectionTypeHTTP, ConnectionString: schemas.NewSecretVar("https://x.invalid/mcp"),
+	})
+	assert.ErrorIs(t, err, ErrMCPEndpointSlugInvalid)
+}
+
+// TestCreateVirtualMCP_RejectsUnderivableSlug pins the same typed-error contract on the Virtual MCP
+// side: a name slugifying to empty (with no endpoint_slug) returns ErrMCPEndpointSlugInvalid so
+// handlers can map it to a 400.
+func TestCreateVirtualMCP_RejectsUnderivableSlug(t *testing.T) {
+	s := setupRDBTestStore(t)
+	err := s.CreateVirtualMCP(context.Background(), &tables.TableVirtualMCP{Name: "***", Enabled: true})
+	assert.ErrorIs(t, err, ErrMCPEndpointSlugInvalid)
+}
+
+// TestCreateMCPClientConfig_RejectsSlugTakenByVirtualMCP pins the cross-entity rule from the client
+// side: a client cannot take an endpoint slug a Virtual MCP already serves (shared /mcp/<slug> space).
+func TestCreateMCPClientConfig_RejectsSlugTakenByVirtualMCP(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Shared", EndpointSlug: "shared", Enabled: true}))
+
+	err := s.CreateMCPClientConfig(ctx, &schemas.MCPClientConfig{
+		ID: "c1", Name: "Shared Client", EndpointSlug: "shared",
+		ConnectionType: schemas.MCPConnectionTypeHTTP, ConnectionString: schemas.NewSecretVar("https://x.invalid/mcp"),
+	})
+	assert.ErrorIs(t, err, ErrMCPEndpointSlugExists)
+}
+
+// TestCreateVirtualMCP_RejectsSlugTakenByMCPClient pins the same rule from the Virtual MCP side: a
+// Virtual MCP cannot take an endpoint slug an MCP client already serves.
+func TestCreateVirtualMCP_RejectsSlugTakenByMCPClient(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+	require.NoError(t, s.CreateMCPClientConfig(ctx, &schemas.MCPClientConfig{
+		ID: "c1", Name: "Alpha", EndpointSlug: "alpha",
+		ConnectionType: schemas.MCPConnectionTypeHTTP, ConnectionString: schemas.NewSecretVar("https://x.invalid/mcp"),
+	}))
+
+	err := s.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Alpha Group", EndpointSlug: "alpha", Enabled: true})
+	assert.ErrorIs(t, err, ErrMCPEndpointSlugExists)
+}
+
+// TestBackfillMCPClientEndpointSlugs_FromName pins that a slug-less client gets a slug derived from
+// its name.
+func TestBackfillMCPClientEndpointSlugs_FromName(t *testing.T) {
+	db := setupRDBTestStore(t).DB().WithContext(context.Background())
+	require.NoError(t, db.Create(&tables.TableMCPClient{ClientID: "c1", Name: "My Client", ConnectionType: "stdio"}).Error)
+
+	require.NoError(t, backfillMCPClientEndpointSlugs(db))
+
+	var got tables.TableMCPClient
+	require.NoError(t, db.Where("client_id = ?", "c1").First(&got).Error)
+	assert.Equal(t, "my-client", got.EndpointSlug)
+}
+
+// TestBackfillMCPClientEndpointSlugs_SeedsFromVirtualMCPs pins the cross-entity rule: a client whose
+// name slugifies to a slug a Virtual MCP already owns is suffixed, since both share /mcp/<slug>.
+func TestBackfillMCPClientEndpointSlugs_SeedsFromVirtualMCPs(t *testing.T) {
+	db := setupRDBTestStore(t).DB().WithContext(context.Background())
+	require.NoError(t, db.Create(&tables.TableVirtualMCP{Name: "Shared Tool", EndpointSlug: "shared-tool", Enabled: true}).Error)
+	require.NoError(t, db.Create(&tables.TableMCPClient{ClientID: "c1", Name: "Shared Tool", ConnectionType: "stdio"}).Error)
+
+	require.NoError(t, backfillMCPClientEndpointSlugs(db))
+
+	var got tables.TableMCPClient
+	require.NoError(t, db.Where("client_id = ?", "c1").First(&got).Error)
+	assert.NotEmpty(t, got.EndpointSlug, "backfill assigns a slug")
+	assert.NotEqual(t, "shared-tool", got.EndpointSlug, "must not collide with the Virtual MCP's slug")
+}

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -487,6 +487,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_mcp_oauth_token_status_reason_column"}, run: migrationAddMCPOauthTokenStatusReasonColumn},
 	{IDs: []string{"add_databricks_key_config_columns"}, run: migrationAddDatabricksKeyConfigColumns},
 	{IDs: []string{"add_github_copilot_config_columns"}, run: migrationAddGithubCopilotConfigColumns},
+	{IDs: []string{"add_mcp_client_endpoint_slug"}, run: migrationAddMCPClientEndpointSlug},
 }
 
 // videoResolutionPricingColumns are the resolution-banded video output rate columns.
@@ -1905,7 +1906,7 @@ func backfillVirtualMCPEndpointSlugs(tx *gorm.DB) error {
 	}
 
 	for i := range rows {
-		slug := uniqueVirtualMCPSlug(VirtualMCPSlugify(rows[i].Name), rows[i].ID, taken)
+		slug := uniqueSlug(Slugify(rows[i].Name), fmt.Sprintf("vmcp-%d", rows[i].ID), taken)
 		taken[slug] = true
 		if err := tx.Model(&tables.TableVirtualMCP{}).
 			Where("id = ?", rows[i].ID).
@@ -1916,9 +1917,102 @@ func backfillVirtualMCPEndpointSlugs(tx *gorm.DB) error {
 	return nil
 }
 
-// VirtualMCPSlugify lowercases a name and collapses non-alphanumeric runs to
-// single hyphens, trimmed at the ends.
-func VirtualMCPSlugify(name string) string {
+// migrationAddMCPClientEndpointSlug adds and backfills endpoint_slug on config_mcp_clients. Runs after
+// add_virtual_mcp_tables so the backfill can seed uniqueness from existing Virtual MCP slugs.
+func migrationAddMCPClientEndpointSlug(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_mcp_client_endpoint_slug"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	// Column + backfill run transactionally; the backfill must de-duplicate before the unique index.
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &tables.TableMCPClient{}, "endpoint_slug"); err != nil {
+				return fmt.Errorf("failed to add endpoint_slug column: %w", err)
+			}
+			if err := backfillMCPClientEndpointSlugs(tx); err != nil {
+				return fmt.Errorf("failed to backfill MCP client endpoint slugs: %w", err)
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running db migration: %s", err.Error())
+	}
+	// The unique index is built non-transactionally (UseTransaction=false) with CREATE UNIQUE INDEX
+	// CONCURRENTLY on postgres so it does not take a ShareLock that blocks writes to
+	// config_mcp_clients for the duration of the build. SQLite does not support CONCURRENTLY, so it
+	// uses the plain form. Idempotent via IF NOT EXISTS. The name matches gorm's uniqueIndex tag.
+	noTxOpts := *migrator.DefaultOptions
+	noTxOpts.UseTransaction = false
+	if err := RunSingleMigration(ctx, &noTxOpts, db, logger, &migrator.Migration{
+		ID: migrationName + "_index",
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			var stmt string
+			if tx.Dialector.Name() == "sqlite" {
+				stmt = "CREATE UNIQUE INDEX IF NOT EXISTS idx_config_mcp_clients_endpoint_slug ON config_mcp_clients (endpoint_slug)"
+			} else {
+				stmt = "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS idx_config_mcp_clients_endpoint_slug ON config_mcp_clients (endpoint_slug)"
+			}
+			return tx.Exec(stmt).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return tx.Exec(`DROP INDEX IF EXISTS idx_config_mcp_clients_endpoint_slug`).Error
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to create endpoint_slug index: %w", err)
+	}
+	return nil
+}
+
+// backfillMCPClientEndpointSlugs gives every slug-less MCP client a unique slug from its name. The
+// taken-set includes existing Virtual MCP slugs, since both serve at /mcp/<slug>. No-ops on a fresh table.
+func backfillMCPClientEndpointSlugs(tx *gorm.DB) error {
+	var rows []tables.TableMCPClient
+	if err := tx.Where("endpoint_slug IS NULL OR endpoint_slug = ?", "").Find(&rows).Error; err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	taken := map[string]bool{}
+	var clientSlugs, vmcpSlugs []string
+	if err := tx.Model(&tables.TableMCPClient{}).
+		Where("endpoint_slug IS NOT NULL AND endpoint_slug <> ?", "").
+		Pluck("endpoint_slug", &clientSlugs).Error; err != nil {
+		return err
+	}
+	if err := tx.Model(&tables.TableVirtualMCP{}).
+		Where("endpoint_slug IS NOT NULL AND endpoint_slug <> ?", "").
+		Pluck("endpoint_slug", &vmcpSlugs).Error; err != nil {
+		return err
+	}
+	for _, s := range clientSlugs {
+		taken[s] = true
+	}
+	for _, s := range vmcpSlugs {
+		taken[s] = true
+	}
+
+	for i := range rows {
+		slug := uniqueSlug(Slugify(rows[i].Name), fmt.Sprintf("mcp-%d", rows[i].ID), taken)
+		taken[slug] = true
+		if err := tx.Model(&tables.TableMCPClient{}).
+			Where("id = ?", rows[i].ID).
+			Update("endpoint_slug", slug).Error; err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Slugify lowercases a name and collapses non-alphanumeric runs to single
+// hyphens, trimmed at the ends.
+func Slugify(name string) string {
 	var b strings.Builder
 	prevHyphen := false
 	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
@@ -1935,11 +2029,11 @@ func VirtualMCPSlugify(name string) string {
 	return strings.Trim(b.String(), "-")
 }
 
-// uniqueVirtualMCPSlug returns base, a numbered variant if taken, or an
-// id-based slug if base is empty.
-func uniqueVirtualMCPSlug(base string, id uint, taken map[string]bool) string {
+// uniqueSlug returns base, a numbered variant if base is taken, or fallback
+// (then numbered) when base is empty. taken records slugs already in use.
+func uniqueSlug(base, fallback string, taken map[string]bool) string {
 	if base == "" {
-		base = fmt.Sprintf("vmcp-%d", id)
+		base = fallback
 	}
 	if !taken[base] {
 		return base

--- a/framework/configstore/migrations_test.go
+++ b/framework/configstore/migrations_test.go
@@ -130,6 +130,7 @@ func TestFindUniqueName_NoCollision(t *testing.T) {
 	client := &tables.TableMCPClient{
 		Name:           "existing_client",
 		ClientID:       "client-1",
+		EndpointSlug:   "client-1",
 		ConnectionType: "stdio",
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
@@ -157,6 +158,7 @@ func TestFindUniqueName_WithCollision(t *testing.T) {
 	client1 := &tables.TableMCPClient{
 		Name:           "my_tool",
 		ClientID:       "client-1",
+		EndpointSlug:   "client-1",
 		ConnectionType: "stdio",
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
@@ -168,6 +170,7 @@ func TestFindUniqueName_WithCollision(t *testing.T) {
 	client2 := &tables.TableMCPClient{
 		Name:           "my_tool1",
 		ClientID:       "client-2",
+		EndpointSlug:   "client-2",
 		ConnectionType: "stdio",
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
@@ -195,6 +198,7 @@ func TestFindUniqueName_MultipleCollisions(t *testing.T) {
 	client1 := &tables.TableMCPClient{
 		Name:           "test_tool",
 		ClientID:       "client-1",
+		EndpointSlug:   "client-1",
 		ConnectionType: "stdio",
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
@@ -205,6 +209,7 @@ func TestFindUniqueName_MultipleCollisions(t *testing.T) {
 	client2 := &tables.TableMCPClient{
 		Name:           "test_tool1",
 		ClientID:       "client-2",
+		EndpointSlug:   "client-2",
 		ConnectionType: "stdio",
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
@@ -215,6 +220,7 @@ func TestFindUniqueName_MultipleCollisions(t *testing.T) {
 	client3 := &tables.TableMCPClient{
 		Name:           "test_tool2",
 		ClientID:       "client-3",
+		EndpointSlug:   "client-3",
 		ConnectionType: "stdio",
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
@@ -241,6 +247,7 @@ func TestFindUniqueName_NormalizationAndCollision(t *testing.T) {
 	client := &tables.TableMCPClient{
 		Name:           "my_tool",
 		ClientID:       "client-1",
+		EndpointSlug:   "client-1",
 		ConnectionType: "stdio",
 		CreatedAt:      time.Now(),
 		UpdatedAt:      time.Now(),
@@ -289,6 +296,7 @@ func TestFindUniqueName_MultipleNormalizationsToSameBase(t *testing.T) {
 		{
 			Name:           "mcp client",
 			ClientID:       "client-1",
+			EndpointSlug:   "client-1",
 			ConnectionType: "stdio",
 			CreatedAt:      time.Now(),
 			UpdatedAt:      time.Now(),
@@ -296,6 +304,7 @@ func TestFindUniqueName_MultipleNormalizationsToSameBase(t *testing.T) {
 		{
 			Name:           "mcp-client",
 			ClientID:       "client-2",
+			EndpointSlug:   "client-2",
 			ConnectionType: "stdio",
 			CreatedAt:      time.Now(),
 			UpdatedAt:      time.Now(),
@@ -303,6 +312,7 @@ func TestFindUniqueName_MultipleNormalizationsToSameBase(t *testing.T) {
 		{
 			Name:           "1mcp-client",
 			ClientID:       "client-3",
+			EndpointSlug:   "client-3",
 			ConnectionType: "stdio",
 			CreatedAt:      time.Now(),
 			UpdatedAt:      time.Now(),
@@ -392,6 +402,7 @@ func TestFindUniqueName_MigrationScenarioWithInMemoryTracking(t *testing.T) {
 		{
 			Name:           "mcp client",
 			ClientID:       "client-1",
+			EndpointSlug:   "client-1",
 			ConnectionType: "stdio",
 			CreatedAt:      time.Now(),
 			UpdatedAt:      time.Now(),
@@ -399,6 +410,7 @@ func TestFindUniqueName_MigrationScenarioWithInMemoryTracking(t *testing.T) {
 		{
 			Name:           "mcp-client",
 			ClientID:       "client-2",
+			EndpointSlug:   "client-2",
 			ConnectionType: "stdio",
 			CreatedAt:      time.Now(),
 			UpdatedAt:      time.Now(),
@@ -406,6 +418,7 @@ func TestFindUniqueName_MigrationScenarioWithInMemoryTracking(t *testing.T) {
 		{
 			Name:           "1mcp-client",
 			ClientID:       "client-3",
+			EndpointSlug:   "client-3",
 			ConnectionType: "stdio",
 			CreatedAt:      time.Now(),
 			UpdatedAt:      time.Now(),

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -1608,6 +1608,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 				clientConfigs[i] = &schemas.MCPClientConfig{
 					ID:                        dbClient.ClientID,
 					Name:                      dbClient.Name,
+					EndpointSlug:              dbClient.EndpointSlug,
 					IsCodeModeClient:          dbClient.IsCodeModeClient,
 					ConnectionType:            schemas.MCPConnectionType(dbClient.ConnectionType),
 					ConnectionString:          dbClient.ConnectionString,
@@ -1659,6 +1660,7 @@ func (s *RDBConfigStore) GetMCPConfig(ctx context.Context) (*schemas.MCPConfig, 
 		clientConfigs[i] = &schemas.MCPClientConfig{
 			ID:                        dbClient.ClientID,
 			Name:                      dbClient.Name,
+			EndpointSlug:              dbClient.EndpointSlug,
 			IsCodeModeClient:          dbClient.IsCodeModeClient,
 			ConnectionType:            schemas.MCPConnectionType(dbClient.ConnectionType),
 			ConnectionString:          dbClient.ConnectionString,
@@ -2096,6 +2098,7 @@ func (s *RDBConfigStore) GetMCPClientConfigByID(ctx context.Context, id string) 
 	return &schemas.MCPClientConfig{
 		ID:                        dbClient.ClientID,
 		Name:                      dbClient.Name,
+		EndpointSlug:              dbClient.EndpointSlug,
 		IsCodeModeClient:          dbClient.IsCodeModeClient,
 		ConnectionType:            schemas.MCPConnectionType(dbClient.ConnectionType),
 		ConnectionString:          dbClient.ConnectionString,
@@ -2225,6 +2228,23 @@ func (s *RDBConfigStore) ClearMCPClientPendingOAuthConfig(ctx context.Context, c
 
 // CreateMCPClientConfig creates a new MCP client configuration in the database.
 func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig *schemas.MCPClientConfig) error {
+	// Derive the slug (caller's, else name) and reject a cross-entity collision. Immutable after create.
+	// Checked before the transaction so the read isn't on the write connection (matters for SQLite tests).
+	base := clientConfig.EndpointSlug
+	if base == "" {
+		base = clientConfig.Name
+	}
+	endpointSlug := Slugify(base)
+	if endpointSlug == "" {
+		return ErrMCPEndpointSlugInvalid
+	}
+	if taken, err := s.MCPEndpointSlugTaken(ctx, endpointSlug); err != nil {
+		return err
+	} else if taken {
+		return ErrMCPEndpointSlugExists
+	}
+	// Write the slug back so the in-memory registration serves /mcp/<slug> without a restart.
+	clientConfig.EndpointSlug = endpointSlug
 	return s.DB().Transaction(func(tx *gorm.DB) error {
 		// Check if a client with the same name already exists
 		if _, err := s.GetMCPClientByName(ctx, clientConfig.Name); err == nil {
@@ -2244,6 +2264,7 @@ func (s *RDBConfigStore) CreateMCPClientConfig(ctx context.Context, clientConfig
 		dbClient := tables.TableMCPClient{
 			ClientID:               clientConfigCopy.ID,
 			Name:                   clientConfigCopy.Name,
+			EndpointSlug:           endpointSlug,
 			IsCodeModeClient:       clientConfigCopy.IsCodeModeClient,
 			ConnectionType:         string(clientConfigCopy.ConnectionType),
 			ConnectionString:       clientConfigCopy.ConnectionString,
@@ -4501,7 +4522,7 @@ func (s *RDBConfigStore) GetVirtualMCPAssignments(ctx context.Context) (map[stri
 }
 
 // CreateVirtualMCP inserts a Virtual MCP. The endpoint_slug is taken from the caller's slug when set,
-// else derived from the name; a slug collision is reported as ErrVirtualMCPEndpointExists rather than
+// else derived from the name; a slug collision is reported as ErrMCPEndpointSlugExists rather than
 // auto-suffixed. Name uniqueness is left to the table's own unique index.
 func (s *RDBConfigStore) CreateVirtualMCP(ctx context.Context, def *tables.TableVirtualMCP) error {
 	db := s.DB().WithContext(ctx)
@@ -4509,15 +4530,15 @@ func (s *RDBConfigStore) CreateVirtualMCP(ctx context.Context, def *tables.Table
 	if base == "" {
 		base = def.Name
 	}
-	def.EndpointSlug = VirtualMCPSlugify(base)
+	def.EndpointSlug = Slugify(base)
 	if def.EndpointSlug == "" {
-		return errors.New("could not derive an endpoint from the name; provide an endpoint_slug")
+		return ErrMCPEndpointSlugInvalid
 	}
 
-	if taken, err := s.virtualMCPSlugTaken(ctx, def.EndpointSlug, 0); err != nil {
+	if taken, err := s.MCPEndpointSlugTaken(ctx, def.EndpointSlug); err != nil {
 		return err
 	} else if taken {
-		return ErrVirtualMCPEndpointExists
+		return ErrMCPEndpointSlugExists
 	}
 
 	// Capture intent before Create: enabled has a default:true, which gorm applies to a false and
@@ -4526,8 +4547,8 @@ func (s *RDBConfigStore) CreateVirtualMCP(ctx context.Context, def *tables.Table
 	return db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(def).Error; err != nil {
 			if isUniqueConstraintError(err) {
-				if taken, checkErr := s.virtualMCPSlugTaken(ctx, def.EndpointSlug, 0); checkErr == nil && taken {
-					return ErrVirtualMCPEndpointExists
+				if taken, checkErr := s.MCPEndpointSlugTaken(ctx, def.EndpointSlug); checkErr == nil && taken {
+					return ErrMCPEndpointSlugExists
 				}
 			}
 			return err
@@ -4539,15 +4560,21 @@ func (s *RDBConfigStore) CreateVirtualMCP(ctx context.Context, def *tables.Table
 	})
 }
 
-// virtualMCPSlugTaken reports whether another row (excluding excludeID) has the same endpoint_slug.
-func (s *RDBConfigStore) virtualMCPSlugTaken(ctx context.Context, slug string, excludeID uint) (bool, error) {
-	q := s.DB().WithContext(ctx).Model(&tables.TableVirtualMCP{}).Where("endpoint_slug = ?", slug)
-	if excludeID != 0 {
-		q = q.Where("id <> ?", excludeID)
-	}
+// MCPEndpointSlugTaken reports whether a Virtual MCP or MCP client already uses the slug, across both
+// tables (the /mcp/<slug> namespace is shared). Create-time check: no self-exclusion.
+func (s *RDBConfigStore) MCPEndpointSlugTaken(ctx context.Context, slug string) (bool, error) {
+	db := s.DB().WithContext(ctx)
 	var count int64
-	err := q.Count(&count).Error
-	return count > 0, err
+	if err := db.Model(&tables.TableVirtualMCP{}).Where("endpoint_slug = ?", slug).Count(&count).Error; err != nil {
+		return false, err
+	}
+	if count > 0 {
+		return true, nil
+	}
+	if err := db.Model(&tables.TableMCPClient{}).Where("endpoint_slug = ?", slug).Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
 }
 
 func (s *RDBConfigStore) GetVirtualMCPByID(ctx context.Context, id uint) (*tables.TableVirtualMCP, error) {

--- a/framework/configstore/rdb_mcp_sessions_test.go
+++ b/framework/configstore/rdb_mcp_sessions_test.go
@@ -274,9 +274,9 @@ func TestGetOauthUserSessionByModeIdentityAndMCPClient_AdminMode(t *testing.T) {
 	store := setupMCPSessionsTestStore(t)
 	ctx := context.Background()
 
-	client1 := &tables.TableMCPClient{ClientID: "mcp-1", Name: "MCP One", ConnectionType: "stdio"}
-	client2 := &tables.TableMCPClient{ClientID: "mcp-2", Name: "MCP Two", ConnectionType: "stdio"}
-	client3 := &tables.TableMCPClient{ClientID: "mcp-3", Name: "MCP Three", ConnectionType: "stdio"}
+	client1 := &tables.TableMCPClient{ClientID: "mcp-1", Name: "MCP One", EndpointSlug: "mcp-1", ConnectionType: "stdio"}
+	client2 := &tables.TableMCPClient{ClientID: "mcp-2", Name: "MCP Two", EndpointSlug: "mcp-2", ConnectionType: "stdio"}
+	client3 := &tables.TableMCPClient{ClientID: "mcp-3", Name: "MCP Three", EndpointSlug: "mcp-3", ConnectionType: "stdio"}
 	require.NoError(t, store.DB().WithContext(ctx).Create(client1).Error)
 	require.NoError(t, store.DB().WithContext(ctx).Create(client2).Error)
 	require.NoError(t, store.DB().WithContext(ctx).Create(client3).Error)

--- a/framework/configstore/rdb_oauth2_test.go
+++ b/framework/configstore/rdb_oauth2_test.go
@@ -85,7 +85,7 @@ func seedExpiringTokenFixtures(t *testing.T, s *RDBConfigStore) (mkToken func(id
 	}
 	mkClient = func(name, oauthConfigID string, disabled bool) {
 		require.NoError(t, s.DB().Create(&tables.TableMCPClient{
-			ClientID: "cid-" + name, Name: name, ConnectionType: "http",
+			ClientID: "cid-" + name, Name: name, EndpointSlug: "cid-" + name, ConnectionType: "http",
 			AuthType: "oauth", OauthConfigID: &oauthConfigID, Disabled: disabled,
 			CreatedAt: time.Now(), UpdatedAt: time.Now(),
 		}).Error)

--- a/framework/configstore/rdb_test.go
+++ b/framework/configstore/rdb_test.go
@@ -67,6 +67,10 @@ func setupRDBTestStore(t *testing.T) *RDBConfigStore {
 	)
 	require.NoError(t, err, "Failed to migrate test database")
 
+	// Virtual MCP tables (separate call: the in-batch AutoMigrate above does not create
+	// enterprise_mcp_tool_groups reliably). MCP client create now cross-checks slugs against them.
+	require.NoError(t, db.AutoMigrate(&tables.TableVirtualMCP{}, &tables.TableVirtualKeyVirtualMCP{}), "Failed to migrate virtual MCP tables")
+
 	// Setup join table
 	err = db.SetupJoinTable(&tables.TableVirtualKeyProviderConfig{}, "Keys", &tables.TableVirtualKeyProviderConfigKey{})
 	require.NoError(t, err, "Failed to setup join table")

--- a/framework/configstore/tables/mcp.go
+++ b/framework/configstore/tables/mcp.go
@@ -16,6 +16,7 @@ type TableMCPClient struct {
 	ID                      uint               `gorm:"primaryKey;autoIncrement" json:"id"` // ID is used as the internal primary key and is also accessed by public methods, so it must be present.
 	ClientID                string             `gorm:"type:varchar(255);uniqueIndex;not null" json:"client_id"`
 	Name                    string             `gorm:"type:varchar(255);uniqueIndex;not null" json:"name"`
+	EndpointSlug            string             `gorm:"column:endpoint_slug;type:varchar(255);uniqueIndex" json:"endpoint_slug"`
 	IsCodeModeClient        bool               `gorm:"default:false" json:"is_code_mode_client"`         // Whether the client is a code mode client
 	ConnectionType          string             `gorm:"type:varchar(20);not null" json:"connection_type"` // schemas.MCPConnectionType
 	ConnectionString        *schemas.SecretVar `gorm:"type:text" json:"connection_string,omitempty"`

--- a/framework/configstore/virtualmcp_crud_test.go
+++ b/framework/configstore/virtualmcp_crud_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 func setupVirtualMCPTestStore(t *testing.T) *RDBConfigStore {
-	store := setupRDBTestStore(t)
-	require.NoError(t, store.DB().AutoMigrate(&tables.TableVirtualMCP{}, &tables.TableVirtualKeyVirtualMCP{}))
-	return store
+	// setupRDBTestStore already migrates the Virtual MCP tables.
+	return setupRDBTestStore(t)
 }
 
 func vmcpSpec(clientID string, tools ...string) tables.MCPToolSpec {
@@ -44,7 +43,7 @@ func TestVirtualMCP_RejectsExactDuplicateName(t *testing.T) {
 
 	err := store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Engineering", EndpointSlug: "eng-b", Enabled: true})
 	assert.Error(t, err, "the pre-existing name unique index still rejects an exact duplicate name")
-	assert.NotErrorIs(t, err, ErrVirtualMCPEndpointExists, "a name collision must not be mislabeled as an endpoint conflict")
+	assert.NotErrorIs(t, err, ErrMCPEndpointSlugExists, "a name collision must not be mislabeled as an endpoint conflict")
 }
 
 func TestVirtualMCP_CaseVariantNamesCoexistWithDistinctEndpoints(t *testing.T) {
@@ -65,7 +64,7 @@ func TestVirtualMCP_RejectsDuplicateEndpoint(t *testing.T) {
 	require.NoError(t, store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Support (Legacy)", Enabled: true}))
 
 	err := store.CreateVirtualMCP(ctx, &tables.TableVirtualMCP{Name: "Support - Legacy", Enabled: true})
-	assert.ErrorIs(t, err, ErrVirtualMCPEndpointExists, "distinct names may still collide on endpoint, and that is rejected")
+	assert.ErrorIs(t, err, ErrMCPEndpointSlugExists, "distinct names may still collide on endpoint, and that is rejected")
 }
 
 func TestVirtualMCP_CreateHonorsDisabled(t *testing.T) {

--- a/plugins/governance/allowbydefault_test.go
+++ b/plugins/governance/allowbydefault_test.go
@@ -15,6 +15,7 @@ import (
 type mockInMemoryStore struct {
 	allowedByDefaultClients map[string]string // clientID → clientName
 	clientNames             map[string]string // clientID → clientName, configured clients that are not allowed by default
+	clientSlugs             map[string]string // endpoint slug → clientID
 	configuredProviders     map[schemas.ModelProvider]configstore.ProviderConfig
 }
 
@@ -33,6 +34,14 @@ func (m *mockInMemoryStore) GetMCPClientNames() map[string]string {
 	maps.Copy(names, m.clientNames)
 	maps.Copy(names, m.allowedByDefaultClients)
 	return names
+}
+
+func (m *mockInMemoryStore) GetMCPClientBySlug(slug string) (string, string, bool) {
+	id, ok := m.clientSlugs[slug]
+	if !ok {
+		return "", "", false
+	}
+	return id, m.GetMCPClientNames()[id], true
 }
 
 // accessFor builds the access a key carries on its own, with the given clients open to every

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -42,6 +42,8 @@ type InMemoryStore interface {
 	GetConfiguredProviders() map[schemas.ModelProvider]configstore.ProviderConfig
 	GetMCPClientsAllowedByDefault() map[string]string // clientID → clientName
 	GetMCPClientNames() map[string]string             // clientID → clientName, every client
+	// GetMCPClientBySlug resolves a client by its endpoint slug (for serving one client at /mcp/<slug>).
+	GetMCPClientBySlug(slug string) (clientID, clientName string, ok bool)
 }
 
 type BaseGovernancePlugin interface {

--- a/plugins/governance/mcpclientaccess_test.go
+++ b/plugins/governance/mcpclientaccess_test.go
@@ -1,0 +1,47 @@
+package governance
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/grant"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMCPClientToolAccess covers /mcp/<slug> resolution for a single MCP client: the slug must name a
+// known client the request's access grants (else refused), and the served tools are the client's,
+// narrowed to what access permits.
+func TestMCPClientToolAccess(t *testing.T) {
+	store := &LocalGovernanceStore{
+		inMemoryStore: &mockInMemoryStore{
+			clientNames: map[string]string{"cA": "alpha"},
+			clientSlugs: map[string]string{"alpha-svc": "cA"},
+		},
+		logger: NewMockLogger(),
+	}
+
+	t.Run("an unknown slug is refused", func(t *testing.T) {
+		served, ok := store.MCPClientToolAccess(gatewayCtx(), "nope", nil)
+		assert.False(t, ok)
+		assert.Nil(t, served)
+	})
+
+	t.Run("nil access serves the whole client", func(t *testing.T) {
+		served, ok := store.MCPClientToolAccess(gatewayCtx(), "alpha-svc", nil)
+		assert.True(t, ok)
+		assert.Equal(t, []string{"alpha-" + grant.Wildcard}, served)
+	})
+
+	t.Run("a client open to the key is served, narrowed to its access", func(t *testing.T) {
+		access := accessFor(buildVKNoMCPConfigs(), map[string]string{"cA": "alpha"})
+		served, ok := store.MCPClientToolAccess(gatewayCtx(), "alpha-svc", access)
+		assert.True(t, ok)
+		assert.Equal(t, []string{"alpha-" + grant.Wildcard}, served)
+	})
+
+	t.Run("a client the key cannot reach is refused", func(t *testing.T) {
+		access := accessFor(buildVKNoMCPConfigs(), nil)
+		served, ok := store.MCPClientToolAccess(gatewayCtx(), "alpha-svc", access)
+		assert.False(t, ok)
+		assert.Empty(t, served)
+	})
+}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1560,6 +1560,26 @@ func (gs *LocalGovernanceStore) VirtualMCPToolAccess(ctx *schemas.BifrostContext
 	return access.NarrowMCPToolIncludeList(requested), true
 }
 
+// MCPClientToolAccess resolves what a /mcp/<slug> request may see for one MCP client: the client's tools
+// narrowed to the caller's access (empty → not granted → the caller answers 403). Nil access serves the
+// whole client. No per-request recording (unlike a Virtual MCP): the access already names the clients.
+func (gs *LocalGovernanceStore) MCPClientToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) (served []string, ok bool) {
+	if gs.inMemoryStore == nil {
+		return nil, false
+	}
+	_, clientName, found := gs.inMemoryStore.GetMCPClientBySlug(slug)
+	if !found || clientName == "" {
+		return nil, false
+	}
+	// Narrow the whole client (name-*) to what access grants; empty means not granted.
+	whole := []string{clientName + "-" + grant.Wildcard}
+	if access == nil {
+		return whole, true
+	}
+	served = access.NarrowMCPToolIncludeList(whole)
+	return served, len(served) > 0
+}
+
 // loadVirtualMCPs fills both caches from the store at startup; surgical updates keep them current
 // after. On error the caches are left as-is, not cleared.
 func (gs *LocalGovernanceStore) loadVirtualMCPs(ctx context.Context) error {

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -1428,6 +1428,7 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 		clientConfig := &schemas.MCPClientConfig{
 			ID:                     dbClient.ClientID,
 			Name:                   dbClient.Name,
+			EndpointSlug:           dbClient.EndpointSlug,
 			IsCodeModeClient:       dbClient.IsCodeModeClient,
 			ConnectionType:         schemas.MCPConnectionType(dbClient.ConnectionType),
 			ConnectionString:       dbClient.ConnectionString,
@@ -1730,6 +1731,17 @@ func rejectStdioMCPClientIfAuthBypassed(ctx *fasthttp.RequestCtx, connType strin
 }
 
 // addMCPClient handles POST /api/mcp/client - Add a new MCP client
+// endpointSlugDerivable reports whether a usable /mcp/<slug> can be derived from the caller's
+// endpoint_slug, or failing that the name. The create handlers check this before any upstream dial
+// so an underivable slug fails with a 400 rather than after contacting the MCP server.
+func endpointSlugDerivable(endpointSlug, name string) bool {
+	base := endpointSlug
+	if base == "" {
+		base = name
+	}
+	return configstore.Slugify(base) != ""
+}
+
 func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	if h.store.ConfigStore == nil {
 		SendError(ctx, fasthttp.StatusServiceUnavailable, "MCP operations unavailable: config store is disabled")
@@ -1774,6 +1786,12 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	}
 	if err := mcp.ValidateMCPClientName(req.Name); err != nil {
 		SendError(ctx, fasthttp.StatusBadRequest, fmt.Sprintf("Invalid client name: %v", err))
+		return
+	}
+	// Reject an underivable endpoint slug up front, before any upstream verify/OAuth dial, so
+	// invalid input fails fast with a 400 instead of after contacting the MCP server.
+	if !endpointSlugDerivable(req.EndpointSlug, req.Name) {
+		SendError(ctx, fasthttp.StatusBadRequest, "Could not derive an endpoint slug from the name; provide an endpoint_slug")
 		return
 	}
 	if err := validateAllowedExtraHeaders(req.AllowedExtraHeaders); err != nil {
@@ -1861,6 +1879,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		schemasConfig := &schemas.MCPClientConfig{
 			ID:                     req.ClientID,
 			Name:                   req.Name,
+			EndpointSlug:           req.EndpointSlug,
 			IsCodeModeClient:       req.IsCodeModeClient,
 			IsPingAvailable:        &isPingAvailable,
 			NeedsSessionStickiness: req.NeedsSessionStickiness,
@@ -1895,6 +1914,14 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, schemasConfig); err != nil {
 			if errors.Is(err, configstore.ErrAlreadyExists) {
 				SendError(ctx, fasthttp.StatusConflict, "An MCP client with this name already exists")
+				return
+			}
+			if errors.Is(err, configstore.ErrMCPEndpointSlugExists) {
+				SendError(ctx, fasthttp.StatusConflict, "An MCP endpoint with this slug already exists")
+				return
+			}
+			if errors.Is(err, configstore.ErrMCPEndpointSlugInvalid) {
+				SendError(ctx, fasthttp.StatusBadRequest, "Could not derive an endpoint slug from the name; provide an endpoint_slug")
 				return
 			}
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
@@ -1970,6 +1997,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		schemasConfig := &schemas.MCPClientConfig{
 			ID:                     req.ClientID,
 			Name:                   req.Name,
+			EndpointSlug:           req.EndpointSlug,
 			IsCodeModeClient:       req.IsCodeModeClient,
 			IsPingAvailable:        &isPingAvailable,
 			NeedsSessionStickiness: req.NeedsSessionStickiness,
@@ -2020,6 +2048,14 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, schemasConfig); err != nil {
 			if errors.Is(err, configstore.ErrAlreadyExists) {
 				SendError(ctx, fasthttp.StatusConflict, "An MCP client with this name already exists")
+				return
+			}
+			if errors.Is(err, configstore.ErrMCPEndpointSlugExists) {
+				SendError(ctx, fasthttp.StatusConflict, "An MCP endpoint with this slug already exists")
+				return
+			}
+			if errors.Is(err, configstore.ErrMCPEndpointSlugInvalid) {
+				SendError(ctx, fasthttp.StatusBadRequest, "Could not derive an endpoint slug from the name; provide an endpoint_slug")
 				return
 			}
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
@@ -2244,6 +2280,7 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 	schemasConfig := &schemas.MCPClientConfig{
 		ID:                     req.ClientID,
 		Name:                   req.Name,
+		EndpointSlug:           req.EndpointSlug,
 		IsCodeModeClient:       req.IsCodeModeClient,
 		ConnectionType:         schemas.MCPConnectionType(req.ConnectionType),
 		ConnectionString:       req.ConnectionString,
@@ -2268,6 +2305,14 @@ func (h *MCPHandler) addMCPClient(ctx *fasthttp.RequestCtx) {
 		if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, schemasConfig); err != nil {
 			if errors.Is(err, configstore.ErrAlreadyExists) {
 				SendError(ctx, fasthttp.StatusConflict, "An MCP client with this name already exists")
+				return
+			}
+			if errors.Is(err, configstore.ErrMCPEndpointSlugExists) {
+				SendError(ctx, fasthttp.StatusConflict, "An MCP endpoint with this slug already exists")
+				return
+			}
+			if errors.Is(err, configstore.ErrMCPEndpointSlugInvalid) {
+				SendError(ctx, fasthttp.StatusBadRequest, "Could not derive an endpoint slug from the name; provide an endpoint_slug")
 				return
 			}
 			SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
@@ -3696,6 +3741,14 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 						SendError(ctx, fasthttp.StatusConflict, "An MCP client with this name already exists")
 						return
 					}
+					if errors.Is(err, configstore.ErrMCPEndpointSlugExists) {
+						SendError(ctx, fasthttp.StatusConflict, "An MCP endpoint with this slug already exists")
+						return
+					}
+					if errors.Is(err, configstore.ErrMCPEndpointSlugInvalid) {
+						SendError(ctx, fasthttp.StatusBadRequest, "Could not derive an endpoint slug from the name; provide an endpoint_slug")
+						return
+					}
 					SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))
 					return
 				}
@@ -3828,6 +3881,14 @@ func (h *MCPHandler) completeMCPClientOAuth(ctx *fasthttp.RequestCtx) {
 			if err := h.store.ConfigStore.CreateMCPClientConfig(ctx, mcpClientConfig); err != nil {
 				if errors.Is(err, configstore.ErrAlreadyExists) {
 					SendError(ctx, fasthttp.StatusConflict, "An MCP client with this name already exists")
+					return
+				}
+				if errors.Is(err, configstore.ErrMCPEndpointSlugExists) {
+					SendError(ctx, fasthttp.StatusConflict, "An MCP endpoint with this slug already exists")
+					return
+				}
+				if errors.Is(err, configstore.ErrMCPEndpointSlugInvalid) {
+					SendError(ctx, fasthttp.StatusBadRequest, "Could not derive an endpoint slug from the name; provide an endpoint_slug")
 					return
 				}
 				SendError(ctx, fasthttp.StatusInternalServerError, fmt.Sprintf("Failed to create MCP config: %v", err))

--- a/transports/bifrost-http/handlers/mcp_endpointslug_test.go
+++ b/transports/bifrost-http/handlers/mcp_endpointslug_test.go
@@ -1,0 +1,25 @@
+package handlers
+
+import "testing"
+
+// TestEndpointSlugDerivable pins the pre-dial gate used by the MCP create handlers: an
+// endpoint_slug (or, failing that, a name) that slugifies to empty is rejected, so an invalid
+// request fails with a 400 before any upstream verification runs.
+func TestEndpointSlugDerivable(t *testing.T) {
+	cases := []struct {
+		name         string
+		endpointSlug string
+		clientName   string
+		want         bool
+	}{
+		{"derivable from name", "", "My Client", true},
+		{"explicit slug rescues an underivable name", "custom-slug", "***", true},
+		{"underivable name, no slug", "", "***", false},
+		{"both empty", "", "", false},
+	}
+	for _, tc := range cases {
+		if got := endpointSlugDerivable(tc.endpointSlug, tc.clientName); got != tc.want {
+			t.Errorf("%s: endpointSlugDerivable(%q, %q) = %v, want %v", tc.name, tc.endpointSlug, tc.clientName, got, tc.want)
+		}
+	}
+}

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -50,15 +50,16 @@ type MCPGatewayAdmitter interface {
 	AdmitMCPGatewayRequest(ctx *schemas.BifrostContext) (schemas.Access, *schemas.BifrostError)
 }
 
-// virtualMCPGatewayResolver is the optional capability behind a Virtual MCP endpoint (/mcp/<slug>): it resolves
-// the tools a request may see for the Virtual MCP the slug names, gated on that vMCP being assigned to
-// the request's key. Satisfied by the same admitter that resolves gateway access. Absent (or nil)
-// means there is no governance store to resolve assignment against, so /mcp/<slug> is refused.
-type virtualMCPGatewayResolver interface {
+// mcpSlugResolver is the optional capability behind a /mcp/<slug> endpoint: it resolves the tools a
+// request may see for the Virtual MCP or MCP client the slug names, gated on the caller's grant.
+// Satisfied by the same admitter that resolves gateway access. Absent (or nil) means there is no
+// governance store to resolve against, so /mcp/<slug> is refused.
+type mcpSlugResolver interface {
 	// VirtualMCPToolAccess returns the served tool include-list and whether the slug's Virtual MCP is
-	// assigned to the request's key (assigned=false → 403). The tools are already narrowed to what the
-	// request's access permits.
+	// assigned to the request's key (assigned=false → 403). Tools are narrowed to the request's access.
 	VirtualMCPToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) (served []string, assigned bool)
+	// MCPClientToolAccess is the same for a single MCP client the slug names (ok=false → 403).
+	MCPClientToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) (served []string, ok bool)
 }
 
 // VirtualKeyCache resolves a virtual key by its row ID from an in-memory cache,
@@ -528,30 +529,33 @@ func (h *MCPServerHandler) admit(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.B
 		return &mcpRefusal{status: status, message: bifrost.GetErrorMessage(refused)}
 	}
 
-	// A Virtual MCP endpoint (/mcp/<slug>) serves one Virtual MCP: gate on it being assigned to the key and
+	// A /mcp/<slug> endpoint serves one Virtual MCP or one MCP client: gate on the caller's grant and
 	// narrow the tools to it. The plain /mcp route carries no slug and serves the full access.
 	if slug, _ := ctx.UserValue("slug").(string); slug != "" {
-		return h.admitVirtualMCP(bifrostCtx, slug, access)
+		return h.admitBySlug(bifrostCtx, slug, access)
 	}
 
 	stampToolAccess(bifrostCtx, access)
 	return nil
 }
 
-// admitVirtualMCP narrows an already-admitted request to the Virtual MCP its slug names. The vMCP must be
-// assigned to the request's key, or the request is refused with 403; otherwise the tools it may see
-// are stamped as the served include-list. Reached only from admit, after access is resolved.
-func (h *MCPServerHandler) admitVirtualMCP(bifrostCtx *schemas.BifrostContext, slug string, access schemas.Access) *mcpRefusal {
-	resolver, ok := h.admitter.(virtualMCPGatewayResolver)
+// admitBySlug narrows an already-admitted request to the Virtual MCP or MCP client its slug names,
+// stamping the served tools; 403 if the caller may reach neither.
+func (h *MCPServerHandler) admitBySlug(bifrostCtx *schemas.BifrostContext, slug string, access schemas.Access) *mcpRefusal {
+	resolver, ok := h.admitter.(mcpSlugResolver)
 	if !ok {
 		return &mcpRefusal{status: fasthttp.StatusForbidden, message: "access_denied"}
 	}
-	served, assigned := resolver.VirtualMCPToolAccess(bifrostCtx, slug, access)
-	if !assigned {
-		return &mcpRefusal{status: fasthttp.StatusForbidden, message: "access_denied"}
+	// Slugs are unique across both namespaces, so try the Virtual MCP first, then a single client.
+	if served, assigned := resolver.VirtualMCPToolAccess(bifrostCtx, slug, access); assigned {
+		bifrostCtx.SetValue(schemas.MCPContextKeyIncludeTools, served)
+		return nil
 	}
-	bifrostCtx.SetValue(schemas.MCPContextKeyIncludeTools, served)
-	return nil
+	if served, ok := resolver.MCPClientToolAccess(bifrostCtx, slug, access); ok {
+		bifrostCtx.SetValue(schemas.MCPContextKeyIncludeTools, served)
+		return nil
+	}
+	return &mcpRefusal{status: fasthttp.StatusForbidden, message: "access_denied"}
 }
 
 // admitAccess asks governance what the request may reach. Without an admitter there is nothing to

--- a/transports/bifrost-http/handlers/virtualmcp.go
+++ b/transports/bifrost-http/handlers/virtualmcp.go
@@ -408,8 +408,8 @@ func (h *VirtualMCPHandler) parseID(ctx *fasthttp.RequestCtx) (uint, bool) {
 // clash, or a name clash surfaced by the table's own unique index.
 func virtualMCPConflict(err error) (int, string, bool) {
 	switch {
-	case errors.Is(err, configstore.ErrVirtualMCPEndpointExists):
-		return fasthttp.StatusConflict, configstore.ErrVirtualMCPEndpointExists.Error(), true
+	case errors.Is(err, configstore.ErrMCPEndpointSlugExists):
+		return fasthttp.StatusConflict, configstore.ErrMCPEndpointSlugExists.Error(), true
 	case IsUniqueConstraintError(err):
 		return fasthttp.StatusConflict, "a virtual MCP with this name or endpoint already exists", true
 	}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -5574,6 +5574,23 @@ func (c *Config) GetMCPClientNames() map[string]string {
 	return result
 }
 
+// GetMCPClientBySlug resolves an MCP client by its endpoint slug, returning its ID and name so a single
+// client can be served at /mcp/<slug>. Read-only snapshot.
+func (c *Config) GetMCPClientBySlug(slug string) (clientID, clientName string, ok bool) {
+	c.muMCP.RLock()
+	defer c.muMCP.RUnlock()
+
+	if c.MCPConfig == nil || slug == "" {
+		return "", "", false
+	}
+	for _, client := range c.MCPConfig.ClientConfigs {
+		if client != nil && client.EndpointSlug == slug {
+			return client.ID, client.Name, true
+		}
+	}
+	return "", "", false
+}
+
 // GetPluginOrder returns the names of all base plugins in their sorted placement order.
 // This method is lock-free and safe for concurrent access from hot paths.
 // Do not modify the returned slice; it is a shared snapshot and must be treated read-only.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -322,6 +322,10 @@ func (s *GovernanceInMemoryStore) GetMCPClientNames() map[string]string {
 	return s.Config.GetMCPClientNames()
 }
 
+func (s *GovernanceInMemoryStore) GetMCPClientBySlug(slug string) (string, string, bool) {
+	return s.Config.GetMCPClientBySlug(slug)
+}
+
 // AddMCPClient adds a new MCP client to the in-memory store
 func (s *BifrostHTTPServer) AddMCPClient(ctx context.Context, clientConfig *schemas.MCPClientConfig) error {
 	if err := s.Config.AddMCPClient(ctx, clientConfig); err != nil {
@@ -1521,6 +1525,22 @@ func (s *BifrostHTTPServer) VirtualMCPToolAccess(ctx *schemas.BifrostContext, sl
 		return nil, false
 	}
 	return resolver.VirtualMCPToolAccess(ctx, slug, access)
+}
+
+// MCPClientToolAccess resolves the tools a /mcp/<slug> request may see for a single MCP client, gated
+// on the caller's grant (ok=false → the endpoint is refused). Sibling of VirtualMCPToolAccess.
+func (s *BifrostHTTPServer) MCPClientToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) (served []string, ok bool) {
+	governancePlugin, err := s.getGovernancePlugin()
+	if err != nil {
+		return nil, false
+	}
+	resolver, ok := governancePlugin.GetGovernanceStore().(interface {
+		MCPClientToolAccess(ctx *schemas.BifrostContext, slug string, access schemas.Access) ([]string, bool)
+	})
+	if !ok {
+		return nil, false
+	}
+	return resolver.MCPClientToolAccess(ctx, slug, access)
 }
 
 // backgroundCtx returns the server-lifetime context background workers should

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -5560,6 +5560,11 @@
           "type": "string",
           "description": "Name of the MCP client"
         },
+        "endpoint_slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "URL-safe, immutable slug that serves this client at /mcp/<slug>. Derived from the name when omitted; must be unique across MCP clients and Virtual MCPs."
+        },
         "is_code_mode_client": {
           "type": "boolean",
           "description": "Whether this client is a code mode client"

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -902,6 +902,41 @@ func TestSchemaMCPToolSyncInterval(t *testing.T) {
 	})
 }
 
+func TestSchemaMCPClientEndpointSlug(t *testing.T) {
+	schema := loadSchema(t)
+
+	t.Run("mcp_client_config includes endpoint_slug property", func(t *testing.T) {
+		_, found := navigateJSON(schema, "$defs", "mcp_client_config", "properties", "endpoint_slug")
+		if !found {
+			t.Error("$defs/mcp_client_config is missing 'endpoint_slug' — MCPClientConfig Go struct serializes this field")
+		}
+	})
+
+	clientConfig := func(slug string) string {
+		return fmt.Sprintf(`{
+			"mcp": {
+				"client_configs": [
+					{"name": "example", "connection_type": "http", "connection_string": "https://example.com/mcp", "endpoint_slug": %s}
+				]
+			}
+		}`, slug)
+	}
+
+	t.Run("client config with valid endpoint_slug validates successfully", func(t *testing.T) {
+		compiled := compileSchema(t)
+		if err := validateConfig(t, compiled, clientConfig(`"my-server-1"`)); err != nil {
+			t.Errorf("client config with endpoint_slug should be valid, got: %v", err)
+		}
+	})
+
+	t.Run("client config with non-url-safe endpoint_slug rejected", func(t *testing.T) {
+		compiled := compileSchema(t)
+		if err := validateConfig(t, compiled, clientConfig(`"My Server"`)); err == nil {
+			t.Error("non-url-safe endpoint_slug must be rejected by the schema")
+		}
+	})
+}
+
 func TestSchemaVKRotationCooldownBounds(t *testing.T) {
 	compiled := compileSchema(t)
 

--- a/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientForm.tsx
@@ -36,6 +36,7 @@ const emptySecretVar: SecretVar = { value: "", ref: "" };
 
 const emptyForm: CreateMCPClientRequest = {
 	name: "",
+	endpoint_slug: "",
 	is_code_mode_client: false,
 	is_ping_available: true,
 	connection_type: "http",
@@ -166,6 +167,28 @@ const ClientForm: React.FC<ClientFormProps> = ({ open, onClose, onSaved }) => {
 										<FormControl>
 											<Input id="client-name" data-testid="client-name-input" placeholder="Server name" maxLength={50} {...field} />
 										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
+
+							{/* Endpoint slug: optional on create, immutable after. Served at /mcp/<slug>. */}
+							<FormField
+								control={control}
+								name="endpoint_slug"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel>Endpoint slug</FormLabel>
+										<FormControl>
+											<Input
+												id="client-endpoint-slug"
+												data-testid="client-endpoint-slug-input"
+												placeholder="Leave blank to derive from the name"
+												{...field}
+												value={field.value ?? ""}
+											/>
+										</FormControl>
+										<p className="text-muted-foreground text-xs">{"Served at /mcp/<slug>. Immutable after creation."}</p>
 										<FormMessage />
 									</FormItem>
 								)}

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -39,7 +39,9 @@ import { titleCaseFromSnakeCase } from "@/lib/utils/strings";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ChevronDown, ChevronRight, Info, Plus, Trash2 } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Copy, Info, Plus, Trash2 } from "lucide-react";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { getExternalBaseUrl } from "@/app/workspace/mcp-registry/views/mcpUsageGuide/utils";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { OAuthAdvancedFields } from "./oauthAdvancedFields";
@@ -172,6 +174,9 @@ export default function MCPClientSheet({
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
 	const globalToolSyncInterval = bifrostConfig?.client_config?.mcp_tool_sync_interval ?? 10;
 	const globalToolExecutionTimeout = bifrostConfig?.client_config?.mcp_tool_execution_timeout ?? 30;
+	// External base URL + copy for the read-only endpoint the client is served at (/mcp/<slug>).
+	const baseUrl = getExternalBaseUrl(bifrostConfig?.client_config);
+	const { copy: copyEndpoint, copied: endpointCopied } = useCopyToClipboard({ successMessage: "Endpoint copied" });
 	const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
 
 	const allToolNames = useMemo(() => mcpClient.tools?.map((t) => t.name) ?? [], [mcpClient.tools]);
@@ -759,6 +764,23 @@ export default function MCPClientSheet({
 													</span>
 												</div>
 											</div>
+											{mcpClient.config.endpoint_slug && (
+												<div className="flex flex-col gap-2">
+													<div className="text-sm font-medium">Endpoint</div>
+													<div className="bg-muted/40 text-muted-foreground flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm">
+														<span className="font-mono break-all">/mcp/{mcpClient.config.endpoint_slug}</span>
+														<button
+															type="button"
+															onClick={() => copyEndpoint(`${baseUrl}/mcp/${mcpClient.config.endpoint_slug}`)}
+															className="text-muted-foreground hover:text-foreground shrink-0 cursor-pointer"
+															aria-label="Copy endpoint URL"
+															data-testid={`mcp-client-sheet-endpoint-copy-${mcpClient.config.endpoint_slug}`}
+														>
+															{endpointCopied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+														</button>
+													</div>
+												</div>
+											)}
 											{mcpClient.config.connection_type === "stdio" &&
 												mcpClient.config.stdio_config?.envs &&
 												mcpClient.config.stdio_config.envs.length > 0 && (

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -23,6 +23,7 @@ import { useToast } from "@/hooks/use-toast";
 import {
 	getErrorMessage,
 	useDeleteMCPClientMutation,
+	useGetCoreConfigQuery,
 	useInitiateMCPClientVerificationMutation,
 	useReauthorizeMCPClientMutation,
 	useReconnectMCPClientMutation,
@@ -30,13 +31,17 @@ import {
 	useVerifyMCPClientExchangeMutation,
 	useVerifyMCPClientHeadersMutation,
 } from "@/lib/store";
+import { getExternalBaseUrl } from "@/app/workspace/mcp-registry/views/mcpUsageGuide/utils";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { MCPAuthType, MCPClient } from "@/lib/types/mcp";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
 import {
 	Box,
+	Check,
 	ChevronLeft,
 	ChevronRight,
+	Copy,
 	Info,
 	KeyRound,
 	Loader2,
@@ -255,6 +260,28 @@ interface MCPClientsTableProps {
 	onOffsetChange: (offset: number) => void;
 }
 
+// ClientEndpointCell shows the /mcp/<slug> path and copies the full external URL on click.
+// baseReady gates copying: until the core config query resolves, getExternalBaseUrl falls back to
+// window.location.origin, which is the wrong host when mcp_external_client_url points elsewhere.
+function ClientEndpointCell({ slug, baseUrl, baseReady }: { slug?: string; baseUrl: string; baseReady: boolean }) {
+	const { copy, copied } = useCopyToClipboard({ successMessage: "Endpoint copied" });
+	if (!slug) return <span className="text-muted-foreground text-sm">-</span>;
+	return (
+		<button
+			type="button"
+			disabled={!baseReady}
+			onClick={() => copy(`${baseUrl}/mcp/${slug}`)}
+			className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 font-mono text-sm transition-colors enabled:cursor-pointer disabled:opacity-60"
+			aria-label={baseReady ? "Copy endpoint URL" : "Endpoint URL loading"}
+			title={baseReady ? undefined : "Loading the external base URL…"}
+			data-testid={`mcp-client-endpoint-copy-${slug}`}
+		>
+			/mcp/{slug}
+			{copied ? <Check className="size-3.5 shrink-0" /> : <Copy className="size-3.5 shrink-0" />}
+		</button>
+	);
+}
+
 export default function MCPClientsTable({
 	mcpClients,
 	totalCount,
@@ -273,6 +300,9 @@ export default function MCPClientsTable({
 	const hasCreateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Create);
 	const hasUpdateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Update);
 	const hasDeleteMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Delete);
+	// Externally reachable base URL, so the endpoint cell copies the full URL callers use.
+	const { data: coreConfig, isSuccess: coreConfigReady } = useGetCoreConfigQuery({ fromDB: true });
+	const baseUrl = getExternalBaseUrl(coreConfig?.client_config);
 	const [selectedMCPClient, setSelectedMCPClient] = useState<MCPClient | null>(null);
 	const [clientToDelete, setClientToDelete] = useState<MCPClient | null>(null);
 	// Drives the token_exchange "Re-verify as me" confirm dialog. Unlike
@@ -922,6 +952,7 @@ export default function MCPClientsTable({
 						<TableHeader className="bg-muted sticky top-0 z-20">
 							<TableRow>
 								<TableHead className="w-[260px] font-semibold">Name</TableHead>
+								<TableHead className="w-[180px] font-semibold">Endpoint</TableHead>
 								<TableHead className="w-[150px] font-semibold">Connection Type</TableHead>
 								<TableHead className="w-[150px] font-semibold">Auth Type</TableHead>
 								<TableHead className="w-[140px] font-semibold">Auth Scope</TableHead>
@@ -961,7 +992,7 @@ export default function MCPClientsTable({
 						<TableBody>
 							{mcpClients.length === 0 ? (
 								<TableRow>
-									<TableCell colSpan={11} className="h-24 text-center">
+									<TableCell colSpan={12} className="h-24 text-center">
 										<span className="text-muted-foreground text-sm">No matching MCP servers found.</span>
 									</TableCell>
 								</TableRow>
@@ -999,6 +1030,9 @@ export default function MCPClientsTable({
 												<div className="truncate" title={c.config.name}>
 													{c.config.name}
 												</div>
+											</TableCell>
+											<TableCell>
+												<ClientEndpointCell slug={c.config.endpoint_slug} baseUrl={baseUrl} baseReady={coreConfigReady} />
 											</TableCell>
 											<TableCell data-testid="mcp-client-connection-type">
 												<Badge variant="outline" className="font-mono">

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -119,6 +119,7 @@ export interface OAuthConfigUpdate {
 export interface MCPClientConfig {
 	client_id: string; // Maps to ClientID in TableMCPClient
 	name: string;
+	endpoint_slug?: string; // URL-safe, immutable after creation; served at /mcp/<slug>
 	is_code_mode_client?: boolean;
 	connection_type: MCPConnectionType;
 	connection_string?: SecretVar;
@@ -224,6 +225,7 @@ export interface MCPClient {
 
 export interface CreateMCPClientRequest {
 	name: string;
+	endpoint_slug?: string; // Optional on create (derived from name when blank); immutable after
 	is_code_mode_client?: boolean;
 	connection_type: MCPConnectionType;
 	connection_string?: SecretVar;


### PR DESCRIPTION
## Summary

MCP clients now have a unique `endpoint_slug` field that serves them at `/mcp/<slug>`, the same path namespace already used by Virtual MCPs. This makes individual MCP clients directly addressable via a stable, URL-safe slug, with slug uniqueness enforced across both Virtual MCPs and MCP clients.

## Changes

- Added `endpoint_slug` to `MCPClientConfig` (schema), `TableMCPClient` (DB table), and all read/write paths that map between them.
- `CreateMCPClientConfig` derives the slug from the caller-supplied `endpoint_slug` or falls back to the client name; it rejects creation if the slug is already taken by any Virtual MCP or MCP client (`ErrMCPEndpointSlugExists`).
- Renamed `ErrVirtualMCPEndpointExists` → `ErrMCPEndpointSlugExists` and `VirtualMCPSlugify` → `Slugify` / `uniqueVirtualMCPSlug` → `uniqueSlug` to reflect that the slug namespace is now shared.
- `MCPEndpointSlugTaken` replaces the old `virtualMCPSlugTaken` and checks both tables.
- Added migration `add_mcp_client_endpoint_slug`: adds the column, backfills slugs from client names (seeding the taken-set from existing Virtual MCP slugs to avoid collisions), then creates the unique index.
- `admitBySlug` (formerly `admitVirtualMCP`) now tries Virtual MCP resolution first, then falls back to `MCPClientToolAccess` for a single MCP client, so `/mcp/<slug>` works for both entity types.
- Added `MCPClientToolAccess` to the governance store and `mcpSlugResolver` interface; `GetMCPClientBySlug` added to `InMemoryStore`, `Config`, and `GovernanceInMemoryStore`.
- UI: added an **Endpoint** column to the MCP clients table (shows `/mcp/<slug>` with a copy-to-clipboard button for the full URL), an endpoint display in the client detail sheet, and an optional `endpoint_slug` field in the create-client form.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./plugins/governance/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

- Create an MCP client without an `endpoint_slug`; verify the slug is derived from the name and written back.
- Create a second client whose name slugifies to the same value; expect a 409 with `"an MCP endpoint with this slug already exists"`.
- Create a Virtual MCP whose slug matches an existing MCP client slug; expect the same 409.
- Issue a request to `/mcp/<slug>` for a client slug; verify tools are narrowed to that client's access.
- Confirm the Endpoint column appears in the MCP clients table and the copy button copies the full external URL.

## Breaking changes

- [x] Yes
- [ ] No

`ErrVirtualMCPEndpointExists` is renamed to `ErrMCPEndpointSlugExists`. Any code referencing the old error variable by name must be updated. The database migration adds a `NOT NULL`-equivalent unique column (`endpoint_slug`) to `config_mcp_clients`; the backfill runs automatically, but deployments that skip the migration will see missing slugs.

## Related issues

N/A

## Security considerations

Slug uniqueness is enforced at the application layer (pre-insert check) and backed by a database unique index. The cross-entity check (`MCPEndpointSlugTaken`) queries both tables before any write, preventing one entity type from shadowing another at the same `/mcp/<slug>` path. No secrets or PII are involved in slug derivation.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable