### PR TITLE
removes heartbeats from genai integration

### DIFF
--- a/tests/integrations/python/heartbeat_test.py
+++ b/tests/integrations/python/heartbeat_test.py
@@ -1,0 +1,162 @@
+"""
+Heartbeat probe: stream gemini-3.1-flash-lite through Bifrost via LangChain for
+roughly three minutes and count the SSE heartbeat frames on the wire.
+
+LangChain's SSE decoder ignores comment lines (": heartbeat"), so it cannot see
+them. Two streams of the same prompt therefore run side by side:
+
+  raw       - httpx stream of the same request, logs every heartbeat frame with
+              a timestamp and checks it uses Gemini's delimited framing
+  langchain - ChatGoogleGenerativeAI.stream(), proves the SDK keeps decoding
+              content while heartbeats are interleaved
+
+Run from tests/integrations/python with the gateway on localhost:8080:
+
+    uv run python heartbeat_test.py
+"""
+
+import os
+import threading
+import time
+
+import httpx
+from langchain_core.messages import HumanMessage
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+BASE_URL = os.environ.get("BIFROST_BASE_URL", "http://localhost:8080") + "/langchain"
+MODEL = os.environ.get("MODEL", "gemini-3.1-flash-lite")
+TARGET_SECONDS = int(os.environ.get("TARGET_SECONDS", "180"))
+HARD_TIMEOUT = TARGET_SECONDS + 120
+DUMMY_KEY = "dummy-google-api-key-bifrost-handles-auth"
+
+PROMPT = (
+    "Write an extremely long, detailed technical book about the history of "
+    "computing, one chapter per decade from 1940 to 2020. Every chapter must "
+    "have at least ten long paragraphs. Do not stop early, do not summarise, "
+    "keep writing until you run out of output budget."
+)
+MAX_TOKENS = 65536
+
+started = time.monotonic()
+
+
+def ts() -> str:
+    return f"{time.monotonic() - started:7.2f}s"
+
+
+def raw_stream(result: dict) -> None:
+    url = f"{BASE_URL}/v1beta/models/{MODEL}:streamGenerateContent"
+    body = {
+        "contents": [{"role": "user", "parts": [{"text": PROMPT}]}],
+        "generationConfig": {"maxOutputTokens": MAX_TOKENS},
+    }
+    headers = {"x-goog-api-key": DUMMY_KEY, "Content-Type": "application/json"}
+    heartbeats = 0
+    data_lines = 0
+    bad_frames = 0
+    prev_line = None
+    last_heartbeat_at = None
+    max_gap = 0.0
+    try:
+        with httpx.Client(timeout=httpx.Timeout(HARD_TIMEOUT, read=HARD_TIMEOUT)) as client:
+            with client.stream("POST", url, params={"alt": "sse"}, json=body, headers=headers) as resp:
+                result["status"] = resp.status_code
+                if resp.status_code != 200:
+                    result["error"] = resp.read().decode(errors="replace")[:500]
+                    return
+                for line in resp.iter_lines():
+                    now = time.monotonic()
+                    if line.startswith(":"):
+                        heartbeats += 1
+                        if last_heartbeat_at is not None:
+                            max_gap = max(max_gap, now - last_heartbeat_at)
+                        last_heartbeat_at = now
+                        if heartbeats <= 5 or heartbeats % 20 == 0:
+                            print(f"[raw {ts()}] heartbeat #{heartbeats}: {line!r}")
+                    elif line.startswith("data:"):
+                        data_lines += 1
+                        if prev_line is not None and prev_line.startswith(":"):
+                            # Gemini framing must be ": heartbeat\n\n" - a data line
+                            # directly after the comment means the blank line is missing.
+                            bad_frames += 1
+                            print(f"[raw {ts()}] WARNING heartbeat not followed by blank line")
+                    prev_line = line
+                    if now - started > HARD_TIMEOUT:
+                        print(f"[raw {ts()}] hard timeout, closing")
+                        break
+    except Exception as exc:  # noqa: BLE001
+        result["error"] = repr(exc)
+    result.update(
+        heartbeats=heartbeats,
+        data_lines=data_lines,
+        bad_frames=bad_frames,
+        max_gap_between_heartbeats=round(max_gap, 2),
+        duration=round(time.monotonic() - started, 1),
+    )
+
+
+def langchain_stream(result: dict) -> None:
+    chat = ChatGoogleGenerativeAI(
+        model=MODEL,
+        google_api_key=DUMMY_KEY,
+        max_output_tokens=MAX_TOKENS,
+        streaming=True,
+        base_url=BASE_URL,
+        timeout=HARD_TIMEOUT,
+    )
+    chunks = 0
+    chars = 0
+    try:
+        for chunk in chat.stream([HumanMessage(content=PROMPT)]):
+            chunks += 1
+            text = chunk.content if isinstance(chunk.content, str) else str(chunk.content)
+            chars += len(text)
+            if chunks == 1 or chunks % 50 == 0:
+                print(f"[langchain {ts()}] chunk #{chunks}, {chars} chars so far")
+            if time.monotonic() - started > HARD_TIMEOUT:
+                print(f"[langchain {ts()}] hard timeout, stopping")
+                break
+    except Exception as exc:  # noqa: BLE001
+        result["error"] = repr(exc)
+    result.update(chunks=chunks, chars=chars, duration=round(time.monotonic() - started, 1))
+
+
+def main() -> None:
+    print(f"gateway={BASE_URL} model={MODEL} target={TARGET_SECONDS}s")
+    raw_result: dict = {}
+    lc_result: dict = {}
+    threads = [
+        threading.Thread(target=raw_stream, args=(raw_result,), name="raw"),
+        threading.Thread(target=langchain_stream, args=(lc_result,), name="langchain"),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    print("\n=== raw wire stream ===")
+    for k, v in raw_result.items():
+        print(f"  {k}: {v}")
+    print("=== langchain stream ===")
+    for k, v in lc_result.items():
+        print(f"  {k}: {v}")
+
+    ok = True
+    if raw_result.get("error") or lc_result.get("error"):
+        ok = False
+    if raw_result.get("heartbeats", 0) == 0:
+        print("FAIL: no heartbeat frames seen on the wire")
+        ok = False
+    if raw_result.get("bad_frames", 0):
+        print("FAIL: heartbeat frames without the trailing blank line")
+        ok = False
+    if lc_result.get("chunks", 0) == 0:
+        print("FAIL: langchain received no chunks")
+        ok = False
+    if raw_result.get("duration", 0) < TARGET_SECONDS:
+        print(f"NOTE: stream ended after {raw_result.get('duration')}s, shorter than the {TARGET_SECONDS}s target; raise MAX_TOKENS or use a slower model for a longer run")
+    print("RESULT:", "PASS" if ok else "FAIL")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrations/python/uv.lock
+++ b/tests/integrations/python/uv.lock
@@ -324,11 +324,13 @@ source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "boto3" },
+    { name = "cohere" },
     { name = "google-genai" },
     { name = "httpx" },
     { name = "langchain" },
     { name = "langchain-anthropic" },
     { name = "langchain-aws" },
+    { name = "langchain-cohere" },
     { name = "langchain-community" },
     { name = "langchain-core" },
     { name = "langchain-google-genai" },
@@ -370,12 +372,14 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.25.0" },
     { name = "black", marker = "extra == 'dev'", specifier = ">=23.0.0" },
     { name = "boto3", specifier = ">=1.34.0" },
+    { name = "cohere", specifier = ">=5.13.0" },
     { name = "flake8", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "google-genai", specifier = ">=1.50.0" },
     { name = "httpx", specifier = ">=0.25.0" },
     { name = "langchain", specifier = ">=1.1.0" },
     { name = "langchain-anthropic", specifier = "==1.5.4" },
     { name = "langchain-aws", specifier = ">=1.1.0" },
+    { name = "langchain-cohere", specifier = ">=0.4.0" },
     { name = "langchain-community", specifier = ">=0.4.1" },
     { name = "langchain-core", specifier = ">=1.3.3" },
     { name = "langchain-google-genai", specifier = "==4.1.1" },
@@ -763,6 +767,25 @@ wheels = [
 ]
 
 [[package]]
+name = "cohere"
+version = "5.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastavro" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+    { name = "requests" },
+    { name = "tokenizers" },
+    { name = "types-requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/75/4c346f6e2322e545f8452692304bd4eca15a2a0209ab9af6a0d1a7810b67/cohere-5.21.1.tar.gz", hash = "sha256:e5ade4423b928b01ff2038980e1b62b2a5bb412c8ab83e30882753b810a5509f", size = 191272 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/50/5538f02ec6d10fbb84f29c1b18c68ff2a03d7877926a80275efdf8755a9f/cohere-5.21.1-py3-none-any.whl", hash = "sha256:f15592ec60d8cf12f01563db94ec28c388c61269d9617f23c2d6d910e505344e", size = 334262 },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -1023,6 +1046,52 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317 },
+]
+
+[[package]]
+name = "fastavro"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/5b/ccb338db71f347e3bc031d268bf6dc41e5ead63b6997b8e72af92f05e18e/fastavro-1.12.2.tar.gz", hash = "sha256:3c79502d56cf6b76210032e1c53494ddfbc73c140bccf2ef4092b3f0825323ab", size = 1030127 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/77/058f3c93348624cb695399b27f3f0c1c3d1190586065797e4a48f75d4147/fastavro-1.12.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:d48cd7094598a7e9d4297e8bf4bbe0dc9dc2ba4367d83dbb603e3b3c6aa35566", size = 974559 },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/08bbfa643addd2b98a9ce536613e2098928aa5e3ca098fd5b74f3c03b96a/fastavro-1.12.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:070c6134604bd7b6fd44409406ac50445339682b2e872885db2e859f92d22e93", size = 3352777 },
+    { url = "https://files.pythonhosted.org/packages/d3/ec/55c11108529bdb59e635899f737651f729485ea5af36e128fb6560969c3d/fastavro-1.12.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b73d50978d5e57416fa68461f9f3c8f39ea39e761cb1e12f919745adefe26a7", size = 3387036 },
+    { url = "https://files.pythonhosted.org/packages/d9/b3/4459f7c61804e9b42b49f02fba8fbbb041af76c7cab43cee4018532ecd00/fastavro-1.12.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c57a9920400166398695d92580eca21fd7a79f3c67d691ac7e20a7d1b5300735", size = 3284780 },
+    { url = "https://files.pythonhosted.org/packages/5d/e3/d7f510b9b8c7b73409a6232a9a8d282faa8560f85d024d7212e4c5dff3df/fastavro-1.12.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:81f6108f3ac292fb6cd05758c9e531389d8fc5e94e8c949b9298f4fb0a239662", size = 3368557 },
+    { url = "https://files.pythonhosted.org/packages/cb/10/14fa0abf8e7da07258393ae2b783dd4bb60d1fb93ad790296d27561f33ce/fastavro-1.12.2-cp311-cp311-win_amd64.whl", hash = "sha256:eec44256856fd59d29d1f1d0950ace18a58e4228e7d49de5d5e1b1875b227dde", size = 446499 },
+    { url = "https://files.pythonhosted.org/packages/86/d2/c36f646296794c05d29a07bec84a6c56bfd285203e389a8954987ec1c515/fastavro-1.12.2-cp311-cp311-win_arm64.whl", hash = "sha256:ecd1b23ea7f9af09c865ac8503d07afd7e6bf782d76bb83cbbdba15b7a0db807", size = 388198 },
+    { url = "https://files.pythonhosted.org/packages/0e/bc/fe5731d6724d978694fbd3196bc1c0d7cab3fd0766e9551c40c39f798b52/fastavro-1.12.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0e331896e8efffc72fa03e63b87ebfc37960113127da8e0f5152d91664ffed68", size = 964331 },
+    { url = "https://files.pythonhosted.org/packages/98/36/50abf1145e4f1c4f418cd4b5f2ac806643d0b14e360b60e953826edf1b34/fastavro-1.12.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7f01ebaada59d74fdf6d28e5031a961a413b3752e9edb0c03866fa18480cf4c8", size = 3340170 },
+    { url = "https://files.pythonhosted.org/packages/fc/8c/76ef4641e6c1c1aa3e6bb3c9efb5533ffda5dd975c8b5ae54e794322d9e3/fastavro-1.12.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:25ef6855935f67582740ffa6bb978e40ec51be876117a3555c36fa2488dcdf25", size = 3425061 },
+    { url = "https://files.pythonhosted.org/packages/31/10/379ff23425b2b470d5209cbc6736a6e5cbc34392ff17bb7355b8fd4aa0ca/fastavro-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:84a4f76a0aece0aa72b5ed8162ba2ff8c78908b8361b5a5d92ddd161977ccb74", size = 3243618 },
+    { url = "https://files.pythonhosted.org/packages/88/29/4c8f9e7cd78f932f0d82823899e67a6d7f7e8f2524992db03956f9d9f5ef/fastavro-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81e8da77d201916f6771fc357fda8267c2a256d7aa11923d43bc5f2fc155878b", size = 3378427 },
+    { url = "https://files.pythonhosted.org/packages/e2/a1/eafeb302aaaea6055d4a9c11272b4aeaf713e43fe8eaf782f43a1fee2b44/fastavro-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:1924349c74666c89417bd5cc2749f598e2f15f1d56ee81428b2317ab02c88aae", size = 441077 },
+    { url = "https://files.pythonhosted.org/packages/56/9d/67e831041ba8efc16265c65bd71ba92e1095bba19b91be99e102f19d9be6/fastavro-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:4c346cf449baf3b113e997c34151ad205e7135bc429469b005b180ade7e65e28", size = 378205 },
+    { url = "https://files.pythonhosted.org/packages/83/39/f489a441d41cc9c0a8449fb1325d7a9c9eb57a5634e6ab19dfb0a1105324/fastavro-1.12.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:57bb6b908cb2e05baab63b04c3a31be3b4545a10bfab9748b8763016b5256704", size = 958566 },
+    { url = "https://files.pythonhosted.org/packages/31/69/776cc025aee2d02acacb734cf690d2fbc295eaadde1b5d47caf8c77a6a2b/fastavro-1.12.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a007f95cc682f56e6d83f1d17c29c00bf719d6fe8e003282b535af3a1ba09c0", size = 3276390 },
+    { url = "https://files.pythonhosted.org/packages/8c/bc/b7e15fa788f42cbe65827af2ec06c9ad91bb9f72c213110dbef61b53a5b0/fastavro-1.12.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e90460b0cd21f62be3cb26087e706e2cebb7b3fcef9e05b4473b61bb0415b5e", size = 3372779 },
+    { url = "https://files.pythonhosted.org/packages/79/c2/98993ca810231fc1397212f48c3d46626983722a24bbaaa5c27ee0963751/fastavro-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7ccd15966b8218d41b06ec3e7c2556be89a8a693026c771e6564d2e40bbaf8ea", size = 3187591 },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/c180f340eba6478f1b20deccdd17e2b4a4d5074dafd812e3c4254fd035f7/fastavro-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:06b6971d3dae10cb34353b857d16ad21ebd6f0ea394e86c96abdcad109005d6e", size = 3320589 },
+    { url = "https://files.pythonhosted.org/packages/4d/e9/aca0456216b5b8992e7b0a8542711b66799c05bfe24c8e32ef6f56e7eb93/fastavro-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:98dfcdfaf1498ae2f0e2fafe900a82e8320cc81d8ae5a95b8b8879eaa3298c39", size = 440883 },
+    { url = "https://files.pythonhosted.org/packages/e3/7e/984896e716af504927be71b80a1e9661aa96c6f9e1e777d52823aacb99f2/fastavro-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:3888ef7a51adc77cdf07251bc762566a1be36211e1cff689f13980f3776a2f36", size = 377536 },
+    { url = "https://files.pythonhosted.org/packages/e9/42/09a1e1f8d9998d73848a6ff0aad6713ae6abf0dbf99918776f8ef33344a7/fastavro-1.12.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:283dcd3129b632021894425974bedd0eb6db3bbf5994e448ccad10db4d803d31", size = 1049506 },
+    { url = "https://files.pythonhosted.org/packages/52/ef/80cc16f43919d532f25a707f34b275cccc09dca87a05b000fbbfc8e8f255/fastavro-1.12.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d125e210d5a0a1f701f12c0ecad9a03f1b04b5eddbce6ca36a1fc217da977ef", size = 3495899 },
+    { url = "https://files.pythonhosted.org/packages/c1/54/a0817d1d0236e9e0233f5c996f450cc795b056b8e06edb531f24b9df82ed/fastavro-1.12.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2d4d66afad78e8f47feaa307728a6b71fe3effc63ba2b9eeb109ee687c9bd397", size = 3399232 },
+    { url = "https://files.pythonhosted.org/packages/38/0a/650f256c15f5875b6081544b9ba7ed8254329213e7e49e3db0aec68b5bee/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2328ec07925c04c89719e3971c9068a165c7fd474ea87675b1204de0440e71ff", size = 3320222 },
+    { url = "https://files.pythonhosted.org/packages/f5/54/8351d388f94fbb0870e8cffaae41d3cc607acc8d6a8a6a217e2794829593/fastavro-1.12.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:55dea7e74b834d4b70467fc19c5b9ccb5509fe39abc4d26891187c1b22176423", size = 3337096 },
+    { url = "https://files.pythonhosted.org/packages/da/eb/b36ba9a88826e8c272df02e2f8b5da717e88b6eb508fddca3ca450043731/fastavro-1.12.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8d37c87826ae7195cfbd20fcd448801f2f563bb38f2691ec6574e39cb9eca6c8", size = 963119 },
+    { url = "https://files.pythonhosted.org/packages/e1/02/3d7f540fb26ba4ea1f4ebd2783c586614da9ac00906a3092e92fd3f104a2/fastavro-1.12.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c463a3701f293e30d3d62e71e1989f112028d07f87432baf4507eeb57ec3831", size = 3266238 },
+    { url = "https://files.pythonhosted.org/packages/4c/0b/b77be56c5109da0fc7dcfd7e6b6752fe0a61d0a5c58c6a65e38b4501946a/fastavro-1.12.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f604ba83498e209fff4c7ecc5063a39421dc538dace694bc592f9f338254f3dc", size = 3324020 },
+    { url = "https://files.pythonhosted.org/packages/e7/6e/951d41f244107e91bf2f59245b71783c03eaab4bdbc960d58316c19652bb/fastavro-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bfac2dada8ddc002e8b7d8289d6fad4f070bc1fec20371cec684a7d10d932e96", size = 3170160 },
+    { url = "https://files.pythonhosted.org/packages/94/6f/2adb571fda448d4afd2466e1cef2963fefdc6b37847da05249983e415f17/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c", size = 3281842 },
+    { url = "https://files.pythonhosted.org/packages/17/07/4bad2e96c4c6bae40253be2573cc09c1e5b9ccf821e1ff74e0d33b64bf90/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f", size = 450903 },
+    { url = "https://files.pythonhosted.org/packages/5b/b7/180f67ba9a46ba23a1ff6432f48d3087d4f2048579ecc262b00426cb1c63/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a", size = 391076 },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/18f60329b627d2118a4a2b19e8741fbd807d60bf0470554e1bbfb7f1bca3/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b", size = 1055430 },
+    { url = "https://files.pythonhosted.org/packages/d2/ac/a1fa1fc29df0efc89d4946a743b09bdc9500591b5b92083eaf8e93664916/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa", size = 3503075 },
+    { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900 },
+    { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637 },
+    { url = "https://files.pythonhosted.org/packages/32/f1/f21bd5319113e89ceceed2df840df21e9c5150d181db74b6ba80400f9f48/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:afede7324822800e4f90e96b9514188a237a60f35e8e7a10b2129c10c78f6e4d", size = 3356664 },
 ]
 
 [[package]]
@@ -2107,6 +2176,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8d/65/6b5e8a7ff2f2968652c88a67dcecb925b9d8f0a0ce9458c76cd5a0dbd138/langchain_classic-1.0.8.tar.gz", hash = "sha256:ada0cc341a8a5b80fb24d73bdfaaeb849056ee2d8a41cc468355163fd3667484", size = 10557071 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/9a/b8f5cb7490fdbf233088031fc69c9c747439d4097f67f196c1eb4869916d/langchain_classic-1.0.8-py3-none-any.whl", hash = "sha256:1a11ea7fbe630c4f2af2f3873d27718ceac9488cf32d0821030be7cf039a6213", size = 1041536 },
+]
+
+[[package]]
+name = "langchain-cohere"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cohere" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+    { name = "types-pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/11/de374cbd215d49185c5f70228528887da5253f681291adaad9b86ef52522/langchain_cohere-0.6.0.tar.gz", hash = "sha256:5e45b56d0a5cc6f3de9f61bcd4fd449b9f3ece85e6b569c3d7c304992808bb0c", size = 39408 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5e/90f88e0316411fedf2dfdb7c5d53b106ac0186b2e432b93980acdf2ee250/langchain_cohere-0.6.0-py3-none-any.whl", hash = "sha256:524bc2f390b96a0b1bb98ec6e97f209fe7cd1654e6608e6e89db2e78b6c75838", size = 45108 },
 ]
 
 [[package]]
@@ -4908,6 +4992,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660 },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260724"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/6f/a28f44bcd56bebed42b028a2894c79853e2f5e6b5279e633cb3f287a05e7/types_pyyaml-6.0.12.20260724.tar.gz", hash = "sha256:3c1ce1bb73cd5ec02e90390c2b1f00e810d241d8825fd73ff359696839271b6b", size = 17893 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/42/0337fefc615e20ee55d1c8f71b774a9b2b734a04669139c20753b27a2a3a/types_pyyaml-6.0.12.20260724-py3-none-any.whl", hash = "sha256:d57db930a4b2efbc57cf430ec8882765d246929432fa253092f383902329a453", size = 20312 },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260712"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/51/703318f7b7be8bee126ec13bf615050f932d0179b8784420f3a0199cc769/types_requests-2.33.0.20260712.tar.gz", hash = "sha256:2141b67ab534a5c5cd2dac5034f2a35f42e699c5bf185eee608c5246a069d7fb", size = 25084 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/e7/010c87f559e216d83f9dc51e939633fd0d0ead3377340181ab0e223cd3b5/types_requests-2.33.0.20260712-py3-none-any.whl", hash = "sha256:de027e28c171d3da529689cbfa023b0b4eab188c8dfa22fd834eebd2cee6e7bb", size = 21392 },
 ]
 
 [[package]]

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -240,7 +240,13 @@ func CreateGenAIRouteConfigs(pathPrefix string) []RouteConfig {
 			return gemini.ToGeminiError(err)
 		},
 		StreamConfig: &StreamConfig{
-			HeartbeatFraming: lib.SSEHeartbeatDelimitedCommentBlock,
+			// No SSE heartbeat on this route. The official google-genai Python SDK (and
+			// LangChain's ChatGoogleGenerativeAI on top of it) json.loads every stream line
+			// that is not "data:" or blank, so a comment line in either framing aborts the
+			// stream with UnknownApiResponseError. The delimited block from PR 6252 only
+			// satisfied the JavaScript SDK. Disconnect detection here is therefore reactive
+			// only, the same trade-off the Bedrock route makes.
+			HeartbeatFraming: lib.SSEHeartbeatNone,
 			ResponsesStreamResponseConverter: func(ctx *schemas.BifrostContext, resp *schemas.BifrostResponsesStreamResponse) (string, interface{}, error) {
 				// Store state in context so it persists across chunks of the same stream
 				const stateKey = "gemini_stream_state"

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -2820,13 +2820,15 @@ func (g *GenericRouter) handleStreaming(ctx *fasthttp.RequestCtx, bifrostCtx *sc
 		// AWS SDKs (e.g. Go SDK v2) don't silently drop an unmodeled `:event-type` -- they
 		// surface it to the caller as a typed union member (types.UnknownUnionMember). So
 		// Bedrock streams stay on purely reactive (write-failure-based) disconnect detection.
+		// An integration can opt out the same way by declaring lib.SSEHeartbeatNone (GenAI
+		// does: its official Python SDK rejects any SSE comment line).
 		var heartbeatDone chan struct{}
 		var heartbeatExited <-chan struct{}
-		if config.Type != RouteConfigTypeBedrock {
-			heartbeatFraming := lib.SSEHeartbeatBareCommentLine
-			if config.StreamConfig != nil {
-				heartbeatFraming = config.StreamConfig.HeartbeatFraming
-			}
+		heartbeatFraming := lib.SSEHeartbeatBareCommentLine
+		if config.StreamConfig != nil {
+			heartbeatFraming = config.StreamConfig.HeartbeatFraming
+		}
+		if config.Type != RouteConfigTypeBedrock && heartbeatFraming != lib.SSEHeartbeatNone {
 			sendHeartbeat := func() bool {
 				return reader.SendHeartbeatWithFraming(heartbeatFraming)
 			}
@@ -3399,14 +3401,19 @@ func (g *GenericRouter) handlePassthroughNonStream(
 	ctx.Response.SetBody(resp.Body)
 }
 
-// passthroughHeartbeatEligible reports whether a resolved passthrough response
-// content-type is safe for the SSE-comment heartbeat. handlePassthroughStream proxies
-// raw upstream bytes 1:1, and content-type isn't always SSE -- e.g. Vertex/Gemini's
-// non-alt=sse mode returns an incrementally-delivered JSON array with
-// Content-Type: application/json. The media type is compared exactly (case-insensitively,
-// ignoring parameters like "; charset=utf-8") so lookalikes such as
-// "text/event-stream+json" or "text/event-streaming" aren't treated as SSE.
-func passthroughHeartbeatEligible(contentType string) bool {
+// passthroughHeartbeatEligible reports whether a passthrough stream is safe for the
+// SSE-comment heartbeat. handlePassthroughStream proxies raw upstream bytes 1:1, and
+// content-type isn't always SSE -- e.g. Vertex/Gemini's non-alt=sse mode returns an
+// incrementally-delivered JSON array with Content-Type: application/json. The media type is
+// compared exactly (case-insensitively, ignoring parameters like "; charset=utf-8") so
+// lookalikes such as "text/event-stream+json" or "text/event-streaming" aren't treated as
+// SSE. Gemini and Vertex are excluded even for real SSE: their official Python SDK
+// (google-genai, also used by LangChain) json.loads any non-"data:" line and aborts the
+// stream on a comment, see lib.SSEHeartbeatNone.
+func passthroughHeartbeatEligible(provider schemas.ModelProvider, contentType string) bool {
+	if provider == schemas.Gemini || provider == schemas.Vertex {
+		return false
+	}
 	mediaType, _, _ := strings.Cut(contentType, ";")
 	return strings.EqualFold(strings.TrimSpace(mediaType), "text/event-stream")
 }
@@ -3516,7 +3523,7 @@ func (g *GenericRouter) handlePassthroughStream(
 	// content-type is actually SSE.
 	var heartbeatDone chan struct{}
 	var heartbeatExited <-chan struct{}
-	if passthroughHeartbeatEligible(contentType) {
+	if passthroughHeartbeatEligible(provider, contentType) {
 		heartbeatDone, heartbeatExited = lib.StartSSEHeartbeat(lib.DefaultSSEHeartbeatInterval, reader.SendHeartbeat, cancel)
 	}
 

--- a/transports/bifrost-http/integrations/router_heartbeat_test.go
+++ b/transports/bifrost-http/integrations/router_heartbeat_test.go
@@ -1,7 +1,9 @@
 package integrations
 
 import (
+	"encoding/json"
 	"io"
+	"strings"
 	"testing"
 	"testing/synctest"
 	"time"
@@ -59,11 +61,15 @@ func Test_handleStreamingSSESendsHeartbeatDuringIdleGap(t *testing.T) {
 	})
 }
 
-// Test_handleStreamingGenAIDelimitsHeartbeatComment verifies the GenAI integration emits
-// its heartbeat as a self-contained SSE comment block. The official Google GenAI SDK splits
-// streams on blank-line delimiters and otherwise groups a bare comment line with the next
-// data event, causing that event to be discarded because the combined block starts with ':'.
-func Test_handleStreamingGenAIDelimitsHeartbeatComment(t *testing.T) {
+// Test_handleStreamingGenAIEmitsNoHeartbeat verifies the typed GenAI integration sends no
+// SSE comment heartbeat at all. The official google-genai Python SDK (which LangChain's
+// ChatGoogleGenerativeAI wraps) only understands "data: " lines and blank lines; every other
+// non-empty line is buffered as an error-JSON fragment and json.loads'ed as soon as its brace
+// count balances, so any comment line - bare or blank-line delimited - raises
+// UnknownApiResponseError and aborts the stream. The delimited block that PR 6252 introduced
+// only helped the JavaScript SDK. The body is also replayed through a port of the Python
+// parser so the guard fails on any future non-data frame, not only on this heartbeat text.
+func Test_handleStreamingGenAIEmitsNoHeartbeat(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		stream := make(chan *schemas.BifrostStreamChunk)
 		router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, bifrost.NewNoOpLogger())
@@ -90,40 +96,93 @@ func Test_handleStreamingGenAIDelimitsHeartbeatComment(t *testing.T) {
 			readDone <- readResult{body: string(b), err: err}
 		}()
 
-		time.Sleep(2*lib.DefaultSSEHeartbeatInterval + time.Millisecond)
+		time.Sleep(3*lib.DefaultSSEHeartbeatInterval + time.Millisecond)
 		close(stream)
 
 		result := <-readDone
 		require.NoError(t, result.err)
-		assert.Contains(t, result.body, ": heartbeat\n\n")
+		assert.NotContains(t, result.body, ": heartbeat", "google-genai Python rejects any SSE comment line")
+		for _, seg := range googleGenAIPythonSegments(result.body) {
+			assert.True(t, json.Valid([]byte(seg)),
+				"google-genai Python would raise UnknownApiResponseError on segment %q", seg)
+		}
 	})
 }
 
-// Test_passthroughHeartbeatEligible pins down the content-type gate handlePassthroughStream
-// uses to decide whether the heartbeat is safe to inject: only when the resolved
-// content-type is actually SSE. Injecting anything into a non-SSE passthrough body (e.g.
+// googleGenAIPythonSegments is a line-for-line port of HttpResponse._iter_response_stream in
+// google/genai/_api_client.py (google-genai 1.75.0, unchanged on upstream main as of
+// 2026-09-03). It yields the strings the SDK hands to json.loads: "data: " payloads grouped
+// until a blank line, and every other non-empty line accumulated until its braces balance.
+func googleGenAIPythonSegments(body string) []string {
+	var segments []string
+	var chunk strings.Builder
+	var dataBuffer []string
+	balance := 0
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			if len(dataBuffer) > 0 {
+				segments = append(segments, strings.Join(dataBuffer, "\n"))
+				dataBuffer = nil
+			}
+			continue
+		}
+		if strings.HasPrefix(line, "data: ") {
+			dataBuffer = append(dataBuffer, line[len("data: "):])
+			continue
+		}
+		for _, c := range line {
+			switch c {
+			case '{':
+				balance++
+			case '}':
+				balance--
+			}
+		}
+		chunk.WriteString(line)
+		if balance == 0 {
+			segments = append(segments, chunk.String())
+			chunk.Reset()
+		}
+	}
+	if chunk.Len() > 0 {
+		segments = append(segments, chunk.String())
+	}
+	if len(dataBuffer) > 0 {
+		segments = append(segments, strings.Join(dataBuffer, "\n"))
+	}
+	return segments
+}
+
+// Test_passthroughHeartbeatEligible pins down the gate handlePassthroughStream uses to
+// decide whether the heartbeat is safe to inject: only when the resolved content-type is
+// actually SSE, and never for Gemini or Vertex, whose official Python SDK rejects any SSE
+// comment line (see Test_handleStreamingGenAIEmitsNoHeartbeat). Injecting anything into a non-SSE passthrough body (e.g.
 // Vertex/Gemini's raw incrementally-delivered JSON array) would corrupt a framing this
 // path doesn't control, and lookalike media types (e.g. "text/event-stream+json") must not
 // be mistaken for SSE either.
 func Test_passthroughHeartbeatEligible(t *testing.T) {
 	cases := []struct {
 		name        string
+		provider    schemas.ModelProvider
 		contentType string
 		want        bool
 	}{
-		{"plain SSE", "text/event-stream", true},
-		{"SSE with charset param", "text/event-stream; charset=utf-8", true},
-		{"SSE uppercase", "TEXT/EVENT-STREAM", true},
-		{"SSE with surrounding space before param", "text/event-stream ; charset=utf-8", true},
-		{"raw JSON passthrough", "application/json", false},
-		{"empty content-type", "", false},
-		{"binary passthrough", "application/vnd.amazon.eventstream", false},
-		{"prefix-collision suffix", "text/event-stream+json", false},
-		{"prefix-collision longer type", "text/event-streaming", false},
+		{"plain SSE", schemas.OpenAI, "text/event-stream", true},
+		{"SSE with charset param", schemas.OpenAI, "text/event-stream; charset=utf-8", true},
+		{"SSE uppercase", schemas.OpenAI, "TEXT/EVENT-STREAM", true},
+		{"SSE with surrounding space before param", schemas.OpenAI, "text/event-stream ; charset=utf-8", true},
+		{"raw JSON passthrough", schemas.OpenAI, "application/json", false},
+		{"empty content-type", schemas.OpenAI, "", false},
+		{"binary passthrough", schemas.Bedrock, "application/vnd.amazon.eventstream", false},
+		{"prefix-collision suffix", schemas.OpenAI, "text/event-stream+json", false},
+		{"prefix-collision longer type", schemas.OpenAI, "text/event-streaming", false},
+		{"Gemini SSE passthrough", schemas.Gemini, "text/event-stream", false},
+		{"Vertex SSE passthrough", schemas.Vertex, "text/event-stream; charset=utf-8", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, passthroughHeartbeatEligible(tc.contentType))
+			assert.Equal(t, tc.want, passthroughHeartbeatEligible(tc.provider, tc.contentType))
 		})
 	}
 }

--- a/transports/bifrost-http/lib/streamreader.go
+++ b/transports/bifrost-http/lib/streamreader.go
@@ -153,6 +153,12 @@ const (
 	// SSEHeartbeatDelimitedCommentBlock emits a self-contained comment block for
 	// clients that parse streams as blank-line-delimited blocks.
 	SSEHeartbeatDelimitedCommentBlock
+	// SSEHeartbeatNone writes nothing. Some official decoders reject every SSE line that
+	// is not "data:" or blank - the google-genai Python SDK json.loads a comment line and
+	// raises UnknownApiResponseError - so no comment framing is safe for them. A route on
+	// this framing keeps only reactive (write-failure-based) disconnect detection, like
+	// Bedrock's binary EventStream route.
+	SSEHeartbeatNone
 )
 
 var (
@@ -205,7 +211,7 @@ func (r *SSEStreamReader) SendHeartbeatWithFraming(framing SSEHeartbeatFraming) 
 		return false
 	default:
 	}
-	if !r.atLineBoundary {
+	if !r.atLineBoundary || framing == SSEHeartbeatNone {
 		return true
 	}
 	heartbeatFrame := sseHeartbeatFrame

--- a/transports/bifrost-http/lib/streamreader_test.go
+++ b/transports/bifrost-http/lib/streamreader_test.go
@@ -1345,3 +1345,32 @@ func TestStartSSEHeartbeatCallsOnDisconnectAfterClose(t *testing.T) {
 		t.Errorf("onDisconnect calls = %d, want exactly 1", got)
 	}
 }
+
+// TestSSEStreamReaderSendHeartbeatNone verifies the SSEHeartbeatNone framing writes nothing
+// to the wire while keeping StartSSEHeartbeat's return-value contract: true while the reader
+// is open, false once the client has gone. Routes whose official decoder rejects any SSE
+// comment line (google-genai Python) select it to opt out of the heartbeat entirely.
+func TestSSEStreamReaderSendHeartbeatNone(t *testing.T) {
+	r := NewSSEStreamReader()
+	go func() {
+		if !r.SendHeartbeatWithFraming(SSEHeartbeatNone) {
+			t.Error("SendHeartbeatWithFraming(SSEHeartbeatNone) on an open reader = false, want true")
+		}
+		r.SendEvent("", []byte(`{"ok":true}`))
+		r.Done()
+	}()
+
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "data: {\"ok\":true}\n\n"; string(got) != want {
+		t.Errorf("stream = %q, want only the event %q (no heartbeat bytes)", got, want)
+	}
+
+	closed := NewSSEStreamReader()
+	closed.Close()
+	if closed.SendHeartbeatWithFraming(SSEHeartbeatNone) {
+		t.Error("SendHeartbeatWithFraming(SSEHeartbeatNone) after Close = true, want false (disconnect must still be reported)")
+	}
+}

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,0 +1,7 @@
+## 🐞 Fixed
+
+- **GenAI streams no longer send SSE heartbeats.** The official `google-genai` Python SDK (and LangChain's `ChatGoogleGenerativeAI` on top of it) parses every non-`data:` stream line as error JSON, so the `: heartbeat` comment aborted `/genai` streams with `UnknownApiResponseError` at the first idle second. The delimited comment block introduced for the JavaScript SDK did not help Python. The typed GenAI route and Gemini/Vertex SSE passthrough now opt out of the heartbeat via the new `lib.SSEHeartbeatNone` framing and rely on reactive disconnect detection, the same trade-off the Bedrock route already makes. Every other route keeps its heartbeat unchanged.
+
+Affected packages:
+- transports/bifrost-http/lib
+- transports/bifrost-http/integrations


### PR DESCRIPTION
## Summary

The official `google-genai` Python SDK (and LangChain's `ChatGoogleGenerativeAI` on top of it) treats every non-`data:`, non-blank SSE line as error JSON, `json.loads`-ing it as soon as its brace count balances. This means the `: heartbeat` SSE comment injected during idle gaps caused `/genai` streams to abort with `UnknownApiResponseError` at the first idle second. The delimited comment block introduced previously only helped the JavaScript SDK. This PR disables SSE heartbeats entirely for the typed GenAI route and Gemini/Vertex SSE passthrough, falling back to reactive (write-failure-based) disconnect detection — the same trade-off the Bedrock route already makes.

## Changes

- Introduced `lib.SSEHeartbeatNone` framing, which writes nothing to the wire but preserves the `SendHeartbeatWithFraming` return-value contract (returns `false` after the client disconnects so disconnect detection still works).
- Switched the GenAI typed route from `SSEHeartbeatDelimitedCommentBlock` to `SSEHeartbeatNone`.
- Updated `passthroughHeartbeatEligible` to accept a provider argument and unconditionally return `false` for Gemini and Vertex, even when the content-type is `text/event-stream`.
- Refactored the heartbeat startup in `handleStreaming` so any route declaring `SSEHeartbeatNone` skips the heartbeat goroutine, independent of the Bedrock-specific check.
- Renamed `Test_handleStreamingGenAIDelimitsHeartbeatComment` to `Test_handleStreamingGenAIEmitsNoHeartbeat` and updated it to assert no `": heartbeat"` bytes appear and that every segment the Python SDK would parse is valid JSON, using a line-for-line Go port of the Python SDK's `_iter_response_stream` parser.
- Added `TestSSEStreamReaderSendHeartbeatNone` to verify the new framing writes nothing while still reporting disconnects correctly.
- Added a Python integration test (`heartbeat_test.py`) that runs two concurrent streams — a raw `httpx` wire stream counting SSE comment frames and a LangChain stream counting decoded chunks — to validate end-to-end behaviour against a live gateway.
- Added `cohere`, `langchain-cohere`, `fastavro`, `types-pyyaml`, and `types-requests` to the Python integration test dependencies.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# Unit tests
go test ./transports/bifrost-http/...

# Integration test against a live gateway (requires gateway on localhost:8080)
cd tests/integrations/python
uv run python heartbeat_test.py
# Expected: RESULT: PASS, heartbeats=0 in raw wire stream, chunks>0 in langchain stream
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Follows up on PR #6252 (which introduced `SSEHeartbeatDelimitedCommentBlock` for the JavaScript SDK).

## Security considerations

None.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable