### PR TITLE
feat: add VMCP assignment into VK sheets

### DIFF
--- a/framework/configstore/mcpclient_endpoint_slug_test.go
+++ b/framework/configstore/mcpclient_endpoint_slug_test.go
@@ -34,6 +34,34 @@ func TestCreateMCPClientConfig_RejectsUnderivableSlug(t *testing.T) {
 	assert.ErrorIs(t, err, ErrMCPEndpointSlugInvalid)
 }
 
+// TestGetVirtualMCPIDsForVirtualKey pins the reverse assignment lookup: the Virtual MCPs a key is
+// attached to, so the VK detail view can list and edit them.
+func TestGetVirtualMCPIDsForVirtualKey(t *testing.T) {
+	s := setupRDBTestStore(t)
+	ctx := context.Background()
+
+	alpha := &tables.TableVirtualMCP{Name: "Alpha", EndpointSlug: "alpha", Enabled: true}
+	beta := &tables.TableVirtualMCP{Name: "Beta", EndpointSlug: "beta", Enabled: true}
+	require.NoError(t, s.CreateVirtualMCP(ctx, alpha))
+	require.NoError(t, s.CreateVirtualMCP(ctx, beta))
+
+	require.NoError(t, s.AttachVirtualMCPToVirtualKey(ctx, alpha.ID, "vk-1"))
+	require.NoError(t, s.AttachVirtualMCPToVirtualKey(ctx, beta.ID, "vk-1"))
+	require.NoError(t, s.AttachVirtualMCPToVirtualKey(ctx, alpha.ID, "vk-2"))
+
+	got, err := s.GetVirtualMCPIDsForVirtualKey(ctx, "vk-1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{alpha.ID, beta.ID}, got)
+
+	only, err := s.GetVirtualMCPIDsForVirtualKey(ctx, "vk-2")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []uint{alpha.ID}, only)
+
+	none, err := s.GetVirtualMCPIDsForVirtualKey(ctx, "vk-none")
+	require.NoError(t, err)
+	assert.Empty(t, none)
+}
+
 // TestCreateVirtualMCP_RejectsUnderivableSlug pins the same typed-error contract on the Virtual MCP
 // side: a name slugifying to empty (with no endpoint_slug) returns ErrMCPEndpointSlugInvalid so
 // handlers can map it to a 400.

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -4647,6 +4647,14 @@ func (s *RDBConfigStore) GetVirtualKeyIDsForVirtualMCP(ctx context.Context, vmcp
 	return ids, err
 }
 
+func (s *RDBConfigStore) GetVirtualMCPIDsForVirtualKey(ctx context.Context, virtualKeyID string) ([]uint, error) {
+	var ids []uint
+	err := s.DB().WithContext(ctx).Model(&tables.TableVirtualKeyVirtualMCP{}).
+		Where("virtual_key_id = ?", virtualKeyID).
+		Pluck("tool_group_id", &ids).Error
+	return ids, err
+}
+
 // GetVirtualKeyIDsForVirtualMCPs returns assigned virtual-key IDs for a set of Virtual MCPs in one
 // query, grouped by Virtual MCP ID.
 func (s *RDBConfigStore) GetVirtualKeyIDsForVirtualMCPs(ctx context.Context, vmcpIDs []uint) (map[uint][]string, error) {

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -375,6 +375,9 @@ type ConfigStore interface {
 	// GetVirtualKeyIDsForVirtualMCPs returns assigned virtual-key IDs for a set of Virtual MCPs in one
 	// query, grouped by Virtual MCP ID. Used by the list view to avoid a per-row lookup.
 	GetVirtualKeyIDsForVirtualMCPs(ctx context.Context, vmcpIDs []uint) (map[uint][]string, error)
+	// GetVirtualMCPIDsForVirtualKey returns the IDs of the Virtual MCPs a virtual key is assigned to,
+	// the reverse of GetVirtualKeyIDsForVirtualMCP, so the VK detail view can show its assignments.
+	GetVirtualMCPIDsForVirtualKey(ctx context.Context, virtualKeyID string) ([]uint, error)
 
 	// Team CRUD
 	GetTeams(ctx context.Context, customerID string) ([]tables.TableTeam, error)

--- a/plugins/governance/mcp.go
+++ b/plugins/governance/mcp.go
@@ -62,6 +62,23 @@ func (acc *MCPToolAccumulator) GrantTool(clientID, tool string) {
 	}
 }
 
+// GrantClientTools registers a client — so it counts as configured and the allowed-by-default
+// fallback can't reopen it — names it when a name is known, and grants each tool: "*" grants the
+// whole client, and an empty list registers the client with no tools. The exported entry point for
+// holders (access profiles, projects) that hold a per-client allowlist plus a resolvable name.
+func (acc *MCPToolAccumulator) GrantClientTools(clientID, clientName string, tools []string) {
+	if clientID == "" {
+		return
+	}
+	entry := acc.client(clientID)
+	if clientName != "" {
+		entry.name = clientName
+	}
+	for _, tool := range tools {
+		acc.GrantTool(clientID, tool)
+	}
+}
+
 // addMCPConfig folds in a key's own config: the client is registered even with no tools, and carries
 // its own name.
 func (acc *MCPToolAccumulator) addMCPConfig(cfg *configstoreTables.TableVirtualKeyMCPConfig) {

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -1889,8 +1889,16 @@ func (h *GovernanceHandler) getVirtualKey(ctx *fasthttp.RequestCtx) {
 	// untracked rows so the admin detail panel matches the self-service quota view.
 	h.applyExternalBudgets(ctx, vk)
 
+	// The Virtual MCPs this key is assigned to, so the detail view can show and edit them.
+	vmcpIDs, err := h.configStore.GetVirtualMCPIDsForVirtualKey(ctx, vkID)
+	if err != nil {
+		SendError(ctx, 500, "Failed to retrieve virtual key")
+		return
+	}
+
 	SendJSON(ctx, map[string]interface{}{
-		"virtual_key": vk,
+		"virtual_key":     vk,
+		"virtual_mcp_ids": vmcpIDs,
 	})
 }
 

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -1127,6 +1127,10 @@ func (m *MockConfigStore) GetVirtualKeyIDsForVirtualMCPs(ctx context.Context, vm
 	return map[uint][]string{}, nil
 }
 
+func (m *MockConfigStore) GetVirtualMCPIDsForVirtualKey(ctx context.Context, virtualKeyID string) ([]uint, error) {
+	return nil, nil
+}
+
 func (m *MockConfigStore) CreateVirtualKeyMCPConfig(ctx context.Context, virtualKeyMCPConfig *tables.TableVirtualKeyMCPConfig, tx ...*gorm.DB) error {
 	return nil
 }

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -39,15 +39,20 @@ import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { getUserPicker } from "@/lib/registries/userPicker";
 import {
 	getErrorMessage,
+	useAttachVirtualMCPVirtualKeyMutation,
 	useCreateVirtualKeyMutation,
+	useDetachVirtualMCPVirtualKeyMutation,
 	useGetAllKeysQuery,
 	useGetProvidersQuery,
 	useGetTeamQuery,
+	useGetVirtualKeyQuery,
 	useRemoveVirtualKeyBudgetOverrideMutation,
 	useRotateVirtualKeyMutation,
 	useSetVirtualKeyBudgetOverrideMutation,
 	useUpdateVirtualKeyMutation,
 } from "@/lib/store";
+import { VirtualMcpAssignmentsEditor } from "@/components/mcp/virtualMcpAssignmentsEditor";
+import { diffVmcpAssignments, vmcpAssignmentsDirty } from "./virtualKeySheet.utils";
 import { KnownProvider } from "@/lib/types/config";
 import { BudgetOverrideRequest, CreateVirtualKeyRequest, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
 import {
@@ -344,7 +349,60 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 	const [detachVirtualKeyUser, { isLoading: isDetachingUser }] = useDetachVirtualKeyUserMutation();
 	const [setBudgetOverride] = useSetVirtualKeyBudgetOverrideMutation();
 	const [removeBudgetOverride] = useRemoveVirtualKeyBudgetOverrideMutation();
-	const isLoading = isCreating || isUpdating || isRotating || isAttachingUser || isDetachingUser;
+	const [attachVirtualMCPVirtualKey] = useAttachVirtualMCPVirtualKeyMutation();
+	const [detachVirtualMCPVirtualKey] = useDetachVirtualMCPVirtualKeyMutation();
+	// Tracks the whole attach/detach reconciliation, which spans several sequential requests whose
+	// own loading states go idle between them; without it Save could re-enable mid-reconcile.
+	const [isReconcilingVmcps, setIsReconcilingVmcps] = useState(false);
+	const isLoading = isCreating || isUpdating || isRotating || isAttachingUser || isDetachingUser || isReconcilingVmcps;
+
+	// Virtual MCPs this key is assigned to. The list VK carries none, so fetch the single VK (which
+	// includes virtual_mcp_ids); stage edits locally and reconcile attach/detach on Save.
+	const {
+		data: vkDetail,
+		isLoading: isVkDetailLoading,
+		isError: isVkDetailError,
+		refetch: refetchVkDetail,
+	} = useGetVirtualKeyQuery(virtualKey?.id ?? "", { skip: !isEditing || !virtualKey?.id });
+	const originalVmcpIds = vkDetail?.virtual_mcp_ids ?? [];
+	const [assignedVmcpIds, setAssignedVmcpIds] = useState<number[]>([]);
+	const vmcpsInitialized = useRef(false);
+	useEffect(() => {
+		if (isEditing && vkDetail && !vmcpsInitialized.current) {
+			setAssignedVmcpIds(vkDetail.virtual_mcp_ids ?? []);
+			vmcpsInitialized.current = true;
+		}
+	}, [isEditing, vkDetail]);
+	// For an existing key the baseline isn't trustworthy until the detail query lands, so the editor
+	// stays disabled and dirty stays false while it loads or errors (see gating on the editor below).
+	const vmcpDetailReady = !isEditing || (!!vkDetail && !isVkDetailLoading && !isVkDetailError);
+	const vmcpDirty = vmcpDetailReady && vmcpAssignmentsDirty(originalVmcpIds, assignedVmcpIds);
+
+	// Attach the newly-assigned Virtual MCPs and detach the removed ones for this key. On any failure,
+	// resync local state from the server so a later Save reconciles against what actually persisted.
+	const reconcileVmcpAssignments = async (vkId: string) => {
+		const { toAttach, toDetach } = diffVmcpAssignments(originalVmcpIds, assignedVmcpIds);
+		if (toAttach.length === 0 && toDetach.length === 0) return;
+		setIsReconcilingVmcps(true);
+		try {
+			for (const id of toAttach) {
+				await attachVirtualMCPVirtualKey({ id, vkId }).unwrap();
+			}
+			for (const id of toDetach) {
+				await detachVirtualMCPVirtualKey({ id, vkId }).unwrap();
+			}
+		} catch (error) {
+			try {
+				const refreshed = await refetchVkDetail().unwrap();
+				setAssignedVmcpIds(refreshed.virtual_mcp_ids ?? []);
+			} catch {
+				// Leave staged state as-is if the resync itself fails; the outer handler surfaces the error.
+			}
+			throw error;
+		} finally {
+			setIsReconcilingVmcps(false);
+		}
+	};
 	const persistedOverrideBudgets = [
 		...(virtualKey?.budgets ?? []).map((budget) => ({
 			budget,
@@ -929,6 +987,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 						}).unwrap();
 					}
 				}
+				await reconcileVmcpAssignments(virtualKey.id);
 				toast.success("Virtual key updated successfully");
 			} else {
 				// Create new virtual key
@@ -983,6 +1042,13 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 						onSave();
 						return;
 					}
+				}
+				try {
+					await reconcileVmcpAssignments(created.virtual_key.id);
+				} catch (error) {
+					toast.error("Virtual key created, but assigning Virtual MCPs failed", { description: getErrorMessage(error) });
+					onSave();
+					return;
 				}
 				toast.success("Virtual key created successfully");
 			}
@@ -1292,6 +1358,29 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 										onChange={(next) => form.setValue("mcpConfigs", next, { shouldDirty: true })}
 										showDefaultsNote
 									/>
+									{/* Virtual MCP assignments: attach this key to Virtual MCPs (reconciled on Save).
+									    For an existing key the editor stays gated until its detail (the assignment baseline)
+									    loads, so an early edit can't be discarded and a failed load can't hide assignments. */}
+									{isEditing && isVkDetailLoading ? (
+										<div className="mt-6 space-y-2">
+											<Label className="text-sm font-medium">Virtual MCP Server Configurations</Label>
+											<div className="text-muted-foreground text-sm">Loading assigned Virtual MCPs...</div>
+										</div>
+									) : isEditing && isVkDetailError ? (
+										<div className="mt-6 space-y-2">
+											<Label className="text-sm font-medium">Virtual MCP Server Configurations</Label>
+											<Alert variant="destructive">
+												<AlertDescription className="flex items-center justify-between gap-2">
+													<span>Could not load assigned Virtual MCPs.</span>
+													<Button type="button" variant="outline" size="sm" onClick={() => refetchVkDetail()}>
+														Retry
+													</Button>
+												</AlertDescription>
+											</Alert>
+										</div>
+									) : (
+										<VirtualMcpAssignmentsEditor value={assignedVmcpIds} onChange={setAssignedVmcpIds} />
+									)}
 									<DottedSeparator className="mt-6 mb-5" />
 									{/* Budget Configuration */}
 									<div className="space-y-4">
@@ -1736,19 +1825,23 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 										<Tooltip>
 											<TooltipTrigger asChild>
 												<span className="inline-block">
-													<Button type="submit" disabled={isLoading || !form.formState.isDirty || !canSubmit} data-testid="vk-save-btn">
+													<Button
+														type="submit"
+														disabled={isLoading || !(form.formState.isDirty || vmcpDirty) || !canSubmit}
+														data-testid="vk-save-btn"
+													>
 														{isLoading ? "Saving..." : isEditing ? "Update" : "Create"}
 													</Button>
 												</span>
 											</TooltipTrigger>
-											{(isLoading || !form.formState.isDirty || !canSubmit) && (
+											{(isLoading || !(form.formState.isDirty || vmcpDirty) || !canSubmit) && (
 												<TooltipContent>
 													<p>
 														{!canSubmit
 															? "You don't have permission to perform this action"
 															: isLoading
 																? "Saving..."
-																: !form.formState.isDirty
+																: !(form.formState.isDirty || vmcpDirty)
 																	? "No changes made"
 																	: ""}
 													</p>

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.utils.test.ts
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.utils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { diffVmcpAssignments, vmcpAssignmentsDirty } from "./virtualKeySheet.utils";
+
+describe("diffVmcpAssignments", () => {
+	it("returns empty diffs when nothing changed (order-insensitive)", () => {
+		expect(diffVmcpAssignments([1, 2, 3], [3, 2, 1])).toEqual({ toAttach: [], toDetach: [] });
+	});
+
+	it("attaches ids added and detaches ids removed", () => {
+		expect(diffVmcpAssignments([1, 2], [2, 3])).toEqual({ toAttach: [3], toDetach: [1] });
+	});
+
+	it("attaches all when starting from empty", () => {
+		expect(diffVmcpAssignments([], [5, 6])).toEqual({ toAttach: [5, 6], toDetach: [] });
+	});
+
+	it("detaches all when clearing", () => {
+		expect(diffVmcpAssignments([5, 6], [])).toEqual({ toAttach: [], toDetach: [5, 6] });
+	});
+
+	it("collapses duplicates within an input", () => {
+		expect(diffVmcpAssignments([1, 1], [1, 2, 2])).toEqual({ toAttach: [2], toDetach: [] });
+	});
+});
+
+describe("vmcpAssignmentsDirty", () => {
+	it("is false for equal sets regardless of order", () => {
+		expect(vmcpAssignmentsDirty([1, 2, 3], [3, 1, 2])).toBe(false);
+	});
+
+	it("is true when an id is added or removed", () => {
+		expect(vmcpAssignmentsDirty([1, 2], [1, 2, 3])).toBe(true);
+		expect(vmcpAssignmentsDirty([1, 2], [1])).toBe(true);
+	});
+});

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.utils.ts
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.utils.ts
@@ -1,0 +1,21 @@
+// Virtual MCP assignments are staged locally in the sheet and reconciled against the key's
+// persisted set on Save via attach/detach calls.
+
+/**
+ * Splits a staged Virtual MCP assignment set against the persisted one into the ids to
+ * attach (staged but not original) and to detach (original but not staged). Order follows
+ * the input arrays; duplicates within an input are collapsed.
+ */
+export function diffVmcpAssignments(original: number[], staged: number[]): { toAttach: number[]; toDetach: number[] } {
+	const originalSet = new Set(original);
+	const stagedSet = new Set(staged);
+	const toAttach = [...new Set(staged)].filter((id) => !originalSet.has(id));
+	const toDetach = [...new Set(original)].filter((id) => !stagedSet.has(id));
+	return { toAttach, toDetach };
+}
+
+/** Reports whether a staged assignment set differs from the persisted one, ignoring order. */
+export function vmcpAssignmentsDirty(original: number[], staged: number[]): boolean {
+	const { toAttach, toDetach } = diffVmcpAssignments(original, staged);
+	return toAttach.length > 0 || toDetach.length > 0;
+}

--- a/ui/components/entitySelectors/entitySelector.tsx
+++ b/ui/components/entitySelectors/entitySelector.tsx
@@ -98,6 +98,8 @@ export interface EntitySelectorCommonProps {
 	 * Single/add only — multi mode renders its chips inside the control.
 	 */
 	trigger?: ReactNode;
+	/** Add mode only: render the trigger full-width instead of the compact inline default. */
+	fullWidth?: boolean;
 }
 
 interface EntitySelectorSingleProps {
@@ -189,6 +191,7 @@ export function EntitySelector(props: EntitySelectorProps) {
 		contentClassName,
 		excludeIds,
 		trigger,
+		fullWidth = false,
 	} = props;
 
 	const isAdd = props.mode === "add";
@@ -364,34 +367,36 @@ export function EntitySelector(props: EntitySelectorProps) {
 
 	const triggerLabel = selectedIds.length > 0 ? labelFor(selectedIds[0]) : "";
 
-	// Add mode has no value to display, so it defaults to a compact action
-	// button rather than the full-width combobox.
-	const defaultTrigger = isAdd ? (
-		<Button type="button" variant="outline" size="sm" disabled={disabled} className="h-7.5 gap-1.5 px-2 py-1 text-sm font-medium">
-			<PlusIcon className="size-4" />
-			{placeholder ?? `Add ${entityLabel}`}
-		</Button>
-	) : (
-		<Button
-			type="button"
-			variant="outline"
-			role="combobox"
-			disabled={disabled}
-			className={cn(
-				"h-8 w-full justify-between !bg-transparent font-normal active:scale-none",
-				!triggerLabel && "text-muted-foreground",
-				triggerClassName,
-			)}
-		>
-			<span className="truncate">{triggerLabel || resolvedPlaceholder}</span>
-			<ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
-		</Button>
-	);
+	// Add mode has no value to display, so it defaults to a compact action button rather than the
+	// full-width combobox — unless fullWidth is set, which uses the combobox trigger (showing the
+	// placeholder) for surfaces that want the picker to span the row.
+	const defaultTrigger =
+		isAdd && !fullWidth ? (
+			<Button type="button" variant="outline" size="sm" disabled={disabled} className="h-7.5 gap-1.5 px-2 py-1 text-sm font-medium">
+				<PlusIcon className="size-4" />
+				{placeholder ?? `Add ${entityLabel}`}
+			</Button>
+		) : (
+			<Button
+				type="button"
+				variant="outline"
+				role="combobox"
+				disabled={disabled}
+				className={cn(
+					"h-8 w-full justify-between !bg-transparent font-normal active:scale-none",
+					!triggerLabel && "text-muted-foreground",
+					triggerClassName,
+				)}
+			>
+				<span className="truncate">{triggerLabel || resolvedPlaceholder}</span>
+				<ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
+			</Button>
+		);
 
 	return (
 		// Single wrapping element, so no vertical spacing utility here — it only
 		// ever holds the trigger and the (invisible) label resolvers.
-		<div className={cn(isAdd ? "inline-flex" : "w-full", className)}>
+		<div className={cn(isAdd && !fullWidth ? "inline-flex" : "w-full", className)}>
 			{labelResolvers}
 			<SearchSelect
 				async
@@ -425,9 +430,9 @@ export function EntitySelector(props: EntitySelectorProps) {
 				// A compact trigger shouldn't dictate the popover width, so add
 				// mode keeps SearchSelect's own fixed width. Either default gives
 				// way to an explicit contentClassName.
-				align={isAdd ? "end" : "start"}
-				className={isAdd ? undefined : "w-full"}
-				contentClassName={contentClassName ?? (isAdd ? undefined : "w-(--radix-popover-trigger-width)")}
+				align={isAdd && !fullWidth ? "end" : "start"}
+				className={isAdd && !fullWidth ? undefined : "w-full"}
+				contentClassName={contentClassName ?? (isAdd && !fullWidth ? undefined : "w-(--radix-popover-trigger-width)")}
 				noPortal={noPortal}
 			/>
 		</div>

--- a/ui/components/entitySelectors/virtualMcpSelector.tsx
+++ b/ui/components/entitySelectors/virtualMcpSelector.tsx
@@ -1,0 +1,64 @@
+// Server-backed searchable Virtual MCP selector; scales past one page of Virtual MCPs.
+
+import {
+	EntitySelector,
+	ENTITY_SELECTOR_PAGE_SIZE,
+	type EntitySelectorCommonProps,
+	type EntityLabelResolverProps,
+	type EntitySelectorModeProps,
+	type EntitySelectorOption,
+	useEntitySelectorSearch,
+} from "@/components/entitySelectors/entitySelector";
+import { useGetVirtualMCPQuery, useGetVirtualMCPsQuery } from "@/lib/store";
+import { useEffect, useMemo } from "react";
+
+export type VirtualMCPSelectorOption = EntitySelectorOption;
+
+// Resolves a selected vMCP id to its name when it's outside the search page.
+function VirtualMCPLabelResolver({ id, onResolved }: EntityLabelResolverProps) {
+	const { data } = useGetVirtualMCPQuery(Number(id));
+	useEffect(() => {
+		if (data) onResolved({ value: id, label: data.name || id });
+	}, [data, id, onResolved]);
+	return null;
+}
+
+interface VirtualMCPSelectorOwnProps extends EntitySelectorCommonProps {
+	/** Page size for each search request. */
+	limit?: number;
+}
+
+export type VirtualMCPSelectorProps = VirtualMCPSelectorOwnProps & EntitySelectorModeProps;
+
+export function VirtualMCPSelector({ limit = ENTITY_SELECTOR_PAGE_SIZE, ...props }: VirtualMCPSelectorProps) {
+	const { open, setOpen, setSearch, debouncedSearch, skip, isDebouncing } = useEntitySelectorSearch();
+
+	const { data, isFetching, isError } = useGetVirtualMCPsQuery({ limit, search: debouncedSearch || undefined }, { skip });
+
+	const options = useMemo(
+		() =>
+			(data?.virtual_mcps ?? []).map((vmcp) => ({
+				value: String(vmcp.id),
+				label: vmcp.name || String(vmcp.id),
+				description: vmcp.endpoint_slug ? `/mcp/${vmcp.endpoint_slug}` : undefined,
+			})),
+		[data],
+	);
+
+	return (
+		<EntitySelector
+			{...props}
+			LabelResolver={VirtualMCPLabelResolver}
+			entityLabel="Virtual MCP"
+			entityLabelPlural="Virtual MCPs"
+			options={options}
+			isFetching={isFetching}
+			isError={isError}
+			open={open}
+			onOpenChange={setOpen}
+			onSearchChange={setSearch}
+			isSearching={isDebouncing || (isFetching && !!debouncedSearch)}
+			debouncedSearch={debouncedSearch}
+		/>
+	);
+}

--- a/ui/components/mcp/mcpClientConfigsEditor.tsx
+++ b/ui/components/mcp/mcpClientConfigsEditor.tsx
@@ -7,7 +7,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useGetMCPClientsQuery } from "@/lib/store";
 import { MCPClient } from "@/lib/types/mcp";
-import { ChevronDownIcon, Info, Trash2 } from "lucide-react";
+import { Info, Trash2 } from "lucide-react";
 import { ReactNode, useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
 
@@ -154,22 +154,10 @@ export function MCPClientConfigsEditor({
 			{/* Add MCP Server dropdown. */}
 			<MCPClientSelector
 				mode="add"
+				fullWidth
+				placeholder="Select an MCP server to add"
 				onSelect={handleAddMCPClient}
 				excludeIds={excludeIds}
-				className="w-full"
-				contentClassName="w-(--radix-popover-trigger-width)"
-				trigger={
-					<Button
-						type="button"
-						variant="outline"
-						role="combobox"
-						className="text-muted-foreground h-8 w-full justify-between !bg-transparent font-normal active:scale-none"
-						data-testid="mcp-server-add-select"
-					>
-						<span className="truncate">Select an MCP server to add</span>
-						<ChevronDownIcon className="ml-2 size-4 shrink-0 opacity-50" />
-					</Button>
-				}
 			/>
 
 			{value.length === 0 && emptyState}

--- a/ui/components/mcp/virtualMcpAssignmentsEditor.tsx
+++ b/ui/components/mcp/virtualMcpAssignmentsEditor.tsx
@@ -1,0 +1,85 @@
+import type { EntitySelectorOption } from "@/components/entitySelectors/entitySelector";
+import { VirtualMCPSelector } from "@/components/entitySelectors/virtualMcpSelector";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useGetVirtualMCPQuery } from "@/lib/store";
+import { Info, Trash2 } from "lucide-react";
+import type { ReactNode } from "react";
+
+const DEFAULT_LABEL = "Virtual MCP Server Configurations";
+
+const DEFAULT_TOOLTIP = (
+	<p>
+		Assign this key to Virtual MCPs. The key can then reach each Virtual MCP at its <span className="font-medium">/mcp/&lt;slug&gt;</span>{" "}
+		endpoint, and the key shows up under that Virtual MCP&apos;s assigned keys.
+	</p>
+);
+
+// One assigned Virtual MCP: resolves its name/slug by id, then renders a removable row.
+function AssignedVirtualMcpRow({ id, onRemove }: { id: number; onRemove: () => void }) {
+	const { data } = useGetVirtualMCPQuery(id);
+	const name = data?.name || `Virtual MCP #${id}`;
+	return (
+		<div className="flex items-center justify-between gap-2 px-3 py-2">
+			<div className="flex min-w-0 flex-col">
+				<span className="truncate text-sm font-medium">{name}</span>
+				{data?.endpoint_slug && <span className="text-muted-foreground truncate text-xs">/mcp/{data.endpoint_slug}</span>}
+			</div>
+			<Button type="button" variant="ghost" size="sm" aria-label={`Remove ${name}`} onClick={onRemove}>
+				<Trash2 className="h-4 w-4" />
+			</Button>
+		</div>
+	);
+}
+
+interface VirtualMcpAssignmentsEditorProps {
+	value: number[];
+	onChange: (ids: number[]) => void;
+	label?: string;
+	tooltip?: ReactNode;
+}
+
+// Assign a virtual key to Virtual MCPs. The picker is server-backed; assignments commit as
+// attach/detach on Save (the parent owns that), mirroring the MCP-server config editor above it.
+export function VirtualMcpAssignmentsEditor({
+	value,
+	onChange,
+	label = DEFAULT_LABEL,
+	tooltip = DEFAULT_TOOLTIP,
+}: VirtualMcpAssignmentsEditorProps) {
+	const add = (option: EntitySelectorOption) => {
+		const id = Number(option.value);
+		if (value.includes(id)) return;
+		onChange([...value, id]);
+	};
+	const remove = (id: number) => onChange(value.filter((v) => v !== id));
+
+	return (
+		<div className="mt-6 space-y-2">
+			<div className="flex items-center gap-2">
+				<Label className="text-sm font-medium">{label}</Label>
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span>
+								<Info className="text-muted-foreground h-3 w-3" />
+							</span>
+						</TooltipTrigger>
+						<TooltipContent>{tooltip}</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			</div>
+
+			<VirtualMCPSelector mode="add" fullWidth placeholder="Select a Virtual MCP to add" onSelect={add} excludeIds={value.map(String)} />
+
+			{value.length > 0 && (
+				<div className="divide-y overflow-hidden rounded-md border">
+					{value.map((id) => (
+						<AssignedVirtualMcpRow key={id} id={id} onRemove={() => remove(id)} />
+					))}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -85,7 +85,7 @@ export const governanceApi = baseApi.injectEndpoints({
 			providesTags: ["VirtualKeys"],
 		}),
 
-		getVirtualKey: builder.query<{ virtual_key: VirtualKey }, string>({
+		getVirtualKey: builder.query<{ virtual_key: VirtualKey; virtual_mcp_ids: number[] }, string>({
 			query: (vkId) => `/governance/virtual-keys/${vkId}`,
 			providesTags: (result, error, vkId) => [{ type: "VirtualKeys", id: vkId }],
 		}),

--- a/ui/lib/store/apis/virtualMcpsApi.ts
+++ b/ui/lib/store/apis/virtualMcpsApi.ts
@@ -56,12 +56,13 @@ export const virtualMcpsApi = baseApi.injectEndpoints({
 
 		attachVirtualMCPVirtualKey: builder.mutation<SuccessResponse, { id: number; vkId: string }>({
 			query: ({ id, vkId }) => ({ url: `/mcp/virtual-mcps/${id}/virtual-keys/${vkId}`, method: "POST" }),
-			invalidatesTags: (_result, _error, { id }) => ["VirtualMCPs", { type: "VirtualMCPs", id }],
+			// Also refresh the affected key's detail (its virtual_mcp_ids) so a reopened sheet sees the change.
+			invalidatesTags: (_result, _error, { id, vkId }) => ["VirtualMCPs", { type: "VirtualMCPs", id }, { type: "VirtualKeys", id: vkId }],
 		}),
 
 		detachVirtualMCPVirtualKey: builder.mutation<SuccessResponse, { id: number; vkId: string }>({
 			query: ({ id, vkId }) => ({ url: `/mcp/virtual-mcps/${id}/virtual-keys/${vkId}`, method: "DELETE" }),
-			invalidatesTags: (_result, _error, { id }) => ["VirtualMCPs", { type: "VirtualMCPs", id }],
+			invalidatesTags: (_result, _error, { id, vkId }) => ["VirtualMCPs", { type: "VirtualMCPs", id }, { type: "VirtualKeys", id: vkId }],
 		}),
 	}),
 });

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -102,6 +102,8 @@ export interface VirtualKey {
 	description?: string;
 	provider_configs?: VirtualKeyProviderConfig[];
 	mcp_configs?: VirtualKeyMCPConfig[];
+	// Virtual MCPs this key is assigned to. Populated by the single-VK GET, not the list.
+	virtual_mcp_ids?: number[];
 	team_id?: string;
 	customer_id?: string;
 	rate_limit_id?: string;


### PR DESCRIPTION
## Summary

Adds the ability to assign a virtual key to one or more Virtual MCPs directly from the virtual key detail panel. Previously, Virtual MCP assignments could only be managed from the Virtual MCP side. This change exposes the reverse lookup (`GetVirtualMCPIDsForVirtualKey`) through the API and wires it into the UI so the virtual key sheet can display, add, and remove Virtual MCP assignments.

## Changes

- Added `GetVirtualMCPIDsForVirtualKey` to `ConfigStore` and implemented it in `RDBConfigStore`, querying the `TableVirtualKeyVirtualMCP` join table by `virtual_key_id` and plucking `tool_group_id`.
- Extended the `getVirtualKey` HTTP handler to fetch and include `virtual_mcp_ids` in the response alongside the virtual key.
- Updated the `getVirtualKey` RTK Query endpoint type to include `virtual_mcp_ids: number[]`, and added `virtual_mcp_ids` as an optional field on the `VirtualKey` type.
- Added `GrantClientTools` to `MCPToolAccumulator` as a convenience entry point for holders that carry a per-client allowlist and a resolvable name.
- Added a `fullWidth` prop to `EntitySelector` so add-mode pickers can render as a full-width combobox instead of the default compact inline button. Used this to simplify `MCPClientConfigsEditor`, removing its custom trigger override.
- Added `VirtualMCPSelector`, a server-backed searchable selector backed by `useGetVirtualMCPsQuery` with label resolution for out-of-page selections.
- Added `VirtualMcpAssignmentsEditor`, a self-contained editor component that renders the `VirtualMCPSelector` and a removable list of assigned Virtual MCPs, mirroring the MCP client configs editor pattern.
- Wired `VirtualMcpAssignmentsEditor` into `VirtualKeySheet`: fetches the single-VK detail (which carries `virtual_mcp_ids`) on edit, stages changes locally, reconciles attach/detach calls on save for both create and update flows, and gates the Save button on `vmcpDirty` in addition to `form.formState.isDirty`.
- Added `TestGetVirtualMCPIDsForVirtualKey` to pin the reverse assignment lookup behavior, covering multi-assignment, single-assignment, and no-assignment cases.
- Added a stub `GetVirtualMCPIDsForVirtualKey` to `MockConfigStore` to satisfy the interface in existing tests.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./framework/configstore/... ./transports/bifrost-http/...

# UI
cd ui
pnpm i
pnpm build
```

1. Open the virtual key detail panel for an existing key.
2. Scroll to the **Virtual MCP Server Configurations** section.
3. Use the picker to assign one or more Virtual MCPs — the Save button should become enabled.
4. Save and reopen the panel; the assigned Virtual MCPs should be pre-populated.
5. Remove an assignment, save, and confirm the detach is reflected when reopening.
6. Verify the assigned key appears under the corresponding Virtual MCP's assigned keys list.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The new endpoint reuses the existing virtual key authorization path. No new secrets or PII are introduced; `virtual_mcp_ids` are internal numeric IDs.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable