### PR TITLE
fix: openai reasoning content in bedrock converse response

### DIFF
--- a/core/providers/bedrock/chat.go
+++ b/core/providers/bedrock/chat.go
@@ -144,17 +144,24 @@ func (response *BedrockConverseResponse) ToBifrostChatResponse(ctx context.Conte
 
 			// Handle reasoning content
 			if contentBlock.ReasoningContent != nil {
-				if contentBlock.ReasoningContent.ReasoningText == nil {
-					continue
-				}
-				reasoningDetails = append(reasoningDetails, schemas.ChatReasoningDetails{
-					Index:     len(reasoningDetails),
-					Type:      schemas.BifrostReasoningDetailsTypeText,
-					Text:      contentBlock.ReasoningContent.ReasoningText.Text,
-					Signature: contentBlock.ReasoningContent.ReasoningText.Signature,
-				})
-				if contentBlock.ReasoningContent.ReasoningText.Text != nil {
-					reasoningText += *contentBlock.ReasoningContent.ReasoningText.Text + "\n"
+				switch {
+				case contentBlock.ReasoningContent.ReasoningText != nil:
+					reasoningDetails = append(reasoningDetails, schemas.ChatReasoningDetails{
+						Index:     len(reasoningDetails),
+						Type:      schemas.BifrostReasoningDetailsTypeText,
+						Text:      contentBlock.ReasoningContent.ReasoningText.Text,
+						Signature: contentBlock.ReasoningContent.ReasoningText.Signature,
+					})
+					if contentBlock.ReasoningContent.ReasoningText.Text != nil {
+						reasoningText += *contentBlock.ReasoningContent.ReasoningText.Text + "\n"
+					}
+				case contentBlock.ReasoningContent.RedactedContent != nil:
+					// Opaque blob: no prose to surface, only the replay token.
+					reasoningDetails = append(reasoningDetails, schemas.ChatReasoningDetails{
+						Index: len(reasoningDetails),
+						Type:  schemas.BifrostReasoningDetailsTypeEncrypted,
+						Data:  contentBlock.ReasoningContent.RedactedContent,
+					})
 				}
 			}
 
@@ -486,8 +493,9 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream(state *BedrockStr
 			// Handle reasoning content delta
 			reasoningContentDelta := chunk.Delta.ReasoningContent
 
-			// Only construct and return a response when either Text or Signature is set
-			if (reasoningContentDelta.Text == nil || *reasoningContentDelta.Text == "") && reasoningContentDelta.Signature == nil {
+			// Only construct and return a response when the delta carries something
+			if (reasoningContentDelta.Text == nil || *reasoningContentDelta.Text == "") &&
+				reasoningContentDelta.Signature == nil && reasoningContentDelta.RedactedContent == nil {
 				return nil, nil, false
 			}
 
@@ -526,6 +534,27 @@ func (chunk *BedrockStreamEvent) ToBifrostChatCompletionStream(state *BedrockStr
 											Index:     0,
 											Type:      schemas.BifrostReasoningDetailsTypeText,
 											Signature: reasoningContentDelta.Signature,
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			} else if reasoningContentDelta.RedactedContent != nil {
+				// Arrives whole in a single delta, so no accumulation is needed.
+				streamResponse = &schemas.BifrostChatResponse{
+					Object: "chat.completion.chunk",
+					Choices: []schemas.BifrostResponseChoice{
+						{
+							Index: 0,
+							ChatStreamResponseChoice: &schemas.ChatStreamResponseChoice{
+								Delta: &schemas.ChatStreamResponseChoiceDelta{
+									ReasoningDetails: []schemas.ChatReasoningDetails{
+										{
+											Index: 0,
+											Type:  schemas.BifrostReasoningDetailsTypeEncrypted,
+											Data:  reasoningContentDelta.RedactedContent,
 										},
 									},
 								},

--- a/core/providers/bedrock/reasoning_replay_test.go
+++ b/core/providers/bedrock/reasoning_replay_test.go
@@ -182,7 +182,7 @@ func TestConvertBifrostReasoningToBedrockReasoning(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			blocks := convertBifrostReasoningToBedrockReasoning(tc.msg)
+			blocks := convertBifrostReasoningToBedrockReasoning(tc.msg, schemas.BedrockReasoningShapeText)
 
 			require.Len(t, blocks, tc.wantBlocks)
 			reasoningTextInvariant(t, blocks)
@@ -222,7 +222,7 @@ func TestConvertBifrostReasoningToBedrockReasoningEncryptedContent(t *testing.T)
 		},
 	}
 
-	blocks := convertBifrostReasoningToBedrockReasoning(message)
+	blocks := convertBifrostReasoningToBedrockReasoning(message, schemas.BedrockReasoningShapeText)
 	require.Len(t, blocks, 1)
 	require.NotNil(t, blocks[0].ReasoningContent)
 	require.NotNil(t, blocks[0].ReasoningContent.ReasoningText)
@@ -244,7 +244,7 @@ func TestConvertBifrostReasoningToBedrockReasoningTextAlwaysSerialized(t *testin
 			Summary:          []schemas.ResponsesReasoningSummary{},
 			EncryptedContent: &signature,
 		},
-	})
+	}, schemas.BedrockReasoningShapeText)
 	require.Len(t, blocks, 1)
 
 	raw, err := sonic.Marshal(blocks[0])
@@ -321,4 +321,162 @@ func TestStreamingReasoningReplaySerialisesForBedrock(t *testing.T) {
 		return true
 	})
 	require.Equal(t, 3, seen, "expected one reasoning block per replayed assistant turn, got %d: %s", seen, raw)
+}
+
+// ---- redactedContent: the OpenAI/xAI reasoning shape on Converse ----
+//
+// Verified against bedrock-runtime us-east-1. gpt-5.6-* and grok-4.6 return
+// reasoningContent.redactedContent, one opaque blob delivered whole in a single
+// contentBlockDelta. They reject reasoningContent.reasoningText in EVERY form --
+// empty text, prose text, with or without a signature -- with an opaque
+// "The system encountered an unexpected error during processing." 500. Anthropic
+// (through 4.8 adaptive thinking) and DeepSeek R1 are the other way round, and
+// answer a redactedContent replay with a 400. Replaying the matching shape
+// verbatim is the only thing either family accepts.
+
+func TestConverseReasoningShapeFamilyFallback(t *testing.T) {
+	tests := []struct {
+		model string
+		want  schemas.BedrockReasoningShape
+	}{
+		{"openai.gpt-5.6-luna", schemas.BedrockReasoningShapeRedacted},
+		{"us.openai.gpt-5.6-sol", schemas.BedrockReasoningShapeRedacted},
+		{"xai.grok-4.6", schemas.BedrockReasoningShapeRedacted},
+		{"us.anthropic.claude-sonnet-4-5-20250929-v1:0", schemas.BedrockReasoningShapeText},
+		{"us.anthropic.claude-opus-4-8", schemas.BedrockReasoningShapeText},
+		{"us.deepseek.r1-v1:0", schemas.BedrockReasoningShapeText},
+		{"us.amazon.nova-premier-v1:0", schemas.BedrockReasoningShapeText},
+	}
+	for _, tc := range tests {
+		t.Run(tc.model, func(t *testing.T) {
+			require.Equal(t, tc.want, converseReasoningShape(tc.model))
+		})
+	}
+}
+
+func TestConverseReasoningShapeDatasheetWinsOverFamily(t *testing.T) {
+	const model = "openai.gpt-5.6-luna"
+
+	t.Run("row overrides the family fallback", func(t *testing.T) {
+		installBedrockCapabilityRecord(t, model, &schemas.ModelCapabilities{
+			BedrockReasoningShape: schemas.BedrockReasoningShapeText,
+		})
+		require.Equal(t, schemas.BedrockReasoningShapeText, converseReasoningShape(model))
+	})
+
+	t.Run("unrecognised value falls back to the family", func(t *testing.T) {
+		installBedrockCapabilityRecord(t, model, &schemas.ModelCapabilities{
+			BedrockReasoningShape: schemas.BedrockReasoningShape("something_new"),
+		})
+		require.Equal(t, schemas.BedrockReasoningShapeRedacted, converseReasoningShape(model))
+	})
+
+	t.Run("empty row falls back to the family", func(t *testing.T) {
+		installBedrockCapabilityRecord(t, model, &schemas.ModelCapabilities{})
+		require.Equal(t, schemas.BedrockReasoningShapeRedacted, converseReasoningShape(model))
+	})
+}
+
+// A Grok alias resolves through capModel before reaching the converters, so the
+// shape must follow the canonical name and not the opaque id the client sent.
+func TestConverseReasoningShapeFollowsCanonicalModel(t *testing.T) {
+	require.Equal(t, schemas.BedrockReasoningShapeRedacted, converseReasoningShape("grok-4.6"),
+		"canonical Grok must pick the redacted shape")
+	require.Equal(t, schemas.BedrockReasoningShapeText, converseReasoningShape("3dnkdwuaalc7"),
+		"an unresolved opaque id carries no family and must not be guessed as redacted")
+}
+
+func TestConvertBifrostReasoningToBedrockReasoningRedactedShape(t *testing.T) {
+	blob := "cnNuXzVaVnJpZjRKMGJYSXFtV2RsZWRqN1FJRmVGZWdz"
+
+	t.Run("blob round-trips as redactedContent", func(t *testing.T) {
+		blocks := convertBifrostReasoningToBedrockReasoning(&schemas.ResponsesMessage{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+			ResponsesReasoning: &schemas.ResponsesReasoning{
+				Summary:          []schemas.ResponsesReasoningSummary{},
+				EncryptedContent: &blob,
+			},
+		}, schemas.BedrockReasoningShapeRedacted)
+
+		require.Len(t, blocks, 1)
+		require.NotNil(t, blocks[0].ReasoningContent)
+		require.NotNil(t, blocks[0].ReasoningContent.RedactedContent)
+		require.Equal(t, blob, *blocks[0].ReasoningContent.RedactedContent)
+		require.Nil(t, blocks[0].ReasoningContent.ReasoningText)
+
+		// Wire level: the struct check above passes even if reasoningText leaks
+		// back in as an empty object, and that is what earns the 500.
+		raw, err := sonic.Marshal(blocks[0])
+		require.NoError(t, err)
+		require.Equal(t, blob, gjson.GetBytes(raw, "reasoningContent.redactedContent").String())
+		require.False(t, gjson.GetBytes(raw, "reasoningContent.reasoningText").Exists(),
+			"reasoningText must never accompany a redacted-shape block")
+	})
+
+	t.Run("reasoning text is dropped rather than sent as reasoningText", func(t *testing.T) {
+		// Exactly the payload that reproduced the 500: an empty, unsigned thinking
+		// block replayed by a client that received a dropped redacted blob.
+		blocks := convertBifrostReasoningToBedrockReasoning(&schemas.ResponsesMessage{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{reasoningTextBlock("", nil)},
+			},
+			ResponsesReasoning: &schemas.ResponsesReasoning{
+				Summary: []schemas.ResponsesReasoningSummary{},
+			},
+		}, schemas.BedrockReasoningShapeRedacted)
+
+		require.Empty(t, blocks, "an unreplayable block must be dropped, not reshaped")
+	})
+
+	t.Run("summary text is dropped too", func(t *testing.T) {
+		blocks := convertBifrostReasoningToBedrockReasoning(&schemas.ResponsesMessage{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+			ResponsesReasoning: &schemas.ResponsesReasoning{
+				Summary: []schemas.ResponsesReasoningSummary{{Text: "step by step"}},
+			},
+		}, schemas.BedrockReasoningShapeRedacted)
+
+		require.Empty(t, blocks)
+	})
+}
+
+// The full loop that produced the bug: Bedrock returns a redacted blob, Bifrost
+// converts it to canonical form, and a client replays that turn.
+func TestRedactedReasoningSurvivesTheReplayLoop(t *testing.T) {
+	blob := "cnNuX2pRenlYWklGSkxscEt5ZmxZa0NmdndJRmVMK2Jp"
+	const model = "openai.gpt-5.6-luna"
+
+	resp := &BedrockConverseResponse{
+		Output: &BedrockConverseOutput{
+			Message: &BedrockMessage{
+				Role: BedrockMessageRoleAssistant,
+				Content: []BedrockContentBlock{
+					{ReasoningContent: &BedrockReasoningContent{RedactedContent: &blob}},
+					{Text: schemas.Ptr("Hello!")},
+				},
+			},
+		},
+	}
+
+	bifrostResp, err := resp.ToBifrostChatResponse(context.Background(), model)
+	require.NoError(t, err)
+	require.NotEmpty(t, bifrostResp.Choices)
+
+	assistant := bifrostResp.Choices[0].ChatNonStreamResponseChoice.Message.ChatAssistantMessage
+	require.NotNil(t, assistant, "the blob must reach the client, not be dropped")
+	require.Len(t, assistant.ReasoningDetails, 1)
+	require.Equal(t, schemas.BifrostReasoningDetailsTypeEncrypted, assistant.ReasoningDetails[0].Type)
+	require.NotNil(t, assistant.ReasoningDetails[0].Data)
+	require.Equal(t, blob, *assistant.ReasoningDetails[0].Data)
+
+	// Replay that assistant turn back to Bedrock.
+	replayed, err := convertMessage(context.Background(), model,
+		*bifrostResp.Choices[0].ChatNonStreamResponseChoice.Message)
+	require.NoError(t, err)
+
+	raw, err := sonic.Marshal(replayed)
+	require.NoError(t, err)
+	require.Equal(t, blob, gjson.GetBytes(raw, "content.0.reasoningContent.redactedContent").String())
+	require.False(t, gjson.GetBytes(raw, "content.0.reasoningContent.reasoningText").Exists())
 }

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -1026,9 +1026,13 @@ func (chunk *BedrockStreamEvent) toBifrostResponsesStream(sequenceNumber int, st
 					},
 				}
 
-				// Preserve signature if present
+				// Preserve the replay token if present. Anthropic sends a signature,
+				// OpenAI and xAI send an opaque redactedContent blob; both ride on
+				// EncryptedContent and the shape decides how it is emitted back.
 				if reasoningDelta.Signature != nil {
 					item.ResponsesReasoning.EncryptedContent = reasoningDelta.Signature
+				} else if reasoningDelta.RedactedContent != nil {
+					item.ResponsesReasoning.EncryptedContent = reasoningDelta.RedactedContent
 				}
 
 				// Track that this content index is a reasoning block
@@ -3797,7 +3801,7 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, model string, 
 
 			// Handle reasoning as content in next assistant message
 			// For now, just add to pending content blocks
-			reasoningBlocks := convertBifrostReasoningToBedrockReasoning(&msg)
+			reasoningBlocks := convertBifrostReasoningToBedrockReasoning(&msg, converseReasoningShape(model))
 			if len(reasoningBlocks) > 0 {
 				pendingReasoningContentBlocks = append(pendingReasoningContentBlocks, reasoningBlocks...)
 			}
@@ -4212,6 +4216,7 @@ func createTextMessage(
 func convertSingleBedrockMessageToBifrostMessages(ctx *schemas.BifrostContext, msg *BedrockMessage, isOutputMessage bool) []schemas.ResponsesMessage {
 	var outputMessages []schemas.ResponsesMessage
 	var reasoningContentBlocks []schemas.ResponsesMessageContentBlock
+	var reasoningRedactedContent *string
 
 	// Check if we have a structured output tool
 	var structuredOutputToolName string
@@ -4326,6 +4331,10 @@ func convertSingleBedrockMessageToBifrostMessages(ctx *schemas.BifrostContext, m
 					Text:      block.ReasoningContent.ReasoningText.Text,
 					Signature: block.ReasoningContent.ReasoningText.Signature,
 				})
+			} else if block.ReasoningContent.RedactedContent != nil {
+				// Opaque blob: carried on the reasoning message rather than as a
+				// content block, since there is no prose for one to hold.
+				reasoningRedactedContent = block.ReasoningContent.RedactedContent
 			}
 		} else if block.ToolUse != nil {
 			// Tool use content
@@ -4683,12 +4692,13 @@ func convertSingleBedrockMessageToBifrostMessages(ctx *schemas.BifrostContext, m
 	}
 
 	// Handle reasoning blocks - prepend reasoning message if we collected any
-	if len(reasoningContentBlocks) > 0 {
+	if len(reasoningContentBlocks) > 0 || reasoningRedactedContent != nil {
 		reasoningMessage := schemas.ResponsesMessage{
 			ID:   new("rs_" + fmt.Sprintf("%d", time.Now().UnixNano())),
 			Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
 			ResponsesReasoning: &schemas.ResponsesReasoning{
-				Summary: []schemas.ResponsesReasoningSummary{},
+				Summary:          []schemas.ResponsesReasoningSummary{},
+				EncryptedContent: reasoningRedactedContent,
 			},
 			Content: &schemas.ResponsesMessageContent{
 				ContentBlocks: reasoningContentBlocks,
@@ -4713,7 +4723,23 @@ func convertSingleBedrockMessageToBifrostMessages(ctx *schemas.BifrostContext, m
 //
 // once per replayed assistant turn. See reasoning_replay_test.go, which pins the
 // invariant at both the struct and the serialised-wire level.
-func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage) []BedrockContentBlock {
+func convertBifrostReasoningToBedrockReasoning(msg *schemas.ResponsesMessage, shape schemas.BedrockReasoningShape) []BedrockContentBlock {
+	if shape == schemas.BedrockReasoningShapeRedacted {
+		// These models reject reasoningText in every form -- with a signature,
+		// without one, empty or not -- with an opaque 500. Only the blob carried
+		// on EncryptedContent is replayable; emitting nothing beats emitting a
+		// shape the model cannot accept.
+		if msg.ResponsesReasoning == nil || msg.ResponsesReasoning.EncryptedContent == nil ||
+			*msg.ResponsesReasoning.EncryptedContent == "" {
+			return nil
+		}
+		return []BedrockContentBlock{{
+			ReasoningContent: &BedrockReasoningContent{
+				RedactedContent: msg.ResponsesReasoning.EncryptedContent,
+			},
+		}}
+	}
+
 	var reasoningBlocks []BedrockContentBlock
 
 	// Track whether the content blocks actually produced reasoning rather than
@@ -4819,6 +4845,11 @@ func convertBifrostResponsesMessageContentBlocksToBedrockContentBlocks(ctx conte
 					bedrockBlock.Image = imageSource
 				}
 			case schemas.ResponsesOutputMessageContentTypeReasoning:
+				// Redacted-shape models carry their blob on the reasoning message,
+				// never on a content block, so there is nothing here to replay.
+				if converseReasoningShape(model) == schemas.BedrockReasoningShapeRedacted {
+					continue
+				}
 				if block.Text != nil {
 					bedrockBlock.ReasoningContent = &BedrockReasoningContent{
 						ReasoningText: &BedrockReasoningContentText{

--- a/core/providers/bedrock/types.go
+++ b/core/providers/bedrock/types.go
@@ -353,11 +353,18 @@ type BedrockGuardContent struct {
 
 type BedrockReasoningContent struct {
 	ReasoningText *BedrockReasoningContentText `json:"reasoningText,omitempty"`
+
+	// Opaque reasoning blob used by OpenAI and xAI instead of ReasoningText.
+	// The two are mutually exclusive; see schemas.BedrockReasoningShape.
+	RedactedContent *string `json:"redactedContent,omitempty"`
 }
 
+// BedrockReasoningContentText is both the reasoningText block and the streaming
+// reasoning delta, which is why RedactedContent appears here too.
 type BedrockReasoningContentText struct {
-	Text      *string `json:"text,omitempty"`
-	Signature *string `json:"signature,omitempty"`
+	Text            *string `json:"text,omitempty"`
+	Signature       *string `json:"signature,omitempty"`
+	RedactedContent *string `json:"redactedContent,omitempty"`
 }
 
 // BedrockGuardContentText represents text content for guardrails

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -1069,7 +1069,20 @@ func convertMessage(ctx context.Context, model string, msg schemas.ChatMessage) 
 
 	// Add reasoning content first
 	if msg.ChatAssistantMessage != nil && len(msg.ChatAssistantMessage.ReasoningDetails) > 0 {
+		shape := converseReasoningShape(model)
 		for _, detail := range msg.ChatAssistantMessage.ReasoningDetails {
+			if shape == schemas.BedrockReasoningShapeRedacted {
+				// These models reject reasoningText in every form -- with a
+				// signature, without one, empty or not -- with an opaque 500. The
+				// encrypted blob is the only replayable detail, and dropping the
+				// rest beats sending a shape that cannot be accepted.
+				if detail.Type == schemas.BifrostReasoningDetailsTypeEncrypted && detail.Data != nil {
+					contentBlocks = append(contentBlocks, BedrockContentBlock{
+						ReasoningContent: &BedrockReasoningContent{RedactedContent: detail.Data},
+					})
+				}
+				continue
+			}
 			if detail.Type == schemas.BifrostReasoningDetailsTypeText {
 				// Text must never reach Bedrock as nil. It is
 				// `*string json:"text,omitempty"`, so a nil pointer drops the key
@@ -1880,6 +1893,26 @@ func converseReasoningEffortLevels(ctx *schemas.BifrostContext, caps schemas.Mod
 		return bedrockConverseOpenAIEffortLevels, true
 	}
 	return nil, false
+}
+
+// converseReasoningShape reports which reasoning content variant the model uses
+// on Converse, preferring the datasheet and falling back to family detection.
+//
+// Verified against bedrock-runtime: gpt-5.6 and Grok return
+// reasoningContent.redactedContent, an opaque blob; Anthropic (through 4.8
+// adaptive thinking) and DeepSeek R1 return reasoningContent.reasoningText.
+// Replaying the wrong variant is rejected either way — 400 on Anthropic, an
+// opaque 500 on OpenAI and xAI.
+//
+// Takes the canonical model id rather than ModelCaps because the message
+// converters that need it hold exactly that and no BifrostContext; they resolve
+// caps inline the same way convertToolConfig does.
+func converseReasoningShape(model string) schemas.BedrockReasoningShape {
+	fallback := schemas.BedrockReasoningShapeText
+	if schemas.IsGrokModel(model) || schemas.IsOpenAIModel(model) {
+		fallback = schemas.BedrockReasoningShapeRedacted
+	}
+	return schemas.ResolveModelCaps(schemas.Bedrock, model).BedrockReasoningShape(fallback)
 }
 
 // setConverseReasoningEffort writes the OpenAI-shaped reasoning field, mapping

--- a/core/schemas/modelcapabilities.go
+++ b/core/schemas/modelcapabilities.go
@@ -264,6 +264,13 @@ type ModelCapabilities struct {
 	// outright (a bare id 400s on bedrock-runtime, a cross-region or ARN id 404s
 	// on bedrock-mantle). Callers must resolve identifier form first.
 	BedrockAPIs []BedrockAPI `json:"bedrock_apis,omitempty"`
+
+	// Wire shape this model uses for reasoning content on Bedrock Converse.
+	// Scoped to Converse specifically: the same model reasons in a different
+	// shape on the mantle chat-completions surface.
+	//
+	// Absent or unrecognised falls back to the caller's family detection.
+	BedrockReasoningShape BedrockReasoningShape `json:"bedrock_reasoning_shape,omitempty"`
 }
 
 // BedrockAPI names one wire API on a Bedrock endpoint. Which endpoint serves it
@@ -297,6 +304,31 @@ var BedrockAPIValues = []BedrockAPI{
 // skip them.
 func (a BedrockAPI) IsValid() bool {
 	return slices.Contains(BedrockAPIValues, a)
+}
+
+// BedrockReasoningShape names the reasoning content variant a model uses on
+// Bedrock Converse. The two are mutually exclusive and not interchangeable:
+// replaying the wrong one is rejected (400 on Anthropic, an opaque 500 on
+// OpenAI and xAI).
+type BedrockReasoningShape string
+
+const (
+	// reasoningContent.reasoningText{text,signature} — Anthropic, DeepSeek.
+	BedrockReasoningShapeText BedrockReasoningShape = "reasoning_text"
+
+	// reasoningContent.redactedContent, one opaque blob — OpenAI, xAI.
+	BedrockReasoningShapeRedacted BedrockReasoningShape = "redacted_content"
+)
+
+// BedrockReasoningShapeValues lists every recognised BedrockReasoningShape.
+var BedrockReasoningShapeValues = []BedrockReasoningShape{
+	BedrockReasoningShapeText,
+	BedrockReasoningShapeRedacted,
+}
+
+// IsValid reports whether s is a shape this binary knows how to emit.
+func (s BedrockReasoningShape) IsValid() bool {
+	return slices.Contains(BedrockReasoningShapeValues, s)
 }
 
 // ModelParameterDescriptor is one entry of the datasheet's model_parameters

--- a/core/schemas/modelcaps.go
+++ b/core/schemas/modelcaps.go
@@ -577,6 +577,17 @@ func (c ModelCaps) MinOutputTokens(fallback int) int {
 	return fallback
 }
 
+// BedrockReasoningShape returns the reasoning wire shape the datasheet says this
+// (provider, model) pair uses on Converse, falling back to the caller's
+// name-based answer when the row says nothing or publishes a value this binary
+// does not recognise.
+func (c ModelCaps) BedrockReasoningShape(fallback BedrockReasoningShape) BedrockReasoningShape {
+	if c.record != nil && c.record.BedrockReasoningShape.IsValid() {
+		return c.record.BedrockReasoningShape
+	}
+	return fallback
+}
+
 // SupportsResponsesEndpoint reports whether the datasheet's supported_endpoints list
 // includes the Responses API.
 func (c ModelCaps) SupportsResponsesEndpoint(fallback bool) bool {

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -139823,6 +139823,306 @@
           }
         }
       ]
+    },
+    {
+      "name": "67. Bedrock Converse redacted reasoning round-trip (converse-redacted-reasoning)",
+      "description": "OpenAI (gpt-5.6-*) and xAI (grok-4.6) on bedrock-runtime Converse return reasoning as\nreasoningContent.redactedContent - one opaque blob - while Anthropic and DeepSeek return\nreasoningContent.reasoningText{text,signature}. The two are mutually exclusive and replaying the\nwrong one is rejected either way: 400 on Anthropic, and on OpenAI/xAI an opaque\n\n  500 \"The system encountered an unexpected error during processing. Try your request again.\"\n\nBifrost modelled only reasoningText, so it dropped the blob on ingress, left the client holding an\nempty unsigned thinking block, and re-emitted that as reasoningContent.reasoningText.text=\"\" on the\nnext turn - earning the 500. Only reachable on turn 2, so every row here is a capture/replay pair.\n\nProduction path: POST /v1/chat/completions (and /v1/responses) -> bedrock provider ->\nconverseReasoningShape() picks the wire shape from the bedrock_reasoning_shape datasheet key,\nfalling back to family detection -> reasoningContent.redactedContent.\n\nThe \"us.\" prefix on each model id is load-bearing: a bare id routes to bedrock-mantle, and only a\ncross-region identifier reaches bedrock-runtime, where Converse lives. The blob is minted and\nvalidated by the model, so it cannot be fixtured - hence capture-then-replay through a collection\nvariable, which runners/lib/chained-vars.mjs detects so sharding keeps each pair together.\n\nThe reasoningText half of the same invariant is already covered for Anthropic-on-Bedrock by\nfolder 46 and is not duplicated here.",
+      "item": [
+        {
+          "name": "bedrock/us.openai.gpt-5.6-luna /v1/chat/completions turn 1: Converse redacted reasoning captured - converse-redacted-reasoning",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/us.openai.gpt-5.6-luna\",\"max_tokens\":512,\"reasoning\":{\"effort\":\"high\"},\"messages\":[{\"role\":\"user\",\"content\":\"Two trains 140 miles apart head toward each other; one leaves at 3:47pm at 62mph, the other at 4:19pm at 71mph. Work out when they meet, step by step.\"}]}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var body = pm.response.text() || '';",
+                  "// A 500 is normally infra noise and skipped, but Bedrock answers THIS defect with",
+                  "// a 500 carrying that exact phrase, so it must fail loudly instead of skipping.",
+                  "var isRegression = body.indexOf('unexpected error during processing') !== -1;",
+                  "if (!isRegression && [401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Converse redacted reasoning reaches the client', function () {",
+                  "  pm.expect(body, 'Bedrock rejected the capture turn').to.not.include('unexpected error during processing');",
+                  "  pm.expect(pm.response.code, 'request failed: ' + body).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.choices, 'expected a choices array').to.be.an('array').that.is.not.empty;",
+                  "  var details = (j.choices[0].message && j.choices[0].message.reasoning_details) || [];",
+                  "  var enc = details.filter(function (d) { return d && d.type === 'reasoning.encrypted' && d.data; });",
+                  "  pm.expect(enc.length, 'no encrypted reasoning detail came back - the redactedContent blob was dropped on ingress, which is the first half of the defect and leaves the replay row nothing to carry').to.be.above(0);",
+                  "});",
+                  "// Echo the assistant turn back verbatim: echoing is the point, it is what",
+                  "// carries the redacted blob out to Bedrock again on the next turn.",
+                  "try {",
+                  "  var captured = pm.response.json();",
+                  "  var msg = captured.choices && captured.choices[0] && captured.choices[0].message;",
+                  "  if (msg) {",
+                  "    pm.collectionVariables.set(",
+                  "      'bedrockConverseRedactedChatMessages',",
+                  "      JSON.stringify([",
+                  "        { role: \"user\", content: \"Two trains 140 miles apart head toward each other; one leaves at 3:47pm at 62mph, the other at 4:19pm at 71mph. Work out when they meet, step by step.\" },",
+                  "        msg,",
+                  "        { role: \"user\", content: \"Now restate the meeting time in one sentence.\" }",
+                  "      ])",
+                  "    );",
+                  "  }",
+                  "} catch (e) {}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "bedrock/us.openai.gpt-5.6-luna /v1/chat/completions turn 2: redacted reasoning replays without a Converse 500 - converse-redacted-reasoning",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/us.openai.gpt-5.6-luna\",\"max_tokens\":256,\"reasoning\":{\"effort\":\"high\"},\"messages\":{{bedrockConverseRedactedChatMessages}}}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Skip when the capture step did not run: the body placeholder stays",
+                  "// unresolved, so there is nothing meaningful to replay.",
+                  "if (pm.request.body && pm.request.body.raw && pm.request.body.raw.indexOf('{{') !== -1) { return; }",
+                  "var body = pm.response.text() || '';",
+                  "// A 500 is normally infra noise and skipped, but Bedrock answers THIS defect with",
+                  "// a 500 carrying that exact phrase, so it must fail loudly instead of skipping.",
+                  "var isRegression = body.indexOf('unexpected error during processing') !== -1;",
+                  "if (!isRegression && [401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Replayed Converse redacted reasoning is accepted', function () {",
+                  "  pm.expect(body, 'Bedrock answered the replayed turn with its opaque 500 - the redacted blob was reshaped into reasoningText, which Converse rejects for every OpenAI and xAI model').to.not.include('unexpected error during processing');",
+                  "  pm.expect(body, 'Bedrock refused the reasoningContent field itself, so the replayed block was not in the shape this model accepts').to.not.include('support the reasoningContent');",
+                  "  pm.expect(pm.response.code, 'replay request failed: ' + body).to.be.below(400);",
+                  "  pm.expect(pm.response.json().choices, 'no choices returned on the replayed turn').to.be.an('array').that.is.not.empty;",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "// The wire-level pin. A 200 alone does not prove the blob went back out in the",
+                  "// right shape. Note that a HEALTHY response echoes \"reasoningContent\" inside",
+                  "// extra_fields.raw_response, so a bare substring check on the response body can",
+                  "// never distinguish success from failure here - assert on what Bifrost SENT.",
+                  "var ef = (pm.response.json() || {}).extra_fields || {};",
+                  "var rr = ef.raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('replay raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var sent = JSON.stringify(rr);",
+                  "pm.test('the replay went out as redactedContent, never reasoningText', function () {",
+                  "  pm.expect(sent, 'the redacted blob never reached Bedrock - it was dropped on ingress or on replay, which is the state that produced the opaque 500').to.include('redactedContent');",
+                  "  pm.expect(sent, 'the blob was reshaped into reasoningText, which is exactly the shape Converse rejects for every OpenAI and xAI model').to.not.include('reasoningText');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "bedrock/us.xai.grok-4.6 /v1/responses turn 1: Converse redacted reasoning captured - converse-redacted-reasoning",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/us.xai.grok-4.6\",\"input\":\"Two trains 140 miles apart head toward each other; one leaves at 3:47pm at 62mph, the other at 4:19pm at 71mph. Work out when they meet, step by step.\",\"reasoning\":{\"effort\":\"high\"},\"max_output_tokens\":2048}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var body = pm.response.text() || '';",
+                  "// A 500 is normally infra noise and skipped, but Bedrock answers THIS defect with",
+                  "// a 500 carrying that exact phrase, so it must fail loudly instead of skipping.",
+                  "var isRegression = body.indexOf('unexpected error during processing') !== -1;",
+                  "if (!isRegression && [401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Converse redacted reasoning reaches the client as a reasoning item', function () {",
+                  "  pm.expect(body, 'Bedrock rejected the capture turn').to.not.include('unexpected error during processing');",
+                  "  pm.expect(pm.response.code, 'request failed: ' + body).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.output, 'expected an output array').to.be.an('array').that.is.not.empty;",
+                  "  var reasoning = j.output.filter(function (o) { return o.type === 'reasoning'; });",
+                  "  pm.expect(reasoning.length, 'no reasoning item came back, so the replay row would silently skip having tested nothing').to.be.above(0);",
+                  "  var carried = reasoning.filter(function (o) { return o.encrypted_content; });",
+                  "  pm.expect(carried.length, 'the reasoning item carries no encrypted_content - the redactedContent blob was dropped on ingress').to.be.above(0);",
+                  "});",
+                  "try {",
+                  "  var captured = pm.response.json();",
+                  "  if (captured.output && captured.output.length) {",
+                  "    pm.collectionVariables.set(",
+                  "      'bedrockConverseRedactedResponsesInput',",
+                  "      JSON.stringify(",
+                  "        [{ type: \"message\", role: \"user\", content: \"Two trains 140 miles apart head toward each other; one leaves at 3:47pm at 62mph, the other at 4:19pm at 71mph. Work out when they meet, step by step.\" }]",
+                  "          .concat(captured.output)",
+                  "          .concat([{ type: \"message\", role: \"user\", content: \"Now restate the meeting time in one sentence.\" }])",
+                  "      )",
+                  "    );",
+                  "  }",
+                  "} catch (e) {}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "bedrock/us.xai.grok-4.6 /v1/responses turn 2: redacted reasoning replays without a Converse 500 - converse-redacted-reasoning",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/us.xai.grok-4.6\",\"input\":{{bedrockConverseRedactedResponsesInput}},\"reasoning\":{\"effort\":\"high\"},\"max_output_tokens\":512}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Skip when the capture step did not run: the body placeholder stays",
+                  "// unresolved, so there is nothing meaningful to replay.",
+                  "if (pm.request.body && pm.request.body.raw && pm.request.body.raw.indexOf('{{') !== -1) { return; }",
+                  "var body = pm.response.text() || '';",
+                  "// A 500 is normally infra noise and skipped, but Bedrock answers THIS defect with",
+                  "// a 500 carrying that exact phrase, so it must fail loudly instead of skipping.",
+                  "var isRegression = body.indexOf('unexpected error during processing') !== -1;",
+                  "if (!isRegression && [401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('Replayed Converse redacted reasoning is accepted on the Responses path', function () {",
+                  "  pm.expect(body, 'Bedrock answered the replayed turn with its opaque 500 - the redacted blob was reshaped into reasoningText, which Converse rejects for every OpenAI and xAI model').to.not.include('unexpected error during processing');",
+                  "  pm.expect(body, 'Bedrock refused the reasoningContent field itself, so the replayed block was not in the shape this model accepts').to.not.include('support the reasoningContent');",
+                  "  pm.expect(pm.response.code, 'replay request failed: ' + body).to.be.below(400);",
+                  "  pm.expect(pm.response.json().output, 'no output returned on the replayed turn').to.be.an('array').that.is.not.empty;",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "// The wire-level pin. A 200 alone does not prove the blob went back out in the",
+                  "// right shape. Note that a HEALTHY response echoes \"reasoningContent\" inside",
+                  "// extra_fields.raw_response, so a bare substring check on the response body can",
+                  "// never distinguish success from failure here - assert on what Bifrost SENT.",
+                  "var ef = (pm.response.json() || {}).extra_fields || {};",
+                  "var rr = ef.raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('replay raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var sent = JSON.stringify(rr);",
+                  "pm.test('the replay went out as redactedContent, never reasoningText', function () {",
+                  "  pm.expect(sent, 'the redacted blob never reached Bedrock - it was dropped on ingress or on replay, which is the state that produced the opaque 500').to.include('redactedContent');",
+                  "  pm.expect(sent, 'the blob was reshaped into reasoningText, which is exactly the shape Converse rejects for every OpenAI and xAI model').to.not.include('reasoningText');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

OpenAI and xAI models on Bedrock Converse use `reasoningContent.redactedContent` — an opaque blob — instead of `reasoningContent.reasoningText`. Replaying the wrong shape causes a 400 on Anthropic and an opaque 500 on OpenAI/xAI. This PR teaches Bifrost to detect which shape a model expects, emit the correct variant on the wire, and round-trip redacted blobs through the full receive → canonical → replay loop without corruption or silent drops.

## Changes

- Introduced `BedrockReasoningShape` (`reasoning_text` | `redacted_content`) as a typed enum in `ModelCapabilities`, with a `BedrockReasoningShape` accessor on `ModelCaps` that prefers the datasheet row and falls back to family detection.
- Added `converseReasoningShape(model)` in `utils.go`: returns `redacted_content` for OpenAI and xAI model families, `reasoning_text` for everything else, with the datasheet able to override either direction.
- Updated `convertBifrostReasoningToBedrockReasoning` to accept the shape and, for `redacted_content` models, emit `redactedContent` from `EncryptedContent` and drop any `reasoningText` block rather than sending a shape the model rejects.
- Updated `convertMessage` (chat path) to apply the same shape logic: only `BifrostReasoningDetailsTypeEncrypted` details are replayed for redacted-shape models; all other detail types are silently dropped.
- Updated `ToBifrostChatResponse` and `ToBifrostChatCompletionStream` to recognise `redactedContent` blocks in non-streaming and streaming responses respectively, mapping them to `BifrostReasoningDetailsTypeEncrypted` with the blob on `Data`.
- Updated the Responses path (`responses.go`) to carry `redactedContent` on `EncryptedContent` during streaming, emit it on the reasoning message during conversion, and skip redacted-shape content blocks during replay.
- Added `RedactedContent *string` to `BedrockReasoningContent` and `BedrockReasoningContentText` (the streaming delta struct).
- Added comprehensive tests covering shape resolution priority (datasheet > family > fallback), the full receive-to-replay loop for redacted blobs, and negative cases (unreplayable blocks must be dropped, not reshaped).

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/bedrock/... -run TestConverseReasoningShape
go test ./core/providers/bedrock/... -run TestConvertBifrostReasoningToBedrockReasoningRedactedShape
go test ./core/providers/bedrock/... -run TestRedactedReasoningSurvivesTheReplayLoop
go test ./core/providers/bedrock/... -run TestConvertBifrostReasoningToBedrockReasoning
go test ./...
```

To validate end-to-end, send a chat or Responses request to an OpenAI (`openai.gpt-5.6-*`) or xAI (`xai.grok-4.*`) model on Bedrock Converse with extended thinking enabled, capture the assistant turn, and replay it in a follow-up request. The follow-up must succeed (no 500) and the model must respond coherently.

## Breaking changes

- [x] No

## Security considerations

The redacted blob is an opaque token issued by Bedrock and replayed verbatim. It is not inspected, logged, or stored beyond the request lifetime. No new secrets or PII handling is introduced.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable