### PR TITLE
feat: add log-level filtering to plugin and routing decision logs with shared `logLevel` utils, level badges, and `LogLevelTabs` component

### DIFF
--- a/plugins/logging/routinglogs_test.go
+++ b/plugins/logging/routinglogs_test.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestFormatRoutingEngineLogs(t *testing.T) {
+	t.Run("empty input yields an empty trail", func(t *testing.T) {
+		if got := formatRoutingEngineLogs(nil); got != "" {
+			t.Fatalf("expected empty string, got %q", got)
+		}
+	})
+
+	t.Run("writes timestamp, engine, level and message on every line", func(t *testing.T) {
+		got := formatRoutingEngineLogs([]schemas.RoutingEngineLogEntry{
+			{Engine: schemas.RoutingEngineCore, Level: schemas.LogLevelInfo, Message: "Retry 1/2 for openai/gpt-4o-mini", Timestamp: 1756881000842},
+			{Engine: schemas.RoutingEngineLoadbalancing, Level: schemas.LogLevelError, Message: "Weighted selection failed: no eligible providers", Timestamp: 1756881000850},
+		})
+		want := "[1756881000842] [core] [info] - Retry 1/2 for openai/gpt-4o-mini\n" +
+			"[1756881000850] [loadbalancing] [error] - Weighted selection failed: no eligible providers\n"
+		if got != want {
+			t.Fatalf("unexpected trail\n got: %q\nwant: %q", got, want)
+		}
+	})
+
+	t.Run("writes a missing level as info so every line keeps the same shape", func(t *testing.T) {
+		got := formatRoutingEngineLogs([]schemas.RoutingEngineLogEntry{
+			{Engine: schemas.RoutingEngineGovernance, Message: "No weighted configs; skipping load balancing", Timestamp: 1756881000006},
+		})
+		want := "[1756881000006] [governance] [info] - No weighted configs; skipping load balancing\n"
+		if got != want {
+			t.Fatalf("unexpected trail\n got: %q\nwant: %q", got, want)
+		}
+	})
+}

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -899,7 +899,9 @@ func mergeRealtimeMetadata(metadata map[string]interface{}, ctx *schemas.Bifrost
 }
 
 // formatRoutingEngineLogs formats routing engine logs into a human-readable string.
-// Format: [timestamp] [engine] - message
+// Format: [timestamp] [engine] [level] - message
+// The level token lets the log detail view filter and badge each line by severity.
+// An entry recorded without a level is written as info so every line keeps the same shape.
 // Parameters:
 //   - logs: Slice of routing engine log entries
 //
@@ -911,7 +913,11 @@ func formatRoutingEngineLogs(logs []schemas.RoutingEngineLogEntry) string {
 	}
 	var sb strings.Builder
 	for _, log := range logs {
-		sb.WriteString(fmt.Sprintf("[%d] [%s] - %s\n", log.Timestamp, log.Engine, log.Message))
+		level := log.Level
+		if level == "" {
+			level = schemas.LogLevelInfo
+		}
+		sb.WriteString(fmt.Sprintf("[%d] [%s] [%s] - %s\n", log.Timestamp, log.Engine, level, log.Message))
 	}
 	return sb.String()
 }

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -44,6 +44,7 @@ import {
 import { useGetProvidersQuery, useGetUserAgentMappingsQuery } from "@/lib/store";
 import { BatchRequestCounts, ContentBlock, LogEntry, OverheadBucket, ResponsesMessage } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
+import { countAtOrAboveEachLevel, LOG_LEVEL_BADGE_CLASSES, meetsMinLogLevel, type LogLevel } from "@/lib/utils/logLevel";
 import { downloadAsJson } from "@/lib/utils/browser-download";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { applyRedactionMapping, applyRedactionMappingToValue, hasRedactionMappingEntries } from "@/lib/utils/redaction";
@@ -60,12 +61,13 @@ import CollapsibleBox from "../views/collapsibleBox";
 import ImageView from "../views/imageView";
 import LogChatMessageView, { LogChatFileBlockView } from "../views/logChatMessageView";
 import LogEntryDetailsView from "../views/logEntryDetailsView";
+import LogLevelTabs from "../views/logLevelTabs";
 import OCRView from "../views/ocrView";
 import PluginLogsView from "../views/pluginLogsView";
 import SpeechView from "../views/speechView";
 import TranscriptionView from "../views/transcriptionView";
 import VideoView from "../views/videoView";
-import { resolveRawJsonNoticeState } from "./logDetailView.utils";
+import { parseRoutingDecisionLine, resolveRawJsonNoticeState } from "./logDetailView.utils";
 
 // Full-precision cost for the detail view; per-request costs are often < $0.01,
 // where formatCost's 2-4 dp rounding would hide the value.
@@ -835,45 +837,66 @@ const messageRoleLabel: Record<MessageRole, string> = {
 
 function RoutingDecisionLogs({ logs }: { logs: string }) {
 	const { copy } = useCopyToClipboard({ successMessage: "Copied" });
+	const [minLevel, setMinLevel] = useState<LogLevel>("debug");
+	const lines = useMemo(
+		() =>
+			logs
+				.split("\n")
+				.filter((line) => line.trim())
+				.map(parseRoutingDecisionLine),
+		[logs],
+	);
+	// Rows written before the level was recorded carry none, so there is nothing to filter on.
+	const hasLevels = lines.some((line) => line.level !== null);
+	const counts = useMemo(() => countAtOrAboveEachLevel(lines.map((line) => line.level)), [lines]);
+	const visible = hasLevels ? lines.filter((line) => meetsMinLogLevel(line.level, minLevel)) : lines;
+
 	return (
 		<div className="w-full rounded-sm border">
-			<div className="flex items-center justify-between border-b py-2 pl-6">
+			<div className="flex items-center justify-between gap-3 border-b py-2 pl-6">
 				<div className="text-sm font-medium">Routing Decision Logs</div>
-				<button
-					type="button"
-					onClick={() => copy(logs)}
-					className="text-muted-foreground mx-2 flex h-6 items-center rounded px-1 py-1 hover:text-black dark:hover:text-white"
-				>
-					<Copy className="h-3 w-3" />
-				</button>
+				<div className="flex items-center gap-1">
+					{hasLevels && <LogLevelTabs value={minLevel} onChange={setMinLevel} counts={counts} testId="routing-logs-level-filter" />}
+					<button
+						type="button"
+						onClick={() => copy(logs)}
+						className="text-muted-foreground mx-2 flex h-6 items-center rounded px-1 py-1 hover:text-black dark:hover:text-white"
+					>
+						<Copy className="h-3 w-3" />
+					</button>
+				</div>
 			</div>
 			<div>
-				{logs
-					.split("\n")
-					.filter((l) => l.trim())
-					.map((line, i) => {
-						const m = line.match(/^\[(\d+)\]\s+\[([^\]]+)\]\s+-\s+(.*)$/);
-						const ts = m ? Number(m[1]) : null;
-						const scope = m ? m[2] : null;
-						const message = m ? m[3] : line;
-						return (
-							<div key={i} className="flex items-start gap-3 border-b px-4 py-1.5 font-mono text-xs last:border-b-0">
-								{ts != null ? <span className="text-muted-foreground shrink-0">{format(new Date(ts), "HH:mm:ss.SSS")}</span> : null}
-								{scope ? (
-									<span
-										className={cn(
-											"inline-block w-24 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase",
-											RoutingEngineUsedColors[scope as keyof typeof RoutingEngineUsedColors] ??
+				{visible.length === 0 ? (
+					<div className="text-muted-foreground px-4 py-3 text-center text-xs">No routing logs at or above {minLevel}.</div>
+				) : (
+					visible.map((line, i) => (
+						<div key={i} className="flex items-start gap-3 border-b px-4 py-1.5 font-mono text-xs last:border-b-0">
+							{line.timestamp != null ? (
+								<span className="text-muted-foreground shrink-0">{format(new Date(line.timestamp), "HH:mm:ss.SSS")}</span>
+							) : null}
+							{line.engine ? (
+								<span
+									className={cn(
+										"inline-block w-24 shrink-0 rounded px-1.5 py-0.5 text-center text-[10px] font-semibold uppercase",
+										RoutingEngineUsedColors[line.engine as keyof typeof RoutingEngineUsedColors] ??
 											"bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
-										)}
-									>
-										{RoutingEngineUsedLabels[scope as keyof typeof RoutingEngineUsedLabels] ?? scope}
-									</span>
-								) : null}
-								<span className="break-words whitespace-pre-wrap">{message}</span>
-							</div>
-						);
-					})}
+									)}
+								>
+									{RoutingEngineUsedLabels[line.engine as keyof typeof RoutingEngineUsedLabels] ?? line.engine}
+								</span>
+							) : null}
+							{line.level ? (
+								<span
+									className={cn("shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase", LOG_LEVEL_BADGE_CLASSES[line.level])}
+								>
+									{line.level}
+								</span>
+							) : null}
+							<span className="break-words whitespace-pre-wrap">{line.message}</span>
+						</div>
+					))
+				)}
 			</div>
 		</div>
 	);

--- a/ui/app/workspace/logs/sheets/logDetailView.utils.test.ts
+++ b/ui/app/workspace/logs/sheets/logDetailView.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveRawJsonNoticeState } from "./logDetailView.utils";
+import { parseRoutingDecisionLine, resolveRawJsonNoticeState } from "./logDetailView.utils";
 
 const base = {
 	hasProvidersAccess: true,
@@ -46,5 +46,50 @@ describe("resolveRawJsonNoticeState", () => {
 		expect(
 			resolveRawJsonNoticeState({ ...base, providers: [{ name: "anthropic", store_raw_request_response: false }] }),
 		).toBe("unknown");
+	});
+});
+
+describe("parseRoutingDecisionLine", () => {
+	it("reads timestamp, engine, level and message from a line written with a level", () => {
+		expect(
+			parseRoutingDecisionLine("[1756881000842] [core] [warn] - Fallback anthropic/claude-sonnet-4-5 skipped: missing provider config"),
+		).toEqual({
+			timestamp: 1756881000842,
+			engine: "core",
+			level: "warn",
+			message: "Fallback anthropic/claude-sonnet-4-5 skipped: missing provider config",
+		});
+	});
+
+	it("parses a line stored before the level was recorded with a null level", () => {
+		expect(parseRoutingDecisionLine("[1756881000412] [loadbalancing] - Selected provider openai for model gpt-4o-mini")).toEqual({
+			timestamp: 1756881000412,
+			engine: "loadbalancing",
+			level: null,
+			message: "Selected provider openai for model gpt-4o-mini",
+		});
+	});
+
+	it("does not mistake a bracketed message prefix on an old line for a level", () => {
+		expect(parseRoutingDecisionLine("[1756881000412] [governance] - [vk-prod] - allow-list applied")).toMatchObject({
+			engine: "governance",
+			level: null,
+			message: "[vk-prod] - allow-list applied",
+		});
+	});
+
+	it("keeps the message intact when it starts with a bracket on a levelled line", () => {
+		expect(parseRoutingDecisionLine("[1756881000412] [governance] [info] - [vk-prod] - allow-list applied")).toMatchObject({
+			level: "info",
+			message: "[vk-prod] - allow-list applied",
+		});
+	});
+
+	it("treats an unknown level token as no level", () => {
+		expect(parseRoutingDecisionLine("[1756881000412] [core] [fatal] - boom").level).toBeNull();
+	});
+
+	it("falls back to the raw line when it does not match the trail shape", () => {
+		expect(parseRoutingDecisionLine("free-form note")).toEqual({ timestamp: null, engine: null, level: null, message: "free-form note" });
 	});
 });

--- a/ui/app/workspace/logs/sheets/logDetailView.utils.ts
+++ b/ui/app/workspace/logs/sheets/logDetailView.utils.ts
@@ -1,3 +1,5 @@
+import { isLogLevel, type LogLevel } from "@/lib/utils/logLevel";
+
 /**
  * Which message the Raw JSON tab shows when a log row carries no raw payload.
  *
@@ -33,4 +35,23 @@ export function resolveRawJsonNoticeState({
 	if (isProvidersLoading || !providers) return "loading";
 	const match = providers.find((p) => p.name === provider);
 	return match && match.store_raw_request_response === false ? "storage-disabled" : "unknown";
+}
+
+export interface RoutingDecisionLine {
+	timestamp: number | null;
+	engine: string | null;
+	level: LogLevel | null;
+	message: string;
+}
+
+// The logging plugin writes each routing entry as `[unix-ms] [engine] [level] - message`.
+// Rows stored before the level was recorded read `[unix-ms] [engine] - message`, so the
+// level group is optional and those lines parse with a null level.
+const ROUTING_LINE_PATTERN = /^\[(\d+)\]\s+\[([^\]]+)\](?:\s+\[([^\]]+)\])?\s+-\s+(.*)$/;
+
+export function parseRoutingDecisionLine(line: string): RoutingDecisionLine {
+	const match = line.match(ROUTING_LINE_PATTERN);
+	if (!match) return { timestamp: null, engine: null, level: null, message: line };
+	const level = match[3]?.toLowerCase();
+	return { timestamp: Number(match[1]), engine: match[2], level: isLogLevel(level) ? level : null, message: match[4] };
 }

--- a/ui/app/workspace/logs/views/logLevelTabs.tsx
+++ b/ui/app/workspace/logs/views/logLevelTabs.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+import { LOG_LEVEL_BADGE_CLASSES, LOG_LEVELS, type LogLevel } from "@/lib/utils/logLevel";
+
+interface LogLevelTabsProps {
+	value: LogLevel;
+	onChange: (level: LogLevel) => void;
+	/** How many entries each level would show when selected, keyed by level. */
+	counts: Record<LogLevel, number>;
+	testId?: string;
+}
+
+/**
+ * Segmented level filter. The selected level is a floor: each tab shows that level
+ * and everything more severe, so debug shows all entries. The active tab borrows the
+ * level's badge colors so it reads the same as the badges on the rows it filters.
+ */
+export default function LogLevelTabs({ value, onChange, counts, testId }: LogLevelTabsProps) {
+	return (
+		<div role="group" aria-label="Minimum log level" className="bg-muted/60 inline-flex gap-0.5 rounded-sm p-0.5" data-testid={testId}>
+			{LOG_LEVELS.map((level) => {
+				const active = level === value;
+				return (
+					<button
+						key={level}
+						type="button"
+						aria-pressed={active}
+						onClick={() => onChange(level)}
+						data-testid={testId ? `${testId}-${level}` : undefined}
+						className={cn(
+							"inline-flex items-center gap-1.5 rounded-[3px] px-2 py-1 font-mono text-[10px] font-semibold tracking-wide uppercase transition-colors",
+							active ? LOG_LEVEL_BADGE_CLASSES[level] : "text-muted-foreground hover:text-foreground",
+						)}
+					>
+						{level}
+						<span className={cn("font-medium tabular-nums", active ? "opacity-75" : "opacity-60")}>{counts[level]}</span>
+					</button>
+				);
+			})}
+		</div>
+	);
+}

--- a/ui/app/workspace/logs/views/pluginLogsView.tsx
+++ b/ui/app/workspace/logs/views/pluginLogsView.tsx
@@ -1,14 +1,11 @@
 import { PluginLogEntry } from "@/lib/types/logs";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { countAtOrAboveEachLevel, LOG_LEVEL_BADGE_CLASSES, meetsMinLogLevel, type LogLevel } from "@/lib/utils/logLevel";
 import { format } from "date-fns";
-import { useState } from "react";
-
-const levelColors: Record<string, string> = {
-	debug: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
-	info: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
-	warn: "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
-	error: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
-};
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useMemo, useState } from "react";
+import LogLevelTabs from "./logLevelTabs";
+import { parsePluginLogs } from "./pluginLogsView.utils";
 
 interface PluginLogsViewProps {
 	pluginLogs: string;
@@ -23,36 +20,38 @@ function formatPluginName(name: string): string {
 }
 
 export default function PluginLogsView({ pluginLogs }: PluginLogsViewProps) {
-	let parsed: Record<string, PluginLogEntry[]>;
-	try {
-		const raw: unknown = JSON.parse(pluginLogs);
-		if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
-		parsed = Object.fromEntries(Object.entries(raw as Record<string, unknown>).filter(([, value]) => Array.isArray(value))) as Record<
-			string,
-			PluginLogEntry[]
-		>;
-	} catch {
-		return null;
-	}
+	const [minLevel, setMinLevel] = useState<LogLevel>("debug");
+	const parsed = useMemo(() => parsePluginLogs(pluginLogs), [pluginLogs]);
+	const counts = useMemo(
+		() => countAtOrAboveEachLevel(parsed ? Object.values(parsed).flatMap((entries) => entries.map((entry) => entry.level)) : []),
+		[parsed],
+	);
 
-	const pluginNames = Object.keys(parsed);
-	if (pluginNames.length === 0) return null;
+	if (!parsed) return null;
 
 	return (
 		<div>
-			<div className="py-3 text-sm font-semibold">Plugin Logs</div>
+			<div className="flex items-center justify-between gap-3 py-3">
+				<div className="text-sm font-semibold">Plugin Logs</div>
+				<LogLevelTabs value={minLevel} onChange={setMinLevel} counts={counts} testId="plugin-logs-level-filter" />
+			</div>
 			<div className="flex flex-col gap-2 pb-3">
-				{pluginNames.map((name) => (
-					<PluginSection key={name} name={name} entries={parsed[name]} />
+				{Object.keys(parsed).map((name) => (
+					<PluginSection key={name} name={name} entries={parsed[name]} minLevel={minLevel} />
 				))}
 			</div>
 		</div>
 	);
 }
 
-function PluginSection({ name, entries }: { name: string; entries: PluginLogEntry[] }) {
+function PluginSection({ name, entries, minLevel }: { name: string; entries: PluginLogEntry[]; minLevel: LogLevel }) {
 	const [isOpen, setIsOpen] = useState(false);
-	const sorted = [...entries].sort((a, b) => a.timestamp - b.timestamp);
+	const visible = useMemo(
+		() => entries.filter((entry) => meetsMinLogLevel(entry.level, minLevel)).sort((a, b) => a.timestamp - b.timestamp),
+		[entries, minLevel],
+	);
+	// At the debug floor nothing is hidden, so the plain total reads better than "N of N".
+	const count = minLevel === "debug" ? `(${entries.length})` : `(${visible.length} of ${entries.length})`;
 
 	return (
 		<div className="rounded-md border">
@@ -67,21 +66,28 @@ function PluginSection({ name, entries }: { name: string; entries: PluginLogEntr
 			>
 				{isOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
 				<span className="font-medium">{formatPluginName(name)}</span>
-				<span className="text-muted-foreground text-xs">({entries.length})</span>
+				<span className="text-muted-foreground text-xs tabular-nums">{count}</span>
 			</button>
 			{isOpen && (
 				<div className="custom-scrollbar max-h-[300px] overflow-y-auto border-t">
-					{sorted.map((entry, idx) => (
-						<div key={idx} className="flex items-start gap-3 border-b px-4 py-1.5 font-mono text-xs last:border-b-0">
-							<span className="text-muted-foreground shrink-0">{format(new Date(entry.timestamp), "HH:mm:ss.SSS")}</span>
-							<span
-								className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase ${levelColors[entry.level] || levelColors.info}`}
-							>
-								{entry.level}
-							</span>
-							<span className="break-words whitespace-pre-wrap">{entry.message}</span>
-						</div>
-					))}
+					{visible.length === 0 ? (
+						<div className="text-muted-foreground px-4 py-2 text-xs">No entries at or above {minLevel}.</div>
+					) : (
+						visible.map((entry, idx) => (
+							<div key={idx} className="flex items-start gap-3 border-b px-4 py-1.5 font-mono text-xs last:border-b-0">
+								<span className="text-muted-foreground shrink-0">{format(new Date(entry.timestamp), "HH:mm:ss.SSS")}</span>
+								<span
+									className={cn(
+										"shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase",
+										LOG_LEVEL_BADGE_CLASSES[entry.level] || LOG_LEVEL_BADGE_CLASSES.info,
+									)}
+								>
+									{entry.level}
+								</span>
+								<span className="break-words whitespace-pre-wrap">{entry.message}</span>
+							</div>
+						))
+					)}
 				</div>
 			)}
 		</div>

--- a/ui/app/workspace/logs/views/pluginLogsView.utils.test.ts
+++ b/ui/app/workspace/logs/views/pluginLogsView.utils.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { parsePluginLogs } from "./pluginLogsView.utils";
+
+const entry = (overrides: Record<string, unknown> = {}) => ({
+	plugin_name: "governance",
+	level: "info",
+	message: "Rate limit window ok",
+	timestamp: 1756881000002,
+	...overrides,
+});
+
+describe("parsePluginLogs", () => {
+	it("groups well-formed entries by plugin name", () => {
+		const parsed = parsePluginLogs(
+			JSON.stringify({ governance: [entry()], telemetry: [entry({ plugin_name: "telemetry", level: "error" })] }),
+		);
+		expect(parsed).not.toBeNull();
+		expect(Object.keys(parsed!)).toEqual(["governance", "telemetry"]);
+		expect(parsed!.governance).toHaveLength(1);
+		expect(parsed!.telemetry[0].level).toBe("error");
+	});
+
+	it("drops null and non-object elements instead of letting them reach the view", () => {
+		const parsed = parsePluginLogs(JSON.stringify({ governance: [null, "oops", 42, entry()] }));
+		expect(parsed!.governance).toEqual([entry()]);
+	});
+
+	it("drops elements missing a field the view reads", () => {
+		const parsed = parsePluginLogs(
+			JSON.stringify({
+				governance: [
+					entry({ level: undefined }),
+					entry({ message: 7 }),
+					entry({ timestamp: "1756881000002" }),
+					entry({ timestamp: Number.NaN }),
+					entry({ message: "kept" }),
+				],
+			}),
+		);
+		expect(parsed!.governance.map((e) => e.message)).toEqual(["kept"]);
+	});
+
+	it("keeps an entry with an unrecognised level string, which the view badges as info", () => {
+		const parsed = parsePluginLogs(JSON.stringify({ governance: [entry({ level: "trace" })] }));
+		expect(parsed!.governance[0].level).toBe("trace");
+	});
+
+	it("drops a plugin whose value is not an array or has no valid entries", () => {
+		const parsed = parsePluginLogs(
+			JSON.stringify({ governance: "not-a-list", cache: [null], telemetry: [entry({ plugin_name: "telemetry" })] }),
+		);
+		expect(Object.keys(parsed!)).toEqual(["telemetry"]);
+	});
+
+	it("stores a plugin named __proto__ as an ordinary group", () => {
+		// Built from a string: an object literal with a __proto__ key would set the prototype, not a property.
+		const parsed = parsePluginLogs(`{"__proto__": [${JSON.stringify(entry({ plugin_name: "__proto__" }))}]}`);
+		expect(parsed).not.toBeNull();
+		expect(Object.keys(parsed!)).toEqual(["__proto__"]);
+		expect(parsed!["__proto__"]).toHaveLength(1);
+		expect(Object.getPrototypeOf(parsed)).toBeNull();
+	});
+
+	it("returns null when nothing renderable remains", () => {
+		expect(parsePluginLogs(JSON.stringify({ governance: [null] }))).toBeNull();
+		expect(parsePluginLogs(JSON.stringify({}))).toBeNull();
+	});
+
+	it("returns null for payloads that are not an object of plugins", () => {
+		expect(parsePluginLogs("not json")).toBeNull();
+		expect(parsePluginLogs("null")).toBeNull();
+		expect(parsePluginLogs(JSON.stringify([entry()]))).toBeNull();
+		expect(parsePluginLogs(JSON.stringify("governance"))).toBeNull();
+	});
+});

--- a/ui/app/workspace/logs/views/pluginLogsView.utils.ts
+++ b/ui/app/workspace/logs/views/pluginLogsView.utils.ts
@@ -1,0 +1,39 @@
+import { PluginLogEntry } from "@/lib/types/logs";
+
+// Keeps only entries carrying every field the view reads, so one malformed element
+// in a stored payload cannot take down the whole detail sheet.
+function isRenderablePluginLogEntry(value: unknown): value is PluginLogEntry {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+	const entry = value as Record<string, unknown>;
+	return (
+		typeof entry.level === "string" &&
+		typeof entry.message === "string" &&
+		typeof entry.timestamp === "number" &&
+		Number.isFinite(entry.timestamp)
+	);
+}
+
+/**
+ * Parses the stored `plugin_logs` JSON (entries grouped by plugin name). Returns null
+ * when the payload is not an object or holds no renderable entries. Plugins whose value
+ * is not an array, and array elements missing a consumed field, are dropped.
+ */
+export function parsePluginLogs(pluginLogs: string): Record<string, PluginLogEntry[]> | null {
+	let raw: unknown;
+	try {
+		raw = JSON.parse(pluginLogs);
+	} catch {
+		return null;
+	}
+	if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+
+	// Prototype-free so a plugin named "__proto__" is stored as a group instead of
+	// rebinding the accumulator's prototype and losing the entries.
+	const parsed: Record<string, PluginLogEntry[]> = Object.create(null);
+	for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
+		if (!Array.isArray(value)) continue;
+		const entries = value.filter(isRenderablePluginLogEntry);
+		if (entries.length > 0) parsed[name] = entries;
+	}
+	return Object.keys(parsed).length > 0 ? parsed : null;
+}

--- a/ui/lib/utils/logLevel.test.ts
+++ b/ui/lib/utils/logLevel.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { countAtOrAboveEachLevel, isLogLevel, meetsMinLogLevel } from "./logLevel";
+
+describe("meetsMinLogLevel", () => {
+	it("treats the chosen level as a floor", () => {
+		expect(meetsMinLogLevel("warn", "warn")).toBe(true);
+		expect(meetsMinLogLevel("error", "warn")).toBe(true);
+		expect(meetsMinLogLevel("info", "warn")).toBe(false);
+		expect(meetsMinLogLevel("debug", "warn")).toBe(false);
+	});
+
+	it("shows everything at the debug floor", () => {
+		for (const level of ["debug", "info", "warn", "error"]) {
+			expect(meetsMinLogLevel(level, "debug")).toBe(true);
+		}
+	});
+
+	it("keeps entries whose level is missing or unrecognised", () => {
+		expect(meetsMinLogLevel(undefined, "error")).toBe(true);
+		expect(meetsMinLogLevel(null, "error")).toBe(true);
+		expect(meetsMinLogLevel("fatal", "error")).toBe(true);
+	});
+});
+
+describe("countAtOrAboveEachLevel", () => {
+	it("counts what each floor would show", () => {
+		expect(countAtOrAboveEachLevel(["debug", "info", "info", "warn", "error"])).toEqual({ debug: 5, info: 4, warn: 2, error: 1 });
+	});
+
+	it("counts an unlevelled entry toward every floor, matching what is rendered", () => {
+		expect(countAtOrAboveEachLevel([null, "error"])).toEqual({ debug: 2, info: 2, warn: 2, error: 2 });
+	});
+
+	it("is all zeros for no entries", () => {
+		expect(countAtOrAboveEachLevel([])).toEqual({ debug: 0, info: 0, warn: 0, error: 0 });
+	});
+});
+
+describe("isLogLevel", () => {
+	it("accepts only the four known levels", () => {
+		expect(isLogLevel("warn")).toBe(true);
+		expect(isLogLevel("WARN")).toBe(false);
+		expect(isLogLevel("")).toBe(false);
+		expect(isLogLevel(3)).toBe(false);
+	});
+});

--- a/ui/lib/utils/logLevel.ts
+++ b/ui/lib/utils/logLevel.ts
@@ -1,0 +1,38 @@
+export const LOG_LEVELS = ["debug", "info", "warn", "error"] as const;
+export type LogLevel = (typeof LOG_LEVELS)[number];
+
+const LOG_LEVEL_RANK: Record<LogLevel, number> = { debug: 0, info: 1, warn: 2, error: 3 };
+
+export function isLogLevel(value: unknown): value is LogLevel {
+	return typeof value === "string" && (LOG_LEVELS as readonly string[]).includes(value);
+}
+
+/**
+ * Whether an entry at `level` is shown when the filter floor is `min`. The floor
+ * keeps its own level and everything more severe, so `debug` shows every entry.
+ * An entry with an unrecognised level is kept: hiding it would make a malformed
+ * entry look like nothing was logged.
+ */
+export function meetsMinLogLevel(level: string | null | undefined, min: LogLevel): boolean {
+	if (!isLogLevel(level)) return true;
+	return LOG_LEVEL_RANK[level] >= LOG_LEVEL_RANK[min];
+}
+
+/** How many of `levels` each floor would show, keyed by that floor. Feeds the counts on the level tabs. */
+export function countAtOrAboveEachLevel(levels: Iterable<string | null | undefined>): Record<LogLevel, number> {
+	const counts: Record<LogLevel, number> = { debug: 0, info: 0, warn: 0, error: 0 };
+	for (const level of levels) {
+		for (const min of LOG_LEVELS) {
+			if (meetsMinLogLevel(level, min)) counts[min] += 1;
+		}
+	}
+	return counts;
+}
+
+/** Badge palette shared by every place a level is rendered next to a log line. */
+export const LOG_LEVEL_BADGE_CLASSES: Record<LogLevel, string> = {
+	debug: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+	info: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+	warn: "bg-amber-100 text-amber-700 dark:bg-amber-900 dark:text-amber-300",
+	error: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+};


### PR DESCRIPTION
## Summary

Routing decision logs and plugin logs now include a severity level on every line, and the log detail view exposes a segmented level filter so users can narrow the visible entries by minimum severity (debug / info / warn / error).

## Changes

- The Go `formatRoutingEngineLogs` function now writes `[timestamp] [engine] [level] - message` instead of `[timestamp] [engine] - message`. Entries recorded without a level default to `info` so every line keeps the same shape.
- A shared `logLevel.ts` utility module was introduced with the `LogLevel` type, `LOG_LEVELS` constant, `isLogLevel` type guard, `meetsMinLogLevel` filter predicate, `countAtOrAboveEachLevel` counter, and `LOG_LEVEL_BADGE_CLASSES` palette. This replaces the inline `levelColors` map that previously lived only in `pluginLogsView.tsx`.
- `parseRoutingDecisionLine` was extracted from the inline regex in `RoutingDecisionLogs` into `logDetailView.utils.ts`. It handles both the new four-token format and legacy three-token lines (null level), and treats unrecognised level tokens as null rather than silently misclassifying them.
- A `LogLevelTabs` component was added. It renders a segmented button group where each tab shows the level name and the count of entries that would be visible at that floor. The active tab borrows the level's badge colors for visual consistency with the row badges.
- `RoutingDecisionLogs` and `PluginLogsView` both adopt `LogLevelTabs` and `meetsMinLogLevel` to filter their visible rows. `PluginSection` shows a "N of N" count when a filter is active and an empty-state message when no entries pass the floor.
- Tests were added for `formatRoutingEngineLogs` (Go), `parseRoutingDecisionLine`, `meetsMinLogLevel`, `countAtOrAboveEachLevel`, and `isLogLevel`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Plugins (Go)
go test ./plugins/logging/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Open a log detail view for a request that has routing decision logs or plugin logs. Confirm:
1. Each routing log line now shows a level badge between the engine badge and the message.
2. The level filter tabs appear above both the routing logs panel and the plugin logs panel.
3. Selecting `warn` hides `debug` and `info` entries and updates the visible count.
4. Legacy routing log lines stored without a level still render without a level badge and are not hidden by any filter floor.

## Screenshots/Recordings

_Add before/after screenshots of the routing decision logs panel and plugin logs panel showing the new level filter tabs and level badges._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. Log content is already visible to authenticated users in the detail view.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable