### PR TITLE
feat(ui): prompt users to switch to first-party integration when custom provider name collides with a natively supported provider

### DIFF
--- a/ui/app/workspace/providers/dialogs/firstPartyProviderAvailableDialog.tsx
+++ b/ui/app/workspace/providers/dialogs/firstPartyProviderAvailableDialog.tsx
@@ -1,0 +1,47 @@
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels } from "@/lib/constants/logs";
+import { KnownProvider } from "@/lib/types/config";
+
+interface Props {
+	show: boolean;
+	customProviderName: string;
+	knownProvider: KnownProvider;
+	onDismiss: () => void;
+	onProceed: () => void;
+}
+
+export default function FirstPartyProviderAvailableDialog({ show, customProviderName, knownProvider, onDismiss, onProceed }: Props) {
+	const label = ProviderLabels[knownProvider];
+
+	return (
+		<AlertDialog open={show}>
+			<AlertDialogContent data-testid="first-party-provider-available-dialog">
+				<AlertDialogHeader>
+					<AlertDialogTitle className="flex items-center gap-2">
+						<RenderProviderIcon provider={knownProvider as ProviderIconType} size="sm" className="h-5 w-5 shrink-0" />
+						Official {label} integration available
+					</AlertDialogTitle>
+					<AlertDialogDescription>
+						We noticed you have a custom provider named <span className="text-foreground font-medium">{customProviderName}</span>.
+						Bifrost now supports {label} natively. You can delete the custom provider and add the official {label} integration from{" "}
+						<span className="text-foreground font-medium">Add Provider</span>, or keep using your custom provider as is.
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+				<AlertDialogFooter>
+					<AlertDialogCancel onClick={onDismiss}>Keep custom provider</AlertDialogCancel>
+					<AlertDialogAction onClick={onProceed}>Take me there</AlertDialogAction>
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -8,6 +8,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { DefaultNetworkConfig, DefaultPerformanceConfig } from "@/lib/constants/config";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderNames } from "@/lib/constants/logs";
+import { useDismissedProviderCollisions } from "@/lib/hooks/useDismissedProviderCollisions";
 import {
 	getErrorMessage,
 	setSelectedProvider,
@@ -19,6 +20,7 @@ import {
 } from "@/lib/store";
 import { KnownProvider, ModelProviderName, ProviderStatus } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
+import { findCustomProviderCollisions, normalizeProviderName } from "@/lib/utils/providerCollision";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useNavigate } from "@tanstack/react-router";
 import { AlertCircle, ArrowLeft, Server } from "lucide-react";
@@ -28,6 +30,7 @@ import { toast } from "sonner";
 import AddCustomProviderSheet from "./dialogs/addNewCustomProviderSheet";
 import ConfirmDeleteProviderDialog from "./dialogs/confirmDeleteProviderDialog";
 import ConfirmRedirectionDialog from "./dialogs/confirmRedirection";
+import FirstPartyProviderAvailableDialog from "./dialogs/firstPartyProviderAvailableDialog";
 import { AddProviderDropdown } from "./views/addProviderDropdown";
 import { ProvidersEmptyState } from "./views/providersEmptyState";
 
@@ -55,6 +58,8 @@ export default function Providers() {
 	const [showCustomProviderSheet, setShowCustomProviderSheet] = useState(false);
 	const [mobileDetailOpen, setMobileDetailOpen] = useState(false);
 	const [provider, setProvider] = useQueryState("provider");
+	const { dismissed: dismissedCollisions, dismiss: dismissCollision, hydrated: collisionsHydrated } = useDismissedProviderCollisions();
+	const [handledCollisions, setHandledCollisions] = useState<Set<string>>(() => new Set());
 
 	const { data: savedProviders, isLoading: isLoadingProviders } = useGetProvidersQuery();
 	const [getProvider, { isLoading: isLoadingProvider }] = useLazyGetProviderQuery();
@@ -66,6 +71,14 @@ export default function Providers() {
 	const existingInSidebarNames = new Set(configuredProviders.map((p) => p.name));
 
 	const knownProviders = ProviderNames.map((name) => ({ name }));
+
+	// Custom providers whose name matches a provider that is now supported natively.
+	const activeCollision = collisionsHydrated
+		? findCustomProviderCollisions(configuredProviders).find((c) => {
+			const key = normalizeProviderName(c.customName);
+			return !dismissedCollisions.has(key) && !handledCollisions.has(key);
+		})
+		: undefined;
 
 	useEffect(() => {
 		if (!provider) return;
@@ -146,6 +159,18 @@ export default function Providers() {
 		}
 	};
 
+	const handleCollisionProceed = () => {
+		if (!activeCollision) return;
+		setHandledCollisions((prev) => new Set(prev).add(normalizeProviderName(activeCollision.customName)));
+		if (providerFormIsDirty) {
+			setPendingRedirection(activeCollision.customName);
+			setShowRedirectionDialog(true);
+			return;
+		}
+		setProvider(activeCollision.customName);
+		if (isMobile) setMobileDetailOpen(true);
+	};
+
 	if (configuredProviders.length === 0) {
 		return (
 			<div className="mx-auto w-full max-w-7xl">
@@ -185,6 +210,15 @@ export default function Providers() {
 					setShowDeleteProviderDialog(false);
 				}}
 			/>
+			{activeCollision && (
+				<FirstPartyProviderAvailableDialog
+					show
+					customProviderName={activeCollision.customName}
+					knownProvider={activeCollision.knownProvider}
+					onDismiss={() => dismissCollision(activeCollision.customName)}
+					onProceed={handleCollisionProceed}
+				/>
+			)}
 			<ConfirmRedirectionDialog
 				show={showRedirectionDialog}
 				onCancel={() => setShowRedirectionDialog(false)}
@@ -217,7 +251,7 @@ export default function Providers() {
 						<div className="custom-scrollbar min-h-0 flex-1 overflow-y-auto">
 							{configuredProviders.length > 0 ? (
 								configuredProviders.map((p) => {
-									const isCustom = !ProviderNames.includes(p.name as KnownProvider);
+									const isCustom = !!p.custom_provider_config || !ProviderNames.includes(p.name as KnownProvider);
 									const label = isCustom ? p.name : ProviderLabels[p.name as keyof typeof ProviderLabels];
 									return (
 										<div

--- a/ui/lib/hooks/useDismissedProviderCollisions.ts
+++ b/ui/lib/hooks/useDismissedProviderCollisions.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { normalizeProviderName } from "@/lib/utils/providerCollision";
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "bifrost.dismissedProviderCollisions";
+
+const readStored = (): string[] => {
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed: unknown = JSON.parse(raw);
+		return Array.isArray(parsed) ? parsed.filter((v): v is string => typeof v === "string") : [];
+	} catch {
+		return [];
+	}
+};
+
+/**
+ * Tracks which custom-provider names the user has chosen to keep even though a
+ * first-party integration exists. Persisted in localStorage as normalized names.
+ *
+ * Reads localStorage lazily in an effect to avoid hydration mismatches; `hydrated`
+ * is false until that read completes, so callers should not act on `dismissed` before then.
+ */
+export function useDismissedProviderCollisions(): {
+	dismissed: Set<string>;
+	dismiss: (customName: string) => void;
+	hydrated: boolean;
+} {
+	const [dismissed, setDismissed] = useState<Set<string>>(() => new Set());
+	const [hydrated, setHydrated] = useState(false);
+
+	useEffect(() => {
+		setDismissed(new Set(readStored()));
+		setHydrated(true);
+	}, []);
+
+	const dismiss = useCallback((customName: string) => {
+		const normalized = normalizeProviderName(customName);
+		setDismissed((prev) => {
+			const next = new Set(prev);
+			next.add(normalized);
+			try {
+				localStorage.setItem(STORAGE_KEY, JSON.stringify(Array.from(next)));
+			} catch {
+				// localStorage unavailable — preference won't persist.
+			}
+			return next;
+		});
+	}, []);
+
+	return { dismissed, dismiss, hydrated };
+}

--- a/ui/lib/utils/providerCollision.test.ts
+++ b/ui/lib/utils/providerCollision.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import { ModelProvider } from "@/lib/types/config";
+import { findCustomProviderCollisions, findFirstPartyMatch, normalizeProviderName } from "./providerCollision";
+
+const custom = (name: string): ModelProvider =>
+	({ name, provider_status: "active", custom_provider_config: { base_provider_type: "openai" } }) as ModelProvider;
+
+describe("providerCollision", () => {
+	it("normalizes names to lowercase alphanumerics", () => {
+		expect(normalizeProviderName("GitHub Copilot")).toBe("githubcopilot");
+		expect(normalizeProviderName("  Databricks_1 ")).toBe("databricks1");
+	});
+
+	it("matches known provider keys case-insensitively", () => {
+		expect(findFirstPartyMatch("databricks")).toBe("databricks");
+		expect(findFirstPartyMatch("DataBricks")).toBe("databricks");
+		expect(findFirstPartyMatch("github-copilot")).toBe("github-copilot");
+	});
+
+	it("matches known provider display labels", () => {
+		expect(findFirstPartyMatch("GitHub Copilot")).toBe("github-copilot");
+		expect(findFirstPartyMatch("AWS Bedrock")).toBe("bedrock");
+		expect(findFirstPartyMatch("Vertex AI")).toBe("vertex");
+	});
+
+	it("does not match names that merely contain a known provider", () => {
+		expect(findFirstPartyMatch("databricks-prod")).toBeUndefined();
+		expect(findFirstPartyMatch("my-openai")).toBeUndefined();
+		expect(findFirstPartyMatch("")).toBeUndefined();
+	});
+
+	it("only reports custom providers that collide with a first-party provider", () => {
+		const providers: ModelProvider[] = [
+			custom("Databricks"),
+			custom("GitHub Copilot"),
+			custom("databricks-prod"),
+			{ name: "openai", provider_status: "active" } as ModelProvider,
+		];
+		expect(findCustomProviderCollisions(providers)).toEqual([
+			{ customName: "Databricks", knownProvider: "databricks" },
+			{ customName: "GitHub Copilot", knownProvider: "github-copilot" },
+		]);
+	});
+});

--- a/ui/lib/utils/providerCollision.ts
+++ b/ui/lib/utils/providerCollision.ts
@@ -1,0 +1,42 @@
+import { KnownProvidersNames, ProviderLabels } from "@/lib/constants/logs";
+import { KnownProvider, ModelProvider } from "@/lib/types/config";
+
+export interface CustomProviderCollision {
+	customName: string;
+	knownProvider: KnownProvider;
+}
+
+/** Lowercase and strip everything except letters and digits, so "GitHub Copilot" matches "github-copilot". */
+export const normalizeProviderName = (name: string): string => name.toLowerCase().replace(/[^a-z0-9]/g, "");
+
+let lookup: Map<string, KnownProvider> | undefined;
+
+const getLookup = (): Map<string, KnownProvider> => {
+	if (lookup) return lookup;
+	lookup = new Map();
+	for (const key of KnownProvidersNames) {
+		lookup.set(normalizeProviderName(key), key);
+		lookup.set(normalizeProviderName(ProviderLabels[key]), key);
+	}
+	return lookup;
+};
+
+/** Returns the first-party provider whose key or display label matches the given name, if any. */
+export const findFirstPartyMatch = (name: string): KnownProvider | undefined => {
+	const normalized = normalizeProviderName(name);
+	if (!normalized) return undefined;
+	return getLookup().get(normalized);
+};
+
+/** Custom providers whose name matches a provider Bifrost now supports natively. */
+export const findCustomProviderCollisions = (providers: ModelProvider[]): CustomProviderCollision[] => {
+	const collisions: CustomProviderCollision[] = [];
+	for (const provider of providers) {
+		if (!provider.custom_provider_config) continue;
+		const knownProvider = findFirstPartyMatch(provider.name);
+		if (knownProvider) {
+			collisions.push({ customName: provider.name, knownProvider });
+		}
+	}
+	return collisions;
+};


### PR DESCRIPTION
## Summary

When a user has configured a custom provider whose name matches a provider that Bifrost now supports natively (e.g., "Databricks" or "GitHub Copilot"), they are shown a one-time dialog prompting them to switch to the official first-party integration. Users can dismiss the dialog to keep their custom provider, and that preference is persisted in `localStorage` so the dialog does not reappear.

## Changes

- Added `providerCollision.ts` with utilities to normalize provider names and detect custom providers that collide with known first-party providers by matching against both provider keys and display labels.
- Added `useDismissedProviderCollisions` hook that reads and writes dismissed collision keys to `localStorage`, with a `hydrated` flag to prevent acting on stale state before the initial read completes.
- Added `FirstPartyProviderAvailableDialog` component that presents the collision warning with options to keep the custom provider or navigate to it for replacement.
- Wired the collision detection and dialog into the Providers page, including handling the case where the provider form is dirty (triggering the existing redirection confirmation flow).
- Fixed the `isCustom` check on the provider list to also consider `custom_provider_config` presence, not just whether the name appears in `ProviderNames`.
- Added unit tests covering name normalization, first-party matching by key and label, partial-name non-matches, and the full collision detection logic.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure a custom provider with a name that matches a known first-party provider (e.g., name it `Databricks` or `GitHub Copilot`).
2. Navigate to the Providers page — the dialog should appear once.
3. Click **Keep custom provider** — the dialog should not reappear on subsequent visits (preference is stored in `localStorage` under `bifrost.dismissedProviderCollisions`).
4. Repeat with a fresh provider name and click **Take me there** — the provider should be selected in the list (with the redirection confirmation dialog appearing if the form is dirty).

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the dialog appearing on the Providers page._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions.

## Security considerations

Dismissed collision preferences are stored in `localStorage` only — no PII or secrets are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable