### PR TITLE
fix(complexity): remove session xml tag check in cc and few complexity ui fixes

### DIFF
--- a/plugins/routing/complexity/extract.go
+++ b/plugins/routing/complexity/extract.go
@@ -71,7 +71,6 @@ const (
 	codexTurnMetadataHeader      = "x-codex-turn-metadata"
 	claudeCodeSessionIDHeader    = "x-claude-code-session-id"
 	maxComplexitySessionIDLength = 255
-	claudeSessionEnvelopeOpen    = "<session>"
 	claudeResumeRecapPrefix      = "The user stepped away and is coming back."
 )
 
@@ -563,15 +562,12 @@ func sanitizeUserText(text string, harness complexityHarness) (string, complexit
 	}
 }
 
-// isClaudeCodeHousekeepingText recognizes complete user-role messages Claude
-// Code injects for background session maintenance. These are not new human
-// intent and therefore must not initialize or escalate session complexity.
-// Detection is deliberately prefix-based and Claude-client-gated so a human
-// request that merely mentions a session XML tag remains classifiable.
+// isClaudeCodeHousekeepingText recognizes Claude Code's injected resume recap.
+// It is background session maintenance rather than new human intent, so it
+// must not initialize or escalate session complexity.
 func isClaudeCodeHousekeepingText(text string) bool {
 	text = strings.TrimSpace(text)
-	return strings.HasPrefix(text, claudeSessionEnvelopeOpen) ||
-		strings.HasPrefix(text, claudeResumeRecapPrefix)
+	return strings.HasPrefix(text, claudeResumeRecapPrefix)
 }
 
 func sanitizeSystemText(text string, harness complexityHarness) string {

--- a/plugins/routing/complexity/extract_test.go
+++ b/plugins/routing/complexity/extract_test.go
@@ -444,7 +444,9 @@ func TestSanitizeUserText_ClaudeCodeWrappers(t *testing.T) {
 			name: "session_title_request",
 			text: "<session>\nhello can u help me understand what sidekiq is\n</session>\n\n" +
 				"Write the title in the predominant language of the session.",
-			wantKind: complexityTextHousekeeping,
+			wantText: "<session>\nhello can u help me understand what sidekiq is\n</session>\n\n" +
+				"Write the title in the predominant language of the session.",
+			wantKind: complexityTextHuman,
 		},
 		{
 			name: "resume_recap_request",
@@ -487,11 +489,6 @@ func TestBuildComplexityInput_ClaudeCodeInjectedMessagesAreContinuations(t *test
 		name string
 		text string
 	}{
-		{
-			name: "session_title_request",
-			text: "<session>\nDebug the distributed queue worker\n</session>\n\n" +
-				"Write the title in the predominant language of the session.",
-		},
 		{
 			name: "resume_recap_request",
 			text: "The user stepped away and is coming back. Recap in under 40 words, 1-2 plain sentences, no markdown.",

--- a/ui/app/workspace/complexity-router/formSchema.test.ts
+++ b/ui/app/workspace/complexity-router/formSchema.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, test } from "vitest";
-import { analyzerConfigSchema, countCanonicalSemanticPhrases, DEFAULT_FORM_VALUES } from "./formSchema";
+import { analyzerConfigSchema, countCanonicalSemanticPhrases, DEFAULT_FORM_VALUES, shouldSeedLLMPrompt } from "./formSchema";
+
+describe("fallback prompt initialization", () => {
+	test("initializes an untouched empty prompt", () => {
+		expect(shouldSeedLLMPrompt(true, "default", "", false)).toBe(true);
+	});
+	test("does not refill an intentionally cleared prompt, including a late default response", () => {
+		expect(shouldSeedLLMPrompt(true, "default", "", true)).toBe(false);
+	});
+	test("does not replace custom text or initialize a disabled fallback", () => {
+		expect(shouldSeedLLMPrompt(true, "default", "custom", false)).toBe(false);
+		expect(shouldSeedLLMPrompt(false, "default", "", false)).toBe(false);
+		expect(shouldSeedLLMPrompt(true, "", "", false)).toBe(false);
+	});
+});
 
 function phraseList(prefix: string, count: number): string[] {
 	return Array.from({ length: count }, (_, index) => `${prefix}-${index}`);

--- a/ui/app/workspace/complexity-router/formSchema.ts
+++ b/ui/app/workspace/complexity-router/formSchema.ts
@@ -287,3 +287,7 @@ export function llmTimeoutFieldValue(timeout: string | undefined): string | numb
 	const millis = timeout?.trim().match(/^([0-9]*\.?[0-9]+)ms$/);
 	return millis ? millis[1] : parseLLMTimeoutMs(timeout);
 }
+// shouldSeedLLMPrompt decides whether the shipped guidance may initialize the draft.
+export function shouldSeedLLMPrompt(enabled: boolean, defaultPrompt: string, prompt: string, edited: boolean): boolean {
+	return enabled && defaultPrompt !== "" && prompt === "" && !edited;
+}

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -37,7 +37,7 @@ import { cn } from "@/lib/utils";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { ExternalLink, Info, LoaderCircle, RotateCcw, Save, Settings2, TriangleAlert } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import {
@@ -47,6 +47,7 @@ import {
 	DEFAULT_FORM_VALUES,
 	toAnalyzerPayload,
 	toFormValues,
+	shouldSeedLLMPrompt,
 } from "./formSchema";
 import { ClassifierStatusBadge } from "./views/classifierStatusBadge";
 import EmbeddingConfigSheet from "./views/embeddingConfigSheet";
@@ -110,6 +111,9 @@ export default function ComplexityRouterPage() {
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
 	const [embeddingSheetOpen, setEmbeddingSheetOpen] = useState(false);
+	// An intentionally empty draft can equal the saved default and be non-dirty.
+	// Track interaction separately so status refreshes never refill it.
+	const promptEdited = useRef(false);
 
 	const { data: providersData, isLoading: providersLoading } = useGetProvidersQuery();
 	const { data: allKeys, isLoading: keysLoading } = useGetAllKeysQuery();
@@ -132,6 +136,7 @@ export default function ComplexityRouterPage() {
 		control,
 		watch,
 		setValue,
+		getValues,
 		formState: { errors, dirtyFields, isDirty, isSubmitted },
 	} = useForm<AnalyzerFormValues>({
 		resolver: zodResolver(analyzerConfigSchema),
@@ -218,18 +223,10 @@ export default function ComplexityRouterPage() {
 	// where a "saving will embed N phrases" line appears next to a disabled Save.
 	const hasPendingSave = isDirty;
 
-	// The prompt editor works on a concrete copy of the shipped guidance, the
-	// same lifecycle as the phrase lists: seeded from the gateway, owned by the
-	// operator once saved. Seeding is not a dirty edit — the operator has not
-	// said anything yet — but any save from then on persists the materialized
-	// text, which is what makes "what exactly is my classifier running?"
-	// answerable from the stored config alone.
+	// Shipped guidance initializes untouched drafts; an empty edited prompt is
+	// valid and means "use default guidance" when saved.
 	const defaultLLMPrompt = semanticStatus?.llm_default_prompt ?? "";
 	const livePrompt = liveLLM?.prompt ?? "";
-	useEffect(() => {
-		if (!isLLMFallbackEnabled || !defaultLLMPrompt || livePrompt !== "") return;
-		setValue("llm.prompt", defaultLLMPrompt, { shouldDirty: false });
-	}, [isLLMFallbackEnabled, defaultLLMPrompt, livePrompt, setValue]);
 
 	// Saving re-runs warmup, but what it costs depends on what changed, because
 	// the gateway caches a vector per phrase (semanticEmbeddingCache).
@@ -296,12 +293,20 @@ export default function ComplexityRouterPage() {
 	const willReembed = willReembedAll || newPhraseCount > 0;
 
 	useEffect(() => {
-		if (!data || isDirty) return;
+		if (!data || isDirty || promptEdited.current) return;
 		reset(toFormValues(data));
 		setSubmitError(null);
 	}, [data, isDirty, reset]);
 
+	// Run after saved-data hydration and read the current form value, not the
+	// previous render's value, when config and status arrive together.
+	useEffect(() => {
+		if (!data || !shouldSeedLLMPrompt(isLLMFallbackEnabled, defaultLLMPrompt, getValues("llm.prompt") ?? "", promptEdited.current)) return;
+		setValue("llm.prompt", defaultLLMPrompt, { shouldDirty: false });
+	}, [data, isLLMFallbackEnabled, defaultLLMPrompt, livePrompt, getValues, setValue]);
+
 	const handleDiscard = () => {
+		promptEdited.current = false;
 		if (data) reset(toFormValues(data));
 		setSubmitError(null);
 	};
@@ -312,6 +317,7 @@ export default function ComplexityRouterPage() {
 		resetConfig()
 			.unwrap()
 			.then((defaults) => {
+				promptEdited.current = false;
 				reset(toFormValues(defaults));
 				toast.success("Reset to defaults", { position: "top-right" });
 			})
@@ -341,6 +347,7 @@ export default function ComplexityRouterPage() {
 		updateConfig(payload)
 			.unwrap()
 			.then((res) => {
+				promptEdited.current = false;
 				reset(toFormValues(res));
 				setEmbeddingSheetOpen(false);
 				toast.success("Configuration saved", { position: "top-right" });
@@ -619,7 +626,10 @@ export default function ComplexityRouterPage() {
 											type="button"
 											variant="ghost"
 											size="sm"
-											onClick={() => setValue("llm.prompt", defaultLLMPrompt, { shouldDirty: true })}
+											onClick={() => {
+												promptEdited.current = true;
+												setValue("llm.prompt", defaultLLMPrompt, { shouldDirty: true });
+											}}
 											disabled={!canUpdate || !defaultLLMPrompt || livePrompt === defaultLLMPrompt}
 											data-testid="complexity-router-llm-prompt-reset-button"
 										>
@@ -637,7 +647,12 @@ export default function ComplexityRouterPage() {
 											rows={8}
 											maxLength={MAX_LLM_PROMPT_CHARACTERS}
 											value={field.value}
-											onChange={field.onChange}
+											onChange={(event) => {
+												promptEdited.current = true;
+												field.onChange(event);
+											}}
+											onBlur={field.onBlur}
+											ref={field.ref}
 											disabled={!canUpdate}
 											aria-invalid={errors.llm?.prompt ? true : undefined}
 											className={cn(
@@ -651,8 +666,8 @@ export default function ComplexityRouterPage() {
 									<p className="text-destructive text-xs">{errors.llm.prompt.message}</p>
 								) : (
 									<p className="text-muted-foreground text-xs leading-relaxed">
-										Bifrost always appends a fixed response-format section (the tier names and the JSON answer contract), so edits here
-										refine what the tiers mean but cannot break routing.{" "}
+										Leave blank to use default guidance. Bifrost always appends a fixed response-format section (the tier names and the JSON
+										answer contract), so edits here refine what the tiers mean but cannot break routing.{" "}
 										<span className="font-mono tabular-nums">
 											{livePrompt.length}/{MAX_LLM_PROMPT_CHARACTERS}
 										</span>

--- a/ui/app/workspace/complexity-router/views/embeddingConfigSheet.tsx
+++ b/ui/app/workspace/complexity-router/views/embeddingConfigSheet.tsx
@@ -300,7 +300,7 @@ export default function EmbeddingConfigSheet({
 								<div className="space-y-2">
 									<FieldLabel
 										htmlFor="semantic-timeout"
-										tooltip="Ceiling on the embedding call, which runs inline on the request path. Exceeding it skips complexity tier based routing for that request."
+										tooltip="Maximum wait for the embedding call, including provider queue and response time. On timeout, the configured fallback applies."
 									>
 										Embedding timeout (ms)
 									</FieldLabel>


### PR DESCRIPTION
## Summary

This PR fixes two distinct issues in the complexity router: (1) the LLM fallback prompt field was being incorrectly re-seeded with default guidance after a user intentionally cleared it, and (2) session title requests wrapped in `<session>` XML tags were being misclassified as housekeeping messages instead of real human intent.

## Changes

- Removed the `claudeSessionEnvelopeOpen` (`<session>`) prefix check from `isClaudeCodeHousekeepingText`, leaving only the resume recap prefix as a housekeeping signal. Session title requests are now correctly classified as human-intent messages.
- Introduced a `promptEdited` ref in the complexity router page to track whether the operator has interacted with the LLM prompt field. Status refreshes and data re-hydrations no longer overwrite an intentionally empty prompt.
- Extracted `shouldSeedLLMPrompt` as a pure, testable function that gates default prompt seeding: it only seeds when the fallback is enabled, a default exists, the current value is empty, and the field has not been edited.
- Moved prompt seeding into a dedicated `useEffect` that runs after saved-data hydration and reads the live form value via `getValues` rather than a stale closure value.
- Reset `promptEdited` on discard, restore-to-defaults, and successful save so the seeding logic re-applies correctly after those actions.
- Updated the prompt field's `onChange` handler to set `promptEdited` and restored the missing `onBlur`/`ref` forwarding that was dropped when the handler was wrapped.
- Updated the embedding timeout tooltip to more accurately describe what the timeout covers and what happens when it is exceeded.
- Updated the prompt field helper text to inform operators that leaving the field blank uses default guidance.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Plugin tests
go test ./plugins/routing/complexity/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

**Prompt seeding behavior to verify manually:**
1. Open the complexity router page with LLM fallback enabled and no saved prompt — the default guidance should auto-populate without marking the form dirty.
2. Clear the prompt field and navigate away or wait for a status refresh — the field should remain empty and not be refilled.
3. Clear the prompt field and click Discard — the field should be refilled from saved state on the next status refresh.
4. Save with an empty prompt — after save, the field should be re-seeded from the default.

**Housekeeping classification to verify:**
- A user message beginning with `<session>` followed by a title-generation instruction should be routed as a normal human-intent message, not skipped as housekeeping.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable