### PR TITLE
fix: remove raw body passthrough if provider does not support output config format

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6723,6 +6723,37 @@ func clearAnthropicPassthroughForNonNativeProvider(ctx *schemas.BifrostContext, 
 	ctx.ClearValue(schemas.BifrostContextKeyURLPath)
 }
 
+// clearAnthropicPassthroughForUnsupportedStructuredOutput disables Anthropic raw-body passthrough
+// when the resolved provider cannot serve native structured outputs but the request carries a
+// schema. The raw body would forward output_config.format verbatim and the provider answers 400
+// "output_config.format: Extra inputs are not permitted"; typed conversion instead rewrites the
+// schema into the synthetic bf_so_* tool these providers do accept. Gated on the final resolved
+// provider so it fires however that was picked (prefix, key alias, governance, routing rule) and
+// re-runs per attempt for fallbacks — the ingress guard in the Anthropic integration only sees a
+// provider the caller spelled out in the model string, so an alias or routing rule hides it.
+func clearAnthropicPassthroughForUnsupportedStructuredOutput(ctx *schemas.BifrostContext, baseProvider schemas.ModelProvider, req *schemas.BifrostRequest) {
+	if integrationType, _ := ctx.Value(schemas.BifrostContextKeyIntegrationType).(string); integrationType != "anthropic" {
+		return
+	}
+	if useRawBody, _ := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); !useRawBody {
+		return
+	}
+	if !anthropic.ProviderRequiresSyntheticStructuredOutput(baseProvider) {
+		return
+	}
+	// Read the bytes that would go on the wire rather than Params.Text: plugins run before
+	// the worker and can drop the typed field (compat's drop-params) while the raw body still
+	// carries it. The Anthropic Messages integration always builds a Responses request.
+	if req == nil || req.ResponsesRequest == nil {
+		return
+	}
+	rawBody := req.ResponsesRequest.GetRawRequestBody()
+	if !providerUtils.JSONFieldExists(rawBody, "output_config.format") && !providerUtils.JSONFieldExists(rawBody, "output_format") {
+		return
+	}
+	ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
+}
+
 // applyRawCaptureSignals writes this attempt's raw-payload capture signals, merging provider
 // config with any per-request context overrides. Call it after
 // clearAnthropicPassthroughForNonNativeProvider: that helper can drop the passthrough overrides
@@ -7091,6 +7122,8 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				req.SetModel(resolvedModel)
 				// Disable Anthropic raw-body passthrough when this attempt's provider/model isn't Anthropic-native.
 				clearAnthropicPassthroughForNonNativeProvider(req.Context, baseProvider, resolvedModel)
+				// Disable it too when this attempt's provider has no native structured outputs.
+				clearAnthropicPassthroughForUnsupportedStructuredOutput(req.Context, baseProvider, &req.BifrostRequest)
 				applyRawCaptureSignals(req.Context, config)
 				// Snapshot per-attempt so postHookRunner doesn't observe a later retry's
 				// alias while this attempt's provider goroutine is still emitting chunks.
@@ -7193,6 +7226,8 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				req.SetModel(resolvedModel)
 				// Disable Anthropic raw-body passthrough when this attempt's provider/model isn't Anthropic-native.
 				clearAnthropicPassthroughForNonNativeProvider(req.Context, baseProvider, resolvedModel)
+				// Disable it too when this attempt's provider has no native structured outputs.
+				clearAnthropicPassthroughForUnsupportedStructuredOutput(req.Context, baseProvider, &req.BifrostRequest)
 				applyRawCaptureSignals(req.Context, config)
 				attemptRoutingInfo = schemas.BuildRoutingInfo(req.Context, provider.GetProviderKey(), originalModelRequested, k)
 				return bifrost.handleProviderRequest(provider, config, req, k, keys)

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -3027,6 +3027,79 @@ func TestClearAnthropicPassthroughForNonNativeProvider(t *testing.T) {
 	}
 }
 
+// TestClearAnthropicPassthroughForUnsupportedStructuredOutput covers a Claude Code session-title
+// call (a one-field JSON schema in output_config.format) that a routing rule retargets to Bedrock
+// Mantle. The ingress guard in the Anthropic integration only sees a provider spelled out in the
+// caller's model string, so an alias or routing rule hides it and the raw body used to reach the
+// Mantle Messages API with output_config.format intact — 400 "Extra inputs are not permitted".
+// Only the raw request body is dropped: the raw response flags stay on, and the response path
+// keys off the synthetic bf_so_* tool name instead. Vertex and Azure take the same route.
+func TestClearAnthropicPassthroughForUnsupportedStructuredOutput(t *testing.T) {
+	const outputConfigBody = `{"model":"claude-sonnet-5","output_config":{"format":{"type":"json_schema","schema":{"type":"object","properties":{"title":{"type":"string"}}}}}}`
+	// Legacy beta shape: top-level output_format instead of output_config.format.
+	const outputFormatBody = `{"model":"claude-sonnet-5","output_format":{"type":"json_schema","schema":{"type":"object"}}}`
+	const noFormatBody = `{"model":"claude-sonnet-5","messages":[]}`
+
+	responsesRequest := func(rawBody string) *schemas.BifrostRequest {
+		return &schemas.BifrostRequest{
+			ResponsesRequest: &schemas.BifrostResponsesRequest{RawRequestBody: []byte(rawBody)},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		integrationType string
+		baseProvider    schemas.ModelProvider
+		useRawBody      bool
+		req             *schemas.BifrostRequest
+		wantCleared     bool
+	}{
+		{"bedrock mantle with output_config.format clears", "anthropic", schemas.BedrockMantle, true, responsesRequest(outputConfigBody), true},
+		{"bedrock mantle with legacy output_format clears", "anthropic", schemas.BedrockMantle, true, responsesRequest(outputFormatBody), true},
+		{"vertex with output_config.format clears", "anthropic", schemas.Vertex, true, responsesRequest(outputConfigBody), true},
+		{"azure with output_config.format clears", "anthropic", schemas.Azure, true, responsesRequest(outputConfigBody), true},
+		// Anthropic and Bedrock Converse serve the schema natively; nothing to rewrite.
+		{"anthropic with output_config.format preserved", "anthropic", schemas.Anthropic, true, responsesRequest(outputConfigBody), false},
+		{"bedrock with output_config.format preserved", "anthropic", schemas.Bedrock, true, responsesRequest(outputConfigBody), false},
+		{"bedrock mantle without a format preserved", "anthropic", schemas.BedrockMantle, true, responsesRequest(noFormatBody), false},
+		// Typed conversion is already in force — the raw body is never consulted.
+		{"passthrough already off stays off", "anthropic", schemas.BedrockMantle, false, responsesRequest(outputConfigBody), false},
+		{"non-anthropic integration preserved", "openai", schemas.BedrockMantle, true, responsesRequest(outputConfigBody), false},
+		{"no integration type preserved", "", schemas.BedrockMantle, true, responsesRequest(outputConfigBody), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			if tt.integrationType != "" {
+				ctx.SetValue(schemas.BifrostContextKeyIntegrationType, tt.integrationType)
+			}
+			ctx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, tt.useRawBody)
+			ctx.SetValue(schemas.BifrostContextKeySendBackRawResponse, true)
+			ctx.SetValue(schemas.BifrostContextKeyPassthroughOverridesPresent, true)
+
+			clearAnthropicPassthroughForUnsupportedStructuredOutput(ctx, tt.baseProvider, tt.req)
+
+			useRawBody, _ := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool)
+			if want := tt.useRawBody && !tt.wantCleared; useRawBody != want {
+				t.Errorf("UseRawRequestBody = %v, want %v", useRawBody, want)
+			}
+
+			// The raw-response side is untouched: the Anthropic integration skips passthrough on
+			// the way back when a structured-output tool name is set, so clearing these here would
+			// only lose the caller's raw-response opt-in.
+			for _, k := range []schemas.BifrostContextKey{
+				schemas.BifrostContextKeySendBackRawResponse,
+				schemas.BifrostContextKeyPassthroughOverridesPresent,
+			} {
+				if flag, _ := ctx.Value(k).(bool); !flag {
+					t.Errorf("flag %v was cleared, want it preserved", k)
+				}
+			}
+		})
+	}
+}
+
 // TestClearCtxForFallback_DropsCallerSuppliedKey verifies that a raw key supplied via
 // x-bf-direct-key does not ride a fallback onto a different provider. Key selection resolves the
 // direct key before it ever reaches the provider's own pool, so an uncleared value would send the

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -580,7 +580,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 		if bifrostReq.Params.ResponseFormat != nil {
 			// Vertex, Bedrock Mantle, and Azure don't accept native structured outputs
 			// (output_config.format), so convert to a tool instead.
-			if bifrostReq.Provider == schemas.Vertex || bifrostReq.Provider == schemas.BedrockMantle || bifrostReq.Provider == schemas.Azure {
+			if ProviderRequiresSyntheticStructuredOutput(bifrostReq.Provider) {
 				responseFormatTool := convertChatResponseFormatToTool(ctx, bifrostReq.Params)
 				if responseFormatTool != nil {
 					anthropicReq.Tools = append(anthropicReq.Tools, *responseFormatTool)

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -4236,7 +4236,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 		if bifrostReq.Params.Text != nil {
 			// Vertex, Bedrock Mantle, and Azure don't accept native structured outputs
 			// (output_config.format), so convert to a tool instead.
-			if bifrostReq.Provider == schemas.Vertex || bifrostReq.Provider == schemas.BedrockMantle || bifrostReq.Provider == schemas.Azure {
+			if ProviderRequiresSyntheticStructuredOutput(bifrostReq.Provider) {
 				if bifrostReq.Params.Text.Format != nil {
 					responseFormatTool, err := convertResponsesTextFormatToTool(ctx, bifrostReq.Params.Text)
 					if err != nil {

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -111,6 +111,15 @@ func ValidateChatToolsForProvider(tools []schemas.ChatTool, caps schemas.ModelCa
 	return keep, dropped
 }
 
+// ProviderRequiresSyntheticStructuredOutput reports whether a provider's Anthropic Messages
+// surface rejects native structured outputs (output_config.format) and must receive the schema as
+// the synthetic bf_so_* tool instead. Single source of truth for the typed converters and for the
+// raw-body passthrough guards, which have to agree: a body the converter would have rewritten must
+// never reach the provider verbatim ("output_config.format: Extra inputs are not permitted").
+func ProviderRequiresSyntheticStructuredOutput(provider schemas.ModelProvider) bool {
+	return provider == schemas.Vertex || provider == schemas.BedrockMantle || provider == schemas.Azure
+}
+
 // ValidateResponsesToolsForProvider is the Responses-path mirror of
 // ValidateChatToolsForProvider. It partitions []schemas.ResponsesTool into a
 // keep-set (function/custom tools + server tools supported on the target

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -351,7 +351,7 @@ func checkAnthropicPassthrough(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.Bif
 		// These providers convert output_config.format through Bifrost, including
 		// their client-facing response events, so raw request and response text
 		// rewriters do not apply.
-		if (provider == schemas.Vertex || provider == schemas.BedrockMantle || provider == schemas.Azure) && hasOutputConfigFormat(req) {
+		if anthropic.ProviderRequiresSyntheticStructuredOutput(provider) && hasOutputConfigFormat(req) {
 			bifrostCtx.SetValue(schemas.BifrostContextKeyUseRawRequestBody, false)
 			return nil
 		}


### PR DESCRIPTION
## Summary

When a Claude Code session-title request (or any Anthropic Responses/Chat request carrying a JSON schema in `output_config.format` or `output_format`) is retargeted to Vertex, Bedrock Mantle, or Azure via a routing rule or key alias, the raw request body was forwarded verbatim to those providers. Because those providers do not accept `output_config.format`, they returned a 400 `"Extra inputs are not permitted"`. The typed conversion path already rewrites the schema into the synthetic `bf_so_*` tool these providers accept, but the raw-body passthrough bypassed that rewrite entirely.

The ingress guard in the Anthropic integration only sees the provider spelled out in the caller's model string, so an alias or routing rule hides the true resolved provider and the guard never fires. This PR adds a per-attempt guard that runs after provider resolution — including fallbacks — to disable raw request body passthrough whenever the resolved provider requires synthetic structured output.

## Changes

- Extracted `ProviderRequiresSyntheticStructuredOutput` in `core/providers/anthropic/utils.go` as a single source of truth for which providers reject native `output_config.format`. Replaced the three inline `provider == schemas.Vertex || ...` checks in `chat.go`, `responses.go`, and the HTTP integration with calls to this function.
- Added `clearAnthropicPassthroughForUnsupportedStructuredOutput` in `core/bifrost.go`, which disables `BifrostContextKeyUseRawRequestBody` when the resolved provider requires synthetic structured output and the raw body contains a format field. It intentionally leaves raw-response flags untouched so the response path can still use the `bf_so_*` tool name to reconstruct structured output events.
- Called the new guard in both the streaming and non-streaming attempt paths in `requestWorker`, immediately after `clearAnthropicPassthroughForNonNativeProvider`, so it re-evaluates on every attempt including fallbacks.
- Added `TestClearAnthropicPassthroughForUnsupportedStructuredOutput` covering Bedrock Mantle, Vertex, Azure, the legacy `output_format` shape, the no-format case, passthrough already off, and non-Anthropic integrations.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/... ./transports/...
```

Validate by routing an Anthropic Responses request with `output_config.format` to a Bedrock Mantle or Vertex target via a routing rule and confirming the request succeeds and returns a structured output response rather than a 400.

## Breaking changes

- [x] No

## Security considerations

None. This change only affects which serialization path is taken for structured output requests; no auth, secrets, or PII handling is modified.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable