### PR TITLE
fix(core): allow GitHub Copilot provider keys to have empty values for GitHub App bundle authentication

### DIFF
--- a/core/utils.go
+++ b/core/utils.go
@@ -133,8 +133,10 @@ func providerRequiresKey(customConfig *schemas.CustomProviderConfig) bool {
 // CanProviderKeyValueBeEmpty returns true if the given provider allows the API key to be empty.
 // Some providers like Vertex and Bedrock have their credentials in additional key configs.
 // Ollama and SGL are keyless (API Key is optional) but use per-key server URLs.
+// GitHub Copilot may authenticate with a GitHub App bundle in github_copilot_key_config
+// instead of a Copilot API token in value; validateKey checks that one of the two is present.
 func CanProviderKeyValueBeEmpty(providerKey schemas.ModelProvider) bool {
-	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.BedrockMantle || providerKey == schemas.VLLM || providerKey == schemas.Azure || providerKey == schemas.Ollama || providerKey == schemas.SGL || providerKey == schemas.Databricks
+	return providerKey == schemas.Vertex || providerKey == schemas.Bedrock || providerKey == schemas.BedrockMantle || providerKey == schemas.VLLM || providerKey == schemas.Azure || providerKey == schemas.Ollama || providerKey == schemas.SGL || providerKey == schemas.Databricks || providerKey == schemas.GithubCopilot
 }
 
 // isKeySkippingAllowed gates SkipKeySelection on the provider this attempt resolved to. The flag

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -417,6 +417,17 @@ func TestClearCtxForFallback(t *testing.T) {
 	}
 }
 
+// TestCanProviderKeyValueBeEmptyGithubCopilot pins that a GitHub Copilot key may carry an
+// empty value. The GitHub App bundle in github_copilot_key_config is a complete credential
+// on its own, and the HTTP key handlers consult this allowlist before their provider-specific
+// checks, so dropping the entry rejects every App-authenticated key at creation with a
+// misleading "value must not be empty" error.
+func TestCanProviderKeyValueBeEmptyGithubCopilot(t *testing.T) {
+	if !CanProviderKeyValueBeEmpty(schemas.GithubCopilot) {
+		t.Fatal("GitHub Copilot keys authenticated through a GitHub App have no value; the allowlist must include the provider")
+	}
+}
+
 // TestValidateKeyGithubCopilot pins that validateKey rejects the same credentials the
 // provider would reject at request time. Accepting a whitespace-only field here defers the
 // failure to the first inference call, where it reads like a runtime fault rather than a


### PR DESCRIPTION
## Summary

Briefly explain the purpose of this PR and the problem it solves.

## Changes

- What was changed and why
- Any notable design decisions or trade-offs

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Describe the steps to validate this change. Include commands and expected outcomes.

```sh
# Core/Transports
go version
go test ./...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

If adding new configs or environment variables, document them here.

## Screenshots/Recordings

If UI changes, add before/after screenshots or short clips.

## Breaking changes

- [ ] Yes
- [ ] No

If yes, describe impact and migration instructions.

## Related issues

Link related issues and discussions. Example: Closes #123

## Security considerations

Note any security implications (auth, secrets, PII, sandboxing, etc.).

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable


