### PR TITLE
feat: record `MCPConnectionFailure` (stage, message, timestamps) on client state and credential rows, surfacing failure reason in client-list API and cluster node states

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4145,9 +4145,10 @@ func (bifrost *Bifrost) GetMCPClients() ([]schemas.MCPClient, error) {
 		})
 
 		clientsInConfig = append(clientsInConfig, schemas.MCPClient{
-			Config: client.ExecutionConfig,
-			Tools:  tools,
-			State:  client.State,
+			Config:      client.ExecutionConfig,
+			Tools:       tools,
+			State:       client.State,
+			LastFailure: client.LastFailure,
 		})
 	}
 

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -253,6 +253,11 @@ func (m *MCPManager) GetClients() []schemas.MCPClientState {
 
 	clients := make([]schemas.MCPClientState, 0, len(m.clientMap))
 	for _, client := range m.clientMap {
+		// A struct copy: ToolMap is cloned below because callers may range
+		// over it while a discovery write-back replaces the original.
+		// LastFailure is shared as-is on purpose — the record is only ever
+		// replaced, never mutated (see MCPConnectionFailure), so the copied
+		// pointer keeps describing the failure this snapshot was taken with.
 		snapshot := *client
 		if client.ToolMap != nil {
 			snapshot.ToolMap = make(map[string]schemas.ChatTool, len(client.ToolMap))
@@ -393,6 +398,7 @@ func (m *MCPManager) CloseAndMarkNeedsReauth(id string) (retErr error) {
 		clientState.Conn = nil
 	}
 	clientState.State = schemas.MCPConnectionStateNeedsReauth
+	recordClientFailure(clientState, schemas.MCPConnectionFailureStageCredential, errCredentialRotated)
 	m.logger.Debug("%s MCP client '%s' closed and marked needs_reauth after credential rotation", MCPLogPrefix, clientState.ExecutionConfig.Name)
 	return nil
 }
@@ -637,7 +643,7 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 					client.ToolMap[toolName] = tool
 				}
 				client.ToolNameMapping = config.DiscoveredToolNameMapping
-				client.State = schemas.MCPConnectionStateHealthy
+				markClientHealthy(client)
 				// Seed the change-detection hash from what was just
 				// restored (without firing the callback — restoring
 				// already-known tools is not a change) so a subsequent
@@ -651,7 +657,7 @@ func (m *MCPManager) AddClient(requestCtx context.Context, config *schemas.MCPCl
 				// ToolMap already says "no tools discovered yet" on its own —
 				// nothing downstream (execution gating, GetToolPerClient)
 				// ever treated the two differently.
-				client.State = schemas.MCPConnectionStateHealthy
+				markClientHealthy(client)
 				m.logger.Debug("%s Per-user (%s) MCP client '%s' registered (connection deferred to runtime)", MCPLogPrefix, config.AuthType, config.Name)
 			}
 		}
@@ -1090,7 +1096,7 @@ func (m *MCPManager) SetClientTools(clientID string, tools map[string]schemas.Ch
 	precomputeToolSerialization(tools)
 	client.ToolMap = tools
 	client.ToolNameMapping = toolNameMapping
-	client.State = schemas.MCPConnectionStateHealthy
+	markClientHealthy(client)
 	m.logger.Debug("%s Set %d tools on client '%s'", MCPLogPrefix, len(tools), client.Name)
 	fire := m.toolsChangedCallback(client, clientID, tools, toolNameMapping)
 	m.mu.Unlock()
@@ -1316,7 +1322,7 @@ func (m *MCPManager) EnableClient(id string) (retErr error) {
 		// Healthy either way — an empty ToolMap already says "no tools
 		// discovered yet" on its own, no dedicated state needed.
 		if cs, exists := m.clientMap[id]; exists {
-			cs.State = schemas.MCPConnectionStateHealthy
+			markClientHealthy(cs)
 		}
 		m.mu.Unlock()
 		if id != BifrostMCPClientKey {
@@ -1604,7 +1610,7 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 			// persistent connection to monitor is simply Healthy, the same
 			// state per-user auth types are given at connect time.
 			if client.State != schemas.MCPConnectionStateDisabled && client.State != schemas.MCPConnectionStateNeedsReauth {
-				client.State = schemas.MCPConnectionStateHealthy
+				markClientHealthy(client)
 			}
 			// A disabled client keeps no checker (DisableClient stopped it,
 			// EnableClient starts a fresh one), so only a live client gets
@@ -1667,6 +1673,11 @@ func (m *MCPManager) UpdateClient(id string, updatedConfig *schemas.MCPClientCon
 					alreadyTerminal = true
 				default:
 					cs.State = schemas.MCPConnectionStateUnstable
+					// connectToMCPClient's own failure exit already recorded
+					// this against the entry it dialed with; re-recording here
+					// keeps the record right if that entry was swapped out
+					// under the attempt (Since is preserved either way).
+					recordClientFailure(cs, schemas.MCPConnectionFailureStageConnect, connErr)
 				}
 			}
 			m.mu.Unlock()
@@ -1766,7 +1777,7 @@ func (m *MCPManager) UpdateClientCredentials(id string, newConfig *schemas.MCPCl
 					cs.ToolMap = restored
 					cs.ToolNameMapping = newConfig.DiscoveredToolNameMapping
 				}
-				cs.State = schemas.MCPConnectionStateHealthy
+				markClientHealthy(cs)
 			}
 			m.mu.Unlock()
 			// A client with nothing to restore gets its first discovery pass
@@ -2311,7 +2322,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 		// authoritative, same invariant the health monitor's updateClientState
 		// guard preserves).
 		needsReauth := gateErr.Error != nil && errors.Is(gateErr.Error.Error, schemas.ErrOAuth2TokenExpired)
-		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, needsReauth)
+		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, needsReauth, errors.New(gateErr.GetErrorString()))
 		return fmt.Errorf("failed to connect MCP client %s: %s", config.Name, gateErr.GetErrorString())
 	}
 
@@ -2337,7 +2348,10 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 		t, mapping, err := m.runListToolsWithHooks(toolRetrievalCtx, externalClient, config.Name)
 		if err != nil {
 			listToolsErr = err
-			m.logger.Warn("%s Failed to retrieve tools from %s: %v", MCPLogPrefix, config.Name, err)
+			// Debug, not Warn: every reconnect attempt during an outage lands
+			// here (the checker retries on a 10s cadence while Unstable), and
+			// failConnectAttempt logs the reason once at the state transition.
+			m.logger.Debug("%s Failed to retrieve tools from %s: %v", MCPLogPrefix, config.Name, err)
 		} else {
 			tools = t
 			toolNameMapping = mapping
@@ -2354,7 +2368,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 	// connect+list. A server that legitimately exposes zero tools returns success with
 	// an empty list (listToolsErr == nil) and is still marked Connected.
 	if listToolsErr != nil {
-		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false)
+		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false, listToolsErr)
 		return fmt.Errorf("failed to retrieve tools from MCP client %s: %w", config.Name, listToolsErr)
 	}
 
@@ -2373,7 +2387,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 		// setup: release both the new handles and any captured old ones to
 		// prevent transport/goroutine leaks, without touching the
 		// replacement entry.
-		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false)
+		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false, nil)
 		return fmt.Errorf("client %s was removed during connection setup", config.Name)
 	}
 
@@ -2382,7 +2396,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 	// the Disabled state. This is a rare edge case.
 	if client.State == schemas.MCPConnectionStateDisabled {
 		m.mu.Unlock()
-		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false)
+		m.failConnectAttempt(entry, config, cancel, externalClient, oldCancel, oldConn, false, nil)
 		m.logger.Debug("%s [%s] Client was disabled during connection setup; rolling back", MCPLogPrefix, config.Name)
 		return fmt.Errorf("client %s was disabled during connection setup", config.Name)
 	}
@@ -2390,7 +2404,7 @@ func (m *MCPManager) connectToMCPClient(requestCtx context.Context, config *sche
 	// Store the external client connection and details
 	client.Conn = externalClient
 	client.ConnectionInfo = connectionInfo
-	client.State = schemas.MCPConnectionStateHealthy
+	markClientHealthy(client)
 
 	// Store cancel function for SSE and STDIO connections to enable proper cleanup
 	if config.ConnectionType == schemas.MCPConnectionTypeSSE || config.ConnectionType == schemas.MCPConnectionTypeSTDIO {
@@ -2487,6 +2501,7 @@ func (m *MCPManager) handleSSEConnectionLost(clientID, clientName string, genera
 		return
 	}
 	client.State = schemas.MCPConnectionStateUnstable
+	recordClientFailure(client, schemas.MCPConnectionFailureStageTransportLost, err)
 	m.mu.Unlock()
 	m.logger.Warn("%s SSE connection lost for MCP server '%s': %v", MCPLogPrefix, clientName, err)
 }
@@ -2531,9 +2546,16 @@ func (m *MCPManager) closeConnHandles(cancel context.CancelFunc, conn *client.Cl
 // attempt started with; a RemoveClient + AddClient cycle for the same ID
 // during the dial installs a different pointer under the same key, and this
 // attempt must not mutate that replacement.
-func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *schemas.MCPClientConfig, newCancel context.CancelFunc, newConn *client.Client, oldCancel context.CancelFunc, oldConn *client.Client, needsReauth bool) {
+//
+// failure is the error the attempt failed with, recorded on the entry as its
+// MCPConnectionFailure so the resulting state carries its own explanation;
+// nil for the exits that are not failures of the connection itself (the
+// entry was removed or disabled while the dial was in flight), which leave
+// any existing record alone.
+func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *schemas.MCPClientConfig, newCancel context.CancelFunc, newConn *client.Client, oldCancel context.CancelFunc, oldConn *client.Client, needsReauth bool, failure error) {
 	m.mu.Lock()
 	var oldState, newState schemas.MCPConnectionState
+	var recorded *schemas.MCPConnectionFailure
 	stateChanged := false
 	if clientState, exists := m.clientMap[config.ID]; exists && clientState == entry && clientState.State != schemas.MCPConnectionStateDisabled {
 		clientState.Conn = nil
@@ -2559,9 +2581,28 @@ func (m *MCPManager) failConnectAttempt(entry *schemas.MCPClientState, config *s
 		}
 		stateChanged = oldState != newState
 		clientState.State = newState
+		if failure != nil {
+			stage := schemas.MCPConnectionFailureStageConnect
+			if needsReauth {
+				stage = schemas.MCPConnectionFailureStageCredential
+			}
+			recordClientFailure(clientState, stage, failure)
+			recorded = clientState.LastFailure
+		}
 	}
 	cb := m.stateChangeCallback
 	m.mu.Unlock()
+
+	// One line per transition, carrying the reason — the per-attempt detail
+	// stays at Debug because a reconnect loop during an outage re-runs this
+	// every 10s and would otherwise flood the log at Warn.
+	if stateChanged {
+		if recorded != nil {
+			m.logger.Info("%s Client %s connection state changed to: %s (%s failed: %s)", MCPLogPrefix, config.Name, newState, recorded.Stage, recorded.Message)
+		} else {
+			m.logger.Info("%s Client %s connection state changed to: %s", MCPLogPrefix, config.Name, newState)
+		}
+	}
 
 	m.closeConnHandles(newCancel, newConn, config.Name)
 	m.closeConnHandles(oldCancel, oldConn, config.Name)

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -110,6 +110,9 @@ func TestCloseAndMarkNeedsReauth_ClosesLiveConnectionAndFlipsState(t *testing.T)
 	assert.Nil(t, state.CancelFunc)
 	assert.Nil(t, state.Conn)
 	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, state.State)
+	require.NotNil(t, state.LastFailure, "needs_reauth carries its own explanation")
+	assert.Equal(t, schemas.MCPConnectionFailureStageCredential, state.LastFailure.Stage)
+	assert.Equal(t, errCredentialRotated.Error(), state.LastFailure.Message)
 }
 
 // TestFailConnectAttempt_NeedsReauthTransition_FiresStateChangeCallback
