### PR TITLE
feat: surface MCP connection failure details in state badge popover and server sheet, with shared `mcpConnectionFailure` utils, credential `status_reason`, and unified credential/session status badge palette

### DIFF
--- a/ui/app/workspace/mcp-registry/views/mcpClientCredentialSection.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientCredentialSection.tsx
@@ -8,6 +8,7 @@ import { RefreshTokenStatus } from "@/components/refreshTokenStatus";
 import { ScopeChips } from "@/components/scopeChips";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { MCP_CREDENTIAL_STATUS_COLORS } from "@/lib/constants/config";
 import { useGetMCPSessionsQuery } from "@/lib/store";
 import { MCPClient, MCPClientCredential } from "@/lib/types/mcp";
 import {
@@ -17,6 +18,7 @@ import {
 	formatTokenExpiry,
 	missingHeaderKeys,
 } from "@/lib/utils/mcpCredential";
+import { titleCaseFromSnakeCase } from "@/lib/utils/strings";
 import { Link } from "@tanstack/react-router";
 import { ArrowUpRight } from "lucide-react";
 import { ReactNode } from "react";
@@ -72,6 +74,14 @@ function OAuthCredentialBlock({ mcpClient }: Props) {
 					<Row label="Status">
 						<CredentialStatusBadge status={credential.status} />
 						{credential.status === "needs_reauth" && <Hint>{copy.needsReauth}</Hint>}
+						{credential.status_reason && (
+							<div
+								className="text-muted-foreground mt-1 font-mono text-[11px] break-words"
+								data-testid="mcpclient-credential-status-reason"
+							>
+								{credential.status_reason}
+							</div>
+						)}
 					</Row>
 					<Row label="Access token expires">
 						{credential.expires_at ? (
@@ -268,27 +278,22 @@ function SessionsRow({ clientId, kind }: { clientId: string; kind: "token" | "he
 	);
 }
 
-// Status vocabulary and colors mirror the sessions table's StatusBadge so a
-// credential reads the same in both places.
+// Status vocabulary mirrors the sessions table's StatusBadge so a credential
+// reads the same in both places; colors come from the shared palette so the
+// badge matches the server state badge above it.
+const CREDENTIAL_STATUS_LABELS: Record<string, string> = {
+	active: "Active",
+	needs_reauth: "Needs re-auth",
+	needs_update: "Needs update",
+	orphaned: "Orphaned",
+};
+
 function CredentialStatusBadge({ status }: { status: MCPClientCredential["status"] }) {
-	switch (status) {
-		case "orphaned":
-			return (
-				<Badge variant="outline" className="border-amber-500 bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
-					Orphaned
-				</Badge>
-			);
-		case "needs_reauth":
-			return <Badge variant="destructive">Needs re-auth</Badge>;
-		case "needs_update":
-			return (
-				<Badge variant="outline" className="border-red-500 bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200">
-					Needs update
-				</Badge>
-			);
-		default:
-			return <Badge>Active</Badge>;
-	}
+	return (
+		<Badge className={MCP_CREDENTIAL_STATUS_COLORS[status] ?? MCP_CREDENTIAL_STATUS_COLORS.unknown}>
+			{CREDENTIAL_STATUS_LABELS[status] ?? titleCaseFromSnakeCase(status)}
+		</Badge>
+	);
 }
 
 function DefinitionList({ children }: { children: ReactNode }) {

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -34,6 +34,7 @@ import { getErrorMessage, useGetCoreConfigQuery, useGetVirtualKeysQuery, useUpda
 import { MCPClient, MCPVKConfig } from "@/lib/types/mcp";
 import { mcpClientUpdateSchema, type MCPClientUpdateSchema } from "@/lib/types/schemas";
 import { parseArrayFromText } from "@/lib/utils/array";
+import { failureStageLabel, formatDurationSince, hasStateReason, stateReasonTitle } from "@/lib/utils/mcpConnectionFailure";
 import { titleCaseFromSnakeCase } from "@/lib/utils/strings";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
@@ -44,6 +45,7 @@ import { useForm } from "react-hook-form";
 import { OAuthAdvancedFields } from "./oauthAdvancedFields";
 import { OAuth2Authorizer } from "./oauth2Authorizer";
 import { MCPClientCredentialSection, MCPClientSessionsSection } from "./mcpClientCredentialSection";
+import { ConnectionFailureBlock } from "./mcpConnectionFailure";
 import { SectionHeader } from "./sectionHeader";
 import { TLSConfigFields } from "./tlsConfigFields";
 import { TokenExchangeFields } from "./tokenExchangeFields";
@@ -55,6 +57,41 @@ interface MCPClientSheetProps {
 	onNavigate?: (direction: "prev" | "next") => void;
 	hasPrev?: boolean;
 	hasNext?: boolean;
+}
+
+// stateDescription is the sentence under the sheet title. The pending and
+// needs_reauth prose is unchanged; unstable and degraded gain a sentence
+// naming what Bifrost's last check ran into, and needs_reauth appends the
+// recorded reason so the explanation sits next to the instruction.
+function stateDescription(mcpClient: MCPClient, isPerUserAuth: boolean): string {
+	const failure = mcpClient.last_failure;
+	switch (mcpClient.state) {
+		case "pending_verification":
+			return mcpClient.config.auth_type === "token_exchange"
+				? "This server needs a one-time verification: Bifrost exchanges your signed-in identity token, tests the connection, and discovers tools. Callers then have their own identity tokens exchanged automatically on every tool call."
+				: mcpClient.config.auth_type === "per_user_oauth"
+					? "This client was declared in config.json. An admin sign-in is needed to verify the OAuth setup and discover tools; Bifrost keeps it on file to refresh the tool list periodically. Each user will still authenticate individually when they use this server."
+					: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used.";
+		case "needs_reauth": {
+			// Each auth type names the repair action the actions menu actually
+			// offers for it, matching the credential block below.
+			const base =
+				mcpClient.config.auth_type === "token_exchange"
+					? "The admin credential Bifrost keeps on file to refresh this server's tool list needs repair. Callers' tool calls are unaffected. Use Re-verify as me from the server's actions menu to fix it."
+					: isPerUserAuth
+						? "The admin credential Bifrost keeps on file to refresh this server's tool list needs repair. End-user credentials and tool calls are unaffected. Use Refresh admin credential from the server's actions menu to fix it."
+						: "This connection's credentials need to be re-authorized. Use Reauthorize from the server's actions menu to redo the OAuth consent flow.";
+			return failure ? `${base} Reason: ${failure.message}` : base;
+		}
+		case "unstable":
+			return failure
+				? `Bifrost's last connection check failed ${formatDurationSince(failure.at)} ago while ${failureStageLabel(failure.stage).toLowerCase()}. Tool calls are still attempted normally; the next check runs within about 10 seconds.`
+				: "Bifrost's last connection check failed. Tool calls are still attempted normally; the next check runs within about 10 seconds.";
+		case "degraded":
+			return "Instances of this deployment disagree about this server's state. Tool calls are still attempted on every instance.";
+		default:
+			return "MCP server configuration and available tools";
+	}
 }
 
 /** API sends tool_sync_interval as nanoseconds (Go time.Duration). Normalize to minutes for form/store. */
@@ -622,19 +659,7 @@ export default function MCPClientSheet({
 									{mcpClient.config.name}
 									<Badge className={MCP_STATUS_COLORS[mcpClient.state]}>{titleCaseFromSnakeCase(mcpClient.state)}</Badge>
 								</SheetTitle>
-								<SheetDescription>
-									{mcpClient.state === "pending_verification"
-										? mcpClient.config.auth_type === "token_exchange"
-											? "This server needs a one-time verification: Bifrost exchanges your signed-in identity token, tests the connection, and discovers tools. Callers then have their own identity tokens exchanged automatically on every tool call."
-											: mcpClient.config.auth_type === "per_user_oauth"
-												? "This client was declared in config.json. An admin sign-in is needed to verify the OAuth setup and discover tools; Bifrost keeps it on file to refresh the tool list periodically. Each user will still authenticate individually when they use this server."
-												: "This client was declared in config.json and needs a one-time OAuth authorization before it can be used."
-										: mcpClient.state === "needs_reauth"
-											? isPerUserAuth
-												? "The admin credential Bifrost keeps on file to refresh this server's tool list needs repair. End-user credentials and tool calls are unaffected. Use Refresh admin credential from the server's actions menu to fix it."
-												: "This connection's credentials need to be re-authorized. Use Reauthorize from the server's actions menu to redo the OAuth consent flow."
-											: "MCP server configuration and available tools"}
-								</SheetDescription>
+								<SheetDescription>{stateDescription(mcpClient, isPerUserAuth)}</SheetDescription>
 							</div>
 							<SheetNavigationButtons
 								hasPrev={hasPrev}
@@ -668,6 +693,15 @@ export default function MCPClientSheet({
 									</div>
 
 									<TabsContent value="general" className="space-y-6 pb-10">
+										{hasStateReason(mcpClient) && (
+											<div className="space-y-4">
+												<SectionHeader
+													title={mcpClient.node_states ? "Connection checks across instances" : "Last connection check"}
+													description={stateReasonTitle(mcpClient.state, !!mcpClient.node_states)}
+												/>
+												<ConnectionFailureBlock client={mcpClient} />
+											</div>
+										)}
 										<div className="space-y-4">
 											<SectionHeader title="Basic Information" description="Identify this server and review its connection details." />
 											<FormField
@@ -1666,8 +1700,8 @@ export default function MCPClientSheet({
 												{form.watch("allow_by_default") && (
 													<p className="text-muted-foreground flex items-center gap-1 text-xs">
 														<Info className="h-3 w-3 shrink-0" />
-														Configuring access for a virtual key here overrides the{" "}
-														<span className="font-medium">Allow by Default</span>&nbsp;setting for that key.
+														Configuring access for a virtual key here overrides the <span className="font-medium">Allow by Default</span>
+														&nbsp;setting for that key.
 													</p>
 												)}
 											</div>
@@ -1735,7 +1769,9 @@ export default function MCPClientSheet({
 												</div>
 											) : form.watch("allow_by_default") ? (
 												<div className="text-muted-foreground rounded-sm border p-6 text-center">
-													<p className="text-sm">This MCP server is allowed by default; a virtual key with an explicit assignment uses that instead.</p>
+													<p className="text-sm">
+														This MCP server is allowed by default; a virtual key with an explicit assignment uses that instead.
+													</p>
 												</div>
 											) : (
 												<div className="text-muted-foreground rounded-sm border p-6 text-center">

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -20,7 +20,6 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { useToast } from "@/hooks/use-toast";
-import { MCP_STATUS_COLORS } from "@/lib/constants/config";
 import {
 	getErrorMessage,
 	useDeleteMCPClientMutation,
@@ -32,7 +31,6 @@ import {
 	useVerifyMCPClientHeadersMutation,
 } from "@/lib/store";
 import { MCPAuthType, MCPClient } from "@/lib/types/mcp";
-import { titleCaseFromSnakeCase } from "@/lib/utils/strings";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
 import {
@@ -55,6 +53,7 @@ import { IconWrap, InfoBox } from "./authorizerUi";
 import MCPClientSheet from "./mcpClientSheet";
 import { authScopeOf } from "./mcpClientFormFields";
 import { canReconnectMCPClient } from "./mcpClientsTable.utils";
+import { StateBadge } from "./mcpConnectionFailure";
 import { MCPHeadersAuthorizer } from "./mcpHeadersAuthorizer";
 import { MCPServersEmptyState } from "./mcpServersEmptyState";
 import { MCPUsageGuideSheet } from "./mcpUsageGuide";
@@ -1048,9 +1047,10 @@ export default function MCPClientsTable({
 												    per-user auth types, so this is just the badge uniformly,
 												    same as shared clients. Column-header tooltip above explains
 												    that "unstable" reflects Bifrost's own connection checks, not
-												    caller traffic. "degraded" additionally gets a drill-down —
-												    see StateBadge below. */}
-												<StateBadge state={c.state} nodeStates={c.node_states} />
+												    caller traffic. Any state with a recorded reason (or a
+												    per-instance breakdown) gets a drill-down, see StateBadge in
+												    mcpConnectionFailure.tsx. */}
+												<StateBadge client={c} />
 											</TableCell>
 											<TableCell onClick={(e) => e.stopPropagation()}>
 												<Switch
@@ -1228,46 +1228,6 @@ export default function MCPClientsTable({
 				/>
 			)}
 		</div>
-	);
-}
-
-// StateBadge renders the plain state badge, except for "degraded" — a
-// distributed deployment's instances currently disagreeing about a client's
-// state — which additionally gets a hover drill-down showing the
-// per-instance breakdown behind the aggregate. summarizeNodeStates groups
-// instance IDs by their reported state so the drill-down reads as counts
-// ("2 instances: Healthy, 1 instance: Unstable") rather than a raw ID list.
-function summarizeNodeStates(nodeStates: Record<string, string>): string[] {
-	const countByState = new Map<string, number>();
-	for (const state of Object.values(nodeStates)) {
-		countByState.set(state, (countByState.get(state) ?? 0) + 1);
-	}
-	return Array.from(countByState.entries()).map(
-		([state, count]) => `${count} ${count === 1 ? "instance" : "instances"}: ${titleCaseFromSnakeCase(state)}`,
-	);
-}
-
-function StateBadge({ state, nodeStates }: { state: string; nodeStates?: Record<string, string> }) {
-	const badge = <Badge className={MCP_STATUS_COLORS[state]}>{titleCaseFromSnakeCase(state)}</Badge>;
-	if (state !== "degraded" || !nodeStates || Object.keys(nodeStates).length === 0) {
-		return badge;
-	}
-	return (
-		<Popover>
-			<PopoverTrigger asChild>
-				<button type="button" data-testid="mcp-client-state-degraded-trigger" className="cursor-help">
-					{badge}
-				</button>
-			</PopoverTrigger>
-			<PopoverContent className="w-xs text-xs" align="start">
-				<p className="text-muted-foreground mb-1.5">Instances disagree about this client&apos;s state:</p>
-				<ul className="space-y-0.5">
-					{summarizeNodeStates(nodeStates).map((line) => (
-						<li key={line}>{line}</li>
-					))}
-				</ul>
-			</PopoverContent>
-		</Popover>
 	);
 }
 

--- a/ui/app/workspace/mcp-registry/views/mcpConnectionFailure.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpConnectionFailure.tsx
@@ -1,0 +1,147 @@
+// The two surfaces that explain a server's connection state: the badge
+// popover in the servers table (a quick view) and the reason block in the
+// server sheet. Both read the same MCPConnectionFailure records, folded the
+// same way, so what the table hints at is exactly what the sheet spells out.
+
+import { Badge } from "@/components/ui/badge";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { MCP_STATUS_COLORS } from "@/lib/constants/config";
+import type { MCPClient, MCPConnectionFailure, MCPConnectionState } from "@/lib/types/mcp";
+import {
+	failureStageLabel,
+	foldInstanceStates,
+	formatFailureTiming,
+	hasStateReason,
+	stateReasonTitle,
+} from "@/lib/utils/mcpConnectionFailure";
+import { titleCaseFromSnakeCase } from "@/lib/utils/strings";
+import { ChevronDown } from "lucide-react";
+
+type StatefulClient = Pick<MCPClient, "state" | "last_failure" | "node_states">;
+
+function FailureDetail({ failure, state }: { failure: MCPConnectionFailure; state: MCPConnectionState }) {
+	return (
+		<div className="space-y-1">
+			<div className="font-medium">{failureStageLabel(failure.stage)}</div>
+			<div className="bg-muted rounded px-1.5 py-1 font-mono text-[11px] break-words whitespace-normal">{failure.message}</div>
+			<div className="text-muted-foreground">{formatFailureTiming(failure, state)}</div>
+		</div>
+	);
+}
+
+/**
+ * StateBadge is the servers table's state cell. A healthy server is a plain
+ * badge. Any other state that carries a reason (its own failure record, or a
+ * per-instance breakdown in a distributed deployment) opens a popover that
+ * names the failed stage, the error, and when it last happened. Instances
+ * are grouped by state and reason with a count; only Degraded shows a badge
+ * per group, because that is the only case where states differ.
+ */
+export function StateBadge({ client }: { client: StatefulClient }) {
+	const { state, last_failure, node_states } = client;
+	const badge = <Badge className={MCP_STATUS_COLORS[state]}>{titleCaseFromSnakeCase(state)}</Badge>;
+	if (!hasStateReason(client)) {
+		return badge;
+	}
+	const groups = node_states ? foldInstanceStates(node_states) : [];
+	const mixed = state === "degraded";
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button type="button" data-testid="mcp-client-state-reason-trigger" className="inline-flex cursor-help items-center gap-1">
+					{badge}
+					<ChevronDown className="text-muted-foreground size-3" />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent className="w-xs text-xs" align="start">
+				<p className="text-muted-foreground mb-1.5">{stateReasonTitle(state, groups.length > 0)}</p>
+				{groups.length > 0 ? (
+					<ul className="space-y-2.5">
+						{groups.map((g, i) => (
+							<li key={i} className="space-y-1">
+								<div className="flex items-center gap-2">
+									{mixed && <Badge className={MCP_STATUS_COLORS[g.state]}>{titleCaseFromSnakeCase(g.state)}</Badge>}
+									<span className={mixed ? "text-muted-foreground" : "font-medium"}>
+										{g.count} {g.count === 1 ? "instance" : "instances"}
+									</span>
+								</div>
+								{g.last_failure && <FailureDetail failure={g.last_failure} state={g.state} />}
+							</li>
+						))}
+					</ul>
+				) : last_failure ? (
+					<FailureDetail failure={last_failure} state={state} />
+				) : null}
+				<p className="text-muted-foreground mt-2 border-t pt-2">
+					<a href="https://docs.getbifrost.ai/mcp/connections" target="_blank" rel="noreferrer" className="underline underline-offset-2">
+						About connection states
+					</a>
+				</p>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
+/**
+ * ConnectionFailureBlock is the server sheet's reason block: the same fold
+ * as the popover, laid out as rows. It explains and never acts: every fix
+ * (reauthorize, refresh the admin credential, edit the configuration) lives
+ * in the servers table's actions menu and the form, not here.
+ */
+export function ConnectionFailureBlock({ client }: { client: MCPClient }) {
+	const { state, last_failure, node_states } = client;
+	if (!hasStateReason(client)) {
+		return null;
+	}
+	const groups = node_states ? foldInstanceStates(node_states) : [];
+	const mixed = state === "degraded";
+	const tone =
+		state === "needs_reauth"
+			? "border-red-200 dark:border-red-900"
+			: state === "degraded"
+				? "border-blue-200 dark:border-blue-900"
+				: "border-yellow-200 dark:border-yellow-900";
+
+	if (groups.length > 0) {
+		return (
+			<div className={`overflow-hidden rounded-md border ${tone}`} data-testid="mcpclient-connection-failure-block">
+				<div className="bg-muted text-muted-foreground hidden gap-3 px-3 py-2 text-[11px] font-medium tracking-wide uppercase sm:grid sm:grid-cols-[6rem_1fr_auto]">
+					<span>Instances</span>
+					<span>Reason</span>
+					<span>Last failed</span>
+				</div>
+				{groups.map((g, i) => (
+					<div key={i} className="grid grid-cols-1 gap-1 border-t px-3 py-2 text-xs sm:grid-cols-[6rem_1fr_auto] sm:items-center sm:gap-3">
+						<span className="flex flex-col gap-1">
+							<span>
+								{g.count} {g.count === 1 ? "instance" : "instances"}
+							</span>
+							{mixed && <Badge className={`w-fit ${MCP_STATUS_COLORS[g.state]}`}>{titleCaseFromSnakeCase(g.state)}</Badge>}
+						</span>
+						<span className="font-mono text-[11px] break-words whitespace-normal">
+							{g.last_failure ? (
+								`${failureStageLabel(g.last_failure.stage)}: ${g.last_failure.message}`
+							) : (
+								<span className="text-muted-foreground">Check passed</span>
+							)}
+						</span>
+						<span className="text-muted-foreground sm:whitespace-nowrap">
+							{g.last_failure ? formatFailureTiming(g.last_failure, g.state) : ""}
+						</span>
+					</div>
+				))}
+			</div>
+		);
+	}
+
+	if (!last_failure) {
+		return null;
+	}
+	return (
+		<div className={`space-y-2 rounded-md border px-3 py-2 text-xs ${tone}`} data-testid="mcpclient-connection-failure-block">
+			<div className="font-medium">{failureStageLabel(last_failure.stage)}</div>
+			<div className="font-mono text-[11px] break-words whitespace-normal">{last_failure.message}</div>
+			<div className="text-muted-foreground">{formatFailureTiming(last_failure, state)}</div>
+		</div>
+	);
+}

--- a/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
+++ b/ui/app/workspace/mcp-sessions/views/sessionsTable.tsx
@@ -19,6 +19,8 @@
 
 import PageTitle from "@/components/pageTitle";
 import { Badge } from "@/components/ui/badge";
+import { MCP_CREDENTIAL_STATUS_COLORS } from "@/lib/constants/config";
+import { titleCaseFromSnakeCase } from "@/lib/utils/strings";
 import { Button } from "@/components/ui/button";
 import {
 	AlertDialog,
@@ -374,34 +376,24 @@ function TypeBadge({ authKind }: { authKind: string }) {
 	return <Badge variant="outline">OAuth</Badge>;
 }
 
+// Colors come from the shared credential palette so a session's status reads
+// the same as the credential block in the server sheet and the server state
+// badge in the registry: green for usable, red for "a human must act", amber
+// and gray for informational.
+const SESSION_STATUS_LABELS: Record<string, string> = {
+	pending: "Pending",
+	orphaned: "Orphaned",
+	needs_reauth: "Needs re-auth",
+	needs_update: "Needs update",
+	active: "Active",
+};
+
 function StatusBadge({ status }: { status: string }) {
-	if (status === "pending") {
-		return <Badge variant="secondary">Pending</Badge>;
-	}
-	if (status === "orphaned") {
-		// Muted amber: distinct from destructive (red, action-required) and
-		// secondary (gray, in-progress). Signals "informational, no action
-		// needed from you" — the auto-restore cascade handles it.
-		return (
-			<Badge variant="outline" className="border-amber-500 bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
-				Orphaned
-			</Badge>
-		);
-	}
-	if (status === "needs_reauth") {
-		return <Badge variant="destructive">Needs re-auth</Badge>;
-	}
-	if (status === "needs_update") {
-		// Outlined red: signals user action required, but visually distinct from
-		// needs_reauth's solid destructive badge (which represents a hard auth failure).
-		// Distinct copy so the row affordance ("Update values") matches.
-		return (
-			<Badge variant="outline" className="border-red-500 bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200">
-				Needs update
-			</Badge>
-		);
-	}
-	return <Badge>Active</Badge>;
+	return (
+		<Badge className={MCP_CREDENTIAL_STATUS_COLORS[status] ?? MCP_CREDENTIAL_STATUS_COLORS.unknown}>
+			{SESSION_STATUS_LABELS[status] ?? titleCaseFromSnakeCase(status)}
+		</Badge>
+	);
 }
 
 interface RowActionsProps {

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -145,6 +145,23 @@ export const MCP_STATUS_COLORS: Record<string, string> = {
 	degraded: "bg-blue-100 text-blue-800",
 };
 
+// Credential row statuses (the admin/shared OAuth token or the admin header
+// values a server holds on its own behalf), in the same soft-pill palette as
+// MCP_STATUS_COLORS so a credential badge reads like every other status
+// badge: green for usable, red for "a human must act", amber for
+// informational.
+export const MCP_CREDENTIAL_STATUS_COLORS: Record<string, string> = {
+	active: "bg-green-100 text-green-800",
+	needs_reauth: "bg-red-100 text-red-800",
+	needs_update: "bg-red-100 text-red-800",
+	orphaned: "bg-yellow-100 text-yellow-800",
+	// Sessions table only: an OAuth flow that was started but not completed.
+	pending: "bg-gray-100 text-gray-800",
+	// Fallback for a status value this build does not know. Neutral on
+	// purpose: an unrecognized status must not read as usable.
+	unknown: "bg-gray-100 text-gray-800",
+};
+
 // Mapping of what IS supported by each base provider
 export const PROVIDER_SUPPORTED_REQUESTS: Record<BaseProvider, string[]> = {
 	openai: [

--- a/ui/lib/types/mcp.ts
+++ b/ui/lib/types/mcp.ts
@@ -18,6 +18,26 @@ export type MCPConnectionState =
 
 export type MCPAuthType = "none" | "headers" | "oauth" | "per_user_oauth" | "per_user_headers" | "token_exchange";
 
+// Which step of Bifrost's own connection handling failed. Mirrors the Go
+// MCPConnectionFailureStage constants.
+export type MCPConnectionFailureStage = "connect" | "ping" | "list_tools" | "tool_discovery" | "transport_lost" | "credential";
+
+// Why a server's state is not healthy: the step that failed, the error it
+// failed with, the most recent failed attempt, and when the current run of
+// failures began. Absent while healthy.
+export interface MCPConnectionFailure {
+	stage: MCPConnectionFailureStage;
+	message: string;
+	at: string;
+	since: string;
+}
+
+// One instance's own view of a server in a distributed deployment.
+export interface MCPInstanceState {
+	state: MCPConnectionState;
+	last_failure?: MCPConnectionFailure;
+}
+
 // Lifecycle states for a per-user MCP header credential row. Mirrors the
 // status column on mcp_per_user_header_credentials.
 //   - active:       caller-submitted, usable
@@ -161,6 +181,11 @@ export interface MCPClientCredential {
 	kind: "oauth" | "headers";
 	// oauth: active | orphaned | needs_reauth. headers: active | orphaned | needs_update.
 	status: "active" | "orphaned" | "needs_reauth" | "needs_update";
+	// oauth only: why the status left active, as recorded when it flipped:
+	// the provider's rejection of the last refresh (HTTP status plus the
+	// OAuth error and description), a credential rotation, or a failed admin
+	// exchange. Absent while active.
+	status_reason?: string;
 	// oauth only: access token expiry; absent when the provider did not report one.
 	expires_at?: string | null;
 	// oauth only: set once the access token has been refreshed or the
@@ -182,10 +207,15 @@ export interface MCPClient {
 	tools: ToolFunction[];
 	state: MCPConnectionState;
 	vk_configs: MCPVKConfigResponse[];
-	// Per-instance breakdown behind `state` when it's "degraded" (instance ID
-	// -> that instance's own self-reported state). Only ever present in a
-	// distributed deployment; absent otherwise.
-	node_states?: Record<string, string>;
+	// The failure behind a `state` other than healthy, as recorded by the
+	// instance that served this request. Absent while healthy.
+	last_failure?: MCPConnectionFailure;
+	// Per-instance breakdown behind `state` in a distributed deployment
+	// (instance ID -> that instance's own state and failure). Present when
+	// instances disagree (`state` is then "degraded") and when they all
+	// report unstable, so each instance's own reason is visible. Never
+	// present in a single-instance deployment.
+	node_states?: Record<string, MCPInstanceState>;
 	// The credential this server holds on its own behalf. Absent for auth
 	// types without one (none, headers) and for servers that have not
 	// completed their one-time authorization yet.

--- a/ui/lib/utils/mcpConnectionFailure.test.ts
+++ b/ui/lib/utils/mcpConnectionFailure.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { MCPInstanceState } from "@/lib/types/mcp";
+import { foldInstanceStates, formatDurationSince, formatFailureTiming, hasStateReason, stateReasonTitle } from "./mcpConnectionFailure";
+
+describe("mcpConnectionFailure", () => {
+	const now = new Date("2026-09-03T12:00:00Z");
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(now);
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test("formatDurationSince keeps seconds under a minute", () => {
+		expect(formatDurationSince("2026-09-03T11:59:53Z")).toBe("7s");
+		expect(formatDurationSince("2026-09-03T11:56:00Z")).toBe("4m");
+		expect(formatDurationSince("2026-09-03T09:00:00Z")).toBe("3h");
+		expect(formatDurationSince("2026-08-30T12:00:00Z")).toBe("4d");
+		expect(formatDurationSince("not a date")).toBe("not a date");
+	});
+
+	test("formatFailureTiming omits the run when it is a single attempt", () => {
+		const at = "2026-09-03T11:59:48Z";
+		expect(formatFailureTiming({ stage: "connect", message: "x", at, since: at }, "unstable")).toBe("Last failed 12s ago");
+		expect(formatFailureTiming({ stage: "connect", message: "x", at, since: "2026-09-03T11:56:00Z" }, "unstable")).toBe(
+			"Last failed 12s ago · unstable for 4m",
+		);
+		expect(formatFailureTiming({ stage: "credential", message: "x", at, since: "2026-09-03T10:00:00Z" }, "needs_reauth")).toBe(
+			"Last failed 12s ago · needs reauth for 2h",
+		);
+	});
+
+	test("foldInstanceStates groups identical failures, newest at and oldest since", () => {
+		const nodes: Record<string, MCPInstanceState> = {
+			a: {
+				state: "unstable",
+				last_failure: {
+					stage: "list_tools",
+					message: "context deadline exceeded",
+					at: "2026-09-03T11:59:48Z",
+					since: "2026-09-03T11:56:00Z",
+				},
+			},
+			b: {
+				state: "unstable",
+				last_failure: {
+					stage: "list_tools",
+					message: "context deadline exceeded",
+					at: "2026-09-03T11:59:53Z",
+					since: "2026-09-03T11:55:30Z",
+				},
+			},
+			c: {
+				state: "unstable",
+				last_failure: { stage: "ping", message: "i/o timeout", at: "2026-09-03T11:59:51Z", since: "2026-09-03T11:59:51Z" },
+			},
+			d: { state: "healthy" },
+		};
+		const groups = foldInstanceStates(nodes);
+		expect(groups.map((g) => [g.state, g.count, g.last_failure?.message])).toEqual([
+			["unstable", 2, "context deadline exceeded"],
+			["unstable", 1, "i/o timeout"],
+			["healthy", 1, undefined],
+		]);
+		expect(groups[0].last_failure?.at).toBe("2026-09-03T11:59:53Z");
+		expect(groups[0].last_failure?.since).toBe("2026-09-03T11:55:30Z");
+		// The fold never mutates the input records.
+		expect(nodes.a.last_failure?.at).toBe("2026-09-03T11:59:48Z");
+	});
+
+	test("foldInstanceStates puts unhealthy groups first", () => {
+		const groups = foldInstanceStates({
+			a: { state: "healthy" },
+			b: {
+				state: "needs_reauth",
+				last_failure: { stage: "credential", message: "invalid_grant", at: "2026-09-03T10:00:00Z", since: "2026-09-03T10:00:00Z" },
+			},
+		});
+		expect(groups.map((g) => g.state)).toEqual(["needs_reauth", "healthy"]);
+	});
+
+	test("hasStateReason and stateReasonTitle", () => {
+		expect(hasStateReason({})).toBe(false);
+		expect(hasStateReason({ node_states: {} })).toBe(false);
+		expect(hasStateReason({ last_failure: { stage: "ping", message: "x", at: "", since: "" } })).toBe(true);
+		expect(stateReasonTitle("unstable", false)).toBe("Last connection check failed");
+		expect(stateReasonTitle("unstable", true)).toBe("Last connection check failed on every instance");
+		expect(stateReasonTitle("degraded", true)).toBe("Instances disagree about this server's state");
+		expect(stateReasonTitle("needs_reauth", false)).toBe("Reauthorization required");
+	});
+});

--- a/ui/lib/utils/mcpConnectionFailure.ts
+++ b/ui/lib/utils/mcpConnectionFailure.ts
@@ -1,0 +1,105 @@
+// Helpers shared by the MCP servers table's state badge popover and the
+// server sheet's reason block, so both surfaces fold and describe the same
+// failure records the same way.
+
+import type { MCPClient, MCPConnectionFailure, MCPConnectionState, MCPInstanceState } from "@/lib/types/mcp";
+
+const STAGE_LABELS: Record<string, string> = {
+	connect: "Connecting",
+	ping: "Ping",
+	list_tools: "Listing tools",
+	tool_discovery: "Discovering tools",
+	transport_lost: "Connection dropped",
+	credential: "Credential",
+};
+
+export function failureStageLabel(stage: string): string {
+	return STAGE_LABELS[stage] ?? stage;
+}
+
+/**
+ * formatDurationSince renders how long ago `iso` was with seconds
+ * granularity: while a server is unstable the checker retries every ten
+ * seconds, so "just now" for anything under a minute would hide whether the
+ * last attempt is fresh.
+ */
+export function formatDurationSince(iso: string): string {
+	const t = new Date(iso).getTime();
+	if (Number.isNaN(t)) return iso;
+	const s = Math.max(0, Math.floor((Date.now() - t) / 1000));
+	if (s < 60) return `${s}s`;
+	const m = Math.floor(s / 60);
+	if (m < 60) return `${m}m`;
+	const h = Math.floor(m / 60);
+	if (h < 48) return `${h}h`;
+	return `${Math.floor(h / 24)}d`;
+}
+
+/**
+ * formatFailureTiming is the timing line under a failure: when the last
+ * attempt failed and, when the run spans more than one attempt, how long the
+ * server has been in this state.
+ */
+export function formatFailureTiming(failure: MCPConnectionFailure, state: MCPConnectionState): string {
+	const line = `Last failed ${formatDurationSince(failure.at)} ago`;
+	if (!failure.since || failure.since === failure.at) return line;
+	const word = state === "needs_reauth" ? "needs reauth" : state;
+	return `${line} · ${word} for ${formatDurationSince(failure.since)}`;
+}
+
+export interface MCPInstanceGroup {
+	state: MCPConnectionState;
+	count: number;
+	last_failure?: MCPConnectionFailure;
+}
+
+const STATE_RANK: Record<string, number> = { needs_reauth: 0, error: 1, unstable: 2, pending_verification: 3, healthy: 9 };
+
+/**
+ * foldInstanceStates collapses a per-instance breakdown into groups that
+ * read the same: same state, same failed stage, same error text. Instances
+ * failing the same way become one row with a count, so a three-node outage
+ * with one cause is one line. A group's `at` is the newest across its
+ * instances (is this still happening?) and its `since` the oldest (how long
+ * has the longest-suffering instance been failing?). Unhealthy groups sort
+ * first.
+ */
+export function foldInstanceStates(nodeStates: Record<string, MCPInstanceState>): MCPInstanceGroup[] {
+	const groups = new Map<string, MCPInstanceGroup>();
+	for (const instance of Object.values(nodeStates)) {
+		const f = instance.last_failure;
+		const key = `${instance.state}|${f ? `${f.stage}|${f.message}` : ""}`;
+		const existing = groups.get(key);
+		if (!existing) {
+			groups.set(key, { state: instance.state, count: 1, last_failure: f ? { ...f } : undefined });
+			continue;
+		}
+		existing.count += 1;
+		if (f && existing.last_failure) {
+			if (Date.parse(f.at) > Date.parse(existing.last_failure.at)) existing.last_failure.at = f.at;
+			if (Date.parse(f.since) < Date.parse(existing.last_failure.since)) existing.last_failure.since = f.since;
+		}
+	}
+	return Array.from(groups.values()).sort((a, b) => (STATE_RANK[a.state] ?? 5) - (STATE_RANK[b.state] ?? 5));
+}
+
+/** hasStateReason reports whether a server carries anything worth opening a popover for. */
+export function hasStateReason(client: Pick<MCPClient, "last_failure" | "node_states">): boolean {
+	return !!client.last_failure || (!!client.node_states && Object.keys(client.node_states).length > 0);
+}
+
+/** stateReasonTitle is the first line of the popover and the sheet's reason block. */
+export function stateReasonTitle(state: MCPConnectionState, hasBreakdown: boolean): string {
+	switch (state) {
+		case "degraded":
+			return "Instances disagree about this server's state";
+		case "unstable":
+			return hasBreakdown ? "Last connection check failed on every instance" : "Last connection check failed";
+		case "needs_reauth":
+			return "Reauthorization required";
+		case "error":
+			return "Not registered in the runtime";
+		default:
+			return "Connection state";
+	}
+}


### PR DESCRIPTION
## Summary

MCP server state badges and the server sheet now surface the recorded failure reason behind any non-healthy state. Previously, a degraded badge opened a popover showing only a per-instance state count; unstable and needs_reauth states had no drill-down at all. This PR wires `last_failure` and the richer `node_states` (now carrying per-instance failure records, not just state strings) through to two new surfaces: a popover on the table badge and a reason block in the server sheet's General tab.

## Changes

- Added `MCPConnectionFailure` and `MCPInstanceState` types to `mcp.ts`. `node_states` is now `Record<string, MCPInstanceState>` instead of `Record<string, string>`, carrying each instance's own failure record alongside its state. `MCPClient` gains `last_failure` for the single-instance case. `MCPClientCredential` gains `status_reason` to surface why an OAuth credential left the active state.
- Extracted `StateBadge` and `ConnectionFailureBlock` into a new `mcpConnectionFailure.tsx` component file. `StateBadge` replaces the previous degraded-only popover in the servers table; it now opens for any state that carries a reason. `ConnectionFailureBlock` is a new sheet-level component that renders the same failure data as a structured block in the General tab.
- Added `mcpConnectionFailure.ts` utility module with `foldInstanceStates` (collapses per-instance records into groups by state + stage + message, newest `at`, oldest `since`), `formatDurationSince` (seconds-granular duration), `formatFailureTiming`, `hasStateReason`, `stateReasonTitle`, and `failureStageLabel`. Unit tests cover all of these.
- Replaced the inline `stateDescription` ternary chain in `mcpClientSheet.tsx` with a named `stateDescription` function. The `needs_reauth` and `unstable` cases now append the failure message and stage to the sheet's subtitle.
- Consolidated credential and session status badge rendering in `mcpClientCredentialSection.tsx` and `sessionsTable.tsx` onto a shared `MCP_CREDENTIAL_STATUS_COLORS` palette constant, replacing per-status switch/if blocks. `status_reason` is rendered inline under the credential status badge when present.
- Added `MCP_CREDENTIAL_STATUS_COLORS` to `config.ts` covering `active`, `needs_reauth`, `needs_update`, `orphaned`, and `pending`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm test
pnpm build
```

1. Open the MCP Registry with a server in `unstable` or `needs_reauth` state. The state badge in the table should show a chevron and open a popover with the failed stage, error message, and timing.
2. Open the server sheet for the same server. The General tab should show a reason block above Basic Information with the same failure detail.
3. For a distributed deployment with instances in differing states (`degraded`), the popover and sheet block should group instances by state and failure, showing counts and per-group badges.
4. Open the MCP Sessions table and the credential section of a server sheet. Status badges should render with the same color palette across both surfaces. A credential with a `status_reason` should show it in monospace below the status badge.

## Screenshots/Recordings

_Add before/after screenshots of the state badge popover and the sheet reason block._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII changes. Failure messages surfaced in the UI originate from Bifrost's own connection check records and are already visible to workspace admins.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable