### PR TITLE
docs: add `last_failure`/`node_states` fields to `MCPClient` schema and document connection-state failure reasons

### DIFF
--- a/docs/mcp/connections.mdx
+++ b/docs/mcp/connections.mdx
@@ -50,6 +50,37 @@ Two entirely separate credential-resolution paths exist for per-user auth types,
 `pending_tools` and a bare `connected`/`disconnected` naming existed in older versions of this doc set — the current state names are exactly the seven above. If you see `connected`, `disconnected`, `connecting`, or `pending_tools` referenced anywhere else in these docs, that's stale and maps to `healthy`, `unstable`, (nothing — was never a real state), and (removed — an empty `healthy` tool map already communicates the same thing) respectively.
 </Note>
 
+### Why a server is in a state
+
+When Bifrost's own connection handling has failed for a server, the state carries its explanation. `GET /api/mcp/clients` returns it as `last_failure`, and the UI shows the same record behind the state badge (click it) and at the top of the server sheet. The field is present only after the serving instance has attempted a connect or check that failed; it is absent while `healthy`, and absent when a state changed without such an attempt.
+
+```json
+"state": "unstable",
+"last_failure": {
+  "stage": "list_tools",
+  "message": "context deadline exceeded",
+  "at": "2026-09-03T10:41:12Z",
+  "since": "2026-09-03T10:32:04Z"
+}
+```
+
+| Field | Meaning |
+| --- | --- |
+| `stage` | Which step of Bifrost's own connection handling failed: `connect` (dial, initialize, connect gate, or the initial `list_tools` a new connection must pass), `ping` and `list_tools` (the periodic check over a sticky connection), `tool_discovery` (the periodic check's ephemeral connect-discover-close cycle for per-call auth types), `transport_lost` (a live SSE stream dropped), or `credential` (the credential the connection depends on was rejected upstream or rotated by an admin). |
+| `message` | The error that step failed with, whitespace-collapsed and capped at 512 characters. |
+| `at` | The most recent failed attempt. While a server is `unstable` the check retries every 10 seconds, so this keeps moving for as long as the outage lasts. |
+| `since` | The first failed attempt of the current unhealthy run. Answers "how long has this been going on". |
+
+A few properties worth knowing:
+
+- **It is the serving instance's own record.** It describes what *this* Bifrost instance last ran into, never the outcome of real tool calls made through the server.
+- **It clears on the first passing check.** A `healthy` server never carries a stale reason; the record is gone the moment the state flips back.
+- **It can lag a credential-driven state.** A `needs_reauth` that comes from a credential row dying in the store (a rejected refresh, a rotation) shows no reason until the server's next scheduled check actually hits the dead credential, at which point the provider's rejection is recorded. Shared-OAuth servers hit it on their next reconnect; per-user servers on their next tool-discovery check.
+- **A single failed check is enough.** There is no consecutive-failure counter across checks. Each check already retries with backoff internally (three retries per operation), and that budget is what absorbs an ordinary blip. A check that exhausts it marks the server `unstable` and records why.
+- **Reasons are logged once per transition.** The state-change log line at `INFO` carries the stage and message. Individual failed checks during an outage log at `DEBUG` only, so a long outage does not flood the log.
+
+**Distributed deployments.** Each instance reports its own state and `last_failure` through the shared node-state heartbeat. When instances disagree, `state` is `degraded` and `node_states` maps each instance ID to its own `{ "state", "last_failure" }`. The same map is also attached when every instance agrees on `unstable`, because their reasons can still differ (one pod missing a binary, another timing out). The UI folds that map by state and reason, so three instances failing the same way read as one line with a count; the per-instance detail stays available in the API.
+
 ---
 
 ## Lifecycle: sticky server-level (`needs_session_stickiness: true`, or `sse`/`stdio`)

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1643,6 +1643,10 @@ components:
       $ref: "./schemas/management/mcp.yaml#/MCPClient"
     MCPClientConfig:
       $ref: "./schemas/management/mcp.yaml#/MCPClientConfig"
+    MCPConnectionFailure:
+      $ref: "./schemas/management/mcp.yaml#/MCPConnectionFailure"
+    MCPInstanceState:
+      $ref: "./schemas/management/mcp.yaml#/MCPInstanceState"
     ExecuteToolRequest:
       $ref: "./schemas/management/mcp.yaml#/ExecuteToolRequest"
     MCPAuthType:

--- a/docs/openapi/schemas/management/mcp.yaml
+++ b/docs/openapi/schemas/management/mcp.yaml
@@ -745,11 +745,82 @@ MCPClient:
         $ref: '#/ChatToolFunction'
     state:
       $ref: '#/MCPConnectionState'
+    last_failure:
+      $ref: '#/MCPConnectionFailure'
+    node_states:
+      type: object
+      additionalProperties:
+        $ref: '#/MCPInstanceState'
+      description: |
+        Per-instance breakdown behind `state` in a distributed deployment:
+        instance ID -> that instance's own self-reported state and
+        last_failure. Present when instances disagree (`state` is then
+        `degraded`) and when they all agree on `unstable`, so each instance's
+        own reason is visible. Never present in a single-instance deployment.
     vk_configs:
       type: array
       items:
         $ref: '#/MCPVKConfigResponse'
       description: Virtual key assignments for this MCP client
+
+MCPConnectionFailure:
+  type: object
+  description: |
+    The latest failure recorded by the instance serving the request for its
+    own connection handling of this client: which step failed, the error it
+    failed with, when that last happened, and when the current run of
+    failures began. Present only after that instance has attempted a connect
+    or check that failed. Absent while `healthy`, cleared the moment a check
+    passes, and absent when a state changed without such an attempt, for
+    example `needs_reauth` projected from a credential row that died before
+    the next scheduled check ran. Describes only Bifrost's own connection
+    checks and connect attempts, never the outcome of real tool calls made
+    through the client.
+  required: [stage, message, at, since]
+  properties:
+    stage:
+      type: string
+      enum: [connect, ping, list_tools, tool_discovery, transport_lost, credential]
+      description: |
+        The step that failed:
+        - connect: establishing the shared connection (dial, initialize,
+          connect gate, or the initial list_tools a new connection must pass)
+        - ping: the periodic check's ping over an existing sticky connection
+        - list_tools: the periodic check's list_tools over an existing sticky
+          connection
+        - tool_discovery: the periodic check's ephemeral connect-discover-close
+          cycle for per-call auth types
+        - transport_lost: a live SSE connection dropped outside any check
+        - credential: a credential the connection depends on was rejected
+          upstream or rotated by an admin
+    message:
+      type: string
+      description: The error the step failed with, whitespace-collapsed and capped at 512 characters.
+    at:
+      type: string
+      format: date-time
+      description: |
+        The most recent failed attempt. While a client is unstable the check
+        retries every 10 seconds, so this keeps moving for as long as the
+        outage lasts.
+    since:
+      type: string
+      format: date-time
+      description: The first failed attempt of the current unhealthy run.
+
+MCPInstanceState:
+  type: object
+  description: One instance's own view of an MCP client in a distributed deployment.
+  required: [state]
+  properties:
+    state:
+      type: string
+      enum: [healthy, unstable, error, pending_verification, needs_reauth, disabled]
+      description: |
+        That instance's own self-reported connection state. Never `degraded`,
+        which only ever exists as the aggregate above this map.
+    last_failure:
+      $ref: '#/MCPConnectionFailure'
 
 MCPClientsListResponse:
   type: object


### PR DESCRIPTION
## Summary

Exposes structured failure diagnostics for MCP client connections. Previously, when a server entered an unhealthy state, there was no machine-readable explanation of what failed or when. This adds `last_failure` and `node_states` to the `MCPClient` response object, and documents the new fields in the connections reference.

## Changes

- Added `MCPConnectionFailure` schema describing the `stage`, `message`, `at`, and `since` fields returned when a client is not `healthy`
- Added `MCPInstanceState` schema representing a single instance's self-reported state and failure record in distributed deployments
- Extended `MCPClient` with `last_failure` (the serving instance's own failure record) and `node_states` (per-instance breakdown, present when instances disagree or all agree on `unstable`)
- Registered both new schemas in the top-level OpenAPI component references
- Added a "Why a server is in a state" section to the connections doc covering the `last_failure` structure, field semantics, clearing behavior, retry/backoff model, log verbosity, and how distributed deployments fold per-instance state into the aggregate

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review `GET /api/mcp/clients` responses for any client in an `unstable` or `degraded` state and confirm `last_failure` is present with `stage`, `message`, `at`, and `since` populated. Confirm `last_failure` is absent on `healthy` clients. In a multi-instance deployment, confirm `node_states` is present when instances disagree or all report `unstable`, and absent in single-instance deployments.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`last_failure.message` is capped at 512 characters and whitespace-collapsed before being stored or returned, limiting the surface area for leaking verbose internal error detail through the API.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable