### PR TITLE
fix: propagate request grant into relay context and export `SettleIdentity` for WebSocket upgrade path so governance sees a settled identity on every turn

### DIFF
--- a/transports/bifrost-http/handlers/webrtc_realtime.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime.go
@@ -1153,6 +1153,14 @@ func newRealtimeRelayContext(requestCtx *schemas.BifrostContext) (*schemas.Bifro
 		}
 	}
 
+	// The relay is the request that opened it, kept alive past the request: it carries that
+	// request's grant, not a copy, the same way a realtime turn carries its session's (see
+	// newRealtimeTurnContext). Every turn derives from the relay, so without this no turn would
+	// carry a grant and governance would refuse each one.
+	if g := requestCtx.Grant(); g != nil {
+		relayCtx.SetGrant(g)
+	}
+
 	// Tag the relay context with transport type for downstream logging/metadata.
 	relayCtx.SetValue(schemas.BifrostContextKeyRealtimeTransport, "webrtc")
 

--- a/transports/bifrost-http/handlers/webrtc_realtime_test.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/grant"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -108,6 +109,30 @@ func TestParseCallsWebRTCRequest_RawSDPKeepsGARoute(t *testing.T) {
 	}
 	if session != nil {
 		t.Fatalf("expected nil session for raw SDP /calls request, got %s", string(session))
+	}
+}
+
+// The relay is the request kept alive, so the turns derived from it must find the grant the
+// request was settled with; governance refuses a turn that carries none.
+func TestNewRealtimeRelayContextCarriesRequestGrant(t *testing.T) {
+	requestCtx, requestCancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer requestCancel()
+	lib.RecordCredential(requestCtx, grant.NewCredential(grant.CredentialVirtualKey, "sk-bf-relay"))
+
+	relayCtx, relayCancel := newRealtimeRelayContext(requestCtx)
+	defer relayCancel()
+
+	if relayCtx.Grant() != requestCtx.Grant() {
+		t.Fatal("relay context should carry the request's grant")
+	}
+	if got := relayCtx.Grant().Identity().Credential(); got.Value != "sk-bf-relay" {
+		t.Fatalf("credential = %+v, want the request's virtual key", got)
+	}
+
+	bare, bareCancel := newRealtimeRelayContext(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline))
+	defer bareCancel()
+	if bare.Grant() != nil {
+		t.Fatal("relay of a request with no grant should carry none")
 	}
 }
 

--- a/transports/bifrost-http/handlers/wsrealtime.go
+++ b/transports/bifrost-http/handlers/wsrealtime.go
@@ -275,6 +275,10 @@ func (h *WSRealtimeHandler) runRealtimeSession(
 	// routing engine logs, raw-storage header overrides, and other values set by
 	// HTTPTransportPreHook plugins (governance, prompts, etc.).
 	applyRealtimeMiddlewareValues(bifrostCtx, middlewareValues)
+	// The middleware values are where the user the upgrade authenticated arrives, after the
+	// session context settled its identity from the headers alone, so it is settled again now
+	// that everything the connection presented is on it.
+	lib.SettleIdentity(bifrostCtx)
 
 	// Resolve ephemeral key mapping to restore virtual key context.
 	token := extractRealtimeBearerTokenFromHeader(auth.authorization)

--- a/transports/bifrost-http/handlers/wsresponses.go
+++ b/transports/bifrost-http/handlers/wsresponses.go
@@ -14,7 +14,6 @@ import (
 	ws "github.com/fasthttp/websocket"
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
-	"github.com/maximhq/bifrost/framework/grant"
 	"github.com/maximhq/bifrost/transports/bifrost-http/integrations"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	bfws "github.com/maximhq/bifrost/transports/bifrost-http/websocket"
@@ -808,10 +807,10 @@ func createBifrostContextFromAuth(handlerStore lib.HandlerStore, auth *authHeade
 			ctx.SetValue(schemas.BifrostContextKeyVirtualKey, auth.googAPIKey)
 		}
 	}
-	// The headers captured at upgrade are all this connection will ever present.
-	if virtualKey, _ := ctx.Value(schemas.BifrostContextKeyVirtualKey).(string); virtualKey != "" {
-		lib.RecordCredential(ctx, grant.NewCredential(grant.CredentialVirtualKey, virtualKey))
-	}
+	// The headers captured at upgrade are all this connection will ever present, so the identity is
+	// settled here the way the HTTP path settles it, a connection that presented nothing included:
+	// governance refuses a request nobody settled, and a keyless connection is not that.
+	lib.SettleIdentity(ctx)
 
 	// Forward x-bf-* headers
 	matcher := (*lib.HeaderMatcher)(nil)

--- a/transports/bifrost-http/handlers/wsresponses_test.go
+++ b/transports/bifrost-http/handlers/wsresponses_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/grant"
 	"github.com/maximhq/bifrost/framework/kvstore"
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -108,6 +109,39 @@ func TestCreateBifrostContextFromAuth_BaggageSessionIDSetsGrouping(t *testing.T)
 
 	if got, _ := ctx.Value(schemas.BifrostContextKeyParentRequestID).(string); got != "rt-ws-123" {
 		t.Fatalf("parent request id = %q, want %q", got, "rt-ws-123")
+	}
+}
+
+// A connection settles its identity at upgrade the way an HTTP request does at conversion, so
+// governance sees a settled request whether or not a key was presented.
+func TestCreateBifrostContextFromAuth_SettlesIdentity(t *testing.T) {
+	cases := map[string]struct {
+		auth     *authHeaders
+		wantKind string
+		wantKey  string
+	}{
+		"no credential":       {auth: &authHeaders{}},
+		"virtual key header":  {auth: &authHeaders{virtualKey: "sk-bf-ws"}, wantKind: string(grant.CredentialVirtualKey), wantKey: "sk-bf-ws"},
+		"bearer virtual key":  {auth: &authHeaders{authorization: "Bearer sk-bf-bearer"}, wantKind: string(grant.CredentialVirtualKey), wantKey: "sk-bf-bearer"},
+		"provider key bearer": {auth: &authHeaders{authorization: "Bearer sk-openai"}},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := createBifrostContextFromAuth(testWSHandlerStore{}, tc.auth)
+			defer cancel()
+
+			g := ctx.Grant()
+			if g == nil {
+				t.Fatal("expected a grant on the connection context")
+			}
+			identity := g.Identity()
+			if identity == nil {
+				t.Fatal("expected a settled identity on the grant")
+			}
+			if got := identity.Credential(); got.Kind != tc.wantKind || got.Value != tc.wantKey {
+				t.Fatalf("credential = %+v, want kind %q value %q", got, tc.wantKind, tc.wantKey)
+			}
+		})
 	}
 }
 

--- a/transports/bifrost-http/lib/ctx.go
+++ b/transports/bifrost-http/lib/ctx.go
@@ -827,7 +827,7 @@ func ConvertToBifrostContext(ctx *fasthttp.RequestCtx, store HandlerStore) (*sch
 
 	// Everything the middlewares and the headers can say about who this request is now sits on the
 	// context, so this is where it is settled onto the request's grant.
-	settleIdentity(bifrostCtx)
+	SettleIdentity(bifrostCtx)
 
 	return bifrostCtx, cancel
 }

--- a/transports/bifrost-http/lib/grant.go
+++ b/transports/bifrost-http/lib/grant.go
@@ -55,18 +55,25 @@ func RecordUser(bifrostCtx *schemas.BifrostContext, user *schemas.UserRef) {
 	g.SetIdentity(identityWith(g.Identity(), schemas.Credential{}, user))
 }
 
-// settleIdentity records who the request is from what the middlewares left on the context, all at
+// SettleIdentity records who the request is from what the middlewares left on the context, all at
 // once, on a grant installed here. The middlewares run before any request context exists, so they
 // hand over what they verified as context values and this is the one place those are read: the
 // user under its own keys, and any credential other than a header virtual key under
 // BifrostContextKeyAuthCredential. The identity is recorded even when nothing was presented, so
 // everything after the transport can tell "settled: nobody" from "not settled".
 //
+// ConvertToBifrostContext calls it for every request context it builds. It is exported for the
+// paths that build a request context of their own, as a connection that authenticates at upgrade
+// or an endpoint that evaluates a request it never forwards: they stamp what they know under the
+// same context keys and settle it here, so what governance reads off them is what it reads off
+// any other request. Settling again replaces the identity whole, so it is called once the last
+// layer that can name the user or the credential has run.
+//
 // A virtual key presented in a header goes first, whatever else was recorded: a request that
 // presents a key goes by the key, and whoever resolves the request's access decides how the user a
 // session named relates to it. A direct key is not a credential at all: it selects which provider
 // key serves the request and says nothing about who made it.
-func settleIdentity(bifrostCtx *schemas.BifrostContext) {
+func SettleIdentity(bifrostCtx *schemas.BifrostContext) {
 	g := contextGrant(bifrostCtx)
 	if g == nil {
 		return


### PR DESCRIPTION
## Summary

WebRTC relay contexts and WebSocket upgrade contexts were not carrying a settled grant, causing governance to refuse every turn derived from a relay and every request made over a keyless WebSocket connection. This PR ensures both paths settle an identity the same way the HTTP request path does.

## Changes

- `newRealtimeRelayContext` now copies the originating request's grant onto the relay context. The relay is the request kept alive past its HTTP lifetime, so every turn derived from it needs the grant the request was settled with — without it, governance refuses each turn.
- `createBifrostContextFromAuth` (WebSocket upgrade path) now calls `SettleIdentity` instead of only recording a credential when a virtual key was present. A connection that presented no key is "settled: nobody", which is distinct from "not settled" and is what governance expects.
- After `applyRealtimeMiddlewareValues` in `runRealtimeSession`, `SettleIdentity` is called again so that any user or credential the middleware layers added is captured on the grant before turns are processed.
- `settleIdentity` is exported as `SettleIdentity` so the WebSocket and relay paths can call it directly without duplicating the logic that lives in `ConvertToBifrostContext`.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Transports (HTTP)

## How to test

```sh
go test ./transports/bifrost-http/handlers/... ./transports/bifrost-http/lib/...
```

The new tests cover the two fixed paths directly:

- `TestNewRealtimeRelayContextCarriesRequestGrant` — verifies the relay context carries the same grant as the request that opened it, and that a request with no grant produces a relay with no grant.
- `TestCreateBifrostContextFromAuth_SettlesIdentity` — verifies that a WebSocket upgrade context always has a settled grant, across the cases of no credential, a virtual key header, a bearer virtual key, and a provider key bearer.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The grant propagation ensures governance enforcement is applied consistently to WebRTC relay turns and WebSocket connections. Previously, turns derived from a relay and requests over keyless WebSocket connections bypassed governance checks because no settled identity was present. This fix closes that gap.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable