### PR TITLE
chore: adds ui tooltip to show cached and uncached input tokens breakdown

### DIFF
--- a/framework/configstore/encryption.go
+++ b/framework/configstore/encryption.go
@@ -3,17 +3,94 @@ package configstore
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 
+	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore/tables"
 	"github.com/maximhq/bifrost/framework/encrypt"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 const (
 	encryptionStatusPlainText = "plain_text"
 	encryptionStatusEncrypted = "encrypted"
-	encryptionBatchSize       = 100
+	// encryptionBatchSize is how many candidate rows one scan reads ahead. The
+	// rows are still written one per transaction; this only bounds the read.
+	encryptionBatchSize = 100
+	// encryptionVaultConcurrency is how many rows are encrypted at once when the
+	// BeforeSave hook writes to the vault. Each row still gets its own
+	// transaction and its own single row lock, so this adds no deadlock risk; it
+	// only overlaps the vault round trips, which otherwise dominate the walk.
+	// Kept well under the runtime pool so a booting node cannot exhaust it.
+	encryptionVaultConcurrency = 8
 )
+
+// encryptConcurrency returns how many rows to encrypt in parallel. OSS, where vault
+// store is not enabled keeps concurrency to 1.
+func encryptConcurrency() int {
+	if schemas.VaultStoreWriteEnabled() {
+		return encryptionVaultConcurrency
+	}
+	return 1
+}
+
+// lockRow takes a row lock so a row claimed by one node is not re-encrypted by
+// another. Exactly one row is locked per transaction, so no transaction ever
+// holds one lock while waiting for a second and a deadlock cycle cannot form.
+// SQLite is single-writer and has no row locks, so the clause is omitted there.
+func lockRow(tx *gorm.DB) *gorm.DB {
+	if tx.Dialector.Name() == "sqlite" {
+		return tx
+	}
+	return tx.Clauses(clause.Locking{Strength: "UPDATE"})
+}
+
+// encryptClaimedRows encrypts the given ids, each in its own transaction that
+// locks the row and re-checks it is still plaintext before the hook runs. A
+// transaction holds exactly one row lock, so no deadlock cycle can form however
+// many run at once, and a row another node already encrypted is dropped before
+// its hook does any work — which matters because that work includes vault
+// writes. where clause must match a single row and take (status, id).
+func encryptClaimedRows[T any, ID any](ctx context.Context, s *RDBConfigStore, ids []ID, where string, statusOf func(*T) string) (int, error) {
+	var encrypted atomic.Int64
+	errs := make([]error, len(ids))
+	sem := make(chan struct{}, encryptConcurrency())
+	var wg sync.WaitGroup
+	for i := range ids {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			errs[i] = s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+				var row []T
+				if err := lockRow(tx).Where(where, encryptionStatusPlainText, ids[i]).
+					Limit(1).Find(&row).Error; err != nil {
+					return err
+				}
+				if len(row) == 0 {
+					return nil // another node encrypted it first
+				}
+				if err := tx.Save(&row[0]).Error; err != nil {
+					return err
+				}
+				if statusOf(&row[0]) == encryptionStatusEncrypted {
+					encrypted.Add(1)
+				}
+				return nil
+			})
+		}(i)
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return int(encrypted.Load()), err
+		}
+	}
+	return int(encrypted.Load()), nil
+}
 
 // EncryptPlaintextRows encrypts all rows with encryption_status='plain_text'
 // across all sensitive tables. Called during startup when encryption is enabled.
@@ -103,308 +180,328 @@ func (s *RDBConfigStore) EncryptPlaintextRows(ctx context.Context) error {
 }
 
 // encryptPlaintextKeys finds all config_keys rows with plaintext encryption status and
-// re-saves them in batches. The TableKey.BeforeSave hook handles the actual encryption.
+// re-saves them one row per transaction. The TableKey.BeforeSave hook handles the actual encryption.
 func (s *RDBConfigStore) encryptPlaintextKeys(ctx context.Context) (int, error) {
 	var count int
+	var cursor uint
 	for {
-		var keys []tables.TableKey
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []uint
 		if err := s.DB().WithContext(ctx).
-			Where("encryption_status = ? OR encryption_status IS NULL OR encryption_status = ''", encryptionStatusPlainText).
+			Model(&tables.TableKey{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&keys).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(keys) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range keys {
-				if err := tx.Save(&keys[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND id = ?",
+			func(r *tables.TableKey) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(keys)
 	}
 	return count, nil
 }
 
 // encryptPlaintextVirtualKeys finds all governance_virtual_keys rows with plaintext encryption
-// status and re-saves them in batches. The TableVirtualKey.BeforeSave hook handles encryption.
+// status and re-saves them one row per transaction. The TableVirtualKey.BeforeSave hook handles encryption.
 func (s *RDBConfigStore) encryptPlaintextVirtualKeys(ctx context.Context) (int, error) {
 	var count int
+	var cursor string
 	for {
-		var vks []tables.TableVirtualKey
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []string
 		if err := s.DB().WithContext(ctx).
-			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND value != ''", encryptionStatusPlainText).
+			Model(&tables.TableVirtualKey{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND value != '' AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&vks).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(vks) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range vks {
-				if err := tx.Save(&vks[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND value != '' AND id = ?",
+			func(r *tables.TableVirtualKey) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(vks)
 	}
 	return count, nil
 }
 
 // encryptPlaintextSessions finds all sessions rows with plaintext encryption status and
-// re-saves them in batches. The SessionsTable.BeforeSave hook handles encryption.
+// re-saves them one row per transaction. The SessionsTable.BeforeSave hook handles encryption.
 func (s *RDBConfigStore) encryptPlaintextSessions(ctx context.Context) (int, error) {
 	var count int
+	var cursor int
 	for {
-		var sessions []tables.SessionsTable
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []int
 		if err := s.DB().WithContext(ctx).
-			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND token != ''", encryptionStatusPlainText).
+			Model(&tables.SessionsTable{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND token != '' AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&sessions).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(sessions) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range sessions {
-				if err := tx.Save(&sessions[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND token != '' AND id = ?",
+			func(r *tables.SessionsTable) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(sessions)
 	}
 	return count, nil
 }
 
 // encryptPlaintextTempTokens finds all temp_tokens rows with plaintext encryption status
-// and re-saves them in batches. The TempToken.BeforeSave hook handles encryption.
+// and re-saves them one row per transaction. The TempToken.BeforeSave hook handles encryption.
 func (s *RDBConfigStore) encryptPlaintextTempTokens(ctx context.Context) (int, error) {
 	var count int
+	var cursor string
 	for {
-		var tokens []tables.TempToken
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []string
 		if err := s.DB().WithContext(ctx).
-			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND token != ''", encryptionStatusPlainText).
+			Model(&tables.TempToken{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND token != '' AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&tokens).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(tokens) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range tokens {
-				if err := tx.Save(&tokens[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND token != '' AND id = ?",
+			func(r *tables.TempToken) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(tokens)
 	}
 	return count, nil
 }
 
 // encryptPlaintextOAuthTokens finds all mcp_oauth_tokens rows with plaintext encryption status
-// and re-saves them in batches. The TableMCPOauthToken.BeforeSave hook handles encryption.
+// and re-saves them one row per transaction. The TableMCPOauthToken.BeforeSave hook handles encryption.
 func (s *RDBConfigStore) encryptPlaintextOAuthTokens(ctx context.Context) (int, error) {
 	var count int
+	var cursor string
 	for {
-		var tokens []tables.TableMCPOauthToken
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []string
 		if err := s.DB().WithContext(ctx).
-			Where("encryption_status = ? OR encryption_status IS NULL OR encryption_status = ''", encryptionStatusPlainText).
+			Model(&tables.TableMCPOauthToken{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&tokens).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(tokens) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range tokens {
-				if err := tx.Save(&tokens[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND id = ?",
+			func(r *tables.TableMCPOauthToken) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(tokens)
 	}
 	return count, nil
 }
 
 // encryptPlaintextOAuthConfigs finds all oauth_configs rows with plaintext encryption status
-// and re-saves them in batches. The TableOauthConfig.BeforeSave hook handles encryption.
+// and re-saves them one row per transaction. The TableOauthConfig.BeforeSave hook handles encryption.
 // client_secret is the only sensitive column left on this table — state/
 // code_verifier/code_challenge/expires_at moved to mcp_oauth_flows (see that
 // migration) and code_verifier was the only one of those that was ever
 // encrypted, so the WHERE clause below no longer needs an OR branch for it.
 func (s *RDBConfigStore) encryptPlaintextOAuthConfigs(ctx context.Context) (int, error) {
 	var count int
+	var cursor string
 	for {
-		var configs []tables.TableOauthConfig
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []string
 		if err := s.DB().WithContext(ctx).
-			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND client_secret != ''", encryptionStatusPlainText).
+			Model(&tables.TableOauthConfig{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND client_secret != '' AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&configs).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(configs) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range configs {
-				if err := tx.Save(&configs[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND client_secret != '' AND id = ?",
+			func(r *tables.TableOauthConfig) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(configs)
 	}
 	return count, nil
 }
 
 // encryptPlaintextMCPClients finds all config_mcp_clients rows with plaintext encryption
-// status and re-saves them in batches. The TableMCPClient.BeforeSave hook handles encryption.
+// status and re-saves them one row per transaction. The TableMCPClient.BeforeSave hook handles encryption.
 func (s *RDBConfigStore) encryptPlaintextMCPClients(ctx context.Context) (int, error) {
 	var count int
+	var cursor uint
 	for {
-		var clients []tables.TableMCPClient
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []uint
 		if err := s.DB().WithContext(ctx).
-			Where("encryption_status = ? OR encryption_status IS NULL OR encryption_status = ''", encryptionStatusPlainText).
+			Model(&tables.TableMCPClient{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&clients).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(clients) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range clients {
-				if err := tx.Save(&clients[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND id = ?",
+			func(r *tables.TableMCPClient) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(clients)
 	}
 	return count, nil
 }
 
 // encryptPlaintextProviderProxies finds all config_providers rows that have a non-empty
-// proxy config with plaintext encryption status and re-saves them in batches. The
+// proxy config with plaintext encryption status and re-saves them one row per transaction. The
 // TableProvider.BeforeSave hook handles encryption.
 func (s *RDBConfigStore) encryptPlaintextProviderProxies(ctx context.Context) (int, error) {
 	var count int
+	var cursor uint
 	for {
-		var providers []tables.TableProvider
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []uint
 		if err := s.DB().WithContext(ctx).
-			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND proxy_config_json != '' AND proxy_config_json IS NOT NULL", encryptionStatusPlainText).
+			Model(&tables.TableProvider{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND proxy_config_json != '' AND proxy_config_json IS NOT NULL AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&providers).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(providers) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range providers {
-				if err := tx.Save(&providers[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND proxy_config_json != '' AND proxy_config_json IS NOT NULL AND id = ?",
+			func(r *tables.TableProvider) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(providers)
 	}
 	return count, nil
 }
 
 // encryptPlaintextVectorStoreConfigs finds all config_vector_store rows that have a non-empty
-// config with plaintext encryption status and re-saves them in batches. The
+// config with plaintext encryption status and re-saves them one row per transaction. The
 // TableVectorStoreConfig.BeforeSave hook handles encryption.
 func (s *RDBConfigStore) encryptPlaintextVectorStoreConfigs(ctx context.Context) (int, error) {
 	var count int
+	var cursor uint
 	for {
-		var configs []tables.TableVectorStoreConfig
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []uint
 		if err := s.DB().WithContext(ctx).
-			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND config IS NOT NULL AND config != ''", encryptionStatusPlainText).
+			Model(&tables.TableVectorStoreConfig{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND config IS NOT NULL AND config != '' AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&configs).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(configs) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range configs {
-				if err := tx.Save(&configs[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND config IS NOT NULL AND config != '' AND id = ?",
+			func(r *tables.TableVectorStoreConfig) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(configs)
 	}
 	return count, nil
 }
 
 // encryptPlaintextPlugins finds all config_plugins rows that have a non-empty config with
-// plaintext encryption status and re-saves them in batches. The TablePlugin.BeforeSave hook
+// plaintext encryption status and re-saves them one row per transaction. The TablePlugin.BeforeSave hook
 // handles encryption.
 func (s *RDBConfigStore) encryptPlaintextPlugins(ctx context.Context) (int, error) {
 	var count int
+	var cursor uint
 	for {
-		var plugins []tables.TablePlugin
+		// Read ids only. Loading whole rows here would run SecretVar.Scan on
+		// every secret column, and a stored vault ref resolves over the
+		// network — work the claim below would then repeat.
+		var ids []uint
 		if err := s.DB().WithContext(ctx).
-			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND config_json != '' AND config_json != '{}'", encryptionStatusPlainText).
+			Model(&tables.TablePlugin{}).
+			Where("(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND config_json != '' AND config_json != '{}' AND id > ?", encryptionStatusPlainText, cursor).
+			Order("id").
 			Limit(encryptionBatchSize).
-			Find(&plugins).Error; err != nil {
+			Pluck("id", &ids).Error; err != nil {
 			return count, err
 		}
-		if len(plugins) == 0 {
+		if len(ids) == 0 {
 			break
 		}
-		if err := s.DB().WithContext(ctx).Transaction(func(tx *gorm.DB) error {
-			for i := range plugins {
-				if err := tx.Save(&plugins[i]).Error; err != nil {
-					return err
-				}
-			}
-			return nil
-		}); err != nil {
+		cursor = ids[len(ids)-1]
+		n, err := encryptClaimedRows(ctx, s, ids, "(encryption_status = ? OR encryption_status IS NULL OR encryption_status = '') AND config_json != '' AND config_json != '{}' AND id = ?",
+			func(r *tables.TablePlugin) string { return r.EncryptionStatus })
+		count += n
+		if err != nil {
 			return count, err
 		}
-		count += len(plugins)
 	}
 	return count, nil
 }

--- a/framework/configstore/encryption_concurrency_postgres_test.go
+++ b/framework/configstore/encryption_concurrency_postgres_test.go
@@ -1,0 +1,322 @@
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	"gorm.io/gorm/logger"
+)
+
+// The startup backfill runs on every booting node against one shared database.
+// These tests cover what that concurrency requires of it: nodes may queue behind
+// each other, but must never deadlock and must never leave a row plaintext.
+
+// newEncryptionPodStore opens an independent pool against the schema that
+// setupPostgresDeadlockStore already migrated, standing in for another node.
+func newEncryptionPodStore(t *testing.T) *RDBConfigStore {
+	t.Helper()
+	db, err := gorm.Open(postgres.Open(postgresDSN), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Skipf("postgres not available: %v", err)
+	}
+	t.Cleanup(func() {
+		if sqlDB, err := db.DB(); err == nil {
+			_ = sqlDB.Close()
+		}
+	})
+	store := &RDBConfigStore{logger: bifrost.NewDefaultLogger(schemas.LogLevelWarn)}
+	store.db.Store(db)
+	store.migrateOnFreshFn = func(ctx context.Context, fn func(context.Context, *gorm.DB) error) error {
+		return fn(ctx, store.DB())
+	}
+	store.refreshPoolFn = func(ctx context.Context) error { return nil }
+	return store
+}
+
+// TestEncryptPlaintextOAuthConfigs_WaitsForHolderThenConverges holds every row
+// under an open transaction and asserts the walk queues behind the holder rather
+// than skipping past it. Each row is written in its own transaction, so the wait
+// is one row long and no lock is held across another, which is what keeps the
+// blocking design deadlock-free while still leaving nothing plaintext.
+func TestEncryptPlaintextOAuthConfigs_WaitsForHolderThenConverges(t *testing.T) {
+	store := setupPostgresDeadlockStore(t)
+	seedPlaintextOAuthConfigs(t, store.DB(), 20, "secret-")
+
+	holder := newEncryptionPodStore(t)
+	tx := holder.DB().Begin()
+	require.NoError(t, tx.Error)
+
+	var held []tables.TableOauthConfig
+	require.NoError(t, tx.Clauses(clause.Locking{Strength: "UPDATE"}).Find(&held).Error)
+	require.Len(t, held, 20, "the holder must own every row for this to prove anything")
+
+	// Release mid-walk. A skipping walk would already have run past these rows
+	// and reported success; a blocking one picks them all up.
+	time.AfterFunc(2*time.Second, func() { _ = tx.Rollback() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	other := newEncryptionPodStore(t)
+	count, err := other.encryptPlaintextOAuthConfigs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, 20, count, "rows held at claim time must still be encrypted, not skipped")
+	assert.Zero(t, plaintextOAuthConfigCount(t, store.DB()),
+		"the walk must not report done while rows are still plaintext")
+}
+
+// TestEncryptPlaintextOAuthConfigs_ConcurrentPodsDoNotDeadlock reproduces the
+// reported startup crash: several nodes booting at once against the same table.
+// Unordered batches let two nodes take the same rows in opposite orders, which
+// Postgres resolves by killing one with SQLSTATE 40P01 — a fatal error at boot.
+func TestEncryptPlaintextOAuthConfigs_ConcurrentPodsDoNotDeadlock(t *testing.T) {
+	store := setupPostgresDeadlockStore(t)
+
+	const (
+		pods  = 5
+		total = encryptionBatchSize * 4
+	)
+	seedPlaintextOAuthConfigs(t, store.DB(), total, "secret-")
+
+	stores := make([]*RDBConfigStore, pods)
+	for i := range stores {
+		stores[i] = newEncryptionPodStore(t)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	start := make(chan struct{})
+	counts := make(chan int, pods)
+	errs := make(chan error, pods)
+	var wg sync.WaitGroup
+	for _, s := range stores {
+		wg.Add(1)
+		go func(s *RDBConfigStore) {
+			defer wg.Done()
+			<-start
+			count, err := s.encryptPlaintextOAuthConfigs(ctx)
+			counts <- count
+			errs <- err
+		}(s)
+	}
+	close(start)
+	wg.Wait()
+	close(counts)
+	close(errs)
+
+	for err := range errs {
+		if isPostgresDeadlock(err) {
+			t.Fatalf("startup encryption deadlocked across nodes: %v", err)
+		}
+		require.NoError(t, err)
+	}
+
+	// Every row is claimed by exactly one node, so the per-node counts partition
+	// the table rather than overlapping.
+	claimed := 0
+	for c := range counts {
+		claimed += c
+	}
+	assert.Equal(t, total, claimed, "each row should be encrypted by exactly one node")
+
+	var remaining int64
+	require.NoError(t, store.DB().Table("oauth_configs").
+		Where("encryption_status = ? OR encryption_status IS NULL OR encryption_status = ''", encryptionStatusPlainText).
+		Count(&remaining).Error)
+	assert.Zero(t, remaining)
+
+	var found tables.TableOauthConfig
+	require.NoError(t, store.DB().Where("id = ?", oauthConfigID(total-1)).First(&found).Error)
+	assert.Equal(t, fmt.Sprintf("secret-%d", total-1), found.ClientSecret.GetValue())
+}
+
+// mockVaultHook installs a vault store hook that sleeps for latency, and
+// reports how many times it ran and the peak number of concurrent calls.
+func mockVaultHook(t *testing.T, latency time.Duration) (puts, peak *atomic.Int64) {
+	t.Helper()
+	var calls, high, inFlight atomic.Int64
+	schemas.VaultStoreHook = func(ctx context.Context, path string, value *string) error {
+		calls.Add(1)
+		cur := inFlight.Add(1)
+		for {
+			p := high.Load()
+			if cur <= p || high.CompareAndSwap(p, cur) {
+				break
+			}
+		}
+		time.Sleep(latency)
+		inFlight.Add(-1)
+		return nil
+	}
+	schemas.VaultRemoveHook = func(ctx context.Context, path string) error { return nil }
+	t.Cleanup(func() {
+		schemas.VaultStoreHook = nil
+		schemas.VaultRemoveHook = nil
+	})
+	return &calls, &high
+}
+
+// seedPlaintextKeys inserts n plaintext config_keys via raw SQL, plus the
+// provider row their foreign key requires.
+func seedPlaintextKeys(t *testing.T, db *gorm.DB, n int) {
+	t.Helper()
+	require.NoError(t, db.Exec("DELETE FROM config_keys").Error)
+	require.NoError(t, db.Exec(`
+		INSERT INTO config_providers (id, name, created_at, updated_at)
+		VALUES (1, 'openai', now(), now()) ON CONFLICT (id) DO NOTHING`).Error)
+	require.NoError(t, db.Exec(`
+		INSERT INTO config_keys (name, provider_id, provider, key_id, value, encryption_status, created_at, updated_at)
+		SELECT 'key-' || lpad(g::text, 6, '0'), 1, 'openai', 'key-id-' || lpad(g::text, 6, '0'),
+		       'sk-plaintext-' || g, 'plain_text', now(), now()
+		FROM generate_series(0, ?) g`, n-1).Error)
+}
+
+func plaintextKeyCount(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Table("config_keys").
+		Where("encryption_status = ? OR encryption_status IS NULL OR encryption_status = ''", encryptionStatusPlainText).
+		Count(&n).Error)
+	return n
+}
+
+// TestEncryptPlaintextKeys_OverlapsVaultWrites pins the reason rows are claimed
+// concurrently: a vault write is a network round trip, and running them one at
+// a time makes boot take rows*latency. It also pins that the hook runs only
+// after the row lock is held, so a row is never hooked twice.
+func TestEncryptPlaintextKeys_OverlapsVaultWrites(t *testing.T) {
+	store := setupPostgresDeadlockStore(t)
+	const rows = 48
+	seedPlaintextKeys(t, store.DB(), rows)
+
+	puts, peak := mockVaultHook(t, 50*time.Millisecond)
+	require.Greater(t, encryptConcurrency(), 1, "vault writes must enable concurrency")
+
+	start := time.Now()
+	count, err := store.encryptPlaintextKeys(context.Background())
+	elapsed := time.Since(start)
+
+	require.NoError(t, err)
+	assert.Equal(t, rows, count)
+	assert.Zero(t, plaintextKeyCount(t, store.DB()))
+	assert.Equal(t, int64(rows), puts.Load(), "each row's hook must run exactly once")
+	assert.Greater(t, peak.Load(), int64(1), "vault writes must overlap, not queue")
+	assert.Less(t, elapsed, rows*50*time.Millisecond,
+		"a serial walk would take rows*latency; the concurrent one must beat it")
+}
+
+// TestEncryptPlaintextKeys_ConcurrentPodsHookEachRowOnce is the multi-node form
+// of the same guarantee: claiming under a row lock before hooking means two
+// nodes never both pay a row's vault writes.
+func TestEncryptPlaintextKeys_ConcurrentPodsHookEachRowOnce(t *testing.T) {
+	store := setupPostgresDeadlockStore(t)
+	const (
+		rows = 40
+		pods = 3
+	)
+	seedPlaintextKeys(t, store.DB(), rows)
+	puts, _ := mockVaultHook(t, 20*time.Millisecond)
+
+	stores := make([]*RDBConfigStore, pods)
+	for i := range stores {
+		stores[i] = newEncryptionPodStore(t)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	counts := make([]int, pods)
+	errs := make([]error, pods)
+	begin := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := range stores {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-begin
+			counts[i], errs[i] = stores[i].encryptPlaintextKeys(ctx)
+		}(i)
+	}
+	close(begin)
+	wg.Wait()
+
+	total := 0
+	for i, err := range errs {
+		if isPostgresDeadlock(err) {
+			t.Fatalf("concurrent claims deadlocked: %v", err)
+		}
+		require.NoError(t, err)
+		total += counts[i]
+	}
+	assert.Equal(t, rows, total, "each row should be encrypted by exactly one node")
+	assert.Equal(t, int64(rows), puts.Load(), "a row's vault writes must not be paid twice")
+	assert.Zero(t, plaintextKeyCount(t, store.DB()))
+}
+
+// TestEncryptConcurrency_SequentialWithoutVault pins that deployments without
+// vault writes keep the simple one-at-a-time path.
+func TestEncryptConcurrency_SequentialWithoutVault(t *testing.T) {
+	require.False(t, schemas.VaultStoreWriteEnabled())
+	assert.Equal(t, 1, encryptConcurrency())
+}
+
+// TestEncryptPlaintextKeys_ResolvesVaultRefsOncePerRow guards the cost of the
+// scan. Rows written while vault writes were on but encryption was off hold a
+// "vault." ref with encryption_status still 'plain_text', and SecretVar.Scan
+// resolves such a ref over the network on every load — regardless of the status
+// column. The walk must therefore read ids only when scanning ahead, so a row's
+// secrets are fetched once, by the claim that actually encrypts it.
+func TestEncryptPlaintextKeys_ResolvesVaultRefsOncePerRow(t *testing.T) {
+	store := setupPostgresDeadlockStore(t)
+	const rows = 10
+
+	require.NoError(t, store.DB().Exec("DELETE FROM config_keys").Error)
+	require.NoError(t, store.DB().Exec(`
+		INSERT INTO config_providers (id, name, created_at, updated_at)
+		VALUES (1, 'openai', now(), now()) ON CONFLICT (id) DO NOTHING`).Error)
+	require.NoError(t, store.DB().Exec(`
+		INSERT INTO config_keys (name, provider_id, provider, key_id, value, encryption_status, created_at, updated_at)
+		SELECT 'k-' || g, 1, 'openai', 'kid-' || g, 'vault.bifrost/config_keys/kid-' || g,
+		       'plain_text', now(), now()
+		FROM generate_series(0, ?) g`, rows-1).Error)
+
+	var resolves, stores atomic.Int64
+	schemas.VaultResolveHook = func(ctx context.Context, value *string) error {
+		resolves.Add(1)
+		*value = "resolved-secret"
+		return nil
+	}
+	schemas.VaultStoreHook = func(ctx context.Context, path string, value *string) error {
+		stores.Add(1)
+		return nil
+	}
+	schemas.VaultRemoveHook = func(ctx context.Context, path string) error { return nil }
+	t.Cleanup(func() {
+		schemas.VaultResolveHook = nil
+		schemas.VaultStoreHook = nil
+		schemas.VaultRemoveHook = nil
+	})
+
+	count, err := store.encryptPlaintextKeys(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, rows, count)
+	assert.Equal(t, int64(rows), resolves.Load(),
+		"scanning ahead must read ids only; loading whole rows resolves every ref twice")
+	assert.Zero(t, stores.Load(), "a value already stored in the vault must not be written back")
+	assert.Zero(t, plaintextKeyCount(t, store.DB()), "vault-ref rows must still leave plain_text")
+}

--- a/framework/configstore/encryption_pagination_test.go
+++ b/framework/configstore/encryption_pagination_test.go
@@ -1,0 +1,205 @@
+package configstore
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// The startup backfill walks each table by primary key. These tests pin the two
+// properties that walk depends on: it must visit every matching row across batch
+// boundaries, and it must terminate even when a row's status never advances.
+
+// oauthConfigID returns a zero-padded id so lexical and insertion order agree,
+// making batch boundaries predictable.
+func oauthConfigID(i int) string { return fmt.Sprintf("oauth-cfg-%05d", i) }
+
+// seedPlaintextOAuthConfigs inserts n oauth_configs rows via raw SQL so the
+// BeforeSave hook never runs and the rows stay unencrypted.
+func seedPlaintextOAuthConfigs(t *testing.T, db *gorm.DB, n int, secretPrefix string, statuses ...string) {
+	t.Helper()
+	if len(statuses) == 0 {
+		statuses = []string{encryptionStatusPlainText}
+	}
+	now := time.Now()
+	for i := 0; i < n; i++ {
+		status := statuses[i%len(statuses)]
+		var statusArg any
+		if status == "NULL" {
+			statusArg = nil
+		} else {
+			statusArg = status
+		}
+		insertPlaintextRow(t, db,
+			`INSERT INTO oauth_configs (id, client_secret, redirect_uri, status, encryption_status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'pending', ?, ?, ?)`,
+			oauthConfigID(i), secretPrefix+fmt.Sprint(i), "https://example.com/cb", statusArg, now, now)
+	}
+}
+
+// countOAuthConfigUpdates counts UPDATE statements issued against oauth_configs,
+// so a test can tell "wrote each row once" from "kept rewriting the same rows".
+func countOAuthConfigUpdates(t *testing.T, db *gorm.DB, n *atomic.Int64) {
+	t.Helper()
+	require.NoError(t, db.Callback().Update().After("gorm:update").
+		Register("test:count_oauth_updates", func(tx *gorm.DB) {
+			if tx.Statement != nil && tx.Statement.Table == "oauth_configs" {
+				n.Add(1)
+			}
+		}))
+}
+
+func plaintextOAuthConfigCount(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var n int64
+	require.NoError(t, db.Table("oauth_configs").
+		Where("encryption_status = ? OR encryption_status IS NULL OR encryption_status = ''", encryptionStatusPlainText).
+		Count(&n).Error)
+	return n
+}
+
+// TestEncryptPlaintextOAuthConfigs_WalksEveryRowPastBatchSize covers the batch
+// walk across several batches, including a partial final one.
+func TestEncryptPlaintextOAuthConfigs_WalksEveryRowPastBatchSize(t *testing.T) {
+	store, db := setupEncryptionTestStore(t)
+	const total = encryptionBatchSize*2 + 37
+	seedPlaintextOAuthConfigs(t, db, total, "secret-")
+
+	count, err := store.encryptPlaintextOAuthConfigs(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, total, count)
+	assert.Zero(t, plaintextOAuthConfigCount(t, db), "every row should have left plain_text")
+
+	// Spot-check the batch boundaries, where an off-by-one cursor would drop rows.
+	for _, i := range []int{0, encryptionBatchSize - 1, encryptionBatchSize, total - 1} {
+		var found tables.TableOauthConfig
+		require.NoError(t, db.Where("id = ?", oauthConfigID(i)).First(&found).Error)
+		assert.Equal(t, fmt.Sprintf("secret-%d", i), found.ClientSecret.GetValue(),
+			"row %d should round-trip through encrypt/decrypt", i)
+	}
+}
+
+// TestEncryptPlaintextOAuthConfigs_WalksRowsWithStatusSentinels covers the three
+// "not yet encrypted" spellings interleaved across batches. The cursor is ANDed
+// onto an OR-chain, so a missing pair of parentheses would bind it to the last
+// disjunct alone and strand rows.
+func TestEncryptPlaintextOAuthConfigs_WalksRowsWithStatusSentinels(t *testing.T) {
+	store, db := setupEncryptionTestStore(t)
+	const total = encryptionBatchSize*2 + 11
+	seedPlaintextOAuthConfigs(t, db, total, "secret-", encryptionStatusPlainText, "NULL", "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	count, err := store.encryptPlaintextOAuthConfigs(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, total, count)
+	assert.Zero(t, plaintextOAuthConfigCount(t, db))
+}
+
+// TestEncryptPlaintextOAuthConfigs_TerminatesWhenStatusNeverAdvances is the
+// regression guard for the boot hang: the loop must not depend on a BeforeSave
+// hook actually stamping the row. A hook that declines to stamp is emulated by
+// pinning the column back to plain_text on every write.
+func TestEncryptPlaintextOAuthConfigs_TerminatesWhenStatusNeverAdvances(t *testing.T) {
+	store, db := setupEncryptionTestStore(t)
+	const total = encryptionBatchSize + 5
+	seedPlaintextOAuthConfigs(t, db, total, "secret-")
+
+	require.NoError(t, db.Callback().Update().Before("gorm:update").
+		Register("test:pin_plaintext", func(tx *gorm.DB) {
+			if tx.Statement != nil && tx.Statement.Table == "oauth_configs" {
+				tx.Statement.SetColumn("encryption_status", encryptionStatusPlainText)
+			}
+		}))
+
+	var updates atomic.Int64
+	countOAuthConfigUpdates(t, db, &updates)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	_, err := store.encryptPlaintextOAuthConfigs(ctx)
+	require.NoError(t, err, "the walk must finish even though no row leaves plain_text")
+	assert.LessOrEqual(t, updates.Load(), int64(total), "each row should be written at most once")
+	assert.Equal(t, int64(total), plaintextOAuthConfigCount(t, db),
+		"guard check: the pin must really have held the rows at plain_text")
+}
+
+// TestEncryptPlaintextOAuthConfigs_SecretRefRowsConverge covers rows whose
+// client_secret is an env/vault reference. There is nothing to cipher, but the
+// row must still leave plain_text so later boots stop re-selecting and
+// re-writing it.
+func TestEncryptPlaintextOAuthConfigs_SecretRefRowsConverge(t *testing.T) {
+	store, db := setupEncryptionTestStore(t)
+	now := time.Now()
+	refs := map[string]string{
+		"oauth-vault": "vault.oauth_configs/cfg/client_secret",
+		"oauth-env":   "env.OAUTH_CLIENT_SECRET",
+	}
+	for id, ref := range refs {
+		insertPlaintextRow(t, db,
+			`INSERT INTO oauth_configs (id, client_secret, redirect_uri, status, encryption_status, created_at, updated_at)
+			 VALUES (?, ?, ?, 'pending', 'plain_text', ?, ?)`,
+			id, ref, "https://example.com/cb", now, now)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	_, err := store.encryptPlaintextOAuthConfigs(ctx)
+	require.NoError(t, err)
+
+	for id, ref := range refs {
+		var raw map[string]any
+		require.NoError(t, db.Table("oauth_configs").Where("id = ?", id).Take(&raw).Error)
+		assert.Equal(t, encryptionStatusEncrypted, raw["encryption_status"],
+			"%s must leave plain_text or the next boot re-selects it forever", id)
+		assert.Equal(t, ref, raw["client_secret"], "%s: the reference must be stored verbatim", id)
+	}
+
+	// A second pass must find nothing left to do.
+	var updates atomic.Int64
+	countOAuthConfigUpdates(t, db, &updates)
+	count, err := store.encryptPlaintextOAuthConfigs(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+	assert.Zero(t, updates.Load(), "converged rows must not be rewritten on later boots")
+}
+
+// TestEncryptPlaintextKeys_WalksEveryRowPastBatchSize covers the same walk on a
+// table with an integer primary key, where the cursor is numeric rather than
+// lexical.
+func TestEncryptPlaintextKeys_WalksEveryRowPastBatchSize(t *testing.T) {
+	store, db := setupEncryptionTestStore(t)
+	const total = encryptionBatchSize + 23
+	now := time.Now()
+	for i := 0; i < total; i++ {
+		insertPlaintextRow(t, db,
+			`INSERT INTO config_keys (name, provider_id, provider, key_id, value, encryption_status, created_at, updated_at)
+			 VALUES (?, ?, ?, ?, ?, 'plain_text', ?, ?)`,
+			fmt.Sprintf("key-%05d", i), 1, "openai", fmt.Sprintf("key-id-%05d", i),
+			fmt.Sprintf("sk-plaintext-%d", i), now, now)
+	}
+
+	count, err := store.encryptPlaintextKeys(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, total, count)
+
+	var remaining int64
+	require.NoError(t, db.Table("config_keys").
+		Where("encryption_status = ? OR encryption_status IS NULL OR encryption_status = ''", encryptionStatusPlainText).
+		Count(&remaining).Error)
+	assert.Zero(t, remaining)
+
+	var found tables.TableKey
+	require.NoError(t, db.Where("key_id = ?", fmt.Sprintf("key-id-%05d", total-1)).First(&found).Error)
+	assert.Equal(t, fmt.Sprintf("sk-plaintext-%d", total-1), found.Value.GetValue())
+}

--- a/framework/configstore/tables/encryption_test.go
+++ b/framework/configstore/tables/encryption_test.go
@@ -618,6 +618,33 @@ func TestTableOauthConfig_EmptySecret_NoError(t *testing.T) {
 	assert.Equal(t, "", found.ClientSecret.GetValue())
 }
 
+// TestTableOauthConfig_SecretRef_StampsStatus covers a client_secret held as an
+// env/vault reference. There is nothing to cipher, but the row must still leave
+// plain_text: the startup backfill selects on that column, so a row left behind
+// is re-selected and re-written on every boot.
+func TestTableOauthConfig_SecretRef_StampsStatus(t *testing.T) {
+	for _, ref := range []string{"vault.oauth_configs/cfg/client_secret", "env.OAUTH_CLIENT_SECRET"} {
+		t.Run(ref, func(t *testing.T) {
+			db := setupTestDB(t)
+
+			config := &TableOauthConfig{
+				ID:           "oauth-cfg-ref",
+				ClientSecret: schemas.NewSecretVar(ref),
+				RedirectURI:  "https://example.com/callback",
+			}
+			require.NoError(t, db.Create(config).Error)
+
+			raw := rawRow(t, db, "oauth_configs", "oauth-cfg-ref")
+			assert.Equal(t, "encrypted", raw["encryption_status"])
+			assert.Equal(t, ref, raw["client_secret"], "the reference must be stored verbatim, not ciphered")
+
+			var found TableOauthConfig
+			require.NoError(t, db.First(&found, "id = ?", "oauth-cfg-ref").Error)
+			assert.Equal(t, ref, found.ClientSecret.GetRawRef())
+		})
+	}
+}
+
 // TestTableMCPOauthFlow_EncryptDecrypt covers the CodeVerifier encrypt/decrypt
 // round trip that TestTableOauthConfig_EncryptDecrypt used to exercise before
 // PKCE fields moved off TableOauthConfig onto TableMCPOauthFlow (see that

--- a/framework/configstore/tables/mcpoauth2.go
+++ b/framework/configstore/tables/mcpoauth2.go
@@ -63,13 +63,14 @@ func (c *TableOauthConfig) BeforeSave(tx *gorm.DB) error {
 		c.Status = "pending"
 	}
 
-	if encrypt.IsEnabled() {
-		if c.ClientSecret != nil && !c.ClientSecret.IsFromSecret() && c.ClientSecret.Val != "" {
-			if err := encryptString(&c.ClientSecret.Val); err != nil {
-				return fmt.Errorf("failed to encrypt oauth client secret: %w", err)
-			}
-			c.EncryptionStatus = EncryptionStatusEncrypted
+	// Stamp the status whenever a secret is present, not only when it was ciphered:
+	// encryptSecretVar leaves env/vault refs alone, and leaving such a row
+	// 'plain_text' makes the startup backfill re-select it forever.
+	if encrypt.IsEnabled() && c.ClientSecret.IsSet() {
+		if err := encryptSecretVar(c.ClientSecret); err != nil {
+			return fmt.Errorf("failed to encrypt oauth client secret: %w", err)
 		}
+		c.EncryptionStatus = EncryptionStatusEncrypted
 	}
 	return nil
 }

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -44,7 +44,7 @@ import {
 } from "@/lib/constants/logs";
 import { useGetProvidersQuery, useGetUserAgentMappingsQuery } from "@/lib/store";
 import { COMPLEXITY_MECHANISM_LABELS } from "@/lib/types/complexityRouter";
-import { BatchRequestCounts, ContentBlock, LogEntry, OverheadBucket, ResponsesMessage } from "@/lib/types/logs";
+import { BatchRequestCounts, ContentBlock, LLMUsage, LogEntry, OverheadBucket, ResponsesMessage } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { LOG_LEVEL_BADGE_CLASSES, meetsMinLogLevel, type LogLevel } from "@/lib/utils/logLevel";
 import { downloadAsJson } from "@/lib/utils/browser-download";
@@ -399,6 +399,28 @@ const batchRequestStates = (counts: BatchRequestCounts): [string, number][] => {
 		["Failed", counts.failed],
 		...optional.filter((entry): entry is [string, number] => Boolean(entry[1])),
 	];
+};
+
+const formatExactNumber = (value: number) => value.toLocaleString("en-US");
+
+// Input tokens are normalized to include cache read/write tokens, so break the total down.
+const getInputTokensTooltip = (usage?: LLMUsage): string | undefined => {
+	const total = usage?.prompt_tokens ?? 0;
+	if (!total || !usage?.prompt_tokens_details) return undefined;
+	const cachedRead = usage?.prompt_tokens_details.cached_read_tokens ?? 0;
+	const cachedWrite = usage?.prompt_tokens_details.cached_write_tokens ?? 0;
+	const lines = ["Input tokens include cached tokens."];
+	if (cachedRead >= 0 || cachedWrite >= 0) {
+		lines.push(`Uncached input: ${formatExactNumber(total - cachedRead - cachedWrite)}`);
+	}
+	if (cachedRead >= 0) {
+		lines.push(`Cache read: ${formatExactNumber(cachedRead)}`);
+	}
+	if (cachedWrite >= 0) {
+		lines.push(`Cache write: ${formatExactNumber(cachedWrite)}`);
+	}
+	lines.push(`Input tokens: ${formatExactNumber(total)}`);
+	return lines.join("\n");
 };
 
 // Helper to detect passthrough operations
@@ -2103,7 +2125,12 @@ export function LogDetailView({
 							<div className="space-y-4">
 								<BlockHeader title="Tokens" />
 								<div className="grid w-full grid-cols-1 items-center justify-between gap-4 md:grid-cols-3">
-									<LogEntryDetailsView className="w-full" label="Input Tokens" value={log.token_usage?.prompt_tokens || "-"} />
+									<LogEntryDetailsView
+										className="w-full"
+										label="Input Tokens"
+										value={log.token_usage?.prompt_tokens || "-"}
+										tooltip={getInputTokensTooltip(log.token_usage)}
+									/>
 									<LogEntryDetailsView className="w-full" label="Output Tokens" value={log.token_usage?.completion_tokens || "-"} />
 									<LogEntryDetailsView className="w-full" label="Total Tokens" value={log.token_usage?.total_tokens || "-"} />
 									{(log.cost_breakdown?.input_cost ?? 0) > 0 && (

--- a/ui/app/workspace/logs/views/logEntryDetailsView.tsx
+++ b/ui/app/workspace/logs/views/logEntryDetailsView.tsx
@@ -41,7 +41,7 @@ export default function LogEntryDetailsView(props: Props) {
 								<TooltipTrigger asChild>
 									<Info className="text-muted-foreground/60 hover:text-muted-foreground h-3 w-3 cursor-help" />
 								</TooltipTrigger>
-								<TooltipContent sideOffset={6} className="max-w-xs">
+								<TooltipContent sideOffset={6} className="max-w-xs whitespace-pre-line">
 									{props.tooltip}
 								</TooltipContent>
 							</Tooltip>


### PR DESCRIPTION
## Summary

The "Input Tokens" field in the log detail view now shows a tooltip breaking down how input tokens are composed, including uncached input, cache read, and cache write token counts. This makes it clearer that the displayed input token total is normalized to include cached tokens.

## Changes

- Added `getInputTokensTooltip` helper that builds a multi-line breakdown of input token usage (uncached input, cache read, cache write, and total) from `LLMUsage` data.
- Added `formatExactNumber` helper to format token counts with locale-aware number formatting.
- Passed the generated tooltip to the `Input Tokens` `LogEntryDetailsView` in the log detail view.
- Added `whitespace-pre-line` to `TooltipContent` in `logEntryDetailsView.tsx` so that newline characters in tooltip strings render as visual line breaks.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Navigate to the Logs section in the workspace.
2. Open a log entry for a request that used cached tokens (cache read or cache write).
3. Hover over the info icon next to "Input Tokens".
4. Verify the tooltip displays a multi-line breakdown showing uncached input, cache read, cache write, and total input token counts.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before: No tooltip on the Input Tokens field.
After: Hovering over the Input Tokens info icon shows a multi-line breakdown of cached and uncached token counts.

![Screenshot 2026-09-04 at 13.16.34.png](https://app.graphite.com/user-attachments/assets/9b6109da-506b-4692-9eb9-857eea650a59.png)



## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable