### PR TITLE
fix(ui): pause background polling while edit sheets are open to prevent in-progress edits from being discarded by refetches

### DIFF
--- a/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
+++ b/ui/app/_fallbacks/enterprise/components/user-groups/teamsView.tsx
@@ -34,7 +34,6 @@ export function TeamsView() {
 		data: teamsData,
 		error: teamsError,
 		isLoading: teamsLoading,
-		isFetching,
 	} = useGetTeamsQuery(
 		{
 			limit: PAGE_SIZE,
@@ -43,7 +42,10 @@ export function TeamsView() {
 		},
 		{
 			skip: !hasTeamsAccess,
-			pollingInterval: POLLING_INTERVAL,
+			// Hold the poll while the team sheet is open so a background refetch
+			// can't reset the form under an in-progress edit.
+			pollingInterval: urlState.selected_team ? 0 : POLLING_INTERVAL,
+			skipPollingIfUnfocused: true,
 		},
 	);
 
@@ -86,7 +88,6 @@ export function TeamsView() {
 				setUrlState({ selected_team: team?.id ?? null });
 			}}
 			onDialogClose={() => setUrlState({ selected_team: null })}
-			isLoading={isFetching}
 		/>
 	);
 }

--- a/ui/app/workspace/governance/customers/page.tsx
+++ b/ui/app/workspace/governance/customers/page.tsx
@@ -5,7 +5,7 @@ import { parseAsSafeString } from "@/lib/queryParamsParser";
 import { getErrorMessage, useGetCustomersQuery, useGetTeamsQuery } from "@/lib/store";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { parseAsInteger, useQueryStates } from "nuqs";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 
 const POLLING_INTERVAL = 5000;
@@ -15,6 +15,10 @@ export default function GovernanceCustomersPage() {
 	const hasTeamsAccess = useRbac(RbacResource.Teams, RbacOperation.View);
 	const hasCustomersAccess = useRbac(RbacResource.Customers, RbacOperation.View);
 	const shownErrorsRef = useRef(new Set<string>());
+	// Background refetches replace the rows behind an open edit sheet, which is
+	// how in-progress edits used to get discarded. Hold the poll while a sheet
+	// is open; it resumes as soon as the operator is done.
+	const [isSheetOpen, setIsSheetOpen] = useState(false);
 
 	const [urlState, setUrlState] = useQueryStates(
 		{
@@ -30,12 +34,15 @@ export default function GovernanceCustomersPage() {
 		data: teamsData,
 		error: teamsError,
 		isLoading: teamsLoading,
-	} = useGetTeamsQuery(undefined, { skip: !hasTeamsAccess, pollingInterval: POLLING_INTERVAL });
+	} = useGetTeamsQuery(undefined, {
+		skip: !hasTeamsAccess,
+		pollingInterval: isSheetOpen ? 0 : POLLING_INTERVAL,
+		skipPollingIfUnfocused: true,
+	});
 	const {
 		data: customersData,
 		error: customersError,
 		isLoading: customersLoading,
-		isFetching,
 	} = useGetCustomersQuery(
 		{
 			limit: PAGE_SIZE,
@@ -44,7 +51,8 @@ export default function GovernanceCustomersPage() {
 		},
 		{
 			skip: !hasCustomersAccess,
-			pollingInterval: POLLING_INTERVAL,
+			pollingInterval: isSheetOpen ? 0 : POLLING_INTERVAL,
+			skipPollingIfUnfocused: true,
 		},
 	);
 
@@ -53,6 +61,9 @@ export default function GovernanceCustomersPage() {
 	// Snap offset back when total shrinks past current page (e.g. delete last item on last page)
 	useEffect(() => {
 		if (!customersData || urlState.offset < customersTotal) return;
+		// Nothing to snap back to on an empty list, and setUrlState pushes a
+		// history entry even when the value is unchanged.
+		if (customersTotal === 0 && urlState.offset === 0) return;
 		setUrlState({ offset: customersTotal === 0 ? 0 : Math.floor((customersTotal - 1) / PAGE_SIZE) * PAGE_SIZE });
 	}, [customersTotal, urlState.offset]);
 
@@ -90,7 +101,7 @@ export default function GovernanceCustomersPage() {
 				offset={urlState.offset}
 				limit={PAGE_SIZE}
 				onOffsetChange={(newOffset) => setUrlState({ offset: newOffset })}
-				isFetching={isFetching}
+				onSheetOpenChange={setIsSheetOpen}
 			/>
 		</div>
 	);

--- a/ui/app/workspace/governance/views/customerSheet.tsx
+++ b/ui/app/workspace/governance/views/customerSheet.tsx
@@ -84,14 +84,17 @@ export default function CustomerSheet({ open, onOpenChange, customer, onSuccess 
 	const [updateCustomer, { isLoading: isUpdating }] = useUpdateCustomerMutation();
 	const loading = isCreating || isUpdating;
 
+	// Keyed on the customer *id*, not the object: the list behind this sheet is
+	// polled, so an unchanged customer still arrives as a fresh object and an
+	// identity-keyed reset would discard whatever the operator had typed.
 	useEffect(() => {
-		if (open) {
-			const init = createInitialState(customer);
-			setInitialState(init);
-			setFormData({ ...init, isDirty: false });
-			setNameError(null);
-		}
-	}, [open, customer]);
+		if (!open) return;
+		const init = createInitialState(customer);
+		setInitialState(init);
+		setFormData({ ...init, isDirty: false });
+		setNameError(null);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [open, customer?.id]);
 
 	const handleCalendarAlignedChange = (checked: boolean) => {
 		if (checked && isEditing && !initialState.calendarAligned) {

--- a/ui/app/workspace/governance/views/customerTable.tsx
+++ b/ui/app/workspace/governance/views/customerTable.tsx
@@ -26,7 +26,7 @@ import { CustomerDetailSheet } from "@enterprise/components/user-groups/sheets/c
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
 import { ChevronLeft, ChevronRight, Edit, MoreHorizontal, Plus, ScrollText, Search, Trash2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { CustomersEmptyState } from "./customersEmptyState";
 import CustomerSheet from "./customerSheet";
@@ -124,7 +124,8 @@ interface CustomersTableProps {
 	offset: number;
 	limit: number;
 	onOffsetChange: (offset: number) => void;
-	isFetching?: boolean;
+	/** Lets the page pause background polling while an edit sheet is open. */
+	onSheetOpenChange?: (open: boolean) => void;
 }
 
 export default function CustomersTable({
@@ -137,7 +138,7 @@ export default function CustomersTable({
 	offset,
 	limit,
 	onOffsetChange,
-	isFetching,
+	onSheetOpenChange,
 }: CustomersTableProps) {
 	const [showCustomerSheet, setShowCustomerSheet] = useState(false);
 	const [editingCustomer, setEditingCustomer] = useState<Customer | null>(null);
@@ -149,6 +150,12 @@ export default function CustomersTable({
 	const hasDeleteAccess = useRbac(RbacResource.Customers, RbacOperation.Delete);
 
 	const [deleteCustomer, { isLoading: isDeleting }] = useDeleteCustomerMutation();
+
+	// Derived from the single source of truth rather than each open/close call
+	// site, so the two can never drift apart.
+	useEffect(() => {
+		onSheetOpenChange?.(showCustomerSheet);
+	}, [showCustomerSheet, onSheetOpenChange]);
 
 	const handleDelete = async (customerId: string) => {
 		try {
@@ -182,34 +189,28 @@ export default function CustomersTable({
 
 	const hasActiveFilters = debouncedSearch;
 
-	// Rendered on the empty branch too, not just the populated one: PageTitle
-	// draws nothing inline, and leaving it out drops the topbar to the
-	// route-derived fallback.
+	const [hasLoadedRows, setHasLoadedRows] = useState(false);
+	useEffect(() => {
+		if (totalCount > 0) setHasLoadedRows(true);
+	}, [totalCount]);
+
+	// Hoisted above the empty/populated branch: PageTitle draws nothing inline,
+	// and leaving it out of either branch drops the topbar to the route-derived
+	// fallback.
 	const pageTitle = <PageTitle title="Customers">Manage customer accounts with their own teams, budgets, and access controls.</PageTitle>;
 
-	// True empty state: no customers at all (not just filtered to zero)
-	if (totalCount === 0 && !hasActiveFilters && !isFetching) {
-		return (
-			<>
-				{pageTitle}
-				<TooltipProvider>
-					<CustomerSheet
-						open={showCustomerSheet}
-						onOpenChange={(open) => {
-							setShowCustomerSheet(open);
-							if (!open) setEditingCustomer(null);
-						}}
-						customer={editingCustomer}
-						onSuccess={handleCustomerSaved}
-					/>
-					<CustomersEmptyState onAddClick={handleAddCustomer} canCreate={hasCreateAccess} />
-				</TooltipProvider>
-			</>
-		);
-	}
+	// True empty state: no customers at all (not just filtered to zero). Rendered
+	// as a branch *inside* the tree rather than an early return with a different
+	// shape, because a shape change here made React remount CustomerSheet and wipe
+	// whatever was being typed. Latched on `hasLoadedRows` rather than the query's
+	// in-flight flag: that flag flips on every background poll, which would toggle
+	// the layout every few seconds on a genuinely empty page, while the latch still
+	// suppresses the empty card during the uncached fetch of a later page.
+	const isTrulyEmpty = totalCount === 0 && !hasActiveFilters && !hasLoadedRows;
 
 	return (
 		<>
+			{pageTitle}
 			<TooltipProvider>
 				<CustomerSheet
 					open={showCustomerSheet}
@@ -229,143 +230,187 @@ export default function CustomersTable({
 					customer={viewingCustomer}
 				/>
 
-				<div className="flex grow flex-col">
-					<div className="mb-4 flex flex-wrap items-center gap-3">
-						{pageTitle}
-						<div className="relative max-w-sm flex-1">
-							<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-							<Input
-								aria-label="Search customers by name"
-								placeholder="Search by name..."
-								value={search}
-								onChange={(e) => onSearchChange(e.target.value)}
-								className="pl-9"
-								data-testid="customers-search-input"
-							/>
+				{isTrulyEmpty && <CustomersEmptyState onAddClick={handleAddCustomer} canCreate={hasCreateAccess} />}
+
+				{!isTrulyEmpty && (
+					<div className="flex grow flex-col">
+						<div className="mb-4 flex flex-wrap items-center gap-3">
+							<div className="relative max-w-sm flex-1">
+								<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+								<Input
+									aria-label="Search customers by name"
+									placeholder="Search by name..."
+									value={search}
+									onChange={(e) => onSearchChange(e.target.value)}
+									className="pl-9"
+									data-testid="customers-search-input"
+								/>
+							</div>
+							<Button className="ml-auto" data-testid="customer-button-create" onClick={handleAddCustomer} disabled={!hasCreateAccess}>
+								<Plus className="h-4 w-4" />
+								Add Customer
+							</Button>
 						</div>
-						<Button className="ml-auto" data-testid="customer-button-create" onClick={handleAddCustomer} disabled={!hasCreateAccess}>
-							<Plus className="h-4 w-4" />
-							Add Customer
-						</Button>
-					</div>
 
-					<div className="mb-2 grow overflow-auto rounded-sm border" data-testid="customer-table-container">
-						<Table className="min-w-[1100px]">
-							<TableHeader>
-								<TableRow>
-									<TableHead>Name</TableHead>
-									<TableHead>Teams</TableHead>
-									<TableHead>Budget</TableHead>
-									<TableHead>Rate Limit</TableHead>
-									<TableHead>Virtual Keys</TableHead>
-									<TableHead className={`bg-muted ${ACTIONS_COLUMN_CLASS}`}></TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{customers.length === 0 ? (
+						<div className="mb-2 grow overflow-auto rounded-sm border" data-testid="customer-table-container">
+							<Table className="min-w-[1100px]">
+								<TableHeader>
 									<TableRow>
-										<TableCell colSpan={6} className="h-24 text-center">
-											<span className="text-muted-foreground text-sm">No matching customers found.</span>
-										</TableCell>
+										<TableHead>Name</TableHead>
+										<TableHead>Teams</TableHead>
+										<TableHead>Budget</TableHead>
+										<TableHead>Rate Limit</TableHead>
+										<TableHead>Virtual Keys</TableHead>
+										<TableHead className={`bg-muted ${ACTIONS_COLUMN_CLASS}`}></TableHead>
 									</TableRow>
-								) : (
-									customers.map((customer) => {
-										const customerTeams = getTeamsForCustomer(customer.id);
-										const vkCount = customer.virtual_key_count ?? 0;
+								</TableHeader>
+								<TableBody>
+									{customers.length === 0 ? (
+										<TableRow>
+											<TableCell colSpan={6} className="h-24 text-center">
+												<span className="text-muted-foreground text-sm">No matching customers found.</span>
+											</TableCell>
+										</TableRow>
+									) : (
+										customers.map((customer) => {
+											const customerTeams = getTeamsForCustomer(customer.id);
+											const vkCount = customer.virtual_key_count ?? 0;
 
-										// Budget calculations (most-exhausted budget drives the row highlight)
-										const budgets = customer.budgets ?? [];
-										const isBudgetExhausted = budgets.some((b) => b.max_limit > 0 && b.current_usage >= b.max_limit);
+											// Budget calculations (most-exhausted budget drives the row highlight)
+											const budgets = customer.budgets ?? [];
+											const isBudgetExhausted = budgets.some((b) => b.max_limit > 0 && b.current_usage >= b.max_limit);
 
-										// Rate limit calculations
-										const isTokenLimitExhausted =
-											customer.rate_limit?.token_max_limit &&
-											customer.rate_limit.token_max_limit > 0 &&
-											customer.rate_limit.token_current_usage >= customer.rate_limit.token_max_limit;
-										const isRequestLimitExhausted =
-											customer.rate_limit?.request_max_limit &&
-											customer.rate_limit.request_max_limit > 0 &&
-											customer.rate_limit.request_current_usage >= customer.rate_limit.request_max_limit;
-										const isRateLimitExhausted = isTokenLimitExhausted || isRequestLimitExhausted;
-										const tokenPercentage =
-											customer.rate_limit?.token_max_limit && customer.rate_limit.token_max_limit > 0
-												? Math.min((customer.rate_limit.token_current_usage / customer.rate_limit.token_max_limit) * 100, 100)
-												: 0;
-										const requestPercentage =
-											customer.rate_limit?.request_max_limit && customer.rate_limit.request_max_limit > 0
-												? Math.min((customer.rate_limit.request_current_usage / customer.rate_limit.request_max_limit) * 100, 100)
-												: 0;
+											// Rate limit calculations
+											const isTokenLimitExhausted =
+												customer.rate_limit?.token_max_limit &&
+												customer.rate_limit.token_max_limit > 0 &&
+												customer.rate_limit.token_current_usage >= customer.rate_limit.token_max_limit;
+											const isRequestLimitExhausted =
+												customer.rate_limit?.request_max_limit &&
+												customer.rate_limit.request_max_limit > 0 &&
+												customer.rate_limit.request_current_usage >= customer.rate_limit.request_max_limit;
+											const isRateLimitExhausted = isTokenLimitExhausted || isRequestLimitExhausted;
+											const tokenPercentage =
+												customer.rate_limit?.token_max_limit && customer.rate_limit.token_max_limit > 0
+													? Math.min((customer.rate_limit.token_current_usage / customer.rate_limit.token_max_limit) * 100, 100)
+													: 0;
+											const requestPercentage =
+												customer.rate_limit?.request_max_limit && customer.rate_limit.request_max_limit > 0
+													? Math.min((customer.rate_limit.request_current_usage / customer.rate_limit.request_max_limit) * 100, 100)
+													: 0;
 
-										const isExhausted = isBudgetExhausted || isRateLimitExhausted;
+											const isExhausted = isBudgetExhausted || isRateLimitExhausted;
 
-										return (
-											<TableRow
-												key={customer.id}
-												data-testid={`customer-row-${customer.name}`}
-												className={cn(
-													"group cursor-pointer transition-colors",
-													isExhausted ? "bg-red-500/5 hover:bg-red-500/10" : "hover:bg-muted/50",
-												)}
-												role="button"
-												tabIndex={0}
-												onClick={() => setViewingCustomer(customer)}
-												onKeyDown={(e) => {
-													if (e.target !== e.currentTarget) return;
-													if (e.key === "Enter" || e.key === " ") {
-														e.preventDefault();
-														setViewingCustomer(customer);
-													}
-												}}
-											>
-												<TableCell className="max-w-[200px] py-4">
-													<div className="flex flex-col gap-2">
-														<span className="truncate font-medium">{customer.name}</span>
-														{isExhausted && (
-															<Badge variant="destructive" className="w-fit text-xs">
-																Limit Reached
-															</Badge>
-														)}
-													</div>
-												</TableCell>
-												<TableCell>
-													{customerTeams?.length > 0 ? (
-														<div className="flex items-center gap-2">
-															<Tooltip>
-																<TooltipTrigger>
-																	<Badge variant="outline" className="text-xs">
-																		{customerTeams.length} {customerTeams.length === 1 ? "team" : "teams"}
-																	</Badge>
-																</TooltipTrigger>
-																<TooltipContent>{customerTeams.map((team) => team.name).join(", ")}</TooltipContent>
-															</Tooltip>
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
+											return (
+												<TableRow
+													key={customer.id}
+													data-testid={`customer-row-${customer.name}`}
+													className={cn(
+														"group cursor-pointer transition-colors",
+														isExhausted ? "bg-red-500/5 hover:bg-red-500/10" : "hover:bg-muted/50",
 													)}
-												</TableCell>
-												<TableCell className="min-w-[180px]">
-													{budgets.length > 0 ? (
-														<div className="space-y-2">
-															{budgets.map((budget) => {
-																const pct = budget.max_limit > 0 ? Math.min((budget.current_usage / budget.max_limit) * 100, 100) : 0;
-																const exhausted = budget.max_limit > 0 && budget.current_usage >= budget.max_limit;
-																return (
-																	<Tooltip key={budget.id}>
+													role="button"
+													tabIndex={0}
+													onClick={() => setViewingCustomer(customer)}
+													onKeyDown={(e) => {
+														if (e.target !== e.currentTarget) return;
+														if (e.key === "Enter" || e.key === " ") {
+															e.preventDefault();
+															setViewingCustomer(customer);
+														}
+													}}
+												>
+													<TableCell className="max-w-[200px] py-4">
+														<div className="flex flex-col gap-2">
+															<span className="truncate font-medium">{customer.name}</span>
+															{isExhausted && (
+																<Badge variant="destructive" className="w-fit text-xs">
+																	Limit Reached
+																</Badge>
+															)}
+														</div>
+													</TableCell>
+													<TableCell>
+														{customerTeams?.length > 0 ? (
+															<div className="flex items-center gap-2">
+																<Tooltip>
+																	<TooltipTrigger>
+																		<Badge variant="outline" className="text-xs">
+																			{customerTeams.length} {customerTeams.length === 1 ? "team" : "teams"}
+																		</Badge>
+																	</TooltipTrigger>
+																	<TooltipContent>{customerTeams.map((team) => team.name).join(", ")}</TooltipContent>
+																</Tooltip>
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">-</span>
+														)}
+													</TableCell>
+													<TableCell className="min-w-[180px]">
+														{budgets.length > 0 ? (
+															<div className="space-y-2">
+																{budgets.map((budget) => {
+																	const pct = budget.max_limit > 0 ? Math.min((budget.current_usage / budget.max_limit) * 100, 100) : 0;
+																	const exhausted = budget.max_limit > 0 && budget.current_usage >= budget.max_limit;
+																	return (
+																		<Tooltip key={budget.id}>
+																			<TooltipTrigger asChild>
+																				<div className="space-y-1">
+																					<div className="flex items-center justify-between gap-4">
+																						<span className="text-sm font-medium">{formatCurrency(budget.max_limit)}</span>
+																						<span className="text-muted-foreground text-xs">
+																							{formatResetDuration(budget.reset_duration)}
+																						</span>
+																					</div>
+																					<Progress
+																						value={pct}
+																						className={cn(
+																							"bg-muted/70 dark:bg-muted/30 h-1.5",
+																							exhausted
+																								? "[&>div]:bg-red-500/70"
+																								: pct > 80
+																									? "[&>div]:bg-amber-500/70"
+																									: "[&>div]:bg-emerald-500/70",
+																						)}
+																					/>
+																				</div>
+																			</TooltipTrigger>
+																			<TooltipContent>
+																				<p className="font-medium">
+																					{formatCurrency(budget.current_usage)} / {formatCurrency(budget.max_limit)}
+																				</p>
+																				<p className="text-primary-foreground/80 text-xs">
+																					Resets {formatResetDuration(budget.reset_duration)}
+																				</p>
+																			</TooltipContent>
+																		</Tooltip>
+																	);
+																})}
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">-</span>
+														)}
+													</TableCell>
+													<TableCell className="min-w-[180px]">
+														{customer.rate_limit ? (
+															<div className="space-y-2.5">
+																{customer.rate_limit.token_max_limit && (
+																	<Tooltip>
 																		<TooltipTrigger asChild>
-																			<div className="space-y-1">
-																				<div className="flex items-center justify-between gap-4">
-																					<span className="text-sm font-medium">{formatCurrency(budget.max_limit)}</span>
-																					<span className="text-muted-foreground text-xs">
-																						{formatResetDuration(budget.reset_duration)}
+																			<div className="space-y-1.5">
+																				<div className="flex items-center justify-between gap-4 text-xs">
+																					<span className="font-medium">{customer.rate_limit.token_max_limit.toLocaleString()} tokens</span>
+																					<span className="text-muted-foreground">
+																						{formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
 																					</span>
 																				</div>
 																				<Progress
-																					value={pct}
+																					value={tokenPercentage}
 																					className={cn(
-																						"bg-muted/70 dark:bg-muted/30 h-1.5",
-																						exhausted
+																						"bg-muted/70 dark:bg-muted/30 h-1",
+																						isTokenLimitExhausted
 																							? "[&>div]:bg-red-500/70"
-																							: pct > 80
+																							: tokenPercentage > 80
 																								? "[&>div]:bg-amber-500/70"
 																								: "[&>div]:bg-emerald-500/70",
 																					)}
@@ -374,168 +419,127 @@ export default function CustomersTable({
 																		</TooltipTrigger>
 																		<TooltipContent>
 																			<p className="font-medium">
-																				{formatCurrency(budget.current_usage)} / {formatCurrency(budget.max_limit)}
+																				{customer.rate_limit.token_current_usage.toLocaleString()} /{" "}
+																				{customer.rate_limit.token_max_limit.toLocaleString()} tokens
 																			</p>
 																			<p className="text-primary-foreground/80 text-xs">
-																				Resets {formatResetDuration(budget.reset_duration)}
+																				Resets {formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
 																			</p>
 																		</TooltipContent>
 																	</Tooltip>
-																);
-															})}
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell className="min-w-[180px]">
-													{customer.rate_limit ? (
-														<div className="space-y-2.5">
-															{customer.rate_limit.token_max_limit && (
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<div className="space-y-1.5">
-																			<div className="flex items-center justify-between gap-4 text-xs">
-																				<span className="font-medium">{customer.rate_limit.token_max_limit.toLocaleString()} tokens</span>
-																				<span className="text-muted-foreground">
-																					{formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
-																				</span>
+																)}
+																{customer.rate_limit.request_max_limit && (
+																	<Tooltip>
+																		<TooltipTrigger asChild>
+																			<div className="space-y-1.5">
+																				<div className="flex items-center justify-between gap-4 text-xs">
+																					<span className="font-medium">{customer.rate_limit.request_max_limit.toLocaleString()} req</span>
+																					<span className="text-muted-foreground">
+																						{formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
+																					</span>
+																				</div>
+																				<Progress
+																					value={requestPercentage}
+																					className={cn(
+																						"bg-muted/70 dark:bg-muted/30 h-1",
+																						isRequestLimitExhausted
+																							? "[&>div]:bg-red-500/70"
+																							: requestPercentage > 80
+																								? "[&>div]:bg-amber-500/70"
+																								: "[&>div]:bg-emerald-500/70",
+																					)}
+																				/>
 																			</div>
-																			<Progress
-																				value={tokenPercentage}
-																				className={cn(
-																					"bg-muted/70 dark:bg-muted/30 h-1",
-																					isTokenLimitExhausted
-																						? "[&>div]:bg-red-500/70"
-																						: tokenPercentage > 80
-																							? "[&>div]:bg-amber-500/70"
-																							: "[&>div]:bg-emerald-500/70",
-																				)}
-																			/>
-																		</div>
-																	</TooltipTrigger>
-																	<TooltipContent>
-																		<p className="font-medium">
-																			{customer.rate_limit.token_current_usage.toLocaleString()} /{" "}
-																			{customer.rate_limit.token_max_limit.toLocaleString()} tokens
-																		</p>
-																		<p className="text-primary-foreground/80 text-xs">
-																			Resets {formatResetDuration(customer.rate_limit.token_reset_duration || "1h")}
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															)}
-															{customer.rate_limit.request_max_limit && (
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<div className="space-y-1.5">
-																			<div className="flex items-center justify-between gap-4 text-xs">
-																				<span className="font-medium">{customer.rate_limit.request_max_limit.toLocaleString()} req</span>
-																				<span className="text-muted-foreground">
-																					{formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
-																				</span>
-																			</div>
-																			<Progress
-																				value={requestPercentage}
-																				className={cn(
-																					"bg-muted/70 dark:bg-muted/30 h-1",
-																					isRequestLimitExhausted
-																						? "[&>div]:bg-red-500/70"
-																						: requestPercentage > 80
-																							? "[&>div]:bg-amber-500/70"
-																							: "[&>div]:bg-emerald-500/70",
-																				)}
-																			/>
-																		</div>
-																	</TooltipTrigger>
-																	<TooltipContent>
-																		<p className="font-medium">
-																			{customer.rate_limit.request_current_usage.toLocaleString()} /{" "}
-																			{customer.rate_limit.request_max_limit.toLocaleString()} requests
-																		</p>
-																		<p className="text-primary-foreground/80 text-xs">
-																			Resets {formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															)}
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell>
-													{vkCount > 0 ? (
-														<Badge variant="outline" className="text-xs">
-															{vkCount} {vkCount === 1 ? "key" : "keys"}
-														</Badge>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell
-													className={cn(
-														"dark:bg-card dark:group-hover:bg-muted",
-														isExhausted ? "bg-red-500/5 group-hover:bg-red-500/10" : "bg-white group-hover:bg-muted",
-														ACTIONS_COLUMN_CLASS,
-													)}
-												>
-													<CustomerActionsMenu
-														customer={customer}
-														canUpdate={hasUpdateAccess}
-														canDelete={hasDeleteAccess}
-														onEdit={handleEditCustomer}
-														onDelete={setConfirmDeleteCustomer}
-													/>
-												</TableCell>
-											</TableRow>
-										);
-									})
-								)}
-							</TableBody>
-						</Table>
-					</div>
+																		</TooltipTrigger>
+																		<TooltipContent>
+																			<p className="font-medium">
+																				{customer.rate_limit.request_current_usage.toLocaleString()} /{" "}
+																				{customer.rate_limit.request_max_limit.toLocaleString()} requests
+																			</p>
+																			<p className="text-primary-foreground/80 text-xs">
+																				Resets {formatResetDuration(customer.rate_limit.request_reset_duration || "1h")}
+																			</p>
+																		</TooltipContent>
+																	</Tooltip>
+																)}
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">-</span>
+														)}
+													</TableCell>
+													<TableCell>
+														{vkCount > 0 ? (
+															<Badge variant="outline" className="text-xs">
+																{vkCount} {vkCount === 1 ? "key" : "keys"}
+															</Badge>
+														) : (
+															<span className="text-muted-foreground text-sm">-</span>
+														)}
+													</TableCell>
+													<TableCell
+														className={cn(
+															"dark:bg-card dark:group-hover:bg-muted",
+															isExhausted ? "bg-red-500/5 group-hover:bg-red-500/10" : "bg-white group-hover:bg-muted",
+															ACTIONS_COLUMN_CLASS,
+														)}
+													>
+														<CustomerActionsMenu
+															customer={customer}
+															canUpdate={hasUpdateAccess}
+															canDelete={hasDeleteAccess}
+															onEdit={handleEditCustomer}
+															onDelete={setConfirmDeleteCustomer}
+														/>
+													</TableCell>
+												</TableRow>
+											);
+										})
+									)}
+								</TableBody>
+							</Table>
+						</div>
 
-					{/* Pagination */}
-					{totalCount > 0 && (
-						<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-							<div className="text-muted-foreground flex items-center gap-2">
-								{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-								entries
-							</div>
-
-							<div className="flex items-center gap-2">
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-									disabled={offset === 0}
-									data-testid="customers-pagination-prev-btn"
-									aria-label="Previous page"
-								>
-									<ChevronLeft className="size-3" />
-								</Button>
-
-								<div className="flex items-center gap-1">
-									<span>Page</span>
-									<span>{Math.floor(offset / limit) + 1}</span>
-									<span>of {Math.ceil(totalCount / limit)}</span>
+						{/* Pagination */}
+						{totalCount > 0 && (
+							<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+								<div className="text-muted-foreground flex items-center gap-2">
+									{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
+									entries
 								</div>
 
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => onOffsetChange(offset + limit)}
-									disabled={offset + limit >= totalCount}
-									data-testid="customers-pagination-next-btn"
-									aria-label="Next page"
-								>
-									<ChevronRight className="size-3" />
-								</Button>
+								<div className="flex items-center gap-2">
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+										disabled={offset === 0}
+										data-testid="customers-pagination-prev-btn"
+										aria-label="Previous page"
+									>
+										<ChevronLeft className="size-3" />
+									</Button>
+
+									<div className="flex items-center gap-1">
+										<span>Page</span>
+										<span>{Math.floor(offset / limit) + 1}</span>
+										<span>of {Math.ceil(totalCount / limit)}</span>
+									</div>
+
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => onOffsetChange(offset + limit)}
+										disabled={offset + limit >= totalCount}
+										data-testid="customers-pagination-next-btn"
+										aria-label="Next page"
+									>
+										<ChevronRight className="size-3" />
+									</Button>
+								</div>
 							</div>
-						</div>
-					)}
-				</div>
+						)}
+					</div>
+				)}
 
 				<AlertDialog open={!!confirmDeleteCustomer} onOpenChange={(open) => !open && setConfirmDeleteCustomer(null)}>
 					<AlertDialogContent>

--- a/ui/app/workspace/governance/views/teamSheet.tsx
+++ b/ui/app/workspace/governance/views/teamSheet.tsx
@@ -29,7 +29,7 @@ import { Validator } from "@/lib/utils/validation";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { formatDistanceToNow } from "date-fns";
 import isEqual from "lodash.isequal";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { v4 as uuid } from "uuid";
 
@@ -97,7 +97,14 @@ export default function TeamSheet({ team, onSave, onCancel }: TeamSheetProps) {
 	});
 	const [nameError, setNameError] = useState<string | null>(null);
 
+	// Keyed on the team *id*, not the object: this sheet is fed from a polled
+	// list, so an unchanged team still arrives as a fresh object every few
+	// seconds and an identity-keyed reset would discard in-progress edits.
+	const seededTeamIdRef = useRef<string | null | undefined>(undefined);
 	useEffect(() => {
+		const teamId = team?.id ?? null;
+		if (seededTeamIdRef.current === teamId) return;
+		seededTeamIdRef.current = teamId;
 		const nextInitial = createInitialState(team);
 		setInitialState(nextInitial);
 		setFormData({ ...nextInitial, isDirty: false });

--- a/ui/app/workspace/governance/views/teamsTable.tsx
+++ b/ui/app/workspace/governance/views/teamsTable.tsx
@@ -137,7 +137,6 @@ interface TeamsTableProps {
 	onTeamAdd: () => void;
 	onTeamSelect: (team: Team | null) => void;
 	onDialogClose: () => void;
-	isLoading?: boolean;
 }
 
 export default function TeamsTable({
@@ -153,7 +152,6 @@ export default function TeamsTable({
 	onTeamAdd,
 	onTeamSelect,
 	onDialogClose,
-	isLoading,
 }: TeamsTableProps) {
 	const showTeamSheet = selectedTeamId !== null && selectedTeamId !== "";
 	const editingTeam = selectedTeamId && selectedTeamId !== "new" ? (teams.find((t) => t.id === selectedTeamId) ?? null) : null;
@@ -203,140 +201,184 @@ export default function TeamsTable({
 
 	const hasActiveFilters = debouncedSearch;
 
-	// Rendered on the empty branch too, not just the populated one: PageTitle
-	// draws nothing inline, and leaving it out drops the topbar to the
-	// route-derived fallback.
+	const [hasLoadedRows, setHasLoadedRows] = useState(false);
+	useEffect(() => {
+		if (totalCount > 0) setHasLoadedRows(true);
+	}, [totalCount]);
+
+	// Hoisted above the empty/populated branch: PageTitle draws nothing inline,
+	// and leaving it out of either branch drops the topbar to the route-derived
+	// fallback.
 	const pageTitle = <PageTitle title="Teams">Organize users into teams with shared budgets and access controls.</PageTitle>;
 
-	// True empty state: no teams at all (not just filtered to zero)
-	if (totalCount === 0 && !hasActiveFilters && !isLoading) {
-		return (
-			<>
-				{pageTitle}
-				<TooltipProvider>
-					{showTeamSheet && <TeamSheet team={editingTeam} onSave={handleTeamSaved} onCancel={onDialogClose} />}
-					<TeamsEmptyState onAddClick={handleAddTeam} canCreate={hasCreateAccess} />
-				</TooltipProvider>
-			</>
-		);
-	}
+	// True empty state: no teams at all (not just filtered to zero). Rendered as a
+	// branch *inside* the tree rather than an early return with a different shape,
+	// because a shape change made React remount TeamSheet and wipe whatever was
+	// being typed. Latched on `hasLoadedRows` rather than the query's in-flight
+	// flag: that flag flips on every background poll, which would toggle the layout
+	// every few seconds on a genuinely empty page, while the latch still suppresses
+	// the empty card during the uncached fetch of a later page.
+	const isTrulyEmpty = totalCount === 0 && !hasActiveFilters && !hasLoadedRows;
 
 	return (
 		<>
+			{pageTitle}
 			<TooltipProvider>
 				{showTeamSheet && <TeamSheet team={editingTeam} onSave={handleTeamSaved} onCancel={onDialogClose} />}
 
-				<div className="flex grow flex-col overflow-y-auto">
-					<div className="mb-4 flex flex-wrap items-center gap-3">
-						{pageTitle}
-						<div className="relative max-w-sm flex-1">
-							<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-							<Input
-								aria-label="Search teams by name"
-								placeholder="Search by name..."
-								value={search}
-								onChange={(e) => onSearchChange(e.target.value)}
-								className="pl-9"
-								data-testid="teams-search-input"
-							/>
+				{isTrulyEmpty && <TeamsEmptyState onAddClick={handleAddTeam} canCreate={hasCreateAccess} />}
+
+				{!isTrulyEmpty && (
+					<div className="flex grow flex-col overflow-y-auto">
+						<div className="mb-4 flex flex-wrap items-center gap-3">
+							<div className="relative max-w-sm flex-1">
+								<Search className="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+								<Input
+									aria-label="Search teams by name"
+									placeholder="Search by name..."
+									value={search}
+									onChange={(e) => onSearchChange(e.target.value)}
+									className="pl-9"
+									data-testid="teams-search-input"
+								/>
+							</div>
+							<Button className="ml-auto" data-testid="create-team-btn" onClick={handleAddTeam} disabled={!hasCreateAccess}>
+								<Plus className="h-4 w-4" />
+								Add Team
+							</Button>
 						</div>
-						<Button className="ml-auto" data-testid="create-team-btn" onClick={handleAddTeam} disabled={!hasCreateAccess}>
-							<Plus className="h-4 w-4" />
-							Add Team
-						</Button>
-					</div>
 
-					<div className="mb-2 grow overflow-auto rounded-sm border" data-testid="teams-table">
-						<Table className="min-w-[1100px]" containerClassName="h-full">
-							<TableHeader className="bg-background sticky top-0">
-								<TableRow>
-									<TableHead>Name</TableHead>
-									<TableHead>Customer</TableHead>
-									<TableHead>Budget</TableHead>
-									<TableHead>Rate Limit</TableHead>
-									<TableHead>Virtual Keys</TableHead>
-									<TableHead className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
-								</TableRow>
-							</TableHeader>
-							<TableBody>
-								{teams.length === 0 ? (
+						<div className="mb-2 grow overflow-auto rounded-sm border" data-testid="teams-table">
+							<Table className="min-w-[1100px]" containerClassName="h-full">
+								<TableHeader className="bg-background sticky top-0">
 									<TableRow>
-										<TableCell colSpan={6} className="h-24 text-center">
-											<span className="text-muted-foreground text-sm">No matching teams found.</span>
-										</TableCell>
+										<TableHead>Name</TableHead>
+										<TableHead>Customer</TableHead>
+										<TableHead>Budget</TableHead>
+										<TableHead>Rate Limit</TableHead>
+										<TableHead>Virtual Keys</TableHead>
+										<TableHead className={`bg-muted sticky right-0 z-10 w-[56px] text-right ${PIN_SHADOW_RIGHT}`}></TableHead>
 									</TableRow>
-								) : (
-									teams.map((team) => {
-										const vkCount = team.virtual_key_count ?? 0;
-										const customerName = getCustomerName(team);
+								</TableHeader>
+								<TableBody>
+									{teams.length === 0 ? (
+										<TableRow>
+											<TableCell colSpan={6} className="h-24 text-center">
+												<span className="text-muted-foreground text-sm">No matching teams found.</span>
+											</TableCell>
+										</TableRow>
+									) : (
+										teams.map((team) => {
+											const vkCount = team.virtual_key_count ?? 0;
+											const customerName = getCustomerName(team);
 
-										// Budget calculations — any of the team's budgets exhausted
-										const teamBudgets = team.budgets ?? [];
-										const isBudgetExhausted = teamBudgets.some((b) => b.max_limit > 0 && b.current_usage >= b.max_limit);
+											// Budget calculations — any of the team's budgets exhausted
+											const teamBudgets = team.budgets ?? [];
+											const isBudgetExhausted = teamBudgets.some((b) => b.max_limit > 0 && b.current_usage >= b.max_limit);
 
-										// Rate limit calculations
-										const isTokenLimitExhausted =
-											team.rate_limit?.token_max_limit &&
-											team.rate_limit.token_max_limit > 0 &&
-											team.rate_limit.token_current_usage >= team.rate_limit.token_max_limit;
-										const isRequestLimitExhausted =
-											team.rate_limit?.request_max_limit &&
-											team.rate_limit.request_max_limit > 0 &&
-											team.rate_limit.request_current_usage >= team.rate_limit.request_max_limit;
-										const isRateLimitExhausted = isTokenLimitExhausted || isRequestLimitExhausted;
-										const tokenPercentage =
-											team.rate_limit?.token_max_limit && team.rate_limit.token_max_limit > 0
-												? Math.min((team.rate_limit.token_current_usage / team.rate_limit.token_max_limit) * 100, 100)
-												: 0;
-										const requestPercentage =
-											team.rate_limit?.request_max_limit && team.rate_limit.request_max_limit > 0
-												? Math.min((team.rate_limit.request_current_usage / team.rate_limit.request_max_limit) * 100, 100)
-												: 0;
+											// Rate limit calculations
+											const isTokenLimitExhausted =
+												team.rate_limit?.token_max_limit &&
+												team.rate_limit.token_max_limit > 0 &&
+												team.rate_limit.token_current_usage >= team.rate_limit.token_max_limit;
+											const isRequestLimitExhausted =
+												team.rate_limit?.request_max_limit &&
+												team.rate_limit.request_max_limit > 0 &&
+												team.rate_limit.request_current_usage >= team.rate_limit.request_max_limit;
+											const isRateLimitExhausted = isTokenLimitExhausted || isRequestLimitExhausted;
+											const tokenPercentage =
+												team.rate_limit?.token_max_limit && team.rate_limit.token_max_limit > 0
+													? Math.min((team.rate_limit.token_current_usage / team.rate_limit.token_max_limit) * 100, 100)
+													: 0;
+											const requestPercentage =
+												team.rate_limit?.request_max_limit && team.rate_limit.request_max_limit > 0
+													? Math.min((team.rate_limit.request_current_usage / team.rate_limit.request_max_limit) * 100, 100)
+													: 0;
 
-										const isExhausted = isBudgetExhausted || isRateLimitExhausted;
+											const isExhausted = isBudgetExhausted || isRateLimitExhausted;
 
-										return (
-											<TableRow
-												key={team.id}
-												data-testid={`team-row-${team.name}`}
-												className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}
-											>
-												<TableCell className="max-w-[200px] py-4">
-													<div className="flex flex-col gap-2">
-														<span className="truncate font-medium">{team.name}</span>
-														{isExhausted && (
-															<Badge variant="destructive" className="w-fit text-xs">
-																Limit Reached
-															</Badge>
+											return (
+												<TableRow
+													key={team.id}
+													data-testid={`team-row-${team.name}`}
+													className={cn("group transition-colors", isExhausted && "bg-red-500/5 hover:bg-red-500/10")}
+												>
+													<TableCell className="max-w-[200px] py-4">
+														<div className="flex flex-col gap-2">
+															<span className="truncate font-medium">{team.name}</span>
+															{isExhausted && (
+																<Badge variant="destructive" className="w-fit text-xs">
+																	Limit Reached
+																</Badge>
+															)}
+														</div>
+													</TableCell>
+													<TableCell data-testid={`team-row-${team.name}-customer`}>
+														<div className="flex items-center gap-2">
+															<Badge variant={team.customer_id ? "secondary" : "outline"}>{customerName}</Badge>
+														</div>
+													</TableCell>
+													<TableCell className="min-w-[180px]">
+														{teamBudgets.length > 0 ? (
+															<div className="space-y-2.5">
+																{teamBudgets.map((b) => {
+																	const budgetPercentage = b.max_limit > 0 ? Math.min((b.current_usage / b.max_limit) * 100, 100) : 0;
+																	const isExhausted = b.max_limit > 0 && b.current_usage >= b.max_limit;
+																	return (
+																		<Tooltip key={b.id}>
+																			<TooltipTrigger asChild>
+																				<div className="space-y-1.5">
+																					<div className="flex items-center justify-between gap-4">
+																						<span className="font-medium">{formatCurrency(b.max_limit)}</span>
+																						<span className="text-muted-foreground text-xs">{formatResetDuration(b.reset_duration)}</span>
+																					</div>
+																					<Progress
+																						value={budgetPercentage}
+																						className={cn(
+																							"bg-muted/70 dark:bg-muted/30 h-1.5",
+																							isExhausted
+																								? "[&>div]:bg-red-500/70"
+																								: budgetPercentage > 80
+																									? "[&>div]:bg-amber-500/70"
+																									: "[&>div]:bg-emerald-500/70",
+																						)}
+																					/>
+																				</div>
+																			</TooltipTrigger>
+																			<TooltipContent>
+																				<p className="font-medium">
+																					{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+																				</p>
+																				<p className="text-primary-foreground/80 text-xs">Resets {formatResetDuration(b.reset_duration)}</p>
+																			</TooltipContent>
+																		</Tooltip>
+																	);
+																})}
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">-</span>
 														)}
-													</div>
-												</TableCell>
-												<TableCell data-testid={`team-row-${team.name}-customer`}>
-													<div className="flex items-center gap-2">
-														<Badge variant={team.customer_id ? "secondary" : "outline"}>{customerName}</Badge>
-													</div>
-												</TableCell>
-												<TableCell className="min-w-[180px]">
-													{teamBudgets.length > 0 ? (
-														<div className="space-y-2.5">
-															{teamBudgets.map((b) => {
-																const budgetPercentage = b.max_limit > 0 ? Math.min((b.current_usage / b.max_limit) * 100, 100) : 0;
-																const isExhausted = b.max_limit > 0 && b.current_usage >= b.max_limit;
-																return (
-																	<Tooltip key={b.id}>
+													</TableCell>
+													<TableCell className="min-w-[180px]">
+														{team.rate_limit ? (
+															<div className="space-y-2.5">
+																{team.rate_limit.token_max_limit && (
+																	<Tooltip>
 																		<TooltipTrigger asChild>
 																			<div className="space-y-1.5">
-																				<div className="flex items-center justify-between gap-4">
-																					<span className="font-medium">{formatCurrency(b.max_limit)}</span>
-																					<span className="text-muted-foreground text-xs">{formatResetDuration(b.reset_duration)}</span>
+																				<div className="flex items-center justify-between gap-4 text-xs">
+																					<span className="font-medium">{team.rate_limit.token_max_limit.toLocaleString()} tokens</span>
+																					<span className="text-muted-foreground">
+																						{formatResetDuration(team.rate_limit.token_reset_duration || "1h")}
+																					</span>
 																				</div>
 																				<Progress
-																					value={budgetPercentage}
+																					value={tokenPercentage}
 																					className={cn(
-																						"bg-muted/70 dark:bg-muted/30 h-1.5",
-																						isExhausted
+																						"bg-muted/70 dark:bg-muted/30 h-1",
+																						isTokenLimitExhausted
 																							? "[&>div]:bg-red-500/70"
-																							: budgetPercentage > 80
+																							: tokenPercentage > 80
 																								? "[&>div]:bg-amber-500/70"
 																								: "[&>div]:bg-emerald-500/70",
 																					)}
@@ -345,165 +387,126 @@ export default function TeamsTable({
 																		</TooltipTrigger>
 																		<TooltipContent>
 																			<p className="font-medium">
-																				{formatCurrency(b.current_usage)} / {formatCurrency(b.max_limit)}
+																				{team.rate_limit.token_current_usage.toLocaleString()} /{" "}
+																				{team.rate_limit.token_max_limit.toLocaleString()} tokens
 																			</p>
-																			<p className="text-primary-foreground/80 text-xs">Resets {formatResetDuration(b.reset_duration)}</p>
+																			<p className="text-primary-foreground/80 text-xs">
+																				Resets {formatResetDuration(team.rate_limit.token_reset_duration || "1h")}
+																			</p>
 																		</TooltipContent>
 																	</Tooltip>
-																);
-															})}
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell className="min-w-[180px]">
-													{team.rate_limit ? (
-														<div className="space-y-2.5">
-															{team.rate_limit.token_max_limit && (
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<div className="space-y-1.5">
-																			<div className="flex items-center justify-between gap-4 text-xs">
-																				<span className="font-medium">{team.rate_limit.token_max_limit.toLocaleString()} tokens</span>
-																				<span className="text-muted-foreground">
-																					{formatResetDuration(team.rate_limit.token_reset_duration || "1h")}
-																				</span>
+																)}
+																{team.rate_limit.request_max_limit && (
+																	<Tooltip>
+																		<TooltipTrigger asChild>
+																			<div className="space-y-1.5">
+																				<div className="flex items-center justify-between gap-4 text-xs">
+																					<span className="font-medium">{team.rate_limit.request_max_limit.toLocaleString()} req</span>
+																					<span className="text-muted-foreground">
+																						{formatResetDuration(team.rate_limit.request_reset_duration || "1h")}
+																					</span>
+																				</div>
+																				<Progress
+																					value={requestPercentage}
+																					className={cn(
+																						"bg-muted/70 dark:bg-muted/30 h-1",
+																						isRequestLimitExhausted
+																							? "[&>div]:bg-red-500/70"
+																							: requestPercentage > 80
+																								? "[&>div]:bg-amber-500/70"
+																								: "[&>div]:bg-emerald-500/70",
+																					)}
+																				/>
 																			</div>
-																			<Progress
-																				value={tokenPercentage}
-																				className={cn(
-																					"bg-muted/70 dark:bg-muted/30 h-1",
-																					isTokenLimitExhausted
-																						? "[&>div]:bg-red-500/70"
-																						: tokenPercentage > 80
-																							? "[&>div]:bg-amber-500/70"
-																							: "[&>div]:bg-emerald-500/70",
-																				)}
-																			/>
-																		</div>
-																	</TooltipTrigger>
-																	<TooltipContent>
-																		<p className="font-medium">
-																			{team.rate_limit.token_current_usage.toLocaleString()} /{" "}
-																			{team.rate_limit.token_max_limit.toLocaleString()} tokens
-																		</p>
-																		<p className="text-primary-foreground/80 text-xs">
-																			Resets {formatResetDuration(team.rate_limit.token_reset_duration || "1h")}
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															)}
-															{team.rate_limit.request_max_limit && (
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<div className="space-y-1.5">
-																			<div className="flex items-center justify-between gap-4 text-xs">
-																				<span className="font-medium">{team.rate_limit.request_max_limit.toLocaleString()} req</span>
-																				<span className="text-muted-foreground">
-																					{formatResetDuration(team.rate_limit.request_reset_duration || "1h")}
-																				</span>
-																			</div>
-																			<Progress
-																				value={requestPercentage}
-																				className={cn(
-																					"bg-muted/70 dark:bg-muted/30 h-1",
-																					isRequestLimitExhausted
-																						? "[&>div]:bg-red-500/70"
-																						: requestPercentage > 80
-																							? "[&>div]:bg-amber-500/70"
-																							: "[&>div]:bg-emerald-500/70",
-																				)}
-																			/>
-																		</div>
-																	</TooltipTrigger>
-																	<TooltipContent>
-																		<p className="font-medium">
-																			{team.rate_limit.request_current_usage.toLocaleString()} /{" "}
-																			{team.rate_limit.request_max_limit.toLocaleString()} requests
-																		</p>
-																		<p className="text-primary-foreground/80 text-xs">
-																			Resets {formatResetDuration(team.rate_limit.request_reset_duration || "1h")}
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															)}
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell>
-													{vkCount > 0 ? (
-														<div className="flex items-center gap-2">
-															<Badge variant="outline" className="text-xs">
-																{vkCount} {vkCount === 1 ? "key" : "keys"}
-															</Badge>
-														</div>
-													) : (
-														<span className="text-muted-foreground text-sm">-</span>
-													)}
-												</TableCell>
-												<TableCell
-													className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
-												>
-													<TeamActionsMenu
-														team={team}
-														hasUpdateAccess={hasUpdateAccess}
-														hasDeleteAccess={hasDeleteAccess}
-														isDeleting={isDeleting}
-														onEdit={handleEditTeam}
-														onDelete={handleDelete}
-													/>
-												</TableCell>
-											</TableRow>
-										);
-									})
-								)}
-							</TableBody>
-						</Table>
-					</div>
+																		</TooltipTrigger>
+																		<TooltipContent>
+																			<p className="font-medium">
+																				{team.rate_limit.request_current_usage.toLocaleString()} /{" "}
+																				{team.rate_limit.request_max_limit.toLocaleString()} requests
+																			</p>
+																			<p className="text-primary-foreground/80 text-xs">
+																				Resets {formatResetDuration(team.rate_limit.request_reset_duration || "1h")}
+																			</p>
+																		</TooltipContent>
+																	</Tooltip>
+																)}
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">-</span>
+														)}
+													</TableCell>
+													<TableCell>
+														{vkCount > 0 ? (
+															<div className="flex items-center gap-2">
+																<Badge variant="outline" className="text-xs">
+																	{vkCount} {vkCount === 1 ? "key" : "keys"}
+																</Badge>
+															</div>
+														) : (
+															<span className="text-muted-foreground text-sm">-</span>
+														)}
+													</TableCell>
+													<TableCell
+														className={`group-hover:bg-muted dark:bg-card dark:group-hover:bg-muted sticky right-0 z-10 bg-white text-right ${PIN_SHADOW_RIGHT}`}
+													>
+														<TeamActionsMenu
+															team={team}
+															hasUpdateAccess={hasUpdateAccess}
+															hasDeleteAccess={hasDeleteAccess}
+															isDeleting={isDeleting}
+															onEdit={handleEditTeam}
+															onDelete={handleDelete}
+														/>
+													</TableCell>
+												</TableRow>
+											);
+										})
+									)}
+								</TableBody>
+							</Table>
+						</div>
 
-					{/* Pagination */}
-					{totalCount > 0 && (
-						<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
-							<div className="text-muted-foreground flex items-center gap-2">
-								{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
-								entries
-							</div>
-
-							<div className="flex items-center gap-2">
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => onOffsetChange(Math.max(0, offset - limit))}
-									disabled={offset === 0}
-									data-testid="teams-pagination-prev-btn"
-									aria-label="Previous page"
-								>
-									<ChevronLeft className="size-3" />
-								</Button>
-
-								<div className="flex items-center gap-1">
-									<span>Page</span>
-									<span>{Math.floor(offset / limit) + 1}</span>
-									<span>of {Math.ceil(totalCount / limit)}</span>
+						{/* Pagination */}
+						{totalCount > 0 && (
+							<div className="flex shrink-0 items-center justify-between text-xs" data-testid="pagination">
+								<div className="text-muted-foreground flex items-center gap-2">
+									{(offset + 1).toLocaleString()}-{Math.min(offset + limit, totalCount).toLocaleString()} of {totalCount.toLocaleString()}{" "}
+									entries
 								</div>
 
-								<Button
-									variant="ghost"
-									size="sm"
-									onClick={() => onOffsetChange(offset + limit)}
-									disabled={offset + limit >= totalCount}
-									data-testid="teams-pagination-next-btn"
-									aria-label="Next page"
-								>
-									<ChevronRight className="size-3" />
-								</Button>
+								<div className="flex items-center gap-2">
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => onOffsetChange(Math.max(0, offset - limit))}
+										disabled={offset === 0}
+										data-testid="teams-pagination-prev-btn"
+										aria-label="Previous page"
+									>
+										<ChevronLeft className="size-3" />
+									</Button>
+
+									<div className="flex items-center gap-1">
+										<span>Page</span>
+										<span>{Math.floor(offset / limit) + 1}</span>
+										<span>of {Math.ceil(totalCount / limit)}</span>
+									</div>
+
+									<Button
+										variant="ghost"
+										size="sm"
+										onClick={() => onOffsetChange(offset + limit)}
+										disabled={offset + limit >= totalCount}
+										data-testid="teams-pagination-next-btn"
+										aria-label="Next page"
+									>
+										<ChevronRight className="size-3" />
+									</Button>
+								</div>
 							</div>
-						</div>
-					)}
-				</div>
+						)}
+					</div>
+				)}
 			</TooltipProvider>
 		</>
 	);


### PR DESCRIPTION
## Summary

Background polling on the Teams and Customers governance pages was silently discarding in-progress edits. Every time the poll fired, the list data was replaced with a fresh response, which caused the edit sheets to re-initialize their form state and wipe whatever the operator had typed.

## Changes

- Polling is now paused while an edit sheet is open. For the Teams view, the poll interval is set to `0` when `urlState.selected_team` is set. For the Customers view, a new `isSheetOpen` state variable tracks sheet visibility and is propagated from `CustomersTable` via a new `onSheetOpenChange` callback prop.
- `skipPollingIfUnfocused: true` is added to all polling queries so background tabs don't burn unnecessary requests.
- `CustomerSheet` now keys its form-reset `useEffect` on `customer?.id` instead of the full `customer` object. Because the list is polled, an unchanged customer still arrives as a new object reference every few seconds; keying on identity rather than reference prevents spurious resets during an active edit.
- `TeamSheet` applies the same fix using a `seededTeamIdRef` to track which team ID has already been used to seed the form, skipping the reset when the same team re-arrives from a poll.
- The "truly empty" early-return branches in `CustomersTable` and `TeamsTable` are replaced with conditional renders inside a single component tree. The early return caused React to see a different component shape whenever `isFetching` flipped (which happens on every poll), remounting the sheet and wiping form state.
- A guard is added to the customers pagination snap-back `useEffect` to skip calling `setUrlState` when the list is empty and the offset is already `0`, preventing a spurious history entry in that case.

## Type of change

- [x] Bug fix

## Affected areas

- [x] UI (React)

## How to test

1. Navigate to the Teams governance page with at least one team present.
2. Open the edit sheet for a team and type changes into any field.
3. Wait for the polling interval (5 seconds) to elapse.
4. Verify that the typed changes are not discarded while the sheet is open.
5. Close the sheet and confirm polling resumes normally (rows update within the next interval).
6. Repeat steps 2–5 on the Customers governance page.
7. Verify that navigating to an empty Customers page and back does not push extra browser history entries.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: typing into an edit sheet would be silently reset every 5 seconds by a background poll.  
After: the form retains all in-progress input until the operator explicitly closes or submits the sheet.

## Breaking changes

- [x] No

## Related issues  
https://github.com/maximhq/bifrost/issues/6734

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable