### PR TITLE
feat: add multi-scope filter support for model configs with `filterUnderScope` registry field and comma-separated scope query param

### DIFF
--- a/framework/configstore/modelconfigscopefilter_test.go
+++ b/framework/configstore/modelconfigscopefilter_test.go
@@ -1,0 +1,91 @@
+package configstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// TestGetModelConfigsPaginatedScopesFilter covers the multi-value scope filter.
+// One UI filter option can cover several scope values, so the query must OR them:
+// in an enterprise build the "User" option covers both "user" and
+// "access_profile". Those two scopes are registered by enterprise at runtime and
+// fail model-config validation in an OSS-only test, so this exercises the same
+// OR-ing over the OSS-native scopes.
+func TestGetModelConfigsPaginatedScopesFilter(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.AutoMigrate(&tables.TableModelConfig{}))
+
+	sid := func(v string) *string { return &v }
+	seed := []tables.TableModelConfig{
+		{ID: "mc-1", Scope: "virtual_key", ScopeID: sid("vk1"), ModelName: "gpt-4o"},
+		{ID: "mc-2", Scope: "virtual_key", ScopeID: sid("vk2"), ModelName: "claude"},
+		{ID: "mc-3", Scope: "global", ModelName: "gemini"},
+	}
+	for i := range seed {
+		require.NoError(t, db.Create(&seed[i]).Error)
+	}
+
+	store := &RDBConfigStore{}
+	store.db.Store(db)
+	ctx := context.Background()
+
+	modelsForParams := func(t *testing.T, params ModelConfigsQueryParams) []string {
+		t.Helper()
+		rows, total, err := store.GetModelConfigsPaginated(ctx, params)
+		require.NoError(t, err)
+		require.Equal(t, int64(len(rows)), total, "total_count must match the filtered rows, not the whole table")
+		out := make([]string, 0, len(rows))
+		for _, r := range rows {
+			out = append(out, r.ModelName)
+		}
+		return out
+	}
+	modelsFor := func(t *testing.T, scopes []string) []string {
+		t.Helper()
+		return modelsForParams(t, ModelConfigsQueryParams{Scopes: scopes})
+	}
+
+	t.Run("single scope filters exactly", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"gemini"}, modelsFor(t, []string{"global"}))
+	})
+
+	t.Run("several scopes are OR-ed", func(t *testing.T) {
+		require.ElementsMatch(t, []string{"gpt-4o", "claude", "gemini"}, modelsFor(t, []string{"global", "virtual_key"}))
+	})
+
+	t.Run("empty scopes means no scope filter", func(t *testing.T) {
+		require.Len(t, modelsFor(t, nil), 3)
+	})
+
+	t.Run("unknown scope matches nothing", func(t *testing.T) {
+		require.Empty(t, modelsFor(t, []string{"nope"}))
+	})
+
+	// The deprecated single Scope field stays supported: an existing caller of
+	// this published module must keep filtering exactly as it did.
+	t.Run("deprecated Scope field still filters on its own", func(t *testing.T) {
+		got := modelsForParams(t, ModelConfigsQueryParams{Scope: "global"})
+		require.ElementsMatch(t, []string{"gemini"}, got)
+	})
+
+	t.Run("deprecated Scope is OR-ed with Scopes", func(t *testing.T) {
+		got := modelsForParams(t, ModelConfigsQueryParams{Scope: "global", Scopes: []string{"virtual_key"}})
+		require.ElementsMatch(t, []string{"gemini", "gpt-4o", "claude"}, got)
+	})
+
+	t.Run("the same scope in both fields is not double-counted", func(t *testing.T) {
+		got := modelsForParams(t, ModelConfigsQueryParams{Scope: "global", Scopes: []string{"global"}})
+		require.ElementsMatch(t, []string{"gemini"}, got)
+	})
+
+	t.Run("both empty means no scope filter", func(t *testing.T) {
+		require.Len(t, modelsForParams(t, ModelConfigsQueryParams{}), 3)
+	})
+}

--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -5942,8 +5942,12 @@ func (s *RDBConfigStore) GetModelConfigsPaginated(ctx context.Context, params Mo
 		search := "%" + strings.ToLower(params.Search) + "%"
 		baseQuery = baseQuery.Where("LOWER(model_name) LIKE ?", search)
 	}
-	if params.Scope != "" {
-		baseQuery = baseQuery.Where("scope = ?", params.Scope)
+	// Scope (deprecated, single) and Scopes are OR-ed together, so a caller still
+	// setting only Scope filters exactly as it always did.
+	if scopes := params.effectiveScopes(); len(scopes) == 1 {
+		baseQuery = baseQuery.Where("scope = ?", scopes[0])
+	} else if len(scopes) > 1 {
+		baseQuery = baseQuery.Where("scope IN ?", scopes)
 	}
 	if params.ScopeID != "" {
 		baseQuery = baseQuery.Where("scope_id = ?", params.ScopeID)

--- a/framework/configstore/store.go
+++ b/framework/configstore/store.go
@@ -32,12 +32,46 @@ type VirtualKeyQueryParams struct {
 
 // ModelConfigsQueryParams holds pagination, filtering, and search parameters for model configs queries.
 type ModelConfigsQueryParams struct {
-	Limit    int
-	Offset   int
-	Search   string
-	Scope    string // optional; filters to an exact scope value (e.g. "global", "virtual_key")
+	Limit  int
+	Offset int
+	Search string
+	// Scope optionally filters to an exact scope value (e.g. "global",
+	// "virtual_key").
+	//
+	// Deprecated: use Scopes, which can carry more than one. Kept so existing
+	// callers of this published module keep compiling and behaving identically; a
+	// value set here is OR-ed together with anything in Scopes.
+	Scope string
+	// Scopes optionally filters to one or more exact scope values. Several values
+	// are OR-ed, which lets a UI present one filter option covering scopes a user
+	// thinks of as the same thing — e.g. rows scoped to a user directly and rows
+	// materialized onto them from an access profile. Empty (with Scope also empty)
+	// means no scope filter.
+	Scopes   []string
 	ScopeID  string // optional; filters to an exact scope target (e.g. a virtual key or user ID)
 	Provider string // optional; filters to an exact provider value (e.g. "openai")
+}
+
+// effectiveScopes returns the scope values to filter on, merging the deprecated
+// single Scope with Scopes and dropping blanks and duplicates. Returns nil when
+// neither is set, meaning "no scope filter".
+func (p ModelConfigsQueryParams) effectiveScopes() []string {
+	seen := make(map[string]struct{}, len(p.Scopes)+1)
+	out := make([]string, 0, len(p.Scopes)+1)
+	for _, s := range append([]string{p.Scope}, p.Scopes...) {
+		if s == "" {
+			continue
+		}
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // SkillListQueryParams holds pagination, filtering, and search parameters for skill repository queries.

--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -3681,10 +3681,18 @@ func (h *GovernanceHandler) getModelConfigs(ctx *fasthttp.RequestCtx) {
 	provider := string(ctx.QueryArgs().Peek("provider"))
 
 	if limitStr != "" || offsetStr != "" || search != "" || scope != "" || scopeID != "" || provider != "" {
-		// Paginated path
+		// Paginated path. `scope` accepts a comma-separated list so one UI filter
+		// option can cover several scope values; scope values are identifiers and
+		// never contain commas, so splitting is unambiguous.
+		var scopes []string
+		for _, s := range strings.Split(scope, ",") {
+			if s = strings.TrimSpace(s); s != "" {
+				scopes = append(scopes, s)
+			}
+		}
 		params := configstore.ModelConfigsQueryParams{
 			Search:   search,
-			Scope:    scope,
+			Scopes:   scopes,
 			ScopeID:  scopeID,
 			Provider: provider,
 		}

--- a/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsTable.tsx
@@ -20,7 +20,7 @@ import { resetDurationLabels, supportsCalendarAlignment } from "@/lib/constants/
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import PageTitle from "@/components/pageTitle";
-import { getModelLimitScope, getModelLimitScopes } from "@/lib/registries/modelLimitScopes";
+import { getModelLimitScope, getModelLimitScopeFilterOptions } from "@/lib/registries/modelLimitScopes";
 import { getErrorMessage, useDeleteModelConfigMutation, useGetModelConfigQuery } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
 import { ModelConfig } from "@/lib/types/governance";
@@ -295,7 +295,7 @@ export default function ModelLimitsTable({
 						</SelectTrigger>
 						<SelectContent>
 							<SelectItem value="all">All Scopes</SelectItem>
-							{getModelLimitScopes().map((o) => (
+							{getModelLimitScopeFilterOptions().map((o) => (
 								<SelectItem key={o.value} value={o.value}>
 									{o.label}
 								</SelectItem>

--- a/ui/app/workspace/model-limits/views/modelLimitsView.tsx
+++ b/ui/app/workspace/model-limits/views/modelLimitsView.tsx
@@ -1,6 +1,7 @@
 import FullPageLoader from "@/components/fullPageLoader";
 import { useDebouncedValue } from "@/hooks/useDebounce";
 import { getErrorMessage, useGetModelConfigsQuery, useGetProvidersQuery } from "@/lib/store";
+import { getModelLimitScopeFilterOptions } from "@/lib/registries/modelLimitScopes";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
@@ -19,6 +20,10 @@ export default function ModelLimitsView() {
 
 	const debouncedSearch = useDebouncedValue(search, 300);
 
+	// One filter option can cover several scope values, so send the whole group as
+	// a comma-separated list rather than the option's own value.
+	const scopeQueryValue = scope ? (getModelLimitScopeFilterOptions().find((o) => o.value === scope)?.scopes ?? [scope]).join(",") : "";
+
 	// Reset to first page when any filter changes
 	useEffect(() => {
 		setOffset(0);
@@ -35,7 +40,9 @@ export default function ModelLimitsView() {
 			limit: PAGE_SIZE,
 			offset,
 			search: debouncedSearch || undefined,
-			scope: scope || undefined,
+			// The filter option's value names one scope, but it may cover several (an
+			// enterprise access-profile row is still a user's limit) — send them all.
+			scope: scopeQueryValue || undefined,
 			provider: provider || undefined,
 		},
 		{

--- a/ui/lib/registries/modelLimitScopes.tsx
+++ b/ui/lib/registries/modelLimitScopes.tsx
@@ -59,6 +59,14 @@ export interface ModelLimitScopeEntry {
 	// literal "user" scope value — still read as "User" wherever a single row is
 	// displayed, without colliding with "user" as a distinct filterable option.
 	displayAsScope?: string;
+	// Optional. Groups this scope under another scope's filter option, so the
+	// Scope filter offers one choice covering both and queries them together.
+	// The value names the scope that owns the option (e.g. enterprise's
+	// "access_profile" rows filter under "user": they are still a user's limits,
+	// just materialized from a profile, so splitting them across two filter
+	// options only hides rows from someone filtering by User). The grouped scope
+	// keeps its own `label` for anywhere it names itself.
+	filterUnderScope?: string;
 	// Optional. Renders additional context next to the Scope Target for a row of
 	// this scope — e.g. enterprise's "Managed by Access Profile: X" note. Passed
 	// the row's own ModelConfig; renders nothing (returns null) itself when there
@@ -91,6 +99,41 @@ export function getModelLimitScopes(): ModelLimitScopeEntry[] {
 
 export function getModelLimitScope(value: string): ModelLimitScopeEntry | undefined {
 	return registry.get(value);
+}
+
+/**
+ * A single Scope filter choice: the option's own label, and every scope value it
+ * should query. Scopes that declare `filterUnderScope` are folded into their
+ * owner's option instead of getting one of their own, so the filter reads the way
+ * a user thinks about the rows rather than mirroring storage.
+ */
+export interface ModelLimitScopeFilterOption {
+	value: string;
+	label: string;
+	scopes: string[];
+}
+
+export function getModelLimitScopeFilterOptions(): ModelLimitScopeFilterOption[] {
+	const options: ModelLimitScopeFilterOption[] = [];
+	const byValue = new Map<string, ModelLimitScopeFilterOption>();
+	for (const entry of getModelLimitScopes()) {
+		if (entry.filterUnderScope) continue;
+		const option = { value: entry.value, label: entry.label, scopes: [entry.value] };
+		options.push(option);
+		byValue.set(entry.value, option);
+	}
+	for (const entry of getModelLimitScopes()) {
+		if (!entry.filterUnderScope) continue;
+		const owner = byValue.get(entry.filterUnderScope);
+		// An unknown owner would silently drop the scope from the filter, so fall
+		// back to giving it its own option rather than hiding its rows.
+		if (owner) {
+			owner.scopes.push(entry.value);
+		} else {
+			options.push({ value: entry.value, label: entry.label, scopes: [entry.value] });
+		}
+	}
+	return options;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


