### PR TITLE
[feat]: otel plugin - message_format option with OTel GenAI semconv parts; export Responses instructions

### DIFF
--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -46,6 +46,7 @@ The plugin supports multiple trace formats to match your observability platform:
 | `group_traces_by_session` | `boolean` | ❌ No | Group requests sharing the same `x-bf-session-id` into one trace (default: `false`). See [Grouping Traces by Session](#grouping-traces-by-session) |
 | `disable_content_logging` | `boolean` | ❌ No | Drop message content from exported spans (default: `false`). See [Controlling Exported Content](#controlling-exported-content) |
 | `disable_root_span_content` | `boolean` | ❌ No | Drop content from the **root span only**, keeping it on child spans (default: `false`). Overridden by `disable_content_logging`, which drops content from every span. See [Controlling Exported Content](#controlling-exported-content) |
+| `message_format` | `string` | ❌ No | Shape of `gen_ai.input.messages` / `gen_ai.output.messages`: `flat` (default) or `parts` (OTel GenAI semantic conventions). See [Message Format](#message-format) |
 | `request_headers` | `string[]` | ❌ No | Request-header name patterns whose values are attached to the root span as `http.request.header.*` attributes. Supports exact names and wildcards (`x-custom-*`, `*`) |
 
 ### Environment Variable Substitution
@@ -780,6 +781,50 @@ Each trace includes comprehensive LLM operation metadata following OpenTelemetry
 - Tool calls and results
 
 When Enterprise guardrail redaction is enabled, Bifrost applies trace redaction replacements before exporting completed traces to OTel. Exported span content receives the redacted or placeholderized value, but reversible reveal mappings are not exported. For the full mode matrix, see [Guardrail Redaction](/enterprise/guardrails/redaction).
+
+### Message Format
+
+`gen_ai.input.messages` and `gen_ai.output.messages` are JSON strings. The per-profile `message_format` option selects their shape:
+
+| Value | Shape | When to use |
+|-------|-------|-------------|
+| `flat` (default) | One object per message: `role`, a plain `content` string, plus `tool_calls`, `tool_call_id` and `reasoning` when present. | Existing dashboards and backends that already parse Bifrost's shape (Langfuse, Datadog, custom collectors). |
+| `parts` | The [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai) shape: one object per message with `role` and a `parts` array of typed parts — `text`, `reasoning`, `tool_call` (`id`, `name`, structured `arguments`) and `tool_call_response` (`id`, `response`). Instructions (`gen_ai.request.instructions`, set for Responses API and speech requests) are additionally mirrored as `gen_ai.system_instructions`, a one-part text array. | Backends that validate messages against the spec and otherwise leave them unmapped — Braintrust, for example, only fills its native input/output fields from spec-shaped messages. |
+
+```json
+{
+  "name": "otel",
+  "config": {
+    "profiles": [
+      {
+        "service_name": "bifrost",
+        "collector_url": "https://api.braintrust.dev/otel/v1/traces",
+        "trace_type": "genai_extension",
+        "message_format": "parts",
+        "trace_headers": {
+          "Authorization": "env.BRAINTRUST_AUTHORIZATION",
+          "x-bt-parent": "env.BRAINTRUST_PARENT"
+        }
+      }
+    ]
+  }
+}
+```
+
+With `parts`, the same exchange is exported as:
+
+```json
+[
+  { "role": "user", "parts": [{ "type": "text", "content": "Weather in Paris?" }] },
+  { "role": "assistant", "parts": [
+      { "type": "reasoning", "content": "need a lookup" },
+      { "type": "tool_call", "id": "call_1", "name": "get_weather", "arguments": { "city": "Paris" } }
+  ] },
+  { "role": "tool", "parts": [{ "type": "tool_call_response", "id": "call_1", "response": "18C, cloudy" }] }
+]
+```
+
+The option is per profile, so one profile can keep `flat` for a backend that depends on it while another emits `parts`. The root span's trace-level input/output excerpt, which is plain text, is wrapped as a single text part. Content dropped by `disable_content_logging` or `disable_root_span_content` is not exported in either format.
 
 ### Controlling Exported Content
 

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,3 +1,5 @@
+[fix]: export Responses API `instructions` as `gen_ai.request.instructions` on tracing spans [@markdawson](https://github.com/markdawson)
+
 ## ✨ Features
 
 - **Virtual Key Rotation Grace Period** - New rotation-state columns on `governance_virtual_keys` (`previous_value`, `previous_value_hash`, `previous_value_expires_at`, `rotated_at`) with encryption support, plus a `vk_rotation_cooldown` client config setting (duration string, default 0 = immediate flip) controlling how long a rotated-out key value keeps authenticating.

--- a/framework/tracing/llmspan.go
+++ b/framework/tracing/llmspan.go
@@ -711,6 +711,14 @@ func PopulateResponsesRequestAttributes(req *schemas.BifrostResponsesRequest, at
 		}
 	}
 
+	// Instructions are the Responses API's system prompt. They never appear in Input, so
+	// without this a collector sees only the user turn and cannot tell which rubric or
+	// persona produced the output. AttrInstructions is already classified as input content,
+	// so disable_content_logging and redaction cover it.
+	if req.Params.Instructions != nil && *req.Params.Instructions != "" {
+		attrs[schemas.AttrInstructions] = *req.Params.Instructions
+	}
+
 	if req.Params.ParallelToolCalls != nil {
 		attrs[schemas.AttrParallelToolCall] = *req.Params.ParallelToolCalls
 	}

--- a/framework/tracing/llmspan_test.go
+++ b/framework/tracing/llmspan_test.go
@@ -335,3 +335,27 @@ func TestErrorAttributesOverrideAccumulatedResponseTokens(t *testing.T) {
 		t.Errorf("%s = %v, want 4224 from BilledUsage", schemas.AttrTotalTokens, got)
 	}
 }
+
+func TestPopulateResponsesRequestAttributesExportsInstructions(t *testing.T) {
+	instructions := "Code every brand mention in the answer."
+	attrs := map[string]any{}
+
+	PopulateResponsesRequestAttributes(&schemas.BifrostResponsesRequest{
+		Params: &schemas.ResponsesParameters{Instructions: &instructions},
+	}, attrs)
+
+	if got := attrs[schemas.AttrInstructions]; got != instructions {
+		t.Fatalf("instructions attribute = %v, want %q", got, instructions)
+	}
+
+	// Absent or empty instructions must not produce the attribute at all.
+	for _, in := range []*string{nil, new(string)} {
+		attrs = map[string]any{}
+		PopulateResponsesRequestAttributes(&schemas.BifrostResponsesRequest{
+			Params: &schemas.ResponsesParameters{Instructions: in},
+		}, attrs)
+		if _, ok := attrs[schemas.AttrInstructions]; ok {
+			t.Fatalf("instructions attribute set for %v, want absent", in)
+		}
+	}
+}

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1544,6 +1544,9 @@ false
 {{- if hasKey $inputConfig "disable_root_span_content" }}
 {{- $_ := set $otelConfig "disable_root_span_content" $inputConfig.disable_root_span_content }}
 {{- end }}
+{{- if hasKey $inputConfig "message_format" }}
+{{- $_ := set $otelConfig "message_format" $inputConfig.message_format }}
+{{- end }}
 {{- if hasKey $inputConfig "request_headers" }}
 {{- $_ := set $otelConfig "request_headers" $inputConfig.request_headers }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5342,6 +5342,12 @@
           "description": "When true, input/output message content is dropped from the root span only; the underlying generation (llm.call) span retains the full content. This removes the duplicate input/output stored at the trace level (e.g. the Langfuse trace Input/Output goes empty) to reduce downstream storage.",
           "default": false
         },
+        "message_format": {
+          "type": "string",
+          "enum": ["flat", "parts"],
+          "description": "Shape of gen_ai.input.messages / gen_ai.output.messages: flat (default) keeps Bifrost's role+content objects; parts emits the OpenTelemetry GenAI semantic-conventions shape (role + typed parts: text, tool_call, tool_call_response, reasoning) and mirrors gen_ai.request.instructions as gen_ai.system_instructions; use it for backends that only map spec-shaped messages into their native input/output fields (e.g. Braintrust).",
+          "default": "flat"
+        },
         "request_headers": {
           "type": "array",
           "items": {
@@ -5496,6 +5502,11 @@
         "disable_root_span_content": {
           "type": "boolean",
           "description": "Deprecated in the profiles wrapper; configure disable_root_span_content per profile instead."
+        },
+        "message_format": {
+          "type": "string",
+          "enum": ["flat", "parts"],
+          "description": "Deprecated in the profiles wrapper; configure message_format per profile instead."
         },
         "request_headers": {
           "type": "array",

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -639,6 +639,7 @@ bifrost:
         #     disable_content_logging: false
         #     group_traces_by_session: false # Group requests sharing x-bf-session-id into one trace (traceparent takes precedence)
         #     disable_root_span_content: false # Drop input/output from the root span only (keeps it on the llm.call span)
+        #     message_format: flat    # "flat" (role+content) or "parts" (OTel GenAI semconv shape; needed by e.g. Braintrust)
         #     request_headers: []     # Header name patterns (exact or wildcard like "x-custom-*") captured as span attributes; "*" includes sensitive headers like Authorization
         #
         # Single-profile shape:
@@ -671,6 +672,9 @@ bifrost:
         group_traces_by_session: false
         # Drop input/output content from the root span only (the llm.call generation span keeps it)
         disable_root_span_content: false
+        # Shape of gen_ai.input.messages / gen_ai.output.messages: "flat" (role+content, default) or
+        # "parts" (OTel GenAI semantic-conventions shape, required by backends such as Braintrust)
+        message_format: flat
         # Request header name patterns (exact or wildcard like "x-custom-*") captured and emitted as span attributes.
         # Note: "*" captures all headers including sensitive ones like Authorization.
         # request_headers: []

--- a/plugins/otel/changelog.md
+++ b/plugins/otel/changelog.md
@@ -1,0 +1,1 @@
+[feat]: add per-profile `message_format` (`flat` | `parts`); `parts` emits OTel GenAI semconv message parts and mirrors instructions as `gen_ai.system_instructions` [@markdawson](https://github.com/markdawson)

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -96,7 +96,7 @@ func hexToBytes(hexStr string, length int) []byte {
 // convertTraceToResourceSpan converts a Bifrost trace to OTEL ResourceSpan for the given
 // profile service name. Span filtering and instance attributes are shared across profiles;
 // only the resource service name differs per profile.
-func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace, requestHeaders []string, disableContentLogging bool, groupTracesBySession bool, disableRootSpanContent bool) *ResourceSpan {
+func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace, requestHeaders []string, disableContentLogging bool, groupTracesBySession bool, disableRootSpanContent bool, messageFormat MessageFormat) *ResourceSpan {
 	reparent := p.pluginSpanFilter.BuildReparentMap(trace.Spans)
 	filteredHeaders := schemas.FilterHeaders(trace.RequestHeaders, requestHeaders)
 
@@ -126,7 +126,7 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 		// disableRootSpanContent drops content from the root span only (the framework duplicates
 		// input/output onto it for trace-level display); child spans keep their full content.
 		spanDisableContent := disableContentLogging || (disableRootSpanContent && span == trace.RootSpan)
-		otelSpan := convertSpanToOTELSpan(traceID, span, spanDisableContent)
+		otelSpan := convertSpanToOTELSpan(traceID, span, spanDisableContent, messageFormat)
 		// If the span's direct parent was filtered, rewrite its parent ID to the
 		// nearest exported ancestor so the hierarchy stays connected.
 		if effectiveParent, ok := reparent[span.ParentID]; ok {
@@ -169,8 +169,14 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 	}
 }
 
-// convertSpanToOTELSpan converts a single Bifrost span to OTEL format
-func convertSpanToOTELSpan(traceID string, span *schemas.Span, disableContentLogging bool) *Span {
+// convertSpanToOTELSpan converts a single Bifrost span to OTEL format. Content attributes
+// are dropped first when disableContentLogging is set, so the message-format rewrite only
+// ever sees content that is allowed to leave.
+func convertSpanToOTELSpan(traceID string, span *schemas.Span, disableContentLogging bool, messageFormat MessageFormat) *Span {
+	attrs := convertAttributesToKeyValues(span.Attributes, disableContentLogging)
+	if messageFormat == MessageFormatParts {
+		attrs = applyPartsMessageFormat(attrs)
+	}
 	otelSpan := &Span{
 		TraceId:           hexToBytes(traceID, 16),
 		SpanId:            hexToBytes(span.SpanID, 8),
@@ -178,7 +184,7 @@ func convertSpanToOTELSpan(traceID string, span *schemas.Span, disableContentLog
 		Kind:              convertSpanKind(span.Kind),
 		StartTimeUnixNano: uint64(span.StartTime.UnixNano()),
 		EndTimeUnixNano:   uint64(span.EndTime.UnixNano()),
-		Attributes:        convertAttributesToKeyValues(span.Attributes, disableContentLogging),
+		Attributes:        attrs,
 		Status:            convertSpanStatus(span.Status, span.StatusMsg),
 		Events:            convertSpanEvents(span.Events, disableContentLogging),
 	}

--- a/plugins/otel/converter_test.go
+++ b/plugins/otel/converter_test.go
@@ -42,7 +42,7 @@ func TestConvertTraceToResourceSpan_PluginSpanFilter(t *testing.T) {
 		},
 	}
 
-	rs := p.convertTraceToResourceSpan("svc", trace, nil, false, false, false)
+	rs := p.convertTraceToResourceSpan("svc", trace, nil, false, false, false, MessageFormatFlat)
 	spans := rs.ScopeSpans[0].Spans
 
 	// The filtered logging span is dropped; root + governance remain.
@@ -103,13 +103,13 @@ func TestConvertTraceToResourceSpan_DisableRootSpanContent(t *testing.T) {
 	}
 
 	// Flag off: root keeps its content (current default behavior).
-	off := p.convertTraceToResourceSpan("svc", makeContentTrace(), nil, false, false, false)
+	off := p.convertTraceToResourceSpan("svc", makeContentTrace(), nil, false, false, false, MessageFormatFlat)
 	if root := findRoot(off.ScopeSpans[0].Spans); attrString(root, schemas.AttrInputMessages) == "" {
 		t.Error("with flag off, root span should retain input content")
 	}
 
 	// Flag on: root content dropped, request model retained, child content untouched.
-	on := p.convertTraceToResourceSpan("svc", makeContentTrace(), nil, false, false, true)
+	on := p.convertTraceToResourceSpan("svc", makeContentTrace(), nil, false, false, true, MessageFormatFlat)
 	root := findRoot(on.ScopeSpans[0].Spans)
 	if got := attrString(root, schemas.AttrInputMessages); got != "" {
 		t.Errorf("root input content = %q, want empty when disableRootSpanContent is set", got)
@@ -198,7 +198,7 @@ func TestSessionGroupingOverridesTraceID(t *testing.T) {
 	wantParent := hexToBytes(sessionParentSpanID(sess), 8)
 
 	for _, original := range []string{"00000000000000000000000000000001", "00000000000000000000000000000002"} {
-		rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, sess, ""), nil, false, true, false)
+		rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, sess, ""), nil, false, true, false, MessageFormatFlat)
 		spans := rs.ScopeSpans[0].Spans
 		if len(spans) != 2 {
 			t.Fatalf("expected 2 spans, got %d", len(spans))
@@ -228,7 +228,7 @@ func TestSessionGroupingTraceparentWins(t *testing.T) {
 	p := &OtelPlugin{}
 	const original = "0123456789abcdef0123456789abcdef"
 	const inboundParent = "fedcba9876543210"
-	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "user-42", inboundParent), nil, false, true, false)
+	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "user-42", inboundParent), nil, false, true, false, MessageFormatFlat)
 	spans := rs.ScopeSpans[0].Spans
 
 	wantTrace := hexToBytes(original, 16)
@@ -255,7 +255,7 @@ func TestSessionGroupingTraceparentWins(t *testing.T) {
 func TestSessionGroupingDisabled(t *testing.T) {
 	p := &OtelPlugin{}
 	const original = "00000000000000000000000000000009"
-	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "user-42", ""), nil, false, false, false)
+	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "user-42", ""), nil, false, false, false, MessageFormatFlat)
 	spans := rs.ScopeSpans[0].Spans
 
 	wantTrace := hexToBytes(original, 16)
@@ -281,7 +281,7 @@ func TestSessionGroupingDisabled(t *testing.T) {
 func TestNoSessionIDNoTag(t *testing.T) {
 	p := &OtelPlugin{}
 	const original = "0000000000000000000000000000000a"
-	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "", ""), nil, false, true, false)
+	rs := p.convertTraceToResourceSpan("svc", makeSessionTrace(original, "", ""), nil, false, true, false, MessageFormatFlat)
 	root := findRoot(rs.ScopeSpans[0].Spans)
 	if root == nil {
 		t.Fatal("root span not found")

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -36,6 +36,32 @@ type TraceType string
 // TraceTypeGenAIExtension is the type of trace to use for the OTEL collector
 const TraceTypeGenAIExtension TraceType = "genai_extension"
 
+// MessageFormat selects the JSON shape of the gen_ai.input.messages and
+// gen_ai.output.messages span attributes.
+type MessageFormat string
+
+const (
+	// MessageFormatFlat is Bifrost's original shape: one object per message carrying a
+	// plain "content" string plus optional tool_calls, tool_call_id and reasoning fields.
+	// The default, so existing collectors and dashboards keep working unchanged.
+	MessageFormatFlat MessageFormat = "flat"
+	// MessageFormatParts is the OpenTelemetry GenAI semantic-conventions shape: one object
+	// per message with a "parts" array of typed parts (text, tool_call, tool_call_response,
+	// reasoning). Backends that validate messages against the spec, Braintrust for one,
+	// only map them into their native input/output fields when they have this shape.
+	MessageFormatParts MessageFormat = "parts"
+)
+
+// validMessageFormat reports whether f is a supported MessageFormat; the empty string
+// means "not configured" and resolves to MessageFormatFlat.
+func validMessageFormat(f MessageFormat) bool {
+	switch f {
+	case "", MessageFormatFlat, MessageFormatParts:
+		return true
+	}
+	return false
+}
+
 // Protocol is the protocol to use for the OTEL collector
 type Protocol string
 
@@ -101,6 +127,12 @@ type Profile struct {
 	Protocol       Protocol           `json:"protocol"`
 	TLSCACert      string             `json:"tls_ca_cert,omitempty"`
 	Insecure       bool               `json:"insecure"` // Skip TLS when true; ignored if TLSCACert is set. Defaults to true when omitted.
+
+	// MessageFormat selects the shape of gen_ai.input.messages / gen_ai.output.messages:
+	// "flat" (default) keeps Bifrost's role+content objects; "parts" emits the OTel GenAI
+	// semantic-conventions shape (role + typed parts) and additionally mirrors
+	// gen_ai.request.instructions as gen_ai.system_instructions. See MessageFormat.
+	MessageFormat MessageFormat `json:"message_format,omitempty"`
 
 	// ExportTimeout bounds a single trace export, in seconds (default 5, max 60).
 	// This is the only deadline on the export: the caller passes context.Background(),
@@ -259,6 +291,7 @@ type profileForStorage struct {
 	TraceHeaders           map[string]string `json:"trace_headers,omitempty"`
 	MetricsHeaders         map[string]string `json:"metrics_headers,omitempty"`
 	TraceType              TraceType         `json:"trace_type"`
+	MessageFormat          MessageFormat     `json:"message_format,omitempty"`
 	Protocol               Protocol          `json:"protocol"`
 	TLSCACert              string            `json:"tls_ca_cert,omitempty"`
 	Insecure               bool              `json:"insecure"`
@@ -300,6 +333,7 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			TraceHeaders:           p.TraceHeaders,
 			MetricsHeaders:         p.MetricsHeaders,
 			TraceType:              p.TraceType,
+			MessageFormat:          p.MessageFormat,
 			Protocol:               p.Protocol,
 			TLSCACert:              p.TLSCACert,
 			Insecure:               p.Insecure,
@@ -386,6 +420,7 @@ type otelTarget struct {
 	serviceName            string
 	url                    string
 	traceType              TraceType
+	messageFormat          MessageFormat
 	client                 OtelClient
 	metricsExporter        *MetricsExporter
 	requestHeaders         []string
@@ -577,10 +612,14 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 	if err != nil {
 		return nil, fmt.Errorf("profile %d: %w", index, err)
 	}
+	if !validMessageFormat(profile.MessageFormat) {
+		return nil, fmt.Errorf("profile %d: message_format must be %q or %q, got %q", index, MessageFormatFlat, MessageFormatParts, profile.MessageFormat)
+	}
 
 	target := &otelTarget{
 		serviceName:            serviceName,
 		traceType:              profile.TraceType,
+		messageFormat:          profile.MessageFormat,
 		requestHeaders:         slices.Clone(profile.RequestHeaders),
 		disableContentLogging:  profile.DisableContentLogging,
 		groupTracesBySession:   profile.GroupTracesBySession,
@@ -846,7 +885,7 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 			if t.client == nil || t.breakerOpen() {
 				return
 			}
-			resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging, t.groupTracesBySession, t.disableRootSpanContent)
+			resourceSpan := p.convertTraceToResourceSpan(t.serviceName, trace, t.requestHeaders, t.disableContentLogging, t.groupTracesBySession, t.disableRootSpanContent, t.messageFormat)
 			// The caller passes context.Background(), so this deadline is the only bound
 			// on the export — and the only bound at all on the gRPC path.
 			emitCtx, cancel := context.WithTimeout(ctx, t.exportTimeout)

--- a/plugins/otel/mapping_test.go
+++ b/plugins/otel/mapping_test.go
@@ -247,7 +247,7 @@ func TestConvertTraceRequestHeaderFiltering(t *testing.T) {
 		},
 	}
 
-	rs := p.convertTraceToResourceSpan("svc", trace, []string{"x-tenant-id"}, false, false, false)
+	rs := p.convertTraceToResourceSpan("svc", trace, []string{"x-tenant-id"}, false, false, false, MessageFormatFlat)
 	spans := rs.ScopeSpans[0].Spans
 
 	rootOut := findRoot(spans)
@@ -389,7 +389,7 @@ func TestConvertTraceContentFidelity(t *testing.T) {
 	}
 
 	// Content logging enabled (disableContentLogging=false, disableRootSpanContent=false).
-	rs := p.convertTraceToResourceSpan("svc", trace, nil, false, false, false)
+	rs := p.convertTraceToResourceSpan("svc", trace, nil, false, false, false, MessageFormatFlat)
 
 	// Find the fixture's llm.call span by its span ID, not by kind/position — other span
 	// kinds (MCP tool/client, embedding, speech, transcription) also map to CLIENT, so a

--- a/plugins/otel/semconv.go
+++ b/plugins/otel/semconv.go
@@ -1,0 +1,166 @@
+package otel
+
+import (
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// AttrSystemInstructions is the OTel GenAI semantic-conventions attribute for the system
+// prompt: a JSON array of parts. Bifrost records instructions as the plain string
+// gen_ai.request.instructions; the parts message format mirrors it here so spec-following
+// backends can display it alongside the input messages.
+const AttrSystemInstructions = "gen_ai.system_instructions"
+
+// flatMessage is the union of the message shapes the framework serializes into
+// gen_ai.input.messages / gen_ai.output.messages (MessageSummary for chat, plus the
+// tool_call_id field of ResponsesMessageSummary). It is decoded leniently: unknown fields
+// are ignored and every field is optional.
+type flatMessage struct {
+	Role             string          `json:"role"`
+	Content          string          `json:"content"`
+	ToolCalls        []flatToolCall  `json:"tool_calls,omitempty"`
+	ToolCallID       string          `json:"tool_call_id,omitempty"`
+	Reasoning        string          `json:"reasoning,omitempty"`
+	ReasoningDetails []flatReasoning `json:"reasoning_details,omitempty"`
+	Refusal          string          `json:"refusal,omitempty"`
+	Audio            *flatAudio      `json:"audio,omitempty"`
+}
+
+type flatToolCall struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Name string `json:"name"`
+	Args string `json:"args,omitempty"`
+}
+
+type flatReasoning struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type flatAudio struct {
+	ID         string `json:"id,omitempty"`
+	Transcript string `json:"transcript,omitempty"`
+}
+
+// partsMessage is one message in the semantic-conventions shape. Parts is always emitted,
+// even when empty, because the spec marks it required.
+type partsMessage struct {
+	Role  string        `json:"role"`
+	Parts []messagePart `json:"parts"`
+}
+
+// messagePart covers the spec part types Bifrost can populate: text, reasoning, tool_call
+// and tool_call_response. Refusals have no spec part; they are emitted as a generic
+// "refusal" part, which the spec allows for extension types.
+type messagePart struct {
+	Type      string `json:"type"`
+	Content   string `json:"content,omitempty"`
+	ID        string `json:"id,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Arguments any    `json:"arguments,omitempty"`
+	Response  any    `json:"response,omitempty"`
+}
+
+// applyPartsMessageFormat rewrites the GenAI message attributes of an exported span into the
+// semantic-conventions parts shape and mirrors gen_ai.request.instructions as
+// gen_ai.system_instructions. Values are rewritten in place; anything that is not the
+// framework's flat shape (the root span carries a bare text excerpt, transcription output is
+// a bare string) is wrapped as a single text part so no content is lost.
+func applyPartsMessageFormat(kvs []*KeyValue) []*KeyValue {
+	var instructions string
+	for _, kv := range kvs {
+		if kv == nil || kv.Value == nil {
+			continue
+		}
+		raw, ok := kv.Value.Value.(*StringValue)
+		if !ok {
+			continue
+		}
+		switch kv.Key {
+		case schemas.AttrInputMessages:
+			kv.Value = &AnyValue{Value: &StringValue{StringValue: toPartsMessages(raw.StringValue, "user")}}
+		case schemas.AttrOutputMessages:
+			kv.Value = &AnyValue{Value: &StringValue{StringValue: toPartsMessages(raw.StringValue, "assistant")}}
+		case schemas.AttrInstructions:
+			instructions = raw.StringValue
+		}
+	}
+	if instructions != "" {
+		if data, err := schemas.MarshalString([]messagePart{{Type: "text", Content: instructions}}); err == nil {
+			kvs = append(kvs, kvStr(AttrSystemInstructions, data))
+		}
+	}
+	return kvs
+}
+
+// toPartsMessages converts one serialized message attribute to the parts shape. A value that
+// is not a JSON array of flat messages becomes a single message with the given role.
+func toPartsMessages(raw string, fallbackRole string) string {
+	var flat []flatMessage
+	if strings.HasPrefix(strings.TrimSpace(raw), "[") {
+		if err := schemas.Unmarshal([]byte(raw), &flat); err != nil {
+			flat = nil
+		}
+	}
+	var out []partsMessage
+	if flat == nil {
+		out = []partsMessage{{Role: fallbackRole, Parts: []messagePart{{Type: "text", Content: raw}}}}
+	} else {
+		out = make([]partsMessage, 0, len(flat))
+		for i := range flat {
+			out = append(out, toPartsMessage(&flat[i]))
+		}
+	}
+	data, err := schemas.MarshalString(out)
+	if err != nil {
+		return raw
+	}
+	return data
+}
+
+// toPartsMessage maps one flat message to parts. Order follows the model's own sequence:
+// reasoning first, then the visible content, then the tool calls it decided to make.
+func toPartsMessage(m *flatMessage) partsMessage {
+	parts := make([]messagePart, 0, 2+len(m.ToolCalls))
+	if m.Reasoning != "" {
+		parts = append(parts, messagePart{Type: "reasoning", Content: m.Reasoning})
+	}
+	for _, d := range m.ReasoningDetails {
+		if d.Text != "" && d.Text != m.Reasoning {
+			parts = append(parts, messagePart{Type: "reasoning", Content: d.Text})
+		}
+	}
+	// A tool result is a tool_call_response part even when the result is empty: the spec
+	// requires the response field, and the empty string is the truthful value.
+	if m.Role == "tool" || m.ToolCallID != "" {
+		parts = append(parts, messagePart{Type: "tool_call_response", ID: m.ToolCallID, Response: m.Content})
+	} else if m.Content != "" {
+		parts = append(parts, messagePart{Type: "text", Content: m.Content})
+	}
+	if m.Refusal != "" {
+		parts = append(parts, messagePart{Type: "refusal", Content: m.Refusal})
+	}
+	if m.Audio != nil && m.Audio.Transcript != "" {
+		parts = append(parts, messagePart{Type: "text", Content: m.Audio.Transcript})
+	}
+	for _, tc := range m.ToolCalls {
+		parts = append(parts, messagePart{Type: "tool_call", ID: tc.ID, Name: tc.Name, Arguments: toolArguments(tc.Args)})
+	}
+	return partsMessage{Role: m.Role, Parts: parts}
+}
+
+// toolArguments returns the tool call arguments as structured JSON when they parse, else as
+// the raw string, so a collector sees an object rather than an escaped string wherever
+// possible. Empty arguments are omitted (the spec marks the field optional).
+func toolArguments(args string) any {
+	if args == "" {
+		return nil
+	}
+	var v any
+	if err := schemas.Unmarshal([]byte(args), &v); err != nil {
+		return args
+	}
+	return v
+}

--- a/plugins/otel/semconv_test.go
+++ b/plugins/otel/semconv_test.go
@@ -1,0 +1,210 @@
+package otel
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func decodeMessages(t *testing.T, raw string) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	if err := schemas.Unmarshal([]byte(raw), &out); err != nil {
+		t.Fatalf("value %q is not a JSON array of messages: %v", raw, err)
+	}
+	return out
+}
+
+func partsOf(t *testing.T, msg map[string]any) []map[string]any {
+	t.Helper()
+	raw, ok := msg["parts"].([]any)
+	if !ok {
+		t.Fatalf("message %v has no parts array", msg)
+	}
+	parts := make([]map[string]any, 0, len(raw))
+	for _, p := range raw {
+		parts = append(parts, p.(map[string]any))
+	}
+	return parts
+}
+
+func kvsFrom(attrs map[string]any) []*KeyValue {
+	return convertAttributesToKeyValues(attrs, false)
+}
+
+func find(kvs []*KeyValue, key string) string {
+	for _, kv := range kvs {
+		if kv.Key == key {
+			return kv.Value.GetStringValue()
+		}
+	}
+	return ""
+}
+
+// TestPartsFormat_ChatMessages asserts the flat chat shape becomes role+parts with text,
+// reasoning, tool_call and tool_call_response parts in the model's order.
+func TestPartsFormat_ChatMessages(t *testing.T) {
+	kvs := kvsFrom(map[string]any{
+		schemas.AttrInputMessages: `[
+			{"role":"system","content":"You are terse."},
+			{"role":"user","content":"Weather in Paris?"},
+			{"role":"assistant","content":"","reasoning":"need a lookup","tool_calls":[{"id":"call_1","type":"function","name":"get_weather","args":"{\"city\":\"Paris\"}"}]},
+			{"role":"tool","content":"18C, cloudy","tool_call_id":"call_1"}
+		]`,
+		schemas.AttrOutputMessages: `[{"role":"assistant","content":"18C and cloudy."}]`,
+		schemas.AttrRequestModel:   "gpt-4o-mini",
+	})
+	kvs = applyPartsMessageFormat(kvs)
+
+	in := decodeMessages(t, find(kvs, schemas.AttrInputMessages))
+	if len(in) != 4 {
+		t.Fatalf("input messages = %d, want 4", len(in))
+	}
+	if p := partsOf(t, in[1]); len(p) != 1 || p[0]["type"] != "text" || p[0]["content"] != "Weather in Paris?" {
+		t.Errorf("user parts = %v, want one text part", p)
+	}
+	assistant := partsOf(t, in[2])
+	if len(assistant) != 2 {
+		t.Fatalf("assistant parts = %v, want reasoning then tool_call", assistant)
+	}
+	if assistant[0]["type"] != "reasoning" || assistant[0]["content"] != "need a lookup" {
+		t.Errorf("assistant part 0 = %v, want reasoning", assistant[0])
+	}
+	call := assistant[1]
+	if call["type"] != "tool_call" || call["id"] != "call_1" || call["name"] != "get_weather" {
+		t.Errorf("assistant part 1 = %v, want tool_call call_1/get_weather", call)
+	}
+	if args, ok := call["arguments"].(map[string]any); !ok || args["city"] != "Paris" {
+		t.Errorf("tool_call arguments = %v, want parsed object with city=Paris", call["arguments"])
+	}
+	tool := partsOf(t, in[3])
+	if len(tool) != 1 || tool[0]["type"] != "tool_call_response" || tool[0]["id"] != "call_1" || tool[0]["response"] != "18C, cloudy" {
+		t.Errorf("tool parts = %v, want one tool_call_response", tool)
+	}
+
+	out := decodeMessages(t, find(kvs, schemas.AttrOutputMessages))
+	if len(out) != 1 || out[0]["role"] != "assistant" {
+		t.Fatalf("output messages = %v, want one assistant message", out)
+	}
+	if p := partsOf(t, out[0]); len(p) != 1 || p[0]["type"] != "text" || p[0]["content"] != "18C and cloudy." {
+		t.Errorf("output parts = %v, want one text part", p)
+	}
+	if got := find(kvs, schemas.AttrRequestModel); got != "gpt-4o-mini" {
+		t.Errorf("non-message attribute rewritten: model = %q", got)
+	}
+}
+
+// TestPartsFormat_BareStringAndEmptyContent asserts values that are not the flat shape
+// (the root span's text excerpt) are wrapped rather than dropped, an empty tool result
+// still yields a tool_call_response, and an empty message keeps an empty parts array.
+func TestPartsFormat_BareStringAndEmptyContent(t *testing.T) {
+	kvs := applyPartsMessageFormat(kvsFrom(map[string]any{
+		schemas.AttrInputMessages:  "Weather in Paris?",
+		schemas.AttrOutputMessages: `[{"role":"tool","content":"","tool_call_id":"call_9"},{"role":"assistant","content":""}]`,
+	}))
+
+	in := decodeMessages(t, find(kvs, schemas.AttrInputMessages))
+	if len(in) != 1 || in[0]["role"] != "user" {
+		t.Fatalf("bare input = %v, want one user message", in)
+	}
+	if p := partsOf(t, in[0]); len(p) != 1 || p[0]["content"] != "Weather in Paris?" {
+		t.Errorf("bare input parts = %v, want the text wrapped", p)
+	}
+
+	out := decodeMessages(t, find(kvs, schemas.AttrOutputMessages))
+	tool := partsOf(t, out[0])
+	if len(tool) != 1 || tool[0]["type"] != "tool_call_response" || tool[0]["response"] != "" {
+		t.Errorf("empty tool result parts = %v, want tool_call_response with empty response", tool)
+	}
+	if p := partsOf(t, out[1]); len(p) != 0 {
+		t.Errorf("empty assistant parts = %v, want []", p)
+	}
+}
+
+// TestPartsFormat_InstructionsMirroredAsSystemInstructions asserts the Responses/speech
+// instructions string is mirrored to the spec attribute as a text part while the original
+// attribute is kept.
+func TestPartsFormat_InstructionsMirroredAsSystemInstructions(t *testing.T) {
+	kvs := applyPartsMessageFormat(kvsFrom(map[string]any{
+		schemas.AttrInstructions: "Code every brand mention.",
+	}))
+	if got := find(kvs, schemas.AttrInstructions); got != "Code every brand mention." {
+		t.Errorf("original instructions attribute = %q, want kept", got)
+	}
+	var parts []map[string]any
+	if err := schemas.Unmarshal([]byte(find(kvs, AttrSystemInstructions)), &parts); err != nil || len(parts) != 1 {
+		t.Fatalf("%s = %q, want one-part JSON array (%v)", AttrSystemInstructions, find(kvs, AttrSystemInstructions), err)
+	}
+	if parts[0]["type"] != "text" || parts[0]["content"] != "Code every brand mention." {
+		t.Errorf("system instructions part = %v", parts[0])
+	}
+
+	// No instructions: no spec attribute either.
+	if got := find(applyPartsMessageFormat(kvsFrom(map[string]any{schemas.AttrRequestModel: "m"})), AttrSystemInstructions); got != "" {
+		t.Errorf("%s emitted without instructions: %q", AttrSystemInstructions, got)
+	}
+}
+
+// TestConvertTraceToResourceSpan_MessageFormat asserts the profile option is applied per
+// span, defaults to the flat shape, and never resurrects content dropped by
+// disableContentLogging.
+func TestConvertTraceToResourceSpan_MessageFormat(t *testing.T) {
+	p := &OtelPlugin{pluginSpanFilter: &PluginSpanFilter{}}
+	makeTrace := func() *schemas.Trace {
+		root := makeSpan("aaaa", "", "request", schemas.SpanKindInternal)
+		root.Attributes = map[string]any{schemas.AttrInputMessages: "hello"}
+		child := makeSpan("bbbb", "aaaa", "chat", schemas.SpanKindLLMCall)
+		child.Attributes = map[string]any{
+			schemas.AttrInputMessages: `[{"role":"user","content":"hello"}]`,
+			schemas.AttrInstructions:  "Be brief.",
+		}
+		return &schemas.Trace{TraceID: "00000000000000000000000000000003", RootSpan: root, Spans: []*schemas.Span{root, child}}
+	}
+	child := func(rs *ResourceSpan) *Span {
+		for _, s := range rs.ScopeSpans[0].Spans {
+			if string(s.SpanId) == string(hexToBytes("bbbb", 8)) {
+				return s
+			}
+		}
+		return nil
+	}
+
+	flat := p.convertTraceToResourceSpan("svc", makeTrace(), nil, false, false, false, MessageFormatFlat)
+	if got := attrString(child(flat), schemas.AttrInputMessages); got != `[{"role":"user","content":"hello"}]` {
+		t.Errorf("flat format rewrote input: %q", got)
+	}
+	if attrString(child(flat), AttrSystemInstructions) != "" {
+		t.Error("flat format emitted gen_ai.system_instructions")
+	}
+
+	parts := p.convertTraceToResourceSpan("svc", makeTrace(), nil, false, false, false, MessageFormatParts)
+	msgs := decodeMessages(t, attrString(child(parts), schemas.AttrInputMessages))
+	if len(msgs) != 1 || len(partsOf(t, msgs[0])) != 1 {
+		t.Errorf("parts format child input = %v", msgs)
+	}
+	if attrString(child(parts), AttrSystemInstructions) == "" {
+		t.Error("parts format did not emit gen_ai.system_instructions")
+	}
+	rootMsgs := decodeMessages(t, attrString(findRoot(parts.ScopeSpans[0].Spans), schemas.AttrInputMessages))
+	if len(rootMsgs) != 1 || rootMsgs[0]["role"] != "user" {
+		t.Errorf("parts format root input = %v, want wrapped bare text", rootMsgs)
+	}
+
+	dropped := p.convertTraceToResourceSpan("svc", makeTrace(), nil, true, false, false, MessageFormatParts)
+	if attrString(child(dropped), schemas.AttrInputMessages) != "" || attrString(child(dropped), AttrSystemInstructions) != "" {
+		t.Error("disableContentLogging content reappeared under parts format")
+	}
+}
+
+// TestBuildTargetRejectsUnknownMessageFormat asserts a typo in message_format fails
+// configuration instead of silently exporting the flat shape.
+func TestBuildTargetRejectsUnknownMessageFormat(t *testing.T) {
+	for _, f := range []MessageFormat{"", MessageFormatFlat, MessageFormatParts} {
+		if !validMessageFormat(f) {
+			t.Errorf("validMessageFormat(%q) = false, want true", f)
+		}
+	}
+	if validMessageFormat("semconv") {
+		t.Error(`validMessageFormat("semconv") = true, want false`)
+	}
+}

--- a/plugins/otel/semconv_test.go
+++ b/plugins/otel/semconv_test.go
@@ -41,6 +41,17 @@ func find(kvs []*KeyValue, key string) string {
 	return ""
 }
 
+// has reports whether the key is present at all, so a test can distinguish "absent"
+// from "emitted with an empty value".
+func has(kvs []*KeyValue, key string) bool {
+	for _, kv := range kvs {
+		if kv.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
 // TestPartsFormat_ChatMessages asserts the flat chat shape becomes role+parts with text,
 // reasoning, tool_call and tool_call_response parts in the model's order.
 func TestPartsFormat_ChatMessages(t *testing.T) {
@@ -139,9 +150,9 @@ func TestPartsFormat_InstructionsMirroredAsSystemInstructions(t *testing.T) {
 		t.Errorf("system instructions part = %v", parts[0])
 	}
 
-	// No instructions: no spec attribute either.
-	if got := find(applyPartsMessageFormat(kvsFrom(map[string]any{schemas.AttrRequestModel: "m"})), AttrSystemInstructions); got != "" {
-		t.Errorf("%s emitted without instructions: %q", AttrSystemInstructions, got)
+	// No instructions: the spec attribute must be absent, not present with an empty value.
+	if kvs := applyPartsMessageFormat(kvsFrom(map[string]any{schemas.AttrRequestModel: "m"})); has(kvs, AttrSystemInstructions) {
+		t.Errorf("%s emitted without instructions: %q", AttrSystemInstructions, find(kvs, AttrSystemInstructions))
 	}
 }
 

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -3439,6 +3439,12 @@
           "description": "When true, input/output message content is dropped from the root span only; the underlying generation (llm.call) span retains the full content. This removes the duplicate input/output stored at the trace level (e.g. the Langfuse trace Input/Output goes empty) to reduce downstream storage.",
           "default": false
         },
+        "message_format": {
+          "type": "string",
+          "enum": ["flat", "parts"],
+          "description": "Shape of gen_ai.input.messages / gen_ai.output.messages: flat (default) keeps Bifrost's role+content objects; parts emits the OpenTelemetry GenAI semantic-conventions shape (role + typed parts: text, tool_call, tool_call_response, reasoning) and mirrors gen_ai.request.instructions as gen_ai.system_instructions; use it for backends that only map spec-shaped messages into their native input/output fields (e.g. Braintrust).",
+          "default": "flat"
+        },
         "headers": {
           "type": "object",
           "additionalProperties": {

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -43,6 +43,7 @@ interface StoredOtelProfile {
 	disable_content_logging?: boolean;
 	group_traces_by_session?: boolean;
 	disable_root_span_content?: boolean;
+	message_format?: "flat" | "parts";
 }
 
 // StoredOtelConfig is either the canonical { profiles: [...] } wrapper or a legacy single
@@ -59,6 +60,11 @@ interface OtelFormFragmentProps {
 	isDeleting?: boolean;
 	isLoading?: boolean;
 }
+
+const messageFormatOptions: { value: "flat" | "parts"; label: string }[] = [
+	{ value: "flat", label: "Flat (role + content)" },
+	{ value: "parts", label: "Parts (OTel GenAI semantic conventions)" },
+];
 
 const traceTypeOptions: {
 	value: string;
@@ -111,6 +117,7 @@ const emptyProfile = (): ProfileForm => ({
 	disable_content_logging: false,
 	group_traces_by_session: false,
 	disable_root_span_content: false,
+	message_format: "flat",
 });
 
 // toProfileForm normalizes a stored profile into the SecretVar-based form representation.
@@ -134,6 +141,7 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	disable_content_logging: p?.disable_content_logging ?? false,
 	group_traces_by_session: p?.group_traces_by_session ?? false,
 	disable_root_span_content: p?.disable_root_span_content ?? false,
+	message_format: p?.message_format ?? "flat",
 });
 
 // buildDefaults handles both stored shapes: the { profiles: [...] } wrapper and the legacy
@@ -661,6 +669,36 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 										)}
 									/>
 									</div>
+									<FormField
+										control={control}
+										name={`${base}.message_format`}
+										render={({ field }) => (
+											<FormItem className="w-full">
+												<FormLabel>Message Format</FormLabel>
+												<Select onValueChange={field.onChange} value={field.value ?? "flat"} disabled={!hasOtelAccess}>
+													<FormControl>
+														<SelectTrigger className="w-full" data-testid={`otel-profile-${index}-message-format-select`}>
+															<SelectValue placeholder="Select message format" />
+														</SelectTrigger>
+													</FormControl>
+													<SelectContent>
+														{messageFormatOptions.map((option) => (
+															<SelectItem key={option.value} value={option.value}>
+																{option.label}
+															</SelectItem>
+														))}
+													</SelectContent>
+												</Select>
+												<FormDescription>
+													Shape of <code className="text-xs">gen_ai.input.messages</code> / <code className="text-xs">gen_ai.output.messages</code>.
+													Parts follows the OTel GenAI semantic conventions (role + typed parts) and mirrors instructions as{" "}
+													<code className="text-xs">gen_ai.system_instructions</code>; backends that validate against the spec (e.g.
+													Braintrust) need it to populate their native input/output fields.
+												</FormDescription>
+												<FormMessage />
+											</FormItem>
+										)}
+									/>
 									<FormField
 										control={control}
 										name={`${base}.request_headers`}

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -914,6 +914,7 @@ export const otelConfigSchema = z
 		disable_content_logging: z.boolean().default(false),
 		group_traces_by_session: z.boolean().default(false),
 		disable_root_span_content: z.boolean().default(false),
+		message_format: z.enum(["flat", "parts"]).default("flat"),
 	})
 	.superRefine((data, ctx) => {
 		// A disabled profile is not sent anywhere, so skip all validation for it.


### PR DESCRIPTION
## Summary

Two gaps in the tracing export path, described in #6816:

1. The otel plugin only ever exported `gen_ai.input.messages` / `gen_ai.output.messages` as Bifrost's flat `{role, content, tool_calls, ...}` objects. The [OTel GenAI semantic conventions](https://github.com/open-telemetry/semantic-conventions-genai) define `{role, parts: [{type, ...}]}` instead, and backends that validate against the spec (Braintrust, for one) leave the flat shape unmapped, so their native input/output fields stay empty for every request through the gateway.
2. `PopulateResponsesRequestAttributes` never read `req.Params.Instructions`, so a Responses API call exported its input messages but not the system prompt that shaped the output.

Closes #6816

## Changes

**`framework/tracing/llmspan.go`** (`[fix]`): set `gen_ai.request.instructions` from Responses `Params.Instructions` when non-empty. The attribute already existed (speech requests set it) and is classified as input content, so `disable_content_logging` and guardrail redaction cover it unchanged.

**`plugins/otel`** (`[feat]`): a per-profile `message_format` option, `"flat"` (default, byte-for-byte unchanged) or `"parts"`. The rewrite happens at export time in `convertSpanToOTELSpan`, per profile, so the framework's stored span shape and every other consumer (log store, BigQuery, Kafka, Datadog) are untouched, and one profile can stay flat while another emits parts. Under `parts`:

- `text`, `reasoning`, `tool_call` (structured `arguments` when they parse, the raw string otherwise) and `tool_call_response` parts, in the model's own order; refusals become a generic `refusal` part
- the root span's bare-text excerpt and other non-array values are wrapped as a single text part rather than dropped
- `gen_ai.request.instructions` is mirrored as `gen_ai.system_instructions` (one text part); the original attribute is kept
- content removed by `disable_content_logging` / `disable_root_span_content` is dropped before the rewrite, so nothing reappears
- an unknown value fails profile configuration instead of silently exporting the flat shape

**Surface** (`[chore]`): `transports/config.schema.json` declares the option; Helm `values.yaml` / `values.schema.json` / `_helpers.tpl` pass it through; the UI's observability form gets a Message Format select on the traces tab (`otelFormFragment.tsx`, zod enum with `flat` default in `schemas.ts`); `docs/features/observability/otel.mdx` gains a config-table row and a "Message Format" section with a Braintrust profile example.

Changelog entries added to `framework/changelog.md` and `plugins/otel/changelog.md`.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
make setup-workspace          # local go.work so plugins/otel builds against dev's core/framework

cd framework && go test ./tracing/...
# TestPopulateResponsesRequestAttributesExportsInstructions: set, nil, empty

cd ../plugins/otel && go test ./...
# semconv_test.go: chat/tool exchange, bare string + empty content, instructions mirroring,
# per-span application vs flat default vs disable_content_logging, value validation;
# converter/mapping tests updated for the new parameter

cd ../../ui && npm ci && npx tsc --noEmit
helm lint helm-charts/bifrost
```

End to end: add `"message_format": "parts"` to an otel profile pointed at Braintrust, send a chat completion with a tool call, and the LLM span's input/output panels populate with the typed parts. Leave it out (or set `"flat"`) and the export is unchanged from today.

New config: `plugins[otel].config.profiles[].message_format` (`flat` | `parts`, default `flat`), also as `plugins.otel.profiles[].messageFormat` in the Helm values.

## Screenshots/Recordings

The UI change is one `Select` (Message Format: Flat / Parts) in the existing traces tab of the otel profile form.

## Breaking changes

- [ ] Yes
- [x] No

`flat` stays the default and the flat serialization is unchanged. The Responses `instructions` attribute is new on spans that previously lacked it; it is input content, so existing redaction and `disable_content_logging` settings apply to it.

## Related issues

Closes #6816

## Security considerations

No new data leaves the gateway that was not already in the span. Instructions are classified as input content (`gen_ai.request.instructions` is already in the input-content set), so content-logging and redaction controls cover them. `parts` re-shapes the same message content that `flat` exports.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
