### PR TITLE
fix(helm): use configured image version in labels

### DIFF
--- a/.github/workflows/scripts/validate-helm-templates.sh
+++ b/.github/workflows/scripts/validate-helm-templates.sh
@@ -54,7 +54,7 @@ test_template() {
 
 # 1. Storage Combinations (9 tests)
 echo ""
-echo -e "${CYAN}📦 1/7 - Testing Storage Combinations (9 tests)...${NC}"
+echo -e "${CYAN}📦 1/8 - Testing Storage Combinations (9 tests)...${NC}"
 echo "---------------------------------------------------"
 
 # config=no, logs=no
@@ -126,7 +126,7 @@ test_template "config=postgres, logs=postgres" \
 
 # 2. Vector Store Combinations (6 tests)
 echo ""
-echo -e "${CYAN}🗄️  2/7 - Testing Vector Store Combinations (6 tests)...${NC}"
+echo -e "${CYAN}🗄️  2/8 - Testing Vector Store Combinations (6 tests)...${NC}"
 echo "--------------------------------------------------------"
 
 # Weaviate
@@ -175,7 +175,7 @@ test_template "sqlite + qdrant" \
 
 # 3. Special Configurations (7 tests)
 echo ""
-echo -e "${CYAN}⚙️  3/7 - Testing Special Configurations (7 tests)...${NC}"
+echo -e "${CYAN}⚙️  3/8 - Testing Special Configurations (7 tests)...${NC}"
 echo "-----------------------------------------------------"
 
 # semantic cache: direct mode (dimension: 1, no provider/keys)
@@ -251,7 +251,7 @@ test_template "production-like config" \
 
 # 4. New Property Rendering (Gap 1-8 tests)
 echo ""
-echo -e "${CYAN}🆕 4/7 - Testing New Property Rendering (Gap 1-8)...${NC}"
+echo -e "${CYAN}🆕 4/8 - Testing New Property Rendering (Gap 1-8)...${NC}"
 echo "-----------------------------------------------------"
 
 # Gap 1+2: Client new properties
@@ -337,7 +337,7 @@ test_template "combined: all new Gap 1-9 fields" \
 
 # 5. Plugin Name Validation
 echo ""
-echo -e "${CYAN}🔌 5/7 - Validating Plugin Names Match Go Registry...${NC}"
+echo -e "${CYAN}🔌 5/8 - Validating Plugin Names Match Go Registry...${NC}"
 echo "------------------------------------------------------"
 
 # Verify semantic cache plugin renders with correct name ("semantic_cache", not "semantic_cache")
@@ -366,7 +366,7 @@ fi
 
 # 6. Custom Plugin Placement and Order Rendering
 echo ""
-echo -e "${CYAN}🔧 6/7 - Validating Custom Plugin placement and order Rendering...${NC}"
+echo -e "${CYAN}🔧 6/8 - Validating Custom Plugin placement and order Rendering...${NC}"
 echo "-------------------------------------------------------------------"
 
 # Test custom plugin renders successfully with placement and order
@@ -423,7 +423,7 @@ fi
 
 # 7. Security Context Rendering
 echo ""
-echo -e "${CYAN}🔒 7/7 - Validating OpenShift-compatible Security Contexts...${NC}"
+echo -e "${CYAN}🔒 7/8 - Validating OpenShift-compatible Security Contexts...${NC}"
 echo "----------------------------------------------------------------"
 
 # Images before v1.6.4 use a non-numeric `USER appuser`, so kubelet can only
@@ -483,6 +483,31 @@ if helm template bifrost ./helm-charts/bifrost \
     echo -e "${YELLOW}  runAsUser/fsGroup still rendered with null overrides (OpenShift SCC cannot assign a UID)${NC}"
   else
     report_result "$test_name" 0
+  fi
+else
+  report_result "$test_name" 1
+  echo -e "${YELLOW}  Error output:${NC}"
+  head -10 /tmp/helm-template-output.yaml | sed 's/^/    /'
+fi
+
+# 8. Application Version Label
+echo ""
+echo -e "${CYAN}🏷️  8/8 - Validating Application Version Label...${NC}"
+echo "-----------------------------------------------------"
+
+test_name="application version label matches the configured image tag"
+if helm template bifrost ./helm-charts/bifrost \
+  --set image.tag=v9.8.7-test \
+  --set storage.mode=postgres \
+  --set postgresql.enabled=true \
+  --set postgresql.auth.password=testpass \
+  -s templates/deployment.yaml \
+  > /tmp/helm-template-output.yaml 2>&1; then
+  if grep -Eq 'app.kubernetes.io/version:[[:space:]]*"9\.8\.7-test"' /tmp/helm-template-output.yaml; then
+    report_result "$test_name" 0
+  else
+    report_result "$test_name" 1
+    echo -e "${YELLOW}  application version label does not match image.tag${NC}"
   fi
 else
   report_result "$test_name" 1

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -10,6 +10,7 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ### Upcoming
 
+- Fixed `app.kubernetes.io/version` labels to reflect the configured `image.tag` instead of the chart's static `appVersion`.
 - Added `bifrost.client.compat.azureDeepseek` (default `false`) — converts Azure DeepSeek responses requests to chat completions so reasoning is preserved for coding harnesses. Renders into `client.compat.azure_deepseek`.
 - Removed the `version` field from every plugin (`telemetry`, `logging`, `governance`, `maxim`, `semanticCache`, `otel`, `datadog`, `bigquery`, `kafka`, `pubsub`, `splunk` and `birost.plugins.custom[]`).
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -19,11 +19,16 @@
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
+{{- define "bifrost.appVersion" -}}
+{{- default .Chart.AppVersion .Values.image.tag | trimPrefix "v" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "bifrost.labels" -}}
 helm.sh/chart: {{ include "bifrost.chart" . }}
 {{ include "bifrost.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- $appVersion := include "bifrost.appVersion" . }}
+{{- if $appVersion }}
+app.kubernetes.io/version: {{ $appVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}


### PR DESCRIPTION
## Summary

Make Helm's `app.kubernetes.io/version` label report the Bifrost image version that is actually configured for the release.

The chart requires operators to set `image.tag`, but its shared labels currently use the static `Chart.appVersion`. When those values differ, Kubernetes inventory and incident tooling report a version that the pod is not running.

## Changes

- derive the application version label from `image.tag`, trimming the conventional leading `v`
- retain `Chart.appVersion` as a fallback for renders without an image tag
- add a regression assertion to the Helm template validation suite
- document the correction in the chart changelog

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs
- [x] Helm chart

## How to test

```sh
bash .github/workflows/scripts/validate-helm-templates.sh
helm lint ./helm-charts/bifrost --set image.tag=v2.0.0
helm template bifrost ./helm-charts/bifrost --set image.tag=v2.0.0 -s templates/stateful.yaml
```

The rendered StatefulSet and Deployment both label the application as `2.0.0` while using `docker.io/maximhq/bifrost:v2.0.0`.

## Screenshots/Recordings

Not applicable; this corrects Kubernetes metadata.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

ref REI-3570

## Security considerations

None. This only changes rendered Kubernetes labels.

## Checklist

- [x] I read the repository guidance and followed it
- [x] I added regression coverage
- [x] I updated documentation
- [x] I verified the chart validation suite locally
- [ ] I verified the full CI pipeline locally
