### PR TITLE
feat: add scheduled automatic virtual key rotation

### DIFF
--- a/docs/enterprise/access-profiles.mdx
+++ b/docs/enterprise/access-profiles.mdx
@@ -11,8 +11,8 @@ An **Access Profile** is a reusable policy template that describes what a user,t
 A user can hold **several access profiles at once**. Together they decide what the user can reach, and one of them pays for each request - see [Multiple profiles per user](#multiple-profiles-per-user).
 
 <Info>
-  For rest of the article we will focus on access profiles for users. But the same principles apply
-  to access profiles for teams and business units.
+	For rest of the article we will focus on access profiles for users. But the same principles apply to access profiles for teams and
+	business units.
 </Info>
 
 **Key benefits:**
@@ -27,13 +27,11 @@ A user can hold **several access profiles at once**. Together they decide what t
 - **Audit and versioning** - Every change to a profile is recorded with a full snapshot history.
 
 <Info>
-  For the full API contract (every endpoint, request and response shape, error codes), see the
-  **Access Profiles** section of the [API Reference](/api-reference).
+	For the full API contract (every endpoint, request and response shape, error codes), see the **Access Profiles** section of the [API
+	Reference](/api-reference).
 </Info>
 
-<Note>
-  We are also adding access-profile support for teams and business units in upcoming releases.
-</Note>
+<Note>We are also adding access-profile support for teams and business units in upcoming releases.</Note>
 
 ---
 
@@ -97,6 +95,25 @@ A few things to know:
 - **Applies to identified users only.** The creator must sign in with their own identity (SSO/SCIM). Keys created from the local admin account or a raw API key are left as ordinary standalone keys.
 - **Create-time only.** Turning the toggle on does not sweep up keys a member already created. To bring an existing key under the profile, assign it to the user from the key's edit sheet — it is adopted into their profile on assignment.
 
+### Automatic virtual key rotation
+
+A profile can rotate the virtual keys it manages on a schedule, so credentials expire without anyone remembering to call the rotate endpoint. Set an **interval** (for example `30d`) and, optionally, a **first rotation** time; after each run the next one is scheduled at run time + interval.
+
+When a run comes due, Bifrost enqueues a background job that rotates every managed key in batches of 25. A key counts as managed when it is assigned to a user who holds this profile, which is the same rule that locks managed keys from direct edits. Each key gets a brand-new value exactly as if you had rotated it by hand:
+
+- If `client.vk_rotation_cooldown` is set (Config → Security), the previous value keeps authenticating until the cooldown expires, so callers have time to pick up the new key.
+- Leaving it unset, empty, or `0` disables the grace period, so the previous value stops working immediately.
+
+Two dashboard notifications track each run: one when the job starts (profile name, how many keys will rotate, and until when the old values stay valid) and one when it finishes (how many keys rotated, failed, or were skipped).
+
+Safety rules worth knowing:
+
+- **A key is never rotated twice for one scheduled run.** Rotating again would push the previous value out and end the cooldown early. Retries, resumed jobs, catch-up runs after downtime, and keys rotated manually after the schedule fired are all skipped for that run.
+- **Manual rotation still works.** The manual endpoints stay available on managed keys; a key rotated manually inside the window is simply skipped by the scheduled run.
+- **Cluster-safe.** Every node checks the schedule, but only one job is created per profile and due time, and rotated keys are gossiped to all nodes.
+- **Missed runs collapse into one.** If the gateway was down past a due time, the next start performs a single catch-up rotation rather than one per missed period.
+- **Deactivated profiles pause.** A deactivated profile is never rotated; reactivating it re-anchors an overdue schedule to now + interval so it does not fire immediately.
+
 ---
 
 ## Configuration (Web UI)
@@ -106,10 +123,7 @@ A few things to know:
 1. Navigate to **Workspace** -> **Governance & Access Control** -> **Access Profiles**.
 
 <Frame>
-  <img
-    src="/media/access-profiles/access-profiles-home.png"
-    alt="Access Profiles list page with table columns and create button"
-  />
+	<img src="/media/access-profiles/access-profiles-home.png" alt="Access Profiles list page with table columns and create button" />
 </Frame>
 
 The table shows **Name**, **Description**, **Providers**, **Budgets**, **Rate Limit** and per-row actions.
@@ -120,10 +134,7 @@ The table shows **Name**, **Description**, **Providers**, **Budgets**, **Rate Li
 ### Fill in the basics
 
 <Frame>
-  <img
-    src="/media/access-profiles/new-access-profile.png"
-    alt="Access Profiles list page with table columns and create button"
-  />
+	<img src="/media/access-profiles/new-access-profile.png" alt="Access Profiles list page with table columns and create button" />
 </Frame>
 
 - **Name** - Required, unique, trimmed. Max 255 characters.
@@ -134,10 +145,10 @@ The table shows **Name**, **Description**, **Providers**, **Budgets**, **Rate Li
 In the **Allowed Providers** accordion, add providers from the multi-select. For each provider:
 
 <Frame>
-  <img
-    src="/media/access-profiles/access-profile-provider-config.png"
-    alt="Access Profiles list page with table columns and create button"
-  />
+	<img
+		src="/media/access-profiles/access-profile-provider-config.png"
+		alt="Access Profiles list page with table columns and create button"
+	/>
 </Frame>
 
 - **Allowed Models** - Toggle **All Models** to allow every model, or pick specific models from the search-filtered list. An empty selection denies every model from that provider.
@@ -158,13 +169,18 @@ Flip **Align to calendar cycle** to reset budgets and rate limits at the start o
 
 Flip **Govern virtual keys created by members** so any virtual key a member of this profile creates is automatically placed under the profile - same providers, model whitelist, budgets, rate limits, and MCP access, attached to the creator, and locked from direct edits. Leave it off (default) to let members create standalone keys freely. See [Govern virtual keys created by members](#govern-virtual-keys-created-by-members) for the full behavior and its limits.
 
+### Schedule automatic key rotation
+
+Under **Automatic key rotation**, pick **Every 7 / 30 / 90 days** or **Custom** and enter a whole number of days or hours (`14d`, `12h`; minimum `1h`, maximum `365d`). Optionally set **First rotation** to control when the first run happens; leave it empty to start one interval from now. Choose **Off** to stop scheduling. The table and detail sheet show the schedule and the next run. See [Automatic virtual key rotation](#automatic-virtual-key-rotation) for what a run does and its safety rules.
+
+<Frame>
+	<img src="/media/enterprise/access-profiles/auto-rotation.png" alt="Automatic key rotation settings in the access profile form" />
+</Frame>
+
 ### Configure MCP tool access
 
 <Frame>
-  <img
-    src="/media/access-profiles/access-profile-mcp-config.png"
-    alt="Access Profiles MCP configuration"
-  />
+	<img src="/media/access-profiles/access-profile-mcp-config.png" alt="Access Profiles MCP configuration" />
 </Frame>
 
 - **Virtual MCPs** - Multi-select existing [Virtual MCPs](/enterprise/virtual-mcps) to grant. Selected vMCPs appear as removable badges.
@@ -172,9 +188,8 @@ Flip **Govern virtual keys created by members** so any virtual key a member of t
 - **Individual Tool Overrides** - Add specific tools with either `include` or `exclude` action. Use this for surgical adjustments that the group + server selection does not express.
 
 <Warning>
-  If you grant a whole MCP server (allow-all on that client) and then add an `exclude` override
-  targeting the same client, the form shows a conflict alert and saving is rejected. A virtual key
-  can only carry positive allowlists per client; "all minus X" cannot be represented.
+	If you grant a whole MCP server (allow-all on that client) and then add an `exclude` override targeting the same client, the form shows a
+	conflict alert and saving is rejected. A virtual key can only carry positive allowlists per client; "all minus X" cannot be represented.
 </Warning>
 
 ### Save and assign
@@ -182,10 +197,7 @@ Flip **Govern virtual keys created by members** so any virtual key a member of t
 Click **Create**. To make the profile take effect for users, attach it to one or more roles from the Roles page, attach it to a user directly from their User Detail Sheet, or map it from an IdP attribute (see [Attribute mappings](/enterprise/user-provisioning#attribute-mappings)). A user can hold profiles from all three sources at once.
 
 <Frame>
-  <img
-    src="/media/access-profiles/access-profile-rbac.png"
-    alt="Access Profiles RBAC level attachment"
-  />
+	<img src="/media/access-profiles/access-profile-rbac.png" alt="Access Profiles RBAC level attachment" />
 </Frame>
 
 For each attachment you can:
@@ -198,10 +210,7 @@ For each attachment you can:
 When you edit an existing profile, the action bar shows **Save** (template-only edit) and **Save and Propagate** (template edit plus immediate propagation to all user copies). The propagate dialog lets you choose exactly which fields to push:
 
 <Frame>
-  <img
-    src="/media/access-profiles/access-profiles-save-and-propagate.png"
-    alt="Access Profiles save and propagate dialog"
-  />
+	<img src="/media/access-profiles/access-profiles-save-and-propagate.png" alt="Access Profiles save and propagate dialog" />
 </Frame>
 
 - Check the fields to propagate: **Provider Configurations**, **Budgets**, **Rate Limit**, **Virtual
@@ -239,10 +248,7 @@ Use `"mode": "forever"` (omitting `cycles`) to keep the override active until it
 Each row action exposes:
 
 <Frame>
-  <img
-    src="/media/access-profiles/access-profiles-duplicate.png"
-    alt="Access Profiles duplicate action"
-  />
+	<img src="/media/access-profiles/access-profiles-duplicate.png" alt="Access Profiles duplicate action" />
 </Frame>
 
 - **Edit** - Opens the same form in edit mode.
@@ -263,6 +269,7 @@ A profile carries the following pieces of policy. Use the UI walkthrough above f
 - **Calendar alignment** - When on, budgets and rate limits reset at the start of each calendar period (midnight UTC, week start, month start) instead of rolling from creation time. Applies to durations of one day or longer.
 - **Govern created keys** - When on, every virtual key a member creates is adopted into the profile (same policy, attached to the user, profile-managed). Off by default. See [Govern virtual keys created by members](#govern-virtual-keys-created-by-members).
 - **MCP tool access** - Reference [Virtual MCPs](/enterprise/virtual-mcps), grant entire MCP servers, or override individual tools with include/exclude actions.
+- **Automatic key rotation** - An interval (`1h` to `365d`, typically `30d`) and optional first-run time. When due, a background job rotates every managed key, honouring `client.vk_rotation_cooldown`, and posts start/finish notifications. Off by default. See [Automatic virtual key rotation](#automatic-virtual-key-rotation).
 - **Tags** - Up to 50 free-form tags for filtering and grouping in the UI.
 - **Active flag** - Activate or deactivate without deleting; deactivated profiles are hidden from selection but user copies stay intact.
 
@@ -285,6 +292,26 @@ Prerequisite: the Engineering profile is already assigned to the Engineer role (
 1. Edit the Engineering profile and turn on **Govern virtual keys created by members**. Save.
 2. From now on, whenever an Engineer (signed in via SSO) creates a virtual key, it is placed under the Engineering profile automatically - same providers, model whitelist, budgets, rate limits, and MCP access - attached to them and locked from direct edits.
 3. To bring keys they created earlier under the policy too, open each key and assign it to the user; it is adopted into their profile on assignment.
+
+### Rotate every Engineering key monthly
+
+1. Under **Config → Security**, set **Cooldown After Virtual Key Rotation** to something like `1h` so callers have time to switch keys.
+2. Edit the Engineering profile, set **Automatic key rotation** to **Every 30 days**, and optionally pick a **First rotation** such as the next maintenance window. Save.
+3. When the run starts, a notification lists how many keys are rotating and until when the old values keep working; a second notification confirms how many rotated. The profile's **Next Rotation** moves 30 days past the run.
+
+The same schedule can be declared in `config.json`:
+
+```json
+{
+	"access_profiles": [
+		{
+			"name": "Engineering",
+			"auto_rotation_interval": "30d",
+			"provider_configs": [{ "provider_name": "openai", "allow_all_models": true }]
+		}
+	]
+}
+```
 
 ### Raise the monthly budget without resetting accumulated usage
 

--- a/docs/openapi/schemas/management/accessprofiles.yaml
+++ b/docs/openapi/schemas/management/accessprofiles.yaml
@@ -184,6 +184,22 @@ AccessProfile:
       $ref: '#/RateLimit'
     calendar_aligned:
       type: boolean
+    auto_rotation_interval:
+      type: integer
+      format: int64
+      description: Interval between automatic rotations of the profile's managed virtual keys, in nanoseconds. 0 means automatic rotation is off.
+    next_rotation_at:
+      oneOf:
+        - type: string
+          format: date-time
+        - type: 'null'
+      description: When the next scheduled rotation is due. Absent while automatic rotation is off.
+    last_rotation_at:
+      oneOf:
+        - type: string
+          format: date-time
+        - type: 'null'
+      description: When the last scheduled rotation run finished.
     mcp_tool_groups:
       type: array
       items:
@@ -246,6 +262,16 @@ CreateAccessProfileRequest:
       $ref: '#/RateLimit'
     calendar_aligned:
       type: boolean
+    auto_rotation_interval:
+      oneOf:
+        - $ref: '#/RotationIntervalString'
+        - $ref: '#/RotationIntervalNanos'
+      description: 'Schedule automatic rotation of the profile''s managed virtual keys. Accepts a day count ("30d"), a Go duration ("12h"), or integer nanoseconds. Between 1h and 365d; omit, "" or 0 to leave it off.'
+      example: 30d
+    next_rotation_at:
+      type: string
+      format: date-time
+      description: Optional first rotation time; must be in the future and requires auto_rotation_interval. Defaults to now + interval.
     mcp_tool_groups:
       type: array
       items:
@@ -292,6 +318,18 @@ UpdateAccessProfileRequest:
     calendar_aligned:
       type: boolean
       nullable: true
+    auto_rotation_interval:
+      oneOf:
+        - $ref: '#/RotationIntervalString'
+        - $ref: '#/RotationIntervalNanos'
+        - type: 'null'
+      description: 'Replace the rotation schedule ("30d", "12h" or nanoseconds); "" or 0 turns it off. Omit to leave the schedule unchanged.'
+    next_rotation_at:
+      oneOf:
+        - type: string
+          format: date-time
+        - type: 'null'
+      description: Override the next rotation time (must be in the future). null clears it, which is only valid when the interval is off. Omit to keep the existing schedule; a changed interval re-anchors it to now + interval.
     mcp_tool_groups:
       type: array
       items:
@@ -585,3 +623,19 @@ AddVirtualKeyResponse:
   properties:
     virtual_key:
       $ref: '#/VirtualKeySummary'
+
+RotationIntervalString:
+  type: string
+  description: 'Rotation interval as a day count ("30d") or a Go duration ("12h", "720h"). Must resolve to between 1h and 365d. "" disables rotation.'
+  pattern: '^$|^[0-9]+d$|^([0-9]+(\.[0-9]+)?(ns|us|µs|ms|s|m|h))+$'
+  example: 30d
+
+RotationIntervalNanos:
+  type: integer
+  format: int64
+  description: Rotation interval in nanoseconds. 0 disables rotation; otherwise between 1h (3600000000000) and 365d (31536000000000000).
+  oneOf:
+    - const: 0
+    - minimum: 3600000000000
+      maximum: 31536000000000000
+  example: 2592000000000000

--- a/framework/sidekiq/sidekiq.go
+++ b/framework/sidekiq/sidekiq.go
@@ -3,6 +3,7 @@ package sidekiq
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -477,4 +478,23 @@ func (r *Runner) dispatchOnce() {
 func (r *Runner) Shutdown() {
 	r.cancel()
 	r.wg.Wait()
+}
+
+// IsDuplicateJobError reports whether err is a primary-key collision on the job
+// row, i.e. another node enqueued the same deterministic job ID first. Producers
+// that derive the ID from the work itself (an archive window, a scheduled
+// rotation) treat this as "someone else owns it", not as a failure. Matching on
+// message text is the only option: the store surfaces the driver's error
+// verbatim and defines no sentinel for it.
+func IsDuplicateJobError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique constraint") ||
+		strings.Contains(msg, "unique index") ||
+		strings.Contains(msg, "unique_violation") ||
+		strings.Contains(msg, "duplicate key") ||
+		strings.Contains(msg, "duplicate entry") ||
+		strings.Contains(msg, "duplicated key")
 }

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1217,10 +1217,16 @@ func buildVKModelBudgetsIndex(mcs []*configstoreTables.TableModelConfig) map[str
 // hydrateVKGovernance reverse-maps a single VK's governance (top-level, per-provider, and
 // per-model budgets) from its VK-scoped model configs in one bulk load.
 func (h *GovernanceHandler) hydrateVKGovernance(ctx context.Context, vk *configstoreTables.TableVirtualKey) {
+	hydrateVKGovernanceFromStore(ctx, h.configStore, vk)
+}
+
+// hydrateVKGovernanceFromStore is the store-only form of hydrateVKGovernance so
+// producers without a handler (the VirtualKeyRotator) can hydrate a row too.
+func hydrateVKGovernanceFromStore(ctx context.Context, configStore configstore.ConfigStore, vk *configstoreTables.TableVirtualKey) {
 	if vk == nil {
 		return
 	}
-	mcs, err := h.configStore.GetModelConfigsByScopeAndScopeIDs(ctx, configstoreTables.ModelConfigScopeVirtualKey, []string{vk.ID})
+	mcs, err := configStore.GetModelConfigsByScopeAndScopeIDs(ctx, configstoreTables.ModelConfigScopeVirtualKey, []string{vk.ID})
 	if err != nil {
 		logger.Error("failed to load model configs for VK governance hydration: %v", err)
 		return
@@ -2510,49 +2516,10 @@ func (h *GovernanceHandler) updateVirtualKey(ctx *fasthttp.RequestCtx) {
 	})
 }
 
-// vkRotationCooldown reads the effective rotation grace period from the stored
-// client config. Errors degrade to 0 (immediate flip), never block a rotation.
-func (h *GovernanceHandler) vkRotationCooldown(ctx context.Context) time.Duration {
-	clientConfig, err := h.configStore.GetClientConfig(ctx)
-	if err != nil || clientConfig == nil {
-		return 0
-	}
-	return clientConfig.VKRotationCooldown.D()
-}
-
+// rotateVirtualKeyByID rotates one virtual key through the shared
+// VirtualKeyRotator so the endpoints and background producers stay identical.
 func (h *GovernanceHandler) rotateVirtualKeyByID(ctx context.Context, vkID string) (*configstoreTables.TableVirtualKey, error) {
-	vk, err := h.configStore.GetVirtualKey(ctx, vkID)
-	if err != nil {
-		return nil, err
-	}
-	oldValue := vk.Value.GetValue()
-	vk.Value = *schemas.NewSecretVar(governance.GenerateVirtualKey())
-	if vk.Value.GetValue() == oldValue {
-		return nil, fmt.Errorf("generated virtual key matched existing value")
-	}
-	// RotatedAt marks this update as a rotation, making the grace-period fields
-	// authoritative in UpdateVirtualKey (a plain update carries them over
-	// instead). With a cooldown the retired value keeps authenticating until
-	// the expiry; repeated rotation overwrites the previous value, so only one
-	// grace value exists at a time and the second-oldest dies immediately.
-	now := time.Now().UTC()
-	vk.RotatedAt = &now
-	if cooldown := h.vkRotationCooldown(ctx); cooldown > 0 {
-		vk.PreviousValue = *schemas.NewSecretVar(oldValue)
-		expiresAt := now.Add(cooldown)
-		vk.PreviousValueExpiresAt = &expiresAt
-	} else {
-		vk.ClearPreviousValue()
-	}
-	if err := h.configStore.UpdateVirtualKey(ctx, vk); err != nil {
-		return nil, err
-	}
-	preloadedVk, err := h.governanceManager.ReloadVirtualKey(ctx, vk.ID)
-	if err != nil {
-		return nil, fmt.Errorf("virtual key rotated in database but failed to reload in-memory state: %w", err)
-	}
-	h.hydrateVKGovernance(ctx, preloadedVk)
-	return preloadedVk, nil
+	return NewVirtualKeyRotator(h.configStore, h.governanceManager).RotateVirtualKey(ctx, vkID)
 }
 
 // rotateVirtualKey handles POST /api/governance/virtual-keys/{vk_id}/rotate - Rotate only the virtual key value

--- a/transports/bifrost-http/handlers/virtualkeyrotation.go
+++ b/transports/bifrost-http/handlers/virtualkeyrotation.go
@@ -1,0 +1,82 @@
+// Package handlers provides HTTP request handlers for the Bifrost HTTP transport.
+// This file holds the reusable virtual key rotation implementation shared by the
+// rotate endpoints and background producers such as enterprise scheduled rotation.
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/plugins/governance"
+)
+
+// VirtualKeyRotator rotates a virtual key's value exactly the way
+// POST /api/governance/virtual-keys/{vk_id}/rotate does, so every producer
+// (manual endpoint, bulk endpoint, scheduled enterprise rotation) shares one
+// implementation of the cooldown / previous-value rules.
+type VirtualKeyRotator struct {
+	configStore       configstore.ConfigStore
+	governanceManager GovernanceManager
+}
+
+// NewVirtualKeyRotator builds a rotator over the given store and governance
+// manager. The manager is what reloads the rotated key into in-memory
+// enforcement (and, in enterprise, gossips it to cluster peers).
+func NewVirtualKeyRotator(configStore configstore.ConfigStore, governanceManager GovernanceManager) *VirtualKeyRotator {
+	return &VirtualKeyRotator{configStore: configStore, governanceManager: governanceManager}
+}
+
+// VKRotationCooldown reads the effective rotation grace period from the stored
+// client config. Errors degrade to 0 (immediate flip), never block a rotation.
+func (r *VirtualKeyRotator) VKRotationCooldown(ctx context.Context) time.Duration {
+	clientConfig, err := r.configStore.GetClientConfig(ctx)
+	if err != nil || clientConfig == nil {
+		return 0
+	}
+	return clientConfig.VKRotationCooldown.D()
+}
+
+// RotateVirtualKey generates a fresh value for the virtual key, applies the
+// cooldown rules (the retired value stays valid until now+cooldown, or is
+// dropped immediately when no cooldown is configured), persists the change,
+// reloads in-memory governance and hydrates VK-scoped model-config governance
+// onto the returned row. Callers passing a background context run unscoped by
+// DAC, which is intended for system-initiated rotation.
+func (r *VirtualKeyRotator) RotateVirtualKey(ctx context.Context, vkID string) (*configstoreTables.TableVirtualKey, error) {
+	vk, err := r.configStore.GetVirtualKey(ctx, vkID)
+	if err != nil {
+		return nil, err
+	}
+	oldValue := vk.Value.GetValue()
+	vk.Value = *schemas.NewSecretVar(governance.GenerateVirtualKey())
+	if vk.Value.GetValue() == oldValue {
+		return nil, fmt.Errorf("generated virtual key matched existing value")
+	}
+	// RotatedAt marks this update as a rotation, making the grace-period fields
+	// authoritative in UpdateVirtualKey (a plain update carries them over
+	// instead). With a cooldown the retired value keeps authenticating until
+	// the expiry; repeated rotation overwrites the previous value, so only one
+	// grace value exists at a time and the second-oldest dies immediately.
+	now := time.Now().UTC()
+	vk.RotatedAt = &now
+	if cooldown := r.VKRotationCooldown(ctx); cooldown > 0 {
+		vk.PreviousValue = *schemas.NewSecretVar(oldValue)
+		expiresAt := now.Add(cooldown)
+		vk.PreviousValueExpiresAt = &expiresAt
+	} else {
+		vk.ClearPreviousValue()
+	}
+	if err := r.configStore.UpdateVirtualKey(ctx, vk); err != nil {
+		return nil, err
+	}
+	preloadedVk, err := r.governanceManager.ReloadVirtualKey(ctx, vk.ID)
+	if err != nil {
+		return nil, fmt.Errorf("virtual key rotated in database but failed to reload in-memory state: %w", err)
+	}
+	hydrateVKGovernanceFromStore(ctx, r.configStore, preloadedVk)
+	return preloadedVk, nil
+}


### PR DESCRIPTION
## Summary

Adds automatic scheduled virtual key rotation to Access Profiles. Operators can configure a rotation interval (e.g. `30d`) on a profile, and Bifrost will enqueue a background job to rotate every managed key on that schedule without manual intervention. The rotation logic previously inlined in the HTTP handler has been extracted into a shared `VirtualKeyRotator` so the manual endpoint and the scheduled background producer use identical cooldown and previous-value rules.

## Changes

- **Automatic key rotation on Access Profiles** - Profiles now accept `auto_rotation_interval` (e.g. `30d`, `12h`, or nanoseconds) and an optional `next_rotation_at` first-run time. When a run is due, a background job rotates every managed key in batches of 25, honours `vk_rotation_cooldown`, and posts start/finish dashboard notifications.
- **Safety rules** - A key is never rotated twice for the same scheduled run; manual rotation inside the window is respected and that key is skipped. Missed runs collapse into one catch-up rotation. Deactivated profiles are never rotated; reactivating re-anchors the schedule to `now + interval`. The job is cluster-safe via a deterministic job ID so only one node creates it.
- **`VirtualKeyRotator` extraction** - The rotation logic (new value generation, cooldown application, previous-value lifecycle, in-memory reload, governance hydration) has been moved from `GovernanceHandler.rotateVirtualKeyByID` into a standalone `VirtualKeyRotator` struct in `virtualkeyrotation.go`. `hydrateVKGovernance` was split into a store-only form (`hydrateVKGovernanceFromStore`) so the rotator can hydrate rows without a handler reference.
- **`IsDuplicateJobError` helper** - Added to the sidekiq package to let producers treat primary-key collisions on deterministic job IDs as "another node owns it" rather than a failure.
- **OpenAPI schema** - `AccessProfile`, `CreateAccessProfileRequest`, and `UpdateAccessProfileRequest` now include `auto_rotation_interval`, `next_rotation_at`, and `last_rotation_at` fields with descriptions of accepted formats and nullability semantics.
- **Documentation** - Added an [Automatic virtual key rotation](#automatic-virtual-key-rotation) section covering the run lifecycle, all safety rules, and a worked example with a `config.json` snippet. Added a [Schedule automatic key rotation](#schedule-automatic-key-rotation) UI walkthrough with a screenshot. Updated the profile field reference to include the new rotation fields.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./...
```

1. Create an Access Profile with `auto_rotation_interval: "30d"` (via UI or API).
2. Confirm `next_rotation_at` is set to approximately `now + 30d`.
3. Set `vk_rotation_cooldown` under **Config → Security** (e.g. `1h`).
4. Trigger or wait for the scheduled run; verify:
   - A start notification appears listing the number of keys rotating and the cooldown expiry.
   - A finish notification confirms how many keys rotated, failed, or were skipped.
   - The managed keys have new values and `previous_value` is populated with the old value until the cooldown expires.
   - `next_rotation_at` advances by the configured interval.
5. Rotate a managed key manually during the cooldown window and confirm the scheduled run skips it.
6. Deactivate the profile and confirm no rotation job is created; reactivate and confirm `next_rotation_at` is re-anchored to `now + interval`.
7. Simulate a missed run (advance the clock past `next_rotation_at`) and confirm only one catch-up rotation fires.
8. On a multi-node cluster, confirm only one rotation job is created per profile and due time (duplicate job errors are swallowed, not surfaced as failures).

## Screenshots/Recordings

The auto-rotation UI panel is shown in the docs at `docs/enterprise/access-profiles.mdx` with the screenshot at `/media/enterprise/access-profiles/auto-rotation.png`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

- Rotation generates a cryptographically fresh key value via the existing `governance.GenerateVirtualKey()` path.
- The previous value is stored as a `SecretVar` and expires after `vk_rotation_cooldown`; without a cooldown it is cleared immediately so the old credential stops working at rotation time.
- Background rotation runs with a system context (unscoped by DAC), which is intentional and consistent with other system-initiated operations.
- Deterministic job IDs prevent duplicate rotation jobs across cluster nodes; the `IsDuplicateJobError` helper ensures collisions are treated as coordination signals, not errors.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable