### PR TITLE
refactor: remove `counts` prop and `countAtOrAboveEachLevel` from `LogLevelTabs`, routing logs, and plugin logs

### DIFF
--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -44,7 +44,7 @@ import {
 import { useGetProvidersQuery, useGetUserAgentMappingsQuery } from "@/lib/store";
 import { BatchRequestCounts, ContentBlock, LogEntry, OverheadBucket, ResponsesMessage } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { countAtOrAboveEachLevel, LOG_LEVEL_BADGE_CLASSES, meetsMinLogLevel, type LogLevel } from "@/lib/utils/logLevel";
+import { LOG_LEVEL_BADGE_CLASSES, meetsMinLogLevel, type LogLevel } from "@/lib/utils/logLevel";
 import { downloadAsJson } from "@/lib/utils/browser-download";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { applyRedactionMapping, applyRedactionMappingToValue, hasRedactionMappingEntries } from "@/lib/utils/redaction";
@@ -848,7 +848,6 @@ function RoutingDecisionLogs({ logs }: { logs: string }) {
 	);
 	// Rows written before the level was recorded carry none, so there is nothing to filter on.
 	const hasLevels = lines.some((line) => line.level !== null);
-	const counts = useMemo(() => countAtOrAboveEachLevel(lines.map((line) => line.level)), [lines]);
 	const visible = hasLevels ? lines.filter((line) => meetsMinLogLevel(line.level, minLevel)) : lines;
 
 	return (
@@ -856,7 +855,7 @@ function RoutingDecisionLogs({ logs }: { logs: string }) {
 			<div className="flex items-center justify-between gap-3 border-b py-2 pl-6">
 				<div className="text-sm font-medium">Routing Decision Logs</div>
 				<div className="flex items-center gap-1">
-					{hasLevels && <LogLevelTabs value={minLevel} onChange={setMinLevel} counts={counts} testId="routing-logs-level-filter" />}
+					{hasLevels && <LogLevelTabs value={minLevel} onChange={setMinLevel} testId="routing-logs-level-filter" />}
 					<button
 						type="button"
 						onClick={() => copy(logs)}

--- a/ui/app/workspace/logs/views/logLevelTabs.tsx
+++ b/ui/app/workspace/logs/views/logLevelTabs.tsx
@@ -4,8 +4,6 @@ import { LOG_LEVEL_BADGE_CLASSES, LOG_LEVELS, type LogLevel } from "@/lib/utils/
 interface LogLevelTabsProps {
 	value: LogLevel;
 	onChange: (level: LogLevel) => void;
-	/** How many entries each level would show when selected, keyed by level. */
-	counts: Record<LogLevel, number>;
 	testId?: string;
 }
 
@@ -14,7 +12,7 @@ interface LogLevelTabsProps {
  * and everything more severe, so debug shows all entries. The active tab borrows the
  * level's badge colors so it reads the same as the badges on the rows it filters.
  */
-export default function LogLevelTabs({ value, onChange, counts, testId }: LogLevelTabsProps) {
+export default function LogLevelTabs({ value, onChange, testId }: LogLevelTabsProps) {
 	return (
 		<div role="group" aria-label="Minimum log level" className="bg-muted/60 inline-flex gap-0.5 rounded-sm p-0.5" data-testid={testId}>
 			{LOG_LEVELS.map((level) => {
@@ -27,12 +25,11 @@ export default function LogLevelTabs({ value, onChange, counts, testId }: LogLev
 						onClick={() => onChange(level)}
 						data-testid={testId ? `${testId}-${level}` : undefined}
 						className={cn(
-							"inline-flex items-center gap-1.5 rounded-[3px] px-2 py-1 font-mono text-[10px] font-semibold tracking-wide uppercase transition-colors",
+							"inline-flex items-center rounded-[3px] px-2 py-1 font-mono text-[10px] font-semibold tracking-wide uppercase transition-colors",
 							active ? LOG_LEVEL_BADGE_CLASSES[level] : "text-muted-foreground hover:text-foreground",
 						)}
 					>
 						{level}
-						<span className={cn("font-medium tabular-nums", active ? "opacity-75" : "opacity-60")}>{counts[level]}</span>
 					</button>
 				);
 			})}

--- a/ui/app/workspace/logs/views/pluginLogsView.tsx
+++ b/ui/app/workspace/logs/views/pluginLogsView.tsx
@@ -1,6 +1,6 @@
 import { PluginLogEntry } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
-import { countAtOrAboveEachLevel, LOG_LEVEL_BADGE_CLASSES, meetsMinLogLevel, type LogLevel } from "@/lib/utils/logLevel";
+import { LOG_LEVEL_BADGE_CLASSES, meetsMinLogLevel, type LogLevel } from "@/lib/utils/logLevel";
 import { format } from "date-fns";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -22,10 +22,6 @@ function formatPluginName(name: string): string {
 export default function PluginLogsView({ pluginLogs }: PluginLogsViewProps) {
 	const [minLevel, setMinLevel] = useState<LogLevel>("debug");
 	const parsed = useMemo(() => parsePluginLogs(pluginLogs), [pluginLogs]);
-	const counts = useMemo(
-		() => countAtOrAboveEachLevel(parsed ? Object.values(parsed).flatMap((entries) => entries.map((entry) => entry.level)) : []),
-		[parsed],
-	);
 
 	if (!parsed) return null;
 
@@ -33,7 +29,7 @@ export default function PluginLogsView({ pluginLogs }: PluginLogsViewProps) {
 		<div>
 			<div className="flex items-center justify-between gap-3 py-3">
 				<div className="text-sm font-semibold">Plugin Logs</div>
-				<LogLevelTabs value={minLevel} onChange={setMinLevel} counts={counts} testId="plugin-logs-level-filter" />
+				<LogLevelTabs value={minLevel} onChange={setMinLevel} testId="plugin-logs-level-filter" />
 			</div>
 			<div className="flex flex-col gap-2 pb-3">
 				{Object.keys(parsed).map((name) => (

--- a/ui/lib/utils/logLevel.test.ts
+++ b/ui/lib/utils/logLevel.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { countAtOrAboveEachLevel, isLogLevel, meetsMinLogLevel } from "./logLevel";
+import { isLogLevel, meetsMinLogLevel } from "./logLevel";
 
 describe("meetsMinLogLevel", () => {
 	it("treats the chosen level as a floor", () => {
@@ -19,20 +19,6 @@ describe("meetsMinLogLevel", () => {
 		expect(meetsMinLogLevel(undefined, "error")).toBe(true);
 		expect(meetsMinLogLevel(null, "error")).toBe(true);
 		expect(meetsMinLogLevel("fatal", "error")).toBe(true);
-	});
-});
-
-describe("countAtOrAboveEachLevel", () => {
-	it("counts what each floor would show", () => {
-		expect(countAtOrAboveEachLevel(["debug", "info", "info", "warn", "error"])).toEqual({ debug: 5, info: 4, warn: 2, error: 1 });
-	});
-
-	it("counts an unlevelled entry toward every floor, matching what is rendered", () => {
-		expect(countAtOrAboveEachLevel([null, "error"])).toEqual({ debug: 2, info: 2, warn: 2, error: 2 });
-	});
-
-	it("is all zeros for no entries", () => {
-		expect(countAtOrAboveEachLevel([])).toEqual({ debug: 0, info: 0, warn: 0, error: 0 });
 	});
 });
 

--- a/ui/lib/utils/logLevel.ts
+++ b/ui/lib/utils/logLevel.ts
@@ -18,17 +18,6 @@ export function meetsMinLogLevel(level: string | null | undefined, min: LogLevel
 	return LOG_LEVEL_RANK[level] >= LOG_LEVEL_RANK[min];
 }
 
-/** How many of `levels` each floor would show, keyed by that floor. Feeds the counts on the level tabs. */
-export function countAtOrAboveEachLevel(levels: Iterable<string | null | undefined>): Record<LogLevel, number> {
-	const counts: Record<LogLevel, number> = { debug: 0, info: 0, warn: 0, error: 0 };
-	for (const level of levels) {
-		for (const min of LOG_LEVELS) {
-			if (meetsMinLogLevel(level, min)) counts[min] += 1;
-		}
-	}
-	return counts;
-}
-
 /** Badge palette shared by every place a level is rendered next to a log line. */
 export const LOG_LEVEL_BADGE_CLASSES: Record<LogLevel, string> = {
 	debug: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",


### PR DESCRIPTION
## Summary

Removes the per-level entry counts from the `LogLevelTabs` component. Previously, each tab displayed a number indicating how many log entries would be visible at that minimum level. This removes that display and the supporting logic.

## Changes

- Removed the `counts` prop from `LogLevelTabs` and the count badge rendered inside each tab button
- Removed the `countAtOrAboveEachLevel` utility function from `logLevel.ts` and its associated tests
- Removed the `useMemo` calls in `PluginLogsView` and `RoutingDecisionLogs` that computed counts to pass to the tabs
- Adjusted the tab button's flex layout class since the count `<span>` is no longer present

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

Open a log entry that has routing decision logs or plugin logs with multiple log levels present. Verify the level filter tabs render correctly without counts and that filtering by level still works as expected.

## Screenshots/Recordings

Before: Each tab (DEBUG, INFO, WARN, ERROR) displayed a numeric count of entries visible at that level.

After: Tabs display only the level label with no count.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable