### PR TITLE
fix(ui): skip format validation for API-masked secret values in Copilot provider form

### DIFF
--- a/ui/lib/schemas/providerForm.copilot.test.ts
+++ b/ui/lib/schemas/providerForm.copilot.test.ts
@@ -97,6 +97,32 @@ describe("ProviderFormSchema github-copilot credentials", () => {
 			expect(parse({ github_copilot_key_config: appConfig({ private_key: literal(body) }) }).success).toBe(false);
 		});
 
+		it("does not format-check values the API returned masked", () => {
+			// Editing a stored key round-trips the server's mask for every field the operator
+			// did not retype; the server then keeps the original. Short secrets mask to all
+			// asterisks, longer ones to a 4 + 24 asterisks + 4 pattern.
+			const parsed = parse({
+				github_copilot_key_config: {
+					app_id: literal("******"),
+					installation_id: literal("********"),
+					repository_id: literal("9990" + "*".repeat(24) + "0111"),
+					private_key: literal("----" + "*".repeat(24) + "----"),
+				},
+			});
+			expect(parsed.success, parsed.success ? "" : JSON.stringify(parsed.error.issues)).toBe(true);
+		});
+
+		it("still format-checks a retyped field next to masked ones", () => {
+			const parsed = parse({
+				github_copilot_key_config: appConfig({
+					app_id: literal("******"),
+					installation_id: literal("my-install"),
+					private_key: literal("----" + "*".repeat(24) + "----"),
+				}),
+			});
+			expect(parsed.success).toBe(false);
+		});
+
 		it("does not format-check environment references", () => {
 			// Their values resolve on the server, so judging their shape here would reject
 			// every legitimate headless configuration.

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -266,9 +266,14 @@ export const replicateKeyConfigSchema = z.object({
 // trusting the tag would let any malformed literal skip every check below.
 const isSecretVarRef = (v: { value?: string; ref?: string; type?: string } | undefined): boolean => !!v?.ref?.trim();
 
+// A stored secret comes back from the API masked ("******" or "1234****...****5678"), and the
+// edit form round-trips that mask untouched so the server keeps the original. Judging the
+// mask's shape would fail every edit of a key whose credentials were not all retyped.
+const isSecretVarMasked = (v: { value?: string; ref?: string; type?: string } | undefined): boolean => isRedacted(v?.value ?? "");
+
 const isLiteralDigits = (v: { value?: string; ref?: string; type?: string } | undefined): boolean => {
 	if (!isSecretVarSet(v)) return true; // presence is checked separately
-	if (isSecretVarRef(v)) return true;
+	if (isSecretVarRef(v) || isSecretVarMasked(v)) return true;
 	return /^\d+$/.test((v?.value ?? "").trim());
 };
 
@@ -284,7 +289,7 @@ const PEM_PRIVATE_KEY = /^-----BEGIN (RSA PRIVATE KEY|PRIVATE KEY)-----\s*\n([\s
 
 const isLiteralPEM = (v: { value?: string; ref?: string; type?: string } | undefined): boolean => {
 	if (!isSecretVarSet(v)) return true;
-	if (isSecretVarRef(v)) return true;
+	if (isSecretVarRef(v) || isSecretVarMasked(v)) return true;
 	const body = (v?.value ?? "").replace(/\\n/g, "\n").trim();
 	const match = PEM_PRIVATE_KEY.exec(body);
 	// The back-reference makes BEGIN and END agree; the body must also carry something.


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