@@ -140,7 +143,7 @@ func TestFailConnectAttempt_NeedsReauthTransition_FiresStateChangeCallback(t *te
 	m.clientMap[config.ID] = entry
 	m.mu.Unlock()
 
-	m.failConnectAttempt(entry, config, nil, nil, nil, nil, true)
+	m.failConnectAttempt(entry, config, nil, nil, nil, nil, true, errors.New("oauth2 token expired"))
 
 	require.Len(t, calls, 1, "the callback must fire exactly once for a genuine state transition")
 	assert.Equal(t, config.ID, calls[0].clientID)
@@ -175,7 +178,7 @@ func TestFailConnectAttempt_NoStateChange_DoesNotFireCallback(t *testing.T) {
 	m.clientMap[config.ID] = entry
 	m.mu.Unlock()
 
-	m.failConnectAttempt(entry, config, nil, nil, nil, nil, false)
+	m.failConnectAttempt(entry, config, nil, nil, nil, nil, false, errors.New("connection refused"))
 
 	assert.False(t, fired, "the callback must not fire when the transition is a no-op")
 }

--- a/core/mcp/connectionchecker.go
+++ b/core/mcp/connectionchecker.go
@@ -313,7 +313,7 @@ func (c *ClientConnectionChecker) checkLiveConnection(conn *client.Client, clien
 			return c.manager.runPingWithHooks(c.markAsCheck(attemptCtx), conn, clientName)
 		}, ProbeRetryConfig, c.logger)
 		if pingErr != nil {
-			c.recordFailure(clientName, "ping", pingErr, connGeneration)
+			c.recordFailure(clientName, schemas.MCPConnectionFailureStagePing, pingErr, connGeneration)
 			return false
 		}
 	}
@@ -328,7 +328,7 @@ func (c *ClientConnectionChecker) checkLiveConnection(conn *client.Client, clien
 		return err
 	}, ProbeRetryConfig, c.logger)
 	if listErr != nil {
-		c.recordFailure(clientName, "list_tools", listErr, connGeneration)
+		c.recordFailure(clientName, schemas.MCPConnectionFailureStageListTools, listErr, connGeneration)
 		return false
 	}
 
@@ -351,7 +351,7 @@ func (c *ClientConnectionChecker) checkPerCall(config *schemas.MCPClientConfig, 
 		return innerErr
 	}, ProbeRetryConfig, c.logger)
 	if err != nil {
-		c.recordFailure(config.Name, "admin tool discovery", err, connGeneration)
+		c.recordFailure(config.Name, schemas.MCPConnectionFailureStageToolDiscovery, err, connGeneration)
 		return false
 	}
 
@@ -413,21 +413,28 @@ func (c *ClientConnectionChecker) writeBackTools(connGeneration uint64, newTools
 // recordFailure marks the client Unstable — a single transient-classified
 // failure is enough, no consecutive-failure counter: the retry-with-backoff
 // each check already went through (ProbeRetryConfig) is what absorbs an
-// ordinary blip before it ever reaches here. connGeneration is the value
-// captured at the start of this check (see performCheck) — see setState for
-// why it must be threaded through even though this write, unlike
-// writeBackTools, isn't about the connection itself.
-func (c *ClientConnectionChecker) recordFailure(clientName, stage string, err error, connGeneration uint64) {
-	c.logger.Warn("%s Connection check (%s) failed for %s: %v", MCPLogPrefix, stage, clientName, err)
-	c.setState(schemas.MCPConnectionStateUnstable, connGeneration)
+// ordinary blip before it ever reaches here. The stage and error are kept on
+// the client as its MCPConnectionFailure, refreshed on every failed tick so
+// the record always describes the most recent attempt. connGeneration is the
+// value captured at the start of this check (see performCheck) — see
+// setState for why it must be threaded through even though this write,
+// unlike writeBackTools, isn't about the connection itself.
+//
+// Logged at Debug, not Warn: while a client is Unstable this runs every
+// UnstableConnectionCheckInterval for the whole outage, and the reason is
+// already surfaced once, at the transition, by setState's Info line and
+// durably by the record itself.
+func (c *ClientConnectionChecker) recordFailure(clientName string, stage schemas.MCPConnectionFailureStage, err error, connGeneration uint64) {
+	c.logger.Debug("%s Connection check (%s) failed for %s: %v", MCPLogPrefix, stage, clientName, err)
+	c.setState(schemas.MCPConnectionStateUnstable, connGeneration, stage, err)
 }
 
-// recordSuccess marks the client Healthy. A single success is enough to
-// recover — asymmetric on purpose: slow and deliberate into Unstable
-// (respecting the retry budget), instant back out of it once a check
-// actually proves the connection is fine again.
+// recordSuccess marks the client Healthy and clears its failure record. A
+// single success is enough to recover — asymmetric on purpose: slow and
+// deliberate into Unstable (respecting the retry budget), instant back out
+// of it once a check actually proves the connection is fine again.
 func (c *ClientConnectionChecker) recordSuccess(clientName string, connGeneration uint64) {
-	c.setState(schemas.MCPConnectionStateHealthy, connGeneration)
+	c.setState(schemas.MCPConnectionStateHealthy, connGeneration, "", nil)
 }
 
 // setState is the guarded writer every transition in this file funnels
@@ -443,7 +450,13 @@ func (c *ClientConnectionChecker) recordSuccess(clientName string, connGeneratio
 // its state write would land on an entry that has since moved on — e.g.
 // marking Unstable a client that just became per-call and has no connection
 // left to be unstable about.
-func (c *ClientConnectionChecker) setState(state schemas.MCPConnectionState, connGeneration uint64) {
+//
+// stage and err describe the failure behind a non-Healthy state and are
+// recorded on the client under the same guards as the state itself, on every
+// accepted write rather than only on a transition, so a long outage keeps a
+// current "last attempt" timestamp. A Healthy write clears the record. Both
+// are ignored for a Healthy state.
+func (c *ClientConnectionChecker) setState(state schemas.MCPConnectionState, connGeneration uint64, stage schemas.MCPConnectionFailureStage, err error) {
 	c.manager.mu.Lock()
 	clientState, exists := c.manager.clientMap[c.clientID]
 	if !exists {
@@ -465,14 +478,25 @@ func (c *ClientConnectionChecker) setState(state schemas.MCPConnectionState, con
 	if clientState.ExecutionConfig != nil {
 		name = clientState.ExecutionConfig.Name
 	}
-	if stateChanged {
+	var recorded *schemas.MCPConnectionFailure
+	if state == schemas.MCPConnectionStateHealthy {
+		markClientHealthy(clientState)
+	} else {
 		clientState.State = state
+		if err != nil {
+			recordClientFailure(clientState, stage, err)
+			recorded = clientState.LastFailure
+		}
 	}
 	cb := c.manager.stateChangeCallback
 	c.manager.mu.Unlock()
 
 	if stateChanged {
-		c.logger.Info("%s Client %s connection state changed to: %s", MCPLogPrefix, name, state)
+		if recorded != nil {
+			c.logger.Info("%s Client %s connection state changed to: %s (%s failed: %s)", MCPLogPrefix, name, state, recorded.Stage, recorded.Message)
+		} else {
+			c.logger.Info("%s Client %s connection state changed to: %s", MCPLogPrefix, name, state)
+		}
 		// Fired outside the lock — a registered callback is caller-supplied
 		// and may do arbitrary work (including I/O), which must never run
 		// while holding m.mu.

--- a/core/mcp/connectionchecker_test.go
+++ b/core/mcp/connectionchecker_test.go
@@ -259,13 +259,16 @@ func TestSetState_StaleGeneration_DoesNotOverwriteState(t *testing.T) {
 
 	// A check that captured generation 5 (before the transition) finishing
 	// late must not move the state at all.
-	checker.setState(schemas.MCPConnectionStateUnstable, 5)
+	checker.setState(schemas.MCPConnectionStateUnstable, 5, schemas.MCPConnectionFailureStagePing, errors.New("stale"))
 	require.Equal(t, schemas.MCPConnectionStateHealthy, manager.clientMap[config.ID].State, "a stale-generation state write must be dropped")
+	require.Nil(t, manager.clientMap[config.ID].LastFailure, "a dropped state write must not leave a failure record behind either")
 
 	// A check whose captured generation still matches the client's current
 	// one must apply normally — the guard isn't a blanket no-op.
-	checker.setState(schemas.MCPConnectionStateUnstable, 6)
+	checker.setState(schemas.MCPConnectionStateUnstable, 6, schemas.MCPConnectionFailureStagePing, errors.New("current"))
 	require.Equal(t, schemas.MCPConnectionStateUnstable, manager.clientMap[config.ID].State, "a current-generation state write must still apply")
+	require.NotNil(t, manager.clientMap[config.ID].LastFailure, "an applied failure write records its reason")
+	require.Equal(t, "current", manager.clientMap[config.ID].LastFailure.Message)
 }
 
 // TestSetState_FiresStateChangeCallbackOnGenuineTransition verifies
@@ -299,7 +302,7 @@ func TestSetState_FiresStateChangeCallbackOnGenuineTransition(t *testing.T) {
 
 	// Healthy -> Unstable: a genuine transition, must fire once. Generation 0
 	// matches this client's zero-value ConnGeneration (never bumped here).
-	checker.recordFailure(config.Name, "ping", errors.New("boom"), 0)
+	checker.recordFailure(config.Name, schemas.MCPConnectionFailureStagePing, errors.New("boom"), 0)
 	require.Len(t, calls, 1)
 	assert.Equal(t, config.ID, calls[0].clientID)
 	assert.Equal(t, config.Name, calls[0].name)
@@ -307,7 +310,7 @@ func TestSetState_FiresStateChangeCallbackOnGenuineTransition(t *testing.T) {
 	assert.Equal(t, schemas.MCPConnectionStateUnstable, calls[0].newState)
 
 	// Unstable -> Unstable: a no-op, must not fire again.
-	checker.recordFailure(config.Name, "ping", errors.New("boom again"), 0)
+	checker.recordFailure(config.Name, schemas.MCPConnectionFailureStagePing, errors.New("boom again"), 0)
 	require.Len(t, calls, 1, "a repeat failure that doesn't change state must not re-fire the callback")
 
 	// Unstable -> Healthy: a genuine transition, must fire again.

--- a/core/mcp/connectionfailure.go
+++ b/core/mcp/connectionfailure.go
@@ -1,0 +1,74 @@
+package mcp
+
+import (
+	"errors"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// errCredentialRotated is the recorded reason when CloseAndMarkNeedsReauth
+// parks a client: the stored credential was replaced by an admin and the
+// connection it authorized cannot be reused until the new one is authorized.
+var errCredentialRotated = errors.New("credential was rotated and must be reauthorized")
+
+// connectionFailureMessageMaxLen bounds MCPConnectionFailure.Message. The
+// record rides every client-list response and, in a distributed deployment,
+// every node-state heartbeat, so an upstream error that embeds a whole HTML
+// error page must not travel at full length.
+const connectionFailureMessageMaxLen = 512
+
+// newConnectionFailure builds the record for a failure that just happened at
+// stage. previous is the client's current record, if any: a failure that
+// follows another keeps the earlier Since so the record spans the whole
+// unhealthy run, while At always reflects this most recent attempt. The
+// caller replaces the client's pointer with the result rather than mutating
+// the old record in place (see MCPConnectionFailure's doc).
+func newConnectionFailure(stage schemas.MCPConnectionFailureStage, err error, previous *schemas.MCPConnectionFailure) *schemas.MCPConnectionFailure {
+	now := time.Now()
+	since := now
+	if previous != nil && !previous.Since.IsZero() {
+		since = previous.Since
+	}
+	return &schemas.MCPConnectionFailure{
+		Stage:   stage,
+		Message: connectionFailureMessage(err),
+		At:      now,
+		Since:   since,
+	}
+}
+
+// connectionFailureMessage normalizes an error for the record: internal
+// whitespace (including the newlines a multi-line upstream body carries)
+// collapses to single spaces, and the result is cut at
+// connectionFailureMessageMaxLen on a rune boundary.
+func connectionFailureMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := strings.Join(strings.Fields(err.Error()), " ")
+	if utf8.RuneCountInString(msg) <= connectionFailureMessageMaxLen {
+		return msg
+	}
+	runes := []rune(msg)
+	return string(runes[:connectionFailureMessageMaxLen-1]) + "…"
+}
+
+// markClientHealthy is the one way State becomes Healthy: the failure record
+// is cleared in the same write, so a Healthy client never carries a stale
+// explanation. Caller holds m.mu.
+func markClientHealthy(cs *schemas.MCPClientState) {
+	cs.State = schemas.MCPConnectionStateHealthy
+	cs.LastFailure = nil
+}
+
+// recordClientFailure replaces the client's failure record with one for the
+// failure that just happened, preserving the start of the current unhealthy
+// run. It does not touch State: every caller decides that separately, since
+// the same failure lands in Unstable or NeedsReauth depending on its
+// classification. Caller holds m.mu.
+func recordClientFailure(cs *schemas.MCPClientState, stage schemas.MCPConnectionFailureStage, err error) {
+	cs.LastFailure = newConnectionFailure(stage, err, cs.LastFailure)
+}

--- a/core/mcp/connectionfailure_test.go
+++ b/core/mcp/connectionfailure_test.go
@@ -1,0 +1,158 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewConnectionFailure_NormalizesMessage covers the record's message
+// hygiene: an upstream error that arrives as a multi-line body collapses to
+// one line, and one long enough to bloat every list response and heartbeat
+// is cut at connectionFailureMessageMaxLen on a rune boundary.
+func TestNewConnectionFailure_NormalizesMessage(t *testing.T) {
+	multiline := errors.New("dial failed:\n\tconnection refused\n\n  (retry later)")
+	got := newConnectionFailure(schemas.MCPConnectionFailureStageConnect, multiline, nil)
+	assert.Equal(t, "dial failed: connection refused (retry later)", got.Message)
+
+	long := errors.New(strings.Repeat("é", connectionFailureMessageMaxLen+50))
+	got = newConnectionFailure(schemas.MCPConnectionFailureStageConnect, long, nil)
+	assert.Equal(t, connectionFailureMessageMaxLen, len([]rune(got.Message)), "cut on a rune boundary, ellipsis included")
+	assert.True(t, strings.HasSuffix(got.Message, "…"))
+
+	assert.Empty(t, newConnectionFailure(schemas.MCPConnectionFailureStageConnect, nil, nil).Message)
+}
+
+// TestNewConnectionFailure_PreservesSince covers the two timestamps: At is
+// always this attempt, Since is inherited from the record being replaced so
+// it keeps marking where the current unhealthy run began.
+func TestNewConnectionFailure_PreservesSince(t *testing.T) {
+	first := newConnectionFailure(schemas.MCPConnectionFailureStagePing, errors.New("one"), nil)
+	assert.Equal(t, first.At, first.Since, "a first failure starts its own run")
+
+	time.Sleep(2 * time.Millisecond)
+	second := newConnectionFailure(schemas.MCPConnectionFailureStageListTools, errors.New("two"), first)
+	assert.Equal(t, first.Since, second.Since, "a follow-up failure keeps the run's start")
+	assert.True(t, second.At.After(first.At), "At always reflects the latest attempt")
+	assert.Equal(t, schemas.MCPConnectionFailureStageListTools, second.Stage)
+	assert.Equal(t, "two", second.Message)
+}
+
+// TestSetState_RecordsFailureAndClearsOnHealthy walks the periodic checker's
+// own record lifecycle: a failed tick writes the record, a second failed tick
+// refreshes At while keeping Since and swaps in the new stage/message even
+// though the state itself does not change, and the recovering tick clears
+// it along with the flip to Healthy.
+func TestSetState_RecordsFailureAndClearsOnHealthy(t *testing.T) {
+	manager := &MCPManager{
+		logger:    &MockLogger{},
+		clientMap: map[string]*schemas.MCPClientState{},
+	}
+	state, config := newSyncTestClientState("client-rec", "rec-client", schemas.MCPAuthTypeHeaders, nil)
+	state.State = schemas.MCPConnectionStateHealthy
+	manager.clientMap[config.ID] = state
+	checker := NewClientConnectionChecker(manager, config.ID, time.Minute, false, &MockLogger{})
+
+	checker.recordFailure(config.Name, schemas.MCPConnectionFailureStagePing, errors.New("ping: i/o timeout"), 0)
+	first := manager.clientMap[config.ID].LastFailure
+	require.NotNil(t, first)
+	assert.Equal(t, schemas.MCPConnectionStateUnstable, manager.clientMap[config.ID].State)
+	assert.Equal(t, schemas.MCPConnectionFailureStagePing, first.Stage)
+	assert.Equal(t, "ping: i/o timeout", first.Message)
+
+	time.Sleep(2 * time.Millisecond)
+	checker.recordFailure(config.Name, schemas.MCPConnectionFailureStageListTools, errors.New("context deadline exceeded"), 0)
+	second := manager.clientMap[config.ID].LastFailure
+	require.NotNil(t, second)
+	assert.NotSame(t, first, second, "the record is replaced, never mutated in place")
+	assert.Equal(t, schemas.MCPConnectionFailureStageListTools, second.Stage)
+	assert.Equal(t, "context deadline exceeded", second.Message)
+	assert.Equal(t, first.Since, second.Since)
+	assert.True(t, second.At.After(first.At))
+	assert.Equal(t, schemas.MCPConnectionFailureStagePing, first.Stage, "the snapshot a reader already holds is untouched")
+
+	checker.recordSuccess(config.Name, 0)
+	assert.Equal(t, schemas.MCPConnectionStateHealthy, manager.clientMap[config.ID].State)
+	assert.Nil(t, manager.clientMap[config.ID].LastFailure, "Healthy never carries a stale explanation")
+}
+
+// TestFailConnectAttempt_RecordsFailureByClassification checks the connect
+// path's stage choice: a dead credential is recorded as a credential failure
+// alongside NeedsReauth, anything else as a connect failure alongside
+// Unstable, and the not-a-failure exits (nil error) leave the existing record
+// exactly as it was.
+func TestFailConnectAttempt_RecordsFailureByClassification(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-fail-record")
+	entry := &schemas.MCPClientState{Name: config.Name, ExecutionConfig: config, State: schemas.MCPConnectionStateHealthy}
+	m.mu.Lock()
+	m.clientMap[config.ID] = entry
+	m.mu.Unlock()
+
+	m.failConnectAttempt(entry, config, nil, nil, nil, nil, false, errors.New("dial tcp: connection refused"))
+	require.NotNil(t, entry.LastFailure)
+	assert.Equal(t, schemas.MCPConnectionStateUnstable, entry.State)
+	assert.Equal(t, schemas.MCPConnectionFailureStageConnect, entry.LastFailure.Stage)
+	assert.Equal(t, "dial tcp: connection refused", entry.LastFailure.Message)
+	connectRecord := entry.LastFailure
+
+	m.failConnectAttempt(entry, config, nil, nil, nil, nil, false, nil)
+	assert.Same(t, connectRecord, entry.LastFailure, "a removed/disabled-during-setup exit is not a connection failure and must not touch the record")
+
+	m.failConnectAttempt(entry, config, nil, nil, nil, nil, true, errors.New("oauth2 token expired"))
+	require.NotNil(t, entry.LastFailure)
+	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, entry.State)
+	assert.Equal(t, schemas.MCPConnectionFailureStageCredential, entry.LastFailure.Stage)
+	assert.Equal(t, connectRecord.Since, entry.LastFailure.Since, "the run started with the first connect failure")
+}
+
+// TestHandleSSEConnectionLost_RecordsTransportFailure covers the one failure
+// path that happens outside any check or connect attempt: a live SSE stream
+// dropping. The record names the stage so the UI can distinguish "the
+// connection went away" from "a check found it unresponsive".
+func TestHandleSSEConnectionLost_RecordsTransportFailure(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-sse-lost")
+	entry := &schemas.MCPClientState{Name: config.Name, ExecutionConfig: config, State: schemas.MCPConnectionStateHealthy, ConnGeneration: 3}
+	m.mu.Lock()
+	m.clientMap[config.ID] = entry
+	m.mu.Unlock()
+
+	m.handleSSEConnectionLost(config.ID, config.Name, 3, errors.New("unexpected EOF"))
+	require.NotNil(t, entry.LastFailure)
+	assert.Equal(t, schemas.MCPConnectionStateUnstable, entry.State)
+	assert.Equal(t, schemas.MCPConnectionFailureStageTransportLost, entry.LastFailure.Stage)
+	assert.Equal(t, "unexpected EOF", entry.LastFailure.Message)
+
+	// A stale callback (generation already bumped by a reconnect) is ignored
+	// wholesale, record included.
+	entry.State = schemas.MCPConnectionStateHealthy
+	entry.LastFailure = nil
+	m.handleSSEConnectionLost(config.ID, config.Name, 2, errors.New("stale"))
+	assert.Equal(t, schemas.MCPConnectionStateHealthy, entry.State)
+	assert.Nil(t, entry.LastFailure)
+}
+
+// TestGetClients_SnapshotCarriesFailure confirms the record survives the
+// manager's snapshot copy, since that copy is what the client-list API and a
+// distributed deployment's node-state heartbeat both read.
+func TestGetClients_SnapshotCarriesFailure(t *testing.T) {
+	m := NewMCPManager(context.Background(), schemas.MCPConfig{}, expiredOAuthCredStore{}, nil, nil)
+	config := newSharedOAuthClientConfig("client-snapshot")
+	entry := &schemas.MCPClientState{Name: config.Name, ExecutionConfig: config, State: schemas.MCPConnectionStateUnstable}
+	recordClientFailure(entry, schemas.MCPConnectionFailureStageListTools, errors.New("boom"))
+	m.mu.Lock()
+	m.clientMap[config.ID] = entry
+	m.mu.Unlock()
+
+	clients := m.GetClients()
+	require.Len(t, clients, 1)
+	require.NotNil(t, clients[0].LastFailure)
+	assert.Equal(t, "boom", clients[0].LastFailure.Message)
+}

--- a/core/mcp/reauth_state_test.go
+++ b/core/mcp/reauth_state_test.go
@@ -80,6 +80,13 @@ func TestConnectToMCPClient_OAuth2TokenExpired_SetsNeedsReauth(t *testing.T) {
 	m.mu.RUnlock()
 	require.True(t, exists)
 	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, state.State)
+	// The state carries its own explanation: a dead credential, not a
+	// generic connect failure, so the UI can say what needs a human.
+	require.NotNil(t, state.LastFailure)
+	assert.Equal(t, schemas.MCPConnectionFailureStageCredential, state.LastFailure.Stage)
+	assert.Contains(t, state.LastFailure.Message, schemas.ErrOAuth2TokenExpired.Error())
+	assert.False(t, state.LastFailure.At.IsZero())
+	assert.Equal(t, state.LastFailure.At, state.LastFailure.Since, "a first failure starts its own run")
 }
 
 // TestConnectToMCPClient_GenericFailure_StaysDisconnected is the control
@@ -120,6 +127,9 @@ func TestConnectToMCPClient_GenericFailure_StaysDisconnected(t *testing.T) {
 	m.mu.RUnlock()
 	require.True(t, exists)
 	assert.Equal(t, schemas.MCPConnectionStateUnstable, state.State)
+	require.NotNil(t, state.LastFailure)
+	assert.Equal(t, schemas.MCPConnectionFailureStageConnect, state.LastFailure.Stage)
+	assert.Contains(t, state.LastFailure.Message, "connection refused")
 }
 
 // TestUpdateClientState_PreservesNeedsReauth covers healthmonitor.go's
@@ -143,16 +153,18 @@ func TestSetState_PreservesNeedsReauth(t *testing.T) {
 	checker := NewClientConnectionChecker(m, config.ID, DefaultConnectionCheckInterval, true, nil)
 
 	// A failed check tick (recordFailure's path) tries to write Unstable first.
-	checker.setState(schemas.MCPConnectionStateUnstable, 0)
+	checker.setState(schemas.MCPConnectionStateUnstable, 0, schemas.MCPConnectionFailureStagePing, fmt.Errorf("ping failed"))
 	m.mu.RLock()
 	stateAfterFailureTick := m.clientMap[config.ID].State
+	failureAfterFailureTick := m.clientMap[config.ID].LastFailure
 	m.mu.RUnlock()
 	assert.Equal(t, schemas.MCPConnectionStateNeedsReauth, stateAfterFailureTick, "a failed check tick must not clobber NeedsReauth back to Unstable")
+	assert.Nil(t, failureAfterFailureTick, "a rejected state write must not overwrite the credential failure that put the client in NeedsReauth")
 
 	// A successful check (recordSuccess's path) tries to write Healthy — this
 	// must also be rejected: the check succeeding against a stale/absent
 	// transport does not mean the credential is fixed.
-	checker.setState(schemas.MCPConnectionStateHealthy, 0)
+	checker.setState(schemas.MCPConnectionStateHealthy, 0, "", nil)
 	m.mu.RLock()
 	stateAfterSuccessTick := m.clientMap[config.ID].State
 	m.mu.RUnlock()
@@ -204,7 +216,7 @@ func TestSetState_StillPreservesDisabled(t *testing.T) {
 	m.mu.Unlock()
 
 	checker := NewClientConnectionChecker(m, config.ID, DefaultConnectionCheckInterval, true, nil)
-	checker.setState(schemas.MCPConnectionStateHealthy, 0)
+	checker.setState(schemas.MCPConnectionStateHealthy, 0, "", nil)
 
 	m.mu.RLock()
 	state := m.clientMap[config.ID].State

--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -853,6 +853,66 @@ const (
 	MCPConnectionStateDegraded MCPConnectionState = "degraded"
 )
 
+// MCPConnectionFailureStage names the step of Bifrost's own connection
+// handling that most recently failed for a client. It is the "what was
+// Bifrost doing when this broke" half of an MCPConnectionFailure; the error
+// text is the other half.
+type MCPConnectionFailureStage string
+
+const (
+	// MCPConnectionFailureStageConnect is establishing the shared connection:
+	// the dial, the MCP initialize handshake, the connect plugin gate, or the
+	// initial list_tools a fresh connection must pass before it counts as
+	// established.
+	MCPConnectionFailureStageConnect MCPConnectionFailureStage = "connect"
+	// MCPConnectionFailureStagePing is the periodic check's ping over an
+	// existing shared connection.
+	MCPConnectionFailureStagePing MCPConnectionFailureStage = "ping"
+	// MCPConnectionFailureStageListTools is the periodic check's list_tools
+	// over an existing shared connection.
+	MCPConnectionFailureStageListTools MCPConnectionFailureStage = "list_tools"
+	// MCPConnectionFailureStageToolDiscovery is the periodic check's
+	// ephemeral connect-discover-close cycle for per-call auth types, which
+	// never hold a shared connection to ping.
+	MCPConnectionFailureStageToolDiscovery MCPConnectionFailureStage = "tool_discovery"
+	// MCPConnectionFailureStageTransportLost is a live SSE connection
+	// dropping underneath the client, outside any check.
+	MCPConnectionFailureStageTransportLost MCPConnectionFailureStage = "transport_lost"
+	// MCPConnectionFailureStageCredential is a credential the client depends
+	// on becoming unusable: an OAuth refresh rejected upstream, a rotation
+	// that invalidated the stored token, or a retained admin discovery
+	// credential that needs repair.
+	MCPConnectionFailureStageCredential MCPConnectionFailureStage = "credential"
+)
+
+// MCPConnectionFailure records why a client most recently left, or failed to
+// reach, MCPConnectionStateHealthy on this instance. It is the explanation
+// behind a non-healthy State: which step failed, the error it failed with,
+// when that last happened, and when the current run of failures began.
+//
+// Lifecycle: written by every failure path that moves State away from
+// Healthy (the periodic connection check, a failed connect attempt, a dropped
+// SSE transport, a dead credential), refreshed on every subsequent failure so
+// At always reflects the most recent attempt while Since keeps the first, and
+// cleared the moment any success moves State back to Healthy. It is only ever
+// replaced wholesale, never mutated in place, so a snapshot that copied the
+// pointer keeps describing the failure it was taken with.
+type MCPConnectionFailure struct {
+	Stage   MCPConnectionFailureStage `json:"stage"`   // Which step of Bifrost's own connection handling failed
+	Message string                    `json:"message"` // The error, whitespace-collapsed and length-bounded
+	At      time.Time                 `json:"at"`      // The most recent failed attempt
+	Since   time.Time                 `json:"since"`   // The first failed attempt of the current unhealthy run
+}
+
+// MCPInstanceState is one instance's own view of a client: its self-reported
+// connection state and, when that state is not Healthy, the failure behind
+// it. A single instance's view is just this pair; a distributed deployment
+// compares one per instance to decide whether they agree.
+type MCPInstanceState struct {
+	State       MCPConnectionState    `json:"state"`
+	LastFailure *MCPConnectionFailure `json:"last_failure,omitempty"`
+}
+
 // MCPClientState represents a connected MCP client with its configuration and tools.
 // It is used internally by the MCP manager to track the state of a connected MCP client.
 type MCPClientState struct {
@@ -864,8 +924,9 @@ type MCPClientState struct {
 	ConnectionInfo  *MCPClientConnectionInfo `json:"connection_info"` // Connection metadata for management
 	CancelFunc      context.CancelFunc       `json:"-"`               // Cancel function for SSE connections (not serialized)
 	State           MCPConnectionState       // Connection state (healthy, unstable, needs_reauth, ...)
-	ConnGeneration  uint64                   `json:"-"` // Counts connection swaps; late writers bound to an older Conn compare against it to detect staleness (not serialized)
-	LastToolsHash   string                   `json:"-"` // Content hash of the last ToolMap/ToolNameMapping the tools-change callback fired for; gates the funnel to genuine changes only (not serialized)
+	LastFailure     *MCPConnectionFailure    `json:"last_failure,omitempty"` // Why State is not Healthy; nil while Healthy (see MCPConnectionFailure)
+	ConnGeneration  uint64                   `json:"-"`                      // Counts connection swaps; late writers bound to an older Conn compare against it to detect staleness (not serialized)
+	LastToolsHash   string                   `json:"-"`                      // Content hash of the last ToolMap/ToolNameMapping the tools-change callback fired for; gates the funnel to genuine changes only (not serialized)
 }
 
 // MCPClientConnectionInfo stores metadata about how a client is connected.
@@ -879,7 +940,8 @@ type MCPClientConnectionInfo struct {
 // and connection information, after it has been initialized.
 // It is returned by GetMCPClients() method in bifrost.
 type MCPClient struct {
-	Config *MCPClientConfig   `json:"config"` // Tool filtering settings
-	Tools  []ChatToolFunction `json:"tools"`  // Available tools
-	State  MCPConnectionState `json:"state"`  // Connection state
+	Config      *MCPClientConfig      `json:"config"`                 // Tool filtering settings
+	Tools       []ChatToolFunction    `json:"tools"`                  // Available tools
+	State       MCPConnectionState    `json:"state"`                  // Connection state
+	LastFailure *MCPConnectionFailure `json:"last_failure,omitempty"` // Why State is not Healthy; nil while Healthy
 }

--- a/framework/configstore/migrations.go
+++ b/framework/configstore/migrations.go
@@ -482,6 +482,7 @@ var configstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"add_provider_job_kind_columns", "swap_provider_job_indexes"}, run: migrationAddProviderJobKindColumns},
 	{IDs: []string{"add_compat_azure_deepseek_column"}, run: migrationAddCompatAzureDeepseekColumn},
 	{IDs: []string{"clear_plugin_config_hashes"}, run: migrationClearPluginConfigHashes},
+	{IDs: []string{"add_mcp_oauth_token_status_reason_column"}, run: migrationAddMCPOauthTokenStatusReasonColumn},
 }
 
 // videoResolutionPricingColumns are the resolution-banded video output rate columns.
@@ -12740,4 +12741,30 @@ func postgresIndexIsValid(tx *gorm.DB, table, index string) (bool, error) {
 		WHERE pc.relname = ? AND ic.relname = ?
 	`, table, index).Scan(&valid).Error
 	return valid, err
+}
+
+// migrationAddMCPOauthTokenStatusReasonColumn adds mcp_oauth_tokens.status_reason:
+// the explanation behind a row's Status leaving 'active' (the provider's
+// refresh rejection, a credential rotation, a failed admin exchange), which
+// the credential block and the client's connection-failure record surface
+// so an admin can tell a revoked grant from a misconfigured client. Nullable
+// text, no backfill: rows that are already needs_reauth simply have no
+// recorded reason until their next transition.
+func migrationAddMCPOauthTokenStatusReasonColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "add_mcp_oauth_token_status_reason_column"
+	logger.Info("[configstore] starting migration %s", migrationName)
+	defer logger.Info("[configstore] finished migration %s", migrationName)
+	m := migrator.New(db, migrator.DefaultOptions, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			return addColumnIfNotExists(tx.WithContext(ctx), logger, &tables.TableMCPOauthToken{}, "status_reason")
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return dropColumnIfExists(tx.WithContext(ctx), logger, &tables.TableMCPOauthToken{}, "status_reason")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while running %s migration: %s", migrationName, err.Error())
+	}
+	return nil
 }

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -6911,6 +6911,7 @@ func (s *RDBConfigStore) PromoteSharedOauthTokenToAdmin(ctx context.Context, oau
 			admin.Scopes = shared.Scopes
 			admin.EncryptionStatus = shared.EncryptionStatus
 			admin.Status = "active"
+			admin.StatusReason = ""
 			admin.LastRefreshedAt = &now
 			if err := tx.Save(&admin).Error; err != nil {
 				return fmt.Errorf("failed to update admin oauth token for config %s: %w", oauthConfigID, err)
@@ -7501,6 +7502,24 @@ func (s *RDBConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schem
 	return &token, nil
 }
 
+// statusReasonMaxLen bounds mcp_oauth_tokens.status_reason. A provider's
+// rejection body can be a whole error page; the reason travels in every
+// client-list response and, through the connection-failure record, in every
+// node-state heartbeat, so it is cut here at the one place every writer goes
+// through.
+const statusReasonMaxLen = 512
+
+// needsReauthColumns is the column set every needs_reauth flip writes: the
+// status itself and the reason behind it, so a row never reads needs_reauth
+// with a reason left over from an earlier, different transition.
+func needsReauthColumns(reason string) map[string]any {
+	reason = strings.Join(strings.Fields(reason), " ")
+	if runes := []rune(reason); len(runes) > statusReasonMaxLen {
+		reason = string(runes[:statusReasonMaxLen-1]) + "…"
+	}
+	return map[string]any{"status": "needs_reauth", "status_reason": reason}
+}
+
 // MarkOauthUserTokenNeedsReauthByID flips status to 'needs_reauth' on a single
 // token row, regardless of auth_mode. Called by the unified refresh function
 // when the upstream credential is permanently rejected: the row stays
@@ -7511,14 +7530,14 @@ func (s *RDBConfigStore) GetOauthUserTokenByMode(ctx context.Context, mode schem
 // (a token row just loaded by its own refresh path), never an arbitrary
 // caller-supplied ID, so a 'shared' row is just as safe to flip here as a
 // per-identity one.
-func (s *RDBConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error {
+func (s *RDBConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string, reason string) error {
 	if tokenID == "" {
 		return nil
 	}
 	result := s.DB().WithContext(ctx).
 		Model(&tables.TableMCPOauthToken{}).
 		Where("id = ?", tokenID).
-		Update("status", "needs_reauth")
+		Updates(needsReauthColumns(reason))
 	if result.Error != nil {
 		return fmt.Errorf("failed to mark oauth user token %s needs_reauth: %w", tokenID, result.Error)
 	}
@@ -7533,7 +7552,7 @@ func (s *RDBConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, 
 // cached credential equally, since rotation is typically security-driven and
 // must not leave any holder silently still trusted. Precedent for the
 // single-statement bulk UPDATE shape: reconcileVKDirectTokensDB.
-func (s *RDBConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error {
+func (s *RDBConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, reason string, tx ...*gorm.DB) error {
 	if oauthConfigID == "" {
 		return nil
 	}
@@ -7546,7 +7565,7 @@ func (s *RDBConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oa
 	result := txDB.WithContext(ctx).
 		Model(&tables.TableMCPOauthToken{}).
 		Where("oauth_config_id = ?", oauthConfigID).
-		Update("status", "needs_reauth")
+		Updates(needsReauthColumns(reason))
 	if result.Error != nil {
 		return fmt.Errorf("failed to mark tokens needs_reauth for oauth config %s: %w", oauthConfigID, result.Error)
 	}
@@ -7561,14 +7580,14 @@ func (s *RDBConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oa
 // per_user_oauth client's admin row, which is keyed by mcp_client_id too but
 // carries a real oauth_config_id and is already covered by
 // MarkTokensNeedsReauthByConfigID.
-func (s *RDBConfigStore) MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string) error {
+func (s *RDBConfigStore) MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string, reason string) error {
 	if mcpClientID == "" {
 		return nil
 	}
 	result := s.DB().WithContext(ctx).
 		Model(&tables.TableMCPOauthToken{}).
 		Where("mcp_client_id = ? AND auth_mode = ? AND oauth_config_id = ?", mcpClientID, "admin", "").
-		Update("status", "needs_reauth")
+		Updates(needsReauthColumns(reason))
 	if result.Error != nil {
 		return fmt.Errorf("failed to mark admin exchange token needs_reauth for mcp client %s: %w", mcpClientID, result.Error)
 	}
@@ -7690,7 +7709,7 @@ func (s *RDBConfigStore) RotateMCPOAuthConfig(ctx context.Context, existingOauth
 		if err := s.UpdateOauthConfig(ctx, existingOauthConfig, tx); err != nil {
 			return fmt.Errorf("failed to update oauth config: %w", err)
 		}
-		if err := s.MarkTokensNeedsReauthByConfigID(ctx, oauthConfigID, tx); err != nil {
+		if err := s.MarkTokensNeedsReauthByConfigID(ctx, oauthConfigID, "OAuth client credentials were rotated; tokens issued under the previous credentials must be re-authorized", tx); err != nil {
 			return fmt.Errorf("failed to invalidate existing tokens: %w", err)
 		}
 		return nil

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -671,14 +671,18 @@ type ConfigStore interface {
 	// per-user-named methods on this merged table, see GetOauthUserTokenByMode's
 	// comment), this is not scoped away from 'shared' — the tokenID handed in
 	// always comes from an internal lookup already, never an arbitrary
-	// caller-supplied ID.
-	MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error
+	// caller-supplied ID. reason is recorded as the row's StatusReason (the
+	// provider's rejection, e.g. "provider rejected the refresh (HTTP 400,
+	// invalid_grant: Token has been expired or revoked)") so the UI and the
+	// client's connection-failure record can say what actually failed rather
+	// than only that the row is no longer usable.
+	MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string, reason string) error
 	// MarkTokensNeedsReauthByConfigID flips status to 'needs_reauth' on every
 	// token row bound to an OAuth config in one bulk UPDATE, with no
 	// auth_mode filter — rotating an oauth_configs row's client_id/client_secret
 	// invalidates every existing holder's cached credential (shared, per-user,
 	// vk, session, admin alike), not just the shared one.
-	MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error
+	MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, reason string, tx ...*gorm.DB) error
 	// MarkAdminExchangeTokenNeedsReauthByMCPClientID flips status to
 	// 'needs_reauth' on a token_exchange client's retained admin bootstrap
 	// credential (auth_mode='admin', mcp_client_id=<id>, oauth_config_id='' —
@@ -691,7 +695,7 @@ type ConfigStore interface {
 	// cached in-memory only, never persisted (see GetExchangedAccessToken's
 	// doc comment) — the admin row is the only persisted state a
 	// token_exchange config edit can invalidate.
-	MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string) error
+	MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string, reason string) error
 	// RotateMCPOAuthConfig updates every field of an oauth_configs row in
 	// place when ANY of them differs from what's stored (client_id,
 	// client_secret, authorize_url, token_url, registration_url, resource,

--- a/framework/configstore/tables/mcpoauth2.go
+++ b/framework/configstore/tables/mcpoauth2.go
@@ -201,6 +201,7 @@ type TableMCPOauthToken struct {
 	VirtualKeyID     *string    `gorm:"type:varchar(255);index" json:"virtual_key_id"`            // VK identity (vk-mode rows)
 	UserID           *string    `gorm:"type:varchar(255);index" json:"user_id"`                   // User identity (user-mode rows; populated by enterprise middleware/governance)
 	Status           string     `gorm:"type:varchar(20);not null;default:'active'" json:"status"` // 'active' | 'orphaned' | 'needs_reauth' — only 'active' satisfies a runtime lookup; the others are surfaced in the UI with distinct copy
+	StatusReason     string     `gorm:"type:text" json:"status_reason,omitempty"`                 // Why Status left 'active': the provider's refresh rejection (HTTP status plus the OAuth error and description), a credential rotation, or a failed admin exchange. Empty while active; cleared whenever the row becomes active again
 	AccessToken      string     `gorm:"type:text;not null" json:"-"`                              // Encrypted access token
 	RefreshToken     string     `gorm:"type:text" json:"-"`                                       // Encrypted refresh token (optional)
 	TokenType        string     `gorm:"type:varchar(50);not null" json:"token_type"`              // "Bearer"

--- a/framework/oauth2/main.go
+++ b/framework/oauth2/main.go
@@ -192,7 +192,7 @@ func (p *OAuth2Provider) resolveAccessToken(ctx context.Context, token *tables.T
 	// (pending/authorized/failed) and is never consulted here — matching how
 	// GetUserAccessTokenByMode has always worked.
 	if token.Status != "active" {
-		return "", fmt.Errorf("oauth token is not active, status: %s: %w", token.Status, schemas.ErrOAuth2TokenExpired)
+		return "", inactiveTokenError(token)
 	}
 
 	// Refresh only when the token has known expiry and a renewal path: a
@@ -343,7 +343,7 @@ func (p *OAuth2Provider) refreshAccessTokenLocked(ctx context.Context, tokenID s
 			// the singleflight entry indefinitely if the store hangs.
 			statusCtx, cancel := context.WithTimeout(context.Background(), terminalStatusUpdateTimeout)
 			defer cancel()
-			if markErr := p.configStore.MarkOauthUserTokenNeedsReauthByID(statusCtx, token.ID); markErr != nil {
+			if markErr := p.configStore.MarkOauthUserTokenNeedsReauthByID(statusCtx, token.ID, refreshRejectionReason(permErr)); markErr != nil {
 				return fmt.Errorf("oauth refresh permanently rejected but status update failed (mcp_client=%s auth_mode=%s upstream_status=%d): %w",
 					token.MCPClientID, token.AuthMode, permErr.StatusCode, markErr)
 			}
@@ -443,7 +443,7 @@ func (p *OAuth2Provider) ForceRefreshAccessToken(ctx *schemas.BifrostContext, co
 		// needs_reauth short-circuits locally instead of attempting a live
 		// refresh call that's doomed to fail.
 		if token.Status != "active" {
-			return fmt.Errorf("oauth token is not active, status: %s: %w", token.Status, schemas.ErrOAuth2TokenExpired)
+			return inactiveTokenError(token)
 		}
 		return p.RefreshAccessToken(ctx, token.ID)
 	case schemas.MCPAuthTypePerUserOauth:
@@ -1201,6 +1201,37 @@ type PermanentOAuthError struct {
 
 func (e *PermanentOAuthError) Error() string {
 	return fmt.Sprintf("permanent oauth error (status %d): %s", e.StatusCode, e.Body)
+}
+
+// refreshRejectionReason is what gets recorded on the token row when a
+// refresh is permanently rejected: the HTTP status the provider answered
+// with plus the standard OAuth error and error_description from its body
+// (RFC 6749 §5.2), and nothing else from the body, which may be an error
+// page. It is what lets an admin tell "the grant was revoked" from "the
+// client is no longer authorized" without reading the provider's logs.
+func refreshRejectionReason(permErr *PermanentOAuthError) string {
+	var oauthErr struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}
+	if err := json.Unmarshal([]byte(permErr.Body), &oauthErr); err != nil || oauthErr.Error == "" {
+		return fmt.Sprintf("provider rejected the refresh (HTTP %d)", permErr.StatusCode)
+	}
+	if oauthErr.ErrorDescription == "" {
+		return fmt.Sprintf("provider rejected the refresh (HTTP %d, %s)", permErr.StatusCode, oauthErr.Error)
+	}
+	return fmt.Sprintf("provider rejected the refresh (HTTP %d, %s: %s)", permErr.StatusCode, oauthErr.Error, oauthErr.ErrorDescription)
+}
+
+// inactiveTokenError is the error every access-token lookup returns for a
+// row whose Status is not 'active'. It carries the row's StatusReason when
+// one was recorded, so the message a failed connect or check ends up
+// storing on the client says what the provider actually said.
+func inactiveTokenError(token *tables.TableMCPOauthToken) error {
+	if token.StatusReason != "" {
+		return fmt.Errorf("oauth token is not active, status: %s (%s): %w", token.Status, token.StatusReason, schemas.ErrOAuth2TokenExpired)
+	}
+	return fmt.Errorf("oauth token is not active, status: %s: %w", token.Status, schemas.ErrOAuth2TokenExpired)
 }
 
 // sleepIfNotLastAttempt waits with exponential backoff between retry attempts.

--- a/framework/oauth2/statusreason_test.go
+++ b/framework/oauth2/statusreason_test.go
@@ -1,0 +1,44 @@
+package oauth2
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestRefreshRejectionReason pins the text recorded on a token row when a
+// refresh is permanently rejected: the provider's HTTP status plus the
+// standard OAuth error fields, and never the raw body, which may be an
+// error page rather than JSON.
+func TestRefreshRejectionReason(t *testing.T) {
+	assert.Equal(t,
+		"provider rejected the refresh (HTTP 400, invalid_grant: Token has been expired or revoked.)",
+		refreshRejectionReason(&PermanentOAuthError{StatusCode: 400, Body: `{"error":"invalid_grant","error_description":"Token has been expired or revoked."}`}),
+	)
+	assert.Equal(t,
+		"provider rejected the refresh (HTTP 400, unauthorized_client)",
+		refreshRejectionReason(&PermanentOAuthError{StatusCode: 400, Body: `{"error":"unauthorized_client"}`}),
+	)
+	assert.Equal(t,
+		"provider rejected the refresh (HTTP 401)",
+		refreshRejectionReason(&PermanentOAuthError{StatusCode: 401, Body: "<html><body>Unauthorized</body></html>"}),
+		"a non-JSON body contributes nothing beyond the status",
+	)
+}
+
+// TestInactiveTokenError covers the message every access-token lookup
+// returns for a non-active row: it must keep the ErrOAuth2TokenExpired
+// sentinel (the connect gate classifies on it) and carry the recorded
+// reason when there is one.
+func TestInactiveTokenError(t *testing.T) {
+	withReason := inactiveTokenError(&tables.TableMCPOauthToken{Status: "needs_reauth", StatusReason: "provider rejected the refresh (HTTP 400, invalid_grant)"})
+	assert.True(t, errors.Is(withReason, schemas.ErrOAuth2TokenExpired))
+	assert.Equal(t, "oauth token is not active, status: needs_reauth (provider rejected the refresh (HTTP 400, invalid_grant)): oauth2 token expired", withReason.Error())
+
+	bare := inactiveTokenError(&tables.TableMCPOauthToken{Status: "needs_reauth"})
+	assert.True(t, errors.Is(bare, schemas.ErrOAuth2TokenExpired))
+	assert.Equal(t, "oauth token is not active, status: needs_reauth: oauth2 token expired", bare.Error())
+}

--- a/framework/oauth2/sync_test.go
+++ b/framework/oauth2/sync_test.go
@@ -130,7 +130,7 @@ func (s *testConfigStore) RefreshOauthTokenFieldsIfActive(_ context.Context, id 
 // the test-double equivalent of the real store's method of the same name —
 // which, despite the historical "UserToken" naming, is not scoped away from
 // auth_mode='shared' (see its doc comment on the real ConfigStore interface).
-func (s *testConfigStore) MarkOauthUserTokenNeedsReauthByID(_ context.Context, tokenID string) error {
+func (s *testConfigStore) MarkOauthUserTokenNeedsReauthByID(_ context.Context, tokenID string, reason string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	token := s.oauthTokens[tokenID]
@@ -138,12 +138,13 @@ func (s *testConfigStore) MarkOauthUserTokenNeedsReauthByID(_ context.Context, t
 		return nil
 	}
 	token.Status = "needs_reauth"
+	token.StatusReason = reason
 	return nil
 }
 
 // MarkTokensNeedsReauthByConfigID is the test-double equivalent of the real
 // store's bulk, auth_mode-agnostic cascade used by OAuth credential rotation.
-func (s *testConfigStore) MarkTokensNeedsReauthByConfigID(_ context.Context, oauthConfigID string, _ ...*gorm.DB) error {
+func (s *testConfigStore) MarkTokensNeedsReauthByConfigID(_ context.Context, oauthConfigID string, _ string, _ ...*gorm.DB) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for _, token := range s.oauthTokens {
@@ -679,6 +680,8 @@ func TestTokenRefreshWorker_PermanentError_MarksNeedsReauth(t *testing.T) {
 	token, err := store.GetOauthTokenByID(context.Background(), tokenID)
 	require.NoError(t, err)
 	assert.Equal(t, "needs_reauth", token.Status, "permanent auth rejection must mark token needs_reauth")
+	assert.Equal(t, "provider rejected the refresh (HTTP 401, invalid_grant: Refresh token expired or revoked)", token.StatusReason,
+		"the provider's rejection must be recorded on the row so the UI can say what failed")
 }
 
 func TestTokenRefreshWorker_SuccessfulRefresh_UpdatesToken(t *testing.T) {
@@ -742,7 +745,7 @@ func TestTokenRefreshWorker_ConcurrentReauth_DoesNotOverwriteStaleRefresh(t *tes
 	}()
 
 	<-started
-	require.NoError(t, store.MarkOauthUserTokenNeedsReauthByID(context.Background(), tokenID))
+	require.NoError(t, store.MarkOauthUserTokenNeedsReauthByID(context.Background(), tokenID, "test"))
 	close(unblock)
 	wg.Wait()
 

--- a/framework/oauth2/tokenexchange.go
+++ b/framework/oauth2/tokenexchange.go
@@ -229,6 +229,7 @@ func (p *OAuth2Provider) refreshExchangeAdminToken(ctx context.Context, token *t
 		token.ExpiresAt = &exp
 	}
 	token.LastRefreshedAt = &now
+	token.StatusReason = ""
 	if err := p.configStore.UpdateOauthToken(ctx, token); err != nil {
 		return fmt.Errorf("failed to update admin exchange credential: %w", err)
 	}
@@ -242,7 +243,7 @@ func (p *OAuth2Provider) refreshExchangeAdminToken(ctx context.Context, token *t
 // credential looking active, mirroring RefreshAccessToken's permanent-error
 // path) and signals re-verification via the ErrOAuth2TokenExpired sentinel.
 func (p *OAuth2Provider) markExchangeAdminNeedsReauth(token *tables.TableMCPOauthToken, cause error) error {
-	if markErr := p.configStore.MarkOauthUserTokenNeedsReauthByID(context.Background(), token.ID); markErr != nil {
+	if markErr := p.configStore.MarkOauthUserTokenNeedsReauthByID(context.Background(), token.ID, "admin token exchange failed: "+cause.Error()); markErr != nil {
 		return fmt.Errorf("admin exchange credential is dead but status update failed (mcp_client=%s): %w", token.MCPClientID, markErr)
 	}
 	p.EvictUserTokenByID(token.ID)

--- a/framework/oauth2/usertokencache_test.go
+++ b/framework/oauth2/usertokencache_test.go
@@ -524,7 +524,7 @@ func TestGetUserAccessTokenByMode_FlushAfterNeedsReauth(t *testing.T) {
 
 	// Credential rotation marks every token row for the config
 	// needs_reauth, then the handler-level callback flushes the cache.
-	require.NoError(t, store.MarkTokensNeedsReauthByConfigID(ctx, "cfg-1"))
+	require.NoError(t, store.MarkTokensNeedsReauthByConfigID(ctx, "cfg-1", "rotated"))
 	provider.FlushUserTokenCache()
 
 	// The active-only lookup no longer matches the row, so the caller sees

--- a/transports/bifrost-http/handlers/mcp.go
+++ b/transports/bifrost-http/handlers/mcp.go
@@ -805,11 +805,23 @@ type MCPClientResponse struct {
 	Tools     []schemas.ChatToolFunction `json:"tools"`
 	State     schemas.MCPConnectionState `json:"state"`
 	VKConfigs []MCPVKConfigResponse      `json:"vk_configs"`
-	// NodeStates is the per-instance breakdown behind State when it is
-	// schemas.MCPConnectionStateDegraded (instance ID -> that instance's own
-	// self-reported state). Only ever populated by a configured
-	// MCPClusterStateAggregator; nil in a single-instance deployment.
-	NodeStates map[string]string `json:"node_states,omitempty"`
+	// LastFailure is the instance serving this request's own record of what
+	// its connection handling last failed with: the step, the error, when it
+	// last happened and when the current run began (see
+	// schemas.MCPConnectionFailure). Nil while healthy. It is deliberately not
+	// derived from credential rows: when projectMCPCredentialState overlays
+	// needs_reauth onto a runtime that has recorded nothing yet, the state and
+	// the credential block already say why, and the next connect or check to
+	// hit the dead credential records the provider's real error here.
+	LastFailure *schemas.MCPConnectionFailure `json:"last_failure,omitempty"`
+	// NodeStates is the per-instance breakdown behind State in a distributed
+	// deployment (instance ID -> that instance's own self-reported state and
+	// failure). Present when instances disagree (State is then
+	// schemas.MCPConnectionStateDegraded) and when they agree on unstable, so
+	// each instance's own reason is visible; only ever populated by a
+	// configured MCPClusterStateAggregator, nil in a single-instance
+	// deployment.
+	NodeStates map[string]schemas.MCPInstanceState `json:"node_states,omitempty"`
 	// Credential is the read-only view of the credential the client holds on
 	// its own behalf (see MCPClientCredentialResponse). Nil when the client's
 	// auth type has no such credential (none, headers) or when none has been
@@ -827,6 +839,11 @@ type MCPClientResponse struct {
 type MCPClientCredentialResponse struct {
 	Kind   string `json:"kind"`   // "oauth" | "headers"
 	Status string `json:"status"` // oauth: active | orphaned | needs_reauth. headers: active | orphaned | needs_update.
+	// StatusReason says why an oauth credential's status left active: the
+	// provider's rejection of the last refresh (HTTP status plus the OAuth
+	// error and description), a credential rotation, or a failed admin
+	// exchange. Empty while active and for headers credentials.
+	StatusReason string `json:"status_reason,omitempty"`
 	// ExpiresAt is the access token's expiry on oauth credentials; nil when
 	// the provider did not report one. Always nil for headers credentials.
 	ExpiresAt *string `json:"expires_at,omitempty"`
@@ -866,6 +883,7 @@ func mcpClientCredentialResponse(
 		resp := &MCPClientCredentialResponse{
 			Kind:            "oauth",
 			Status:          t.Status,
+			StatusReason:    t.StatusReason,
 			HasRefreshToken: t.RefreshToken != "",
 			Scopes:          parseOauthScopesJSON(t.Scopes),
 			CreatedAt:       t.CreatedAt.UTC().Format(rfc3339Nano),
@@ -910,17 +928,19 @@ func mcpClientCredentialResponse(
 }
 
 // MCPClusterStateAggregator is an optional capability the configured
-// MCPManager may additionally implement: given a client and the state its
-// own runtime already reports locally, it returns the cluster-aggregated
-// view — the same value when every instance agrees, or
-// schemas.MCPConnectionStateDegraded plus a per-instance breakdown when they
-// don't. A nil aggregated map means "agreement" or "not applicable"; a
-// non-nil one is only ever attached to the response when the returned state
-// is actually Degraded. Single-instance deployments never implement this,
-// so the type assertion in getMCPClientsPaginated simply misses and the
-// response is unchanged from today.
+// MCPManager may additionally implement: given a client's locally resolved
+// state and failure record, it folds in every other instance's self-reported
+// pair for the same client and returns the deployment-wide view. A nil
+// nodeStates means the local view stands as-is (every instance agrees on a
+// healthy state, or the state is one that is not compared per instance);
+// a non-nil one is the per-instance breakdown to attach, with state the
+// aggregate to show above it: schemas.MCPConnectionStateDegraded when the
+// instances disagree, or the agreed non-healthy state when they all report
+// it but may each have a different reason. Single-instance deployments never
+// implement this, so the type assertion in getMCPClientsPaginated simply
+// misses and the response is unchanged from today.
 type MCPClusterStateAggregator interface {
-	AggregateMCPClientState(clientID string, localState schemas.MCPConnectionState) (state schemas.MCPConnectionState, nodeStates map[string]string)
+	AggregateMCPClientState(clientID string, local schemas.MCPInstanceState) (state schemas.MCPConnectionState, nodeStates map[string]schemas.MCPInstanceState)
 }
 
 // getMCPClients handles GET /api/mcp/clients - Get all MCP clients
@@ -1473,14 +1493,16 @@ func (h *MCPHandler) getMCPClientsPaginated(ctx *fasthttp.RequestCtx, params con
 				oauthTokenStatus(sharedToken),
 			)
 			resp := MCPClientResponse{
-				Config:     redactedConfig,
-				Tools:      sortedTools,
-				State:      resolvedState,
-				VKConfigs:  vkConfigs,
-				Credential: credential,
+				Config:      redactedConfig,
+				Tools:       sortedTools,
+				State:       resolvedState,
+				LastFailure: connectedClient.LastFailure,
+				VKConfigs:   vkConfigs,
+				Credential:  credential,
 			}
 			if aggregator, ok := h.mcpManager.(MCPClusterStateAggregator); ok {
-				if aggState, nodeStates := aggregator.AggregateMCPClientState(clientConfig.ID, resolvedState); aggState == schemas.MCPConnectionStateDegraded {
+				local := schemas.MCPInstanceState{State: resolvedState, LastFailure: resp.LastFailure}
+				if aggState, nodeStates := aggregator.AggregateMCPClientState(clientConfig.ID, local); nodeStates != nil {
 					resp.State = aggState
 					resp.NodeStates = nodeStates
 				}
@@ -2908,7 +2930,7 @@ func (h *MCPHandler) updateMCPClient(ctx *fasthttp.RequestCtx) {
 	// comment) and no separate config table to update in the same
 	// transaction — the client row was already persisted above.
 	if shouldMarkExchangeNeedsReauth {
-		if err := h.store.ConfigStore.MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx, id); err != nil {
+		if err := h.store.ConfigStore.MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx, id, "token exchange settings were updated; the admin credential must be re-verified"); err != nil {
 			// Mirrors shouldRotateOAuthConfig's [PARTIAL SUCCESS] handling
 			// above: the rest of the update already committed, only the
 			// reauth marking failed.

--- a/transports/bifrost-http/handlers/mcp_client_credential_test.go
+++ b/transports/bifrost-http/handlers/mcp_client_credential_test.go
@@ -68,7 +68,8 @@ func TestMCPClientCredentialResponse(t *testing.T) {
 
 	adminToken := &configstoreTables.TableMCPOauthToken{
 		ID: "admin", AuthMode: "admin", Status: "needs_reauth",
-		AccessToken: "secret", RefreshToken: "",
+		StatusReason: "provider rejected the refresh (HTTP 400, invalid_grant: Token has been expired or revoked.)",
+		AccessToken:  "secret", RefreshToken: "",
 		Scopes: "null", CreatedAt: created, UpdatedAt: updated,
 	}
 	sharedToken := &configstoreTables.TableMCPOauthToken{
@@ -93,7 +94,8 @@ func TestMCPClientCredentialResponse(t *testing.T) {
 	}
 	adminWant := &MCPClientCredentialResponse{
 		Kind: "oauth", Status: "needs_reauth", HasRefreshToken: false,
-		CreatedAt: "2026-08-12T10:00:00Z", UpdatedAt: "2026-08-12T11:00:00Z",
+		StatusReason: "provider rejected the refresh (HTTP 400, invalid_grant: Token has been expired or revoked.)",
+		CreatedAt:    "2026-08-12T10:00:00Z", UpdatedAt: "2026-08-12T11:00:00Z",
 	}
 	headersWant := &MCPClientCredentialResponse{
 		Kind: "headers", Status: "needs_update",

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -2073,7 +2073,7 @@ func rotateMCPTokenExchangeConfigFromFile(ctx context.Context, store configstore
 	if !existing.DiffersFrom(&resolved) {
 		return
 	}
-	if err := store.MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx, clientID); err != nil {
+	if err := store.MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx, clientID, "token exchange settings changed in config.json; the admin credential must be re-verified"); err != nil {
 		logger.Warn("failed to mark admin exchange credential needs_reauth for MCP client %q from config file: %v", clientName, err)
 		return
 	}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1590,11 +1590,11 @@ func (m *MockConfigStore) DeleteOauthUserSessionsByModeIdentityAndMCPClient(ctx 
 	return nil
 }
 
-func (m *MockConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string) error {
+func (m *MockConfigStore) MarkOauthUserTokenNeedsReauthByID(ctx context.Context, tokenID string, reason string) error {
 	return nil
 }
 
-func (m *MockConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, tx ...*gorm.DB) error {
+func (m *MockConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, oauthConfigID string, reason string, tx ...*gorm.DB) error {
 	m.markTokensNeedsReauthCalls = append(m.markTokensNeedsReauthCalls, oauthConfigID)
 	for _, tok := range m.oauthTokensByConfigID[oauthConfigID] {
 		tok.Status = "needs_reauth"
@@ -1602,7 +1602,7 @@ func (m *MockConfigStore) MarkTokensNeedsReauthByConfigID(ctx context.Context, o
 	return nil
 }
 
-func (m *MockConfigStore) MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string) error {
+func (m *MockConfigStore) MarkAdminExchangeTokenNeedsReauthByMCPClientID(ctx context.Context, mcpClientID string, reason string) error {
 	return nil
 }
 
@@ -1641,7 +1641,7 @@ func (m *MockConfigStore) RotateMCPOAuthConfig(ctx context.Context, existingOaut
 	if err := m.UpdateOauthConfig(ctx, existingOauthConfig); err != nil {
 		return false, err
 	}
-	if err := m.MarkTokensNeedsReauthByConfigID(ctx, existingOauthConfig.ID); err != nil {
+	if err := m.MarkTokensNeedsReauthByConfigID(ctx, existingOauthConfig.ID, "rotated"); err != nil {
 		return false, err
 	}
 	return true, nil


### PR DESCRIPTION
## Summary

MCP client connection failures are now recorded with structured context — which step failed, the error message, when it last happened, and when the current unhealthy run began — and surfaced through the client-list API and credential rows. This gives operators a durable, human-readable explanation for why a client is not healthy without requiring them to correlate log lines or read provider logs.

## Changes

- Introduced `MCPConnectionFailure` schema type with `Stage`, `Message`, `At`, and `Since` fields. `Stage` is a typed enum (`MCPConnectionFailureStage`) covering connect, ping, list_tools, tool_discovery, transport_lost, and credential failures.
- Added `LastFailure *MCPConnectionFailure` to `MCPClientState` and `MCPClient`, populated by every failure path: failed connect attempts, dropped SSE transports, periodic check failures, and credential rotations.
- Introduced `markClientHealthy` and `recordClientFailure` helpers so every transition to Healthy atomically clears the record, and every failure atomically writes a new one without mutating the previous pointer (snapshots taken by `GetClients` remain consistent).
- `MCPConnectionFailure.Since` is preserved across consecutive failures so the record spans the whole unhealthy run; `At` always reflects the most recent attempt.
- Added `mcp_oauth_tokens.status_reason` column (nullable text, no backfill) recording why a token row left `active`: the provider's OAuth error fields from the refresh rejection body, a credential rotation, or a failed admin exchange. The reason travels through `inactiveTokenError` into the client's connection-failure record so the connect gate's error message carries the provider's actual explanation.
- `MarkOauthUserTokenNeedsReauthByID`, `MarkTokensNeedsReauthByConfigID`, and `MarkAdminExchangeTokenNeedsReauthByMCPClientID` now accept a `reason string` parameter written alongside the status flip.
- `refreshRejectionReason` extracts only the RFC 6749 §5.2 `error` and `error_description` fields from a provider's rejection body, avoiding embedding raw HTML error pages in stored records.
- `MCPClientResponse` gains `LastFailure` and `NodeStates` is widened from `map[string]string` to `map[string]schemas.MCPInstanceState` so distributed deployments can expose each instance's failure record alongside its state.
- `MCPClusterStateAggregator.AggregateMCPClientState` now receives and returns `MCPInstanceState` instead of bare `MCPConnectionState`, and `NodeStates` is attached whenever instances disagree or all agree on a non-healthy state (not only on Degraded).
- `MCPClientCredentialResponse` gains `StatusReason` forwarded from the token row.
- Repeated check failures while a client is already Unstable are logged at Debug rather than Warn; state transitions log at Info with the failure stage and message included.
- `connectionfailure.go` and its tests are new files; `statusreason_test.go` in the oauth2 package is new.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/mcp/... ./framework/oauth2/... ./transports/bifrost-http/...
```

- Connect an MCP client backed by an OAuth credential, then revoke the token at the provider. Confirm the client-list response carries `last_failure` with `stage: "credential"` and a `message` containing the provider's `error` and `error_description`.
- Simulate a network outage against a shared-connection client. Confirm `last_failure.stage` is `ping` or `list_tools`, `since` stays fixed across repeated check ticks, and `at` advances each tick.
- Restore connectivity and confirm `last_failure` is cleared and `state` returns to `healthy`.
- Rotate an OAuth config's client credentials. Confirm `mcp_oauth_tokens.status_reason` is set on all affected rows and the client-list `credential.status_reason` reflects it.

## Breaking changes

- [x] Yes

`MCPClusterStateAggregator.AggregateMCPClientState` signature changed: the second parameter is now `schemas.MCPInstanceState` instead of `schemas.MCPConnectionState`, and the return type of `nodeStates` is `map[string]schemas.MCPInstanceState` instead of `map[string]string`. Any distributed deployment implementing this interface must update its implementation. The three `MarkOauthUserTokenNeedsReauthByID`, `MarkTokensNeedsReauthByConfigID`, and `MarkAdminExchangeTokenNeedsReauthByMCPClientID` `ConfigStore` methods each gain a required `reason string` parameter; any external `ConfigStore` implementation must be updated.

## Related issues

## Security considerations

`status_reason` and `MCPConnectionFailure.Message` are both length-bounded (512 runes) and whitespace-normalized before storage to prevent a provider's HTML error page from bloating client-list responses and node-state heartbeats. Only the standard OAuth `error` and `error_description` fields are extracted from provider rejection bodies; raw response bodies are never stored.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable