### PR TITLE
fix: anthropic stream truncation

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -3802,7 +3802,11 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 	case schemas.ResponsesStreamResponseTypePing:
 		streamResp.Type = AnthropicStreamEventTypePing
 
-	case schemas.ResponsesStreamResponseTypeCompleted:
+	// response.incomplete is terminal too: a turn cut short by the output-token cap
+	// or a content filter still has to close with message_delta + message_stop, or the
+	// client is left holding a half-written tool_use with no stop_reason to explain it.
+	case schemas.ResponsesStreamResponseTypeCompleted,
+		schemas.ResponsesStreamResponseTypeIncomplete:
 		streamResp.Type = AnthropicStreamEventTypeMessageStop
 		// If a message_delta was already emitted from the upstream event, only emit message_stop
 		// to avoid sending a duplicate message_delta to the client.
@@ -3822,6 +3826,12 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 			if bifrostResp.Response.StopReason != nil {
 				anthropicContentDeltaEvent.Delta = &AnthropicStreamDelta{
 					StopReason:   schemas.Ptr(ConvertBifrostFinishReasonToAnthropic(*bifrostResp.Response.StopReason)),
+					StopSequence: nil,
+				}
+			} else if reason := anthropicStopReasonFromIncompleteDetails(bifrostResp.Response.IncompleteDetails); reason != "" {
+				// A truncated turn carrying only incomplete_details must not report end_turn.
+				anthropicContentDeltaEvent.Delta = &AnthropicStreamDelta{
+					StopReason:   schemas.Ptr(reason),
 					StopSequence: nil,
 				}
 			}
@@ -3922,12 +3932,21 @@ func toAnthropicResponsesStreamEvents(ctx *schemas.BifrostContext, bifrostResp *
 			}
 		}
 
-	case schemas.ResponsesStreamResponseTypeError:
+	// response.failed is terminal as well, and Anthropic spells a failed turn as an
+	// error event rather than message_stop. Dropping it stalls the client silently.
+	case schemas.ResponsesStreamResponseTypeError,
+		schemas.ResponsesStreamResponseTypeFailed:
 		streamResp.Type = AnthropicStreamEventTypeError
+		message := ""
 		if bifrostResp.Message != nil {
+			message = *bifrostResp.Message
+		} else if bifrostResp.Response != nil && bifrostResp.Response.Error != nil {
+			message = bifrostResp.Response.Error.Message
+		}
+		if message != "" {
 			streamResp.Error = &AnthropicStreamError{
 				Type:    "error",
-				Message: *bifrostResp.Message,
+				Message: message,
 			}
 		}
 

--- a/core/providers/anthropic/streamtruncation_test.go
+++ b/core/providers/anthropic/streamtruncation_test.go
@@ -372,3 +372,92 @@ func TestAnthropicResponsesStreamTruncatedBillsCachedTokens(t *testing.T) {
 	assertAnthropicTruncationError(t, final.BifrostError)
 	assertCacheFoldedBilledUsage(t, final.BifrostError)
 }
+
+// A turn the provider cut short at its output-token cap arrives on the Responses
+// stream as response.incomplete, not response.completed. Anthropic's Messages
+// stream has no [DONE] sentinel, so an egress that drops that event leaves the
+// client holding a half-written tool_use with no stop_reason to explain it —
+// Claude Code then fails to parse the partial input_json and retries in a loop.
+func TestAnthropicEgressIncompleteEmitsTerminalEvents(t *testing.T) {
+	cases := []struct {
+		name       string
+		stopReason *string
+		incomplete *schemas.ResponsesResponseIncompleteDetails
+		want       AnthropicStopReason
+	}{
+		{
+			name:       "MaxTokens",
+			stopReason: schemas.Ptr("length"),
+			incomplete: &schemas.ResponsesResponseIncompleteDetails{Reason: schemas.ResponsesResponseIncompleteReasonMaxOutputTokens},
+			want:       AnthropicStopReasonMaxTokens,
+		},
+		{
+			// Stop reason absent: the reason has to come off incomplete_details,
+			// never the end_turn default, which would report a clean finish.
+			name:       "MaxTokensFromIncompleteDetailsOnly",
+			incomplete: &schemas.ResponsesResponseIncompleteDetails{Reason: schemas.ResponsesResponseIncompleteReasonMaxOutputTokens},
+			want:       AnthropicStopReasonMaxTokens,
+		},
+		{
+			name:       "ContentFilterFromIncompleteDetailsOnly",
+			incomplete: &schemas.ResponsesResponseIncompleteDetails{Reason: schemas.ResponsesResponseIncompleteReasonContentFilter},
+			want:       AnthropicStopReasonRefusal,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+			events := ToAnthropicResponsesStreamResponse(ctx, &schemas.BifrostResponsesStreamResponse{
+				Type: schemas.ResponsesStreamResponseTypeIncomplete,
+				Response: &schemas.BifrostResponsesResponse{
+					Status:            schemas.Ptr(schemas.ResponsesResponseStatusIncomplete),
+					StopReason:        tc.stopReason,
+					IncompleteDetails: tc.incomplete,
+					Usage:             &schemas.ResponsesResponseUsage{InputTokens: 55974, OutputTokens: 4096, TotalTokens: 60070},
+				},
+			})
+
+			if len(events) != 2 {
+				t.Fatalf("got %d events, want message_delta + message_stop", len(events))
+			}
+			if events[0].Type != AnthropicStreamEventTypeMessageDelta {
+				t.Errorf("first event = %s, want message_delta", events[0].Type)
+			}
+			if events[1].Type != AnthropicStreamEventTypeMessageStop {
+				t.Errorf("second event = %s, want message_stop", events[1].Type)
+			}
+			if events[0].Delta == nil || events[0].Delta.StopReason == nil {
+				t.Fatal("message_delta must carry a stop_reason")
+			}
+			if got := *events[0].Delta.StopReason; got != tc.want {
+				t.Errorf("stop_reason = %q, want %q", got, tc.want)
+			}
+			if events[0].Usage == nil || events[0].Usage.OutputTokens != 4096 {
+				t.Error("message_delta must carry the turn's usage")
+			}
+		})
+	}
+}
+
+// response.failed is terminal too. Anthropic spells a failed turn as an error
+// event; dropping it stalls the client with no frame at all.
+func TestAnthropicEgressFailedEmitsErrorEvent(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	events := ToAnthropicResponsesStreamResponse(ctx, &schemas.BifrostResponsesStreamResponse{
+		Type: schemas.ResponsesStreamResponseTypeFailed,
+		Response: &schemas.BifrostResponsesResponse{
+			Error: &schemas.ResponsesResponseError{Message: "upstream generation failed"},
+		},
+	})
+
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want a single error event", len(events))
+	}
+	if events[0].Type != AnthropicStreamEventTypeError {
+		t.Fatalf("event = %s, want error", events[0].Type)
+	}
+	if events[0].Error == nil || events[0].Error.Message != "upstream generation failed" {
+		t.Error("error event must carry the upstream failure message")
+	}
+}

--- a/core/providers/anthropic/utils.go
+++ b/core/providers/anthropic/utils.go
@@ -2652,6 +2652,21 @@ func ConvertBifrostFinishReasonToAnthropic(bifrostReason string) AnthropicStopRe
 	return AnthropicStopReason(bifrostReason)
 }
 
+// anthropicStopReasonFromIncompleteDetails maps a Responses incomplete reason to the
+// Anthropic stop_reason, for terminal events that carry no explicit stop reason.
+func anthropicStopReasonFromIncompleteDetails(details *schemas.ResponsesResponseIncompleteDetails) AnthropicStopReason {
+	if details == nil {
+		return ""
+	}
+	switch details.Reason {
+	case schemas.ResponsesResponseIncompleteReasonMaxOutputTokens:
+		return AnthropicStopReasonMaxTokens
+	case schemas.ResponsesResponseIncompleteReasonContentFilter:
+		return AnthropicStopReasonRefusal
+	}
+	return ""
+}
+
 // ConvertToAnthropicImageBlock converts a Bifrost image block to Anthropic format
 // Uses the same pattern as the original buildAnthropicImageSourceMap function
 func ConvertToAnthropicImageBlock(block schemas.ChatContentBlock) AnthropicContentBlock {

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -139289,6 +139289,180 @@
           ]
         }
       ]
+    },
+    {
+      "name": "65. Anthropic Egress Terminal Events on Truncated Turns (#6081)",
+      "description": "Pins that a turn cut short by the output-token cap still closes the Anthropic Messages stream properly on /anthropic/v1/messages.\n\nBug (#6081): Bedrock ConverseStream ending with stopReason max_tokens is finalized by FinalizeBedrockStream as a response.incomplete terminal event, distinct from response.completed. The Anthropic egress converter (toAnthropicResponsesStreamEvents in core/providers/anthropic/responses.go) had a case only for response.completed, so response.incomplete fell through to `default: return nil` and the terminal frame was dropped. The stream ended after content_block_stop with a clean 200 - no message_delta carrying stop_reason, no message_stop, no error. Claude Code therefore treated a tool_use whose input_json had been truncated mid-JSON as complete, failed to parse it, and retried in a loop.\n\nFolder 17 already pins the upstream half (Bedrock emits response.incomplete on /v1/responses, #4680); these cases pin the Anthropic egress that consumes it.\n\nCases: (1) plain text truncation on Bedrock Claude; (2) the reported shape, truncation mid tool_use, where the open block is a function call rather than text so the block-closing path differs; (3) the same invariant through a chat-completions provider, whose finish_reason \"length\" becomes response.incomplete via responsesTerminalFromChatFinishReason in core/schemas/mux.go - guarding against a fix that only works for Bedrock.",
+      "item": [
+        {
+          "name": "Bedrock Claude /anthropic/v1/messages truncated by max_tokens emits message_delta + message_stop - #6081",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('bedrock claude: truncated stream terminates with message_delta(stop_reason=max_tokens) + message_stop - #6081', function () {",
+                  "  var raw = pm.response.text() || '';",
+                  "  pm.expect(pm.response.code, 'failed: ' + raw.slice(0, 400)).to.be.below(400);",
+                  "  pm.expect(raw, 'a truncated turn must still emit message_delta').to.include('message_delta');",
+                  "  pm.expect(raw, 'a truncated turn must still emit message_stop').to.include('message_stop');",
+                  "  pm.expect(raw, 'message_delta must carry the truncation stop_reason').to.include('\"stop_reason\":\"max_tokens\"');",
+                  "  var events = [];",
+                  "  raw.split('\\n').forEach(function (line) {",
+                  "    var t = line.trim();",
+                  "    if (t.indexOf('event:') === 0) { events.push(t.slice(6).trim()); }",
+                  "  });",
+                  "  pm.expect(events.length, 'expected SSE event lines in the response').to.be.above(0);",
+                  "  pm.expect(events[events.length - 1], 'stream must terminate on message_stop, not content_block_stop').to.equal('message_stop');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "anthropic-version",
+                "value": "2023-06-01"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0\",\"max_tokens\":16,\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"Count from 1 to 1000, one number per line.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Bedrock Claude /anthropic/v1/messages tool_use truncated mid input_json still emits message_delta + message_stop - #6081",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('bedrock claude: tool_use truncated mid input_json still terminates with message_delta + message_stop - #6081', function () {",
+                  "  var raw = pm.response.text() || '';",
+                  "  pm.expect(pm.response.code, 'failed: ' + raw.slice(0, 400)).to.be.below(400);",
+                  "  pm.expect(raw, 'a truncated turn must still emit message_delta').to.include('message_delta');",
+                  "  pm.expect(raw, 'a truncated turn must still emit message_stop').to.include('message_stop');",
+                  "  pm.expect(raw, 'message_delta must carry the truncation stop_reason').to.include('\"stop_reason\":\"max_tokens\"');",
+                  "  var events = [];",
+                  "  raw.split('\\n').forEach(function (line) {",
+                  "    var t = line.trim();",
+                  "    if (t.indexOf('event:') === 0) { events.push(t.slice(6).trim()); }",
+                  "  });",
+                  "  pm.expect(events.length, 'expected SSE event lines in the response').to.be.above(0);",
+                  "  pm.expect(events[events.length - 1], 'stream must terminate on message_stop, not content_block_stop').to.equal('message_stop');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "anthropic-version",
+                "value": "2023-06-01"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0\",\"max_tokens\":16,\"stream\":true,\"tool_choice\":{\"type\":\"tool\",\"name\":\"Write\"},\"tools\":[{\"name\":\"Write\",\"description\":\"Writes content to a file\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"file_path\":{\"type\":\"string\"},\"content\":{\"type\":\"string\"}},\"required\":[\"file_path\",\"content\"]}}],\"messages\":[{\"role\":\"user\",\"content\":\"Call Write exactly once for /tmp/numbers.txt. The content must contain the integers 1 through 1000, one per line, with no omissions, abbreviations, or surrounding explanation.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai/gpt-4o-mini /anthropic/v1/messages truncated by max_tokens emits message_delta + message_stop - #6081",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('openai gpt-4o-mini: chat finish_reason length maps to a terminated Anthropic stream - #6081', function () {",
+                  "  var raw = pm.response.text() || '';",
+                  "  pm.expect(pm.response.code, 'failed: ' + raw.slice(0, 400)).to.be.below(400);",
+                  "  pm.expect(raw, 'a truncated turn must still emit message_delta').to.include('message_delta');",
+                  "  pm.expect(raw, 'a truncated turn must still emit message_stop').to.include('message_stop');",
+                  "  pm.expect(raw, 'message_delta must carry the truncation stop_reason').to.include('\"stop_reason\":\"max_tokens\"');",
+                  "  var events = [];",
+                  "  raw.split('\\n').forEach(function (line) {",
+                  "    var t = line.trim();",
+                  "    if (t.indexOf('event:') === 0) { events.push(t.slice(6).trim()); }",
+                  "  });",
+                  "  pm.expect(events.length, 'expected SSE event lines in the response').to.be.above(0);",
+                  "  pm.expect(events[events.length - 1], 'stream must terminate on message_stop, not content_block_stop').to.equal('message_stop');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "anthropic-version",
+                "value": "2023-06-01"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-4o-mini\",\"max_tokens\":16,\"stream\":true,\"messages\":[{\"role\":\"user\",\"content\":\"Count from 1 to 1000, one number per line.\"}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

The Anthropic egress layer was silently dropping two terminal Responses stream event types — `response.incomplete` and `response.failed` — leaving clients with no closing frame. For `response.incomplete` (a turn cut short by the output-token cap or a content filter), the client would receive a half-written `tool_use` block with no `stop_reason` to explain it, causing tools like Claude Code to fail parsing and retry in a loop. For `response.failed`, the client would stall indefinitely with no error signal.

## Changes

- `response.incomplete` is now handled alongside `response.completed`, emitting `message_delta` + `message_stop`. The `stop_reason` is derived from `StopReason` when present, or falls back to `incomplete_details` via a new `anthropicStopReasonFromIncompleteDetails` helper — ensuring a truncated turn never incorrectly reports `end_turn`.
- `response.failed` is now handled alongside `response.error`, emitting an Anthropic `error` event. The error message is sourced from `bifrostResp.Message` when set, or from `bifrostResp.Response.Error.Message` as a fallback.
- Added `anthropicStopReasonFromIncompleteDetails` in `utils.go` to map `max_output_tokens` → `max_tokens` and `content_filter` → `refusal`.
- Added tests covering `response.incomplete` with an explicit stop reason, with only `incomplete_details`, with a content filter reason, and `response.failed` with an upstream error message.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/anthropic/... -run TestAnthropicEgressIncompleteEmitsTerminalEvents
go test ./core/providers/anthropic/... -run TestAnthropicEgressFailedEmitsErrorEvent
go test ./core/providers/anthropic/...
```

The two new tests assert that:
- A `response.incomplete` event produces exactly two events (`message_delta` with the correct `stop_reason` and usage, followed by `message_stop`).
- A `response.failed` event produces exactly one `error` event carrying the upstream failure message.

## Breaking changes

- [x] No

## Security considerations

None. This change only affects how terminal stream events are forwarded to clients; no auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable