### PR TITLE
fix: initialize new model budgets with empty array instead of default budget entry

### DIFF
--- a/ui/components/ui/providerConfigCard.tsx
+++ b/ui/components/ui/providerConfigCard.tsx
@@ -493,7 +493,7 @@ export function ProviderConfigCard({
 												if (!model) return;
 												if (modelBudgets.some((m) => m.model_name === model)) return;
 												update({
-													modelBudgets: [...modelBudgets, { model_name: model, budgets: [{ max_limit: undefined, reset_duration: "1d" }] }],
+													modelBudgets: [...modelBudgets, { model_name: model, budgets: [] }],
 												});
 												setOpenModelEditor(model);
 											}}


### PR DESCRIPTION
## Summary

When adding a new model budget, the initial budget entry was being pre-populated with a default `max_limit: undefined` and `reset_duration: "1d"`. This caused the model editor to open with a partially-formed budget that may not reflect the user's intent. Instead, models should be added with an empty budgets array, letting the user define their own budget constraints from scratch.

## Changes

- New model budgets are now initialized with an empty `budgets: []` array instead of a pre-populated default budget entry, allowing users to configure budgets explicitly via the model editor.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to a provider configuration card in the UI.
2. Add a new model budget by selecting a model.
3. Verify the model editor opens with no pre-populated budget entries.
4. Add a budget manually and confirm it saves correctly.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: Model editor opens with a default budget row (`max_limit: undefined`, `reset_duration: "1d"`).  
After: Model editor opens with an empty budget list, prompting the user to add entries explicitly.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable