### PR TITLE
complexity fixes + added session id in logs table so its filtering on llm logs

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1510,7 +1510,8 @@
                   "GET /api/routing/complexity-analyzer-config",
                   "PUT /api/routing/complexity-analyzer-config",
                   "POST /api/routing/complexity-analyzer-config/reset",
-                  "GET /api/routing/complexity-analyzer-status"
+                  "GET /api/routing/complexity-analyzer-status",
+                  "POST /api/routing/complexity-analyzer-status/retry"
                 ]
               }
             ]

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1098,6 +1098,8 @@ paths:
     $ref: "./paths/management/routing.yaml#/complexity-reset"
   /api/routing/complexity-analyzer-status:
     $ref: "./paths/management/routing.yaml#/complexity-status"
+  /api/routing/complexity-analyzer-status/retry:
+    $ref: "./paths/management/routing.yaml#/complexity-status-retry"
   /api/routing/complexity-analyzer-generations:
     $ref: "./paths/management/routing.yaml#/complexity-generations"
   /api/routing/complexity-analyzer-generations/{namespace}:

--- a/docs/openapi/paths/management/logging.yaml
+++ b/docs/openapi/paths/management/logging.yaml
@@ -58,6 +58,11 @@ logs:
         description: Comma-separated list of complexity decision mechanisms to filter by (semantic, llm, session, or skipped)
         schema:
           type: string
+      - name: session_id
+        in: query
+        description: Exact Bifrost session ID used for key stickiness and request correlation
+        schema:
+          type: string
       - name: start_time
         in: query
         description: Start time filter (RFC3339 format)
@@ -239,6 +244,11 @@ logs-stats:
       - name: complexity_mechanisms
         in: query
         description: Comma-separated list of complexity decision mechanisms to filter by (semantic, llm, session, or skipped)
+        schema:
+          type: string
+      - name: session_id
+        in: query
+        description: Exact Bifrost session ID used for key stickiness and request correlation
         schema:
           type: string
       - name: start_time
@@ -838,6 +848,12 @@ _histogram-parameters:
     description: Comma-separated list of complexity decision mechanisms to filter by (semantic, llm, session, or skipped)
     schema:
       type: string
+  session_id:
+    name: session_id
+    in: query
+    description: Exact Bifrost session ID used for key stickiness and request correlation
+    schema:
+      type: string
   start_time:
     name: start_time
     in: query
@@ -1407,6 +1423,7 @@ logs-rankings:
       - $ref: "#/_histogram-parameters/stop_reasons"
       - $ref: "#/_histogram-parameters/cache_hit_types"
       - $ref: "#/_histogram-parameters/parent_request_id"
+      - $ref: "#/_histogram-parameters/session_id"
       - $ref: "#/_histogram-parameters/metadata_key"
       - $ref: "#/_histogram-parameters/content_search"
       - $ref: "#/_histogram-parameters/request_id"
@@ -1473,6 +1490,7 @@ logs-dashboard:
       - $ref: "#/_histogram-parameters/stop_reasons"
       - $ref: "#/_histogram-parameters/cache_hit_types"
       - $ref: "#/_histogram-parameters/parent_request_id"
+      - $ref: "#/_histogram-parameters/session_id"
       - $ref: "#/_histogram-parameters/metadata_key"
       - $ref: "#/_histogram-parameters/content_search"
       - $ref: "#/_histogram-parameters/request_id"

--- a/docs/openapi/paths/management/routing.yaml
+++ b/docs/openapi/paths/management/routing.yaml
@@ -426,6 +426,29 @@ complexity-status:
       '503':
         $ref: '../../openapi.yaml#/components/responses/ConfigStoreUnavailable'
 
+complexity-status-retry:
+  post:
+    operationId: retryComplexityAnalyzerWarmup
+    summary: Retry failed complexity classifier warmup
+    description: Restarts the saved semantic classifier warmup only when its current state is failed. The retry runs asynchronously and does not change the saved configuration.
+    tags:
+      - Routing
+    responses:
+      '202':
+        description: Semantic warmup retry accepted
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/governance.yaml#/ComplexitySemanticStatus'
+      '409':
+        description: The semantic classifier is not currently failed
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/inference/common.yaml#/BifrostError'
+      '503':
+        $ref: '../../openapi.yaml#/components/responses/ConfigStoreUnavailable'
+
 complexity-generations:
   get:
     operationId: listComplexityGenerations

--- a/docs/openapi/schemas/management/logging.yaml
+++ b/docs/openapi/schemas/management/logging.yaml
@@ -62,6 +62,10 @@ LogEntry:
       type: number
       description: Similarity score of the nearest reference phrase behind the tier. Absent for llm, session, and skipped decisions.
       nullable: true
+    session_id:
+      type: string
+      description: Raw opaque Bifrost session ID resolved at ingress for key stickiness and request correlation.
+      nullable: true
     stream:
       type: boolean
     raw_request:

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -118,6 +118,7 @@ type parityLogSpec struct {
 	tier                       *string
 	mechanism                  *string
 	tierScore                  *float64
+	sessionID                  *string
 	metadata                   *string
 	cacheMetadata              string
 	content                    string
@@ -161,6 +162,7 @@ func (s parityLogSpec) toLog(base time.Time) *Log {
 		ComplexityTier:        s.tier,
 		ComplexityMechanism:   s.mechanism,
 		ComplexityScore:       s.tierScore,
+		SessionID:             s.sessionID,
 		Metadata:              s.metadata,
 		CacheDebug:            s.cacheMetadata,
 		ContentSummary:        s.content,
@@ -179,13 +181,13 @@ func paritySpecs() []parityLogSpec {
 			teamID: strPtrP("t1"), customerID: strPtrP("c1"), buID: strPtrP("b1"), userID: strPtrP("u1"),
 			cost: f64PtrP(0.5), latency: f64PtrP(100), tokens: [3]int{100, 50, 150}, stopReason: strPtrP("stop"),
 			routing: strPtrP("governance,loadbalancing"), metadata: strPtrP(`{"env":"prod"}`),
-			tier: strPtrP("COMPLEX"), mechanism: strPtrP("lexical"), tierScore: f64PtrP(0.55),
+			tier: strPtrP("COMPLEX"), mechanism: strPtrP("lexical"), tierScore: f64PtrP(0.55), sessionID: strPtrP("session-1"),
 			cacheMetadata: `{"hit_type":"direct"}`, content: "alpha bravo hello", parentID: strPtrP("sess1")},
 		{id: "p2", offsetSec: 90, object: "chat.completion", provider: "openai", model: "gpt-4o", status: "success",
 			vkID: strPtrP("vk1"), vkName: strPtrP("VK One"), teamID: strPtrP("t1"), userID: strPtrP("u2"),
 			cost: f64PtrP(1.25), latency: f64PtrP(250), tokens: [3]int{200, 100, 300}, stopReason: strPtrP("length"),
 			routing: strPtrP("governance"), metadata: strPtrP(`{"env":"dev"}`),
-			tier: strPtrP("SIMPLE"), mechanism: strPtrP("lexical"), tierScore: f64PtrP(0.08),
+			tier: strPtrP("SIMPLE"), mechanism: strPtrP("lexical"), tierScore: f64PtrP(0.08), sessionID: strPtrP("session-1"),
 			cacheMetadata: `{"hit_type":"semantic"}`, content: "charlie delta", parentID: strPtrP("sess1")},
 		{id: "p3", offsetSec: 80, object: "chat.completion", provider: "openai", model: "gpt-4o-mini", status: "error",
 			vkID: strPtrP("vk2"), vkName: strPtrP("VK Two"), teamID: strPtrP("t2"), userID: strPtrP("u2"),
@@ -447,8 +449,8 @@ func logProjection(l *Log) map[string]any {
 		"prompt_tokens": l.PromptTokens, "completion_tokens": l.CompletionTokens,
 		"total_tokens": l.TotalTokens, "stop_reason": l.StopReason,
 		"complexity_tier": l.ComplexityTier, "complexity_mechanism": l.ComplexityMechanism,
-		"complexity_score": l.ComplexityScore,
-		"content_summary":  l.ContentSummary,
+		"complexity_score": l.ComplexityScore, "session_id": l.SessionID,
+		"content_summary": l.ContentSummary,
 	}
 }
 
@@ -576,6 +578,7 @@ func TestLogStoreParity(t *testing.T) {
 		"complexity_tiers":      {ComplexityTiers: []string{"COMPLEX", "MEDIUM"}},
 		"complexity_mechanisms": {ComplexityMechanisms: []string{"lexical"}},
 		"mechanism_skipped":     {ComplexityMechanisms: []string{"skipped"}},
+		"session":               {SessionID: "session-1"},
 		"objects":               {Objects: []string{"embedding"}},
 		"aliases":               {Aliases: []string{"a1"}},
 		"selected_keys":         {SelectedKeyIDs: []string{"sk1"}},

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -975,11 +975,12 @@ func startMatViewRefresher(ctx context.Context, db *gorm.DB, interval, timeout t
 
 // canUseMatViewFilters returns true if the given filters can be served from
 // mv_logs_hourly. Per-row filters (content search, request ID, parent request ID,
-// metadata, numeric ranges) require the raw logs table.
+// session ID, metadata, numeric ranges) require the raw logs table.
 func canUseMatViewFilters(f SearchFilters) bool {
 	return f.ContentSearch == "" &&
 		f.RequestID == "" &&
 		f.ParentRequestID == "" &&
+		f.SessionID == "" &&
 		!f.RootsOnly &&
 		len(f.MetadataFilters) == 0 &&
 		canUseMatViewStatusFilter(f.Status) &&

--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -310,6 +310,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"logs_add_video_edit_input_column"}, run: migrationAddVideoEditInputColumn},
 	{IDs: []string{"logs_add_upstream_and_overhead_latency_columns"}, run: migrationAddUpstreamAndOverheadLatencyColumns},
 	{IDs: []string{"logs_add_complexity_routing_columns"}, run: migrationAddComplexityRoutingColumns},
+	{IDs: []string{"logs_add_session_id_column"}, run: migrationAddSessionIDColumn},
 	{IDs: []string{"logs_add_routing_metadata_column"}, run: migrationAddRoutingMetadataColumn},
 	{IDs: []string{"logs_add_batch_debug_column"}, run: migrationAddBatchDebugColumn},
 	{IDs: []string{"logs_add_cost_breakdown_columns"}, run: migrationAddCostBreakdownColumns},
@@ -2927,6 +2928,11 @@ var performanceIndexes = []performanceIndexDef{
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_complexity_mechanism ON logs(complexity_mechanism) WHERE complexity_mechanism IS NOT NULL",
 	},
 	{
+		table: "logs",
+		name:  "idx_logs_session_id",
+		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_logs_session_id ON logs(session_id) WHERE session_id IS NOT NULL",
+	},
+	{
 		table: "mcp_tool_logs",
 		name:  "idx_mcp_logs_user_id",
 		sql:   "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_mcp_logs_user_id ON mcp_tool_logs(user_id)",
@@ -4088,6 +4094,53 @@ func migrationAddComplexityRoutingColumns(ctx context.Context, db *gorm.DB, logg
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding complexity routing columns: %w", err)
+	}
+	return nil
+}
+
+// migrationAddSessionIDColumn adds the generic session identity resolved at
+// ingress so callers can correlate all requests in a Bifrost session.
+func migrationAddSessionIDColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_session_id_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := boundDDLLockWait(tx); err != nil {
+				return err
+			}
+			if err := addColumnIfNotExists(tx, logger, &Log{}, "session_id"); err != nil {
+				return err
+			}
+			if tx.Dialector.Name() != "postgres" && !tx.Migrator().HasIndex(&Log{}, "idx_logs_session_id") {
+				if err := tx.Migrator().CreateIndex(&Log{}, "idx_logs_session_id"); err != nil {
+					return fmt.Errorf("create session_id index: %w", err)
+				}
+			}
+			return nil
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := boundDDLLockWait(tx); err != nil {
+				return err
+			}
+			if tx.Dialector.Name() != "postgres" && tx.Migrator().HasIndex(&Log{}, "idx_logs_session_id") {
+				if err := tx.Migrator().DropIndex(&Log{}, "idx_logs_session_id"); err != nil {
+					return err
+				}
+			}
+			if err := dropColumnIfExists(tx, logger, &Log{}, "session_id"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding session ID column: %w", err)
 	}
 	return nil
 }

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -49,6 +49,25 @@ func TestMigrationAddMCPPluginLogsColumn(t *testing.T) {
 	assert.Equal(t, int64(1), count)
 }
 
+// TestMigrationAddSessionIDColumn verifies that the session lookup
+// column is additive, indexed, and preserves pre-existing request logs.
+func TestMigrationAddSessionIDColumn(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "migrations.db")), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+	require.NoError(t, db.Exec("CREATE TABLE logs (id TEXT PRIMARY KEY)").Error)
+	require.NoError(t, db.Exec("INSERT INTO logs (id) VALUES (?)", "existing-log").Error)
+
+	ctx := context.Background()
+	require.NoError(t, migrationAddSessionIDColumn(ctx, db, testLogger{}))
+	require.True(t, db.Migrator().HasColumn(&Log{}, "SessionID"))
+	require.True(t, db.Migrator().HasIndex(&Log{}, "idx_logs_session_id"))
+	require.NoError(t, migrationAddSessionIDColumn(ctx, db, testLogger{}))
+
+	var count int64
+	require.NoError(t, db.Table("logs").Where("id = ?", "existing-log").Count(&count).Error)
+	assert.Equal(t, int64(1), count)
+}
+
 // pgTestSchema is this package's dedicated Postgres schema. Test packages
 // (configstore, configstore/tables, logstore) run in parallel against the same
 // database, so each one works in its own schema to avoid clobbering the

--- a/framework/logstore/multi_team_filter_test.go
+++ b/framework/logstore/multi_team_filter_test.go
@@ -92,5 +92,6 @@ func TestCanUseMatViewFilters_ExcludesTeamBU(t *testing.T) {
 	// project filter is served from it like a provider filter is.
 	assert.True(t, canUseMatViewFilters(SearchFilters{ProjectIDs: []string{"p1"}}), "project filter is matview-eligible")
 	assert.False(t, canUseMatViewFilters(SearchFilters{ParentRequestID: "req-1"}), "parent request filter has no matview dimension and must force the raw path")
+	assert.False(t, canUseMatViewFilters(SearchFilters{SessionID: "session-1"}), "session ID is not materialized and must force the raw path")
 
 }

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -305,6 +305,9 @@ func (s *RDBLogStore) applyFilters(baseQuery *gorm.DB, filters SearchFilters) *g
 	if len(filters.ComplexityMechanisms) > 0 {
 		baseQuery = baseQuery.Where("complexity_mechanism IN ?", filters.ComplexityMechanisms)
 	}
+	if filters.SessionID != "" {
+		baseQuery = baseQuery.Where("session_id = ?", filters.SessionID)
+	}
 	if len(filters.Objects) > 0 {
 		baseQuery = baseQuery.Where("object_type IN ?", filters.Objects)
 	}
@@ -1267,7 +1270,7 @@ func (s *RDBLogStore) listSelectColumns() string {
 		"selected_key_id", "selected_key_name",
 		"virtual_key_id", "virtual_key_name",
 		"routing_engines_used", "routing_rule_id", "routing_rule_name",
-		"complexity_tier", "complexity_mechanism",
+		"complexity_tier", "complexity_mechanism", "session_id",
 		"user_id", "user_name", "team_id", "team_name", "customer_id", "customer_name",
 		"business_unit_id", "business_unit_name",
 		"team_ids", "team_names", "customer_ids", "customer_names", "business_unit_ids", "business_unit_names",

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -60,11 +60,12 @@ type SearchFilters struct {
 	RoutingRuleIDs       []string          `json:"routing_rule_ids,omitempty"`
 	ComplexityTiers      []string          `json:"complexity_tiers,omitempty"`      // For filtering by routing complexity tier (SIMPLE, MEDIUM, COMPLEX)
 	ComplexityMechanisms []string          `json:"complexity_mechanisms,omitempty"` // For filtering by complexity decision mechanism (semantic, llm, session, skipped)
+	SessionID            string            `json:"session_id,omitempty"`            // Exact Bifrost session ID used for key stickiness and request correlation
 	TeamIDs              []string          `json:"team_ids,omitempty"`
 	CustomerIDs          []string          `json:"customer_ids,omitempty"`
 	UserIDs              []string          `json:"user_ids,omitempty"`
 	BusinessUnitIDs      []string          `json:"business_unit_ids,omitempty"`
-	ProjectIDs        []string          `json:"project_ids,omitempty"`
+	ProjectIDs           []string          `json:"project_ids,omitempty"`
 	RoutingEngineUsed    []string          `json:"routing_engine_used,omitempty"` // For filtering by routing engine (routing-rule, governance, loadbalancing)
 	Apps                 []string          `json:"apps,omitempty"`                // Backend-detected client apps
 	UserAgents           []string          `json:"user_agents,omitempty"`         // Raw User-Agent strings; kept for compatibility/debug filtering
@@ -213,6 +214,7 @@ type Log struct {
 	ComplexityTier          *string   `gorm:"type:varchar(50);index:idx_logs_complexity_tier,where:complexity_tier IS NOT NULL" json:"complexity_tier,omitempty"`                // Complexity tier used for routing ("SIMPLE", "MEDIUM", "COMPLEX"); NULL when no routing rule demanded complexity. Partial index, matching its performanceIndexes entry
 	ComplexityMechanism     *string   `gorm:"type:varchar(50);index:idx_logs_complexity_mechanism,where:complexity_mechanism IS NOT NULL" json:"complexity_mechanism,omitempty"` // How the complexity tier was classified ("semantic", "llm", "session", "skipped"). NULL means no routing rule referenced complexity_tier, so classification never ran. Partial index, matching its performanceIndexes entry
 	ComplexityScore         *float64  `gorm:"column:complexity_score" json:"complexity_score,omitempty"`                                                                         // Raw complexity score behind the tier; unindexed (detail-view only)
+	SessionID               *string   `gorm:"type:varchar(255);index:idx_logs_session_id,where:session_id IS NOT NULL" json:"session_id,omitempty"`                              // Raw opaque session identity resolved at ingress for key stickiness and log correlation
 	SelectedPromptName      *string   `gorm:"type:varchar(255)" json:"selected_prompt_name"`
 	SelectedPromptVersion   *string   `gorm:"type:varchar(64)" json:"selected_prompt_version"`
 	SelectedPromptID        *string   `gorm:"type:varchar(36)" json:"selected_prompt_id"`

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1849,12 +1849,16 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 			// path that fast path exists to keep cheap.
 			complexityTier := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceComplexityTier)
 			complexityMechanism := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceComplexityMechanism)
+			sessionID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySessionID)
 			complexityScore, hasComplexityScore := ctx.Value(schemas.BifrostContextKeyGovernanceComplexityScore).(float64)
 			if complexityTier != "" {
 				entry.ComplexityTier = &complexityTier
 			}
 			if complexityMechanism != "" {
 				entry.ComplexityMechanism = &complexityMechanism
+			}
+			if sessionID != "" {
+				entry.SessionID = &sessionID
 			}
 			if hasComplexityScore {
 				entry.ComplexityScore = &complexityScore
@@ -1923,6 +1927,7 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	routingRuleName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceRoutingRuleName)
 	complexityTier := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceComplexityTier)
 	complexityMechanism := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeyGovernanceComplexityMechanism)
+	sessionID := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySessionID)
 	complexityScore, hasComplexityScore := ctx.Value(schemas.BifrostContextKeyGovernanceComplexityScore).(float64)
 	selectedPromptName := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptName)
 	selectedPromptVersion := bifrost.GetStringFromContext(ctx, schemas.BifrostContextKeySelectedPromptVersion)
@@ -1992,6 +1997,9 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	}
 	if complexityMechanism != "" {
 		entry.ComplexityMechanism = &complexityMechanism
+	}
+	if sessionID != "" {
+		entry.SessionID = &sessionID
 	}
 	if hasComplexityScore {
 		entry.ComplexityScore = &complexityScore

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -432,6 +432,7 @@ func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 	ctx.SetValue(schemas.BifrostIsAsyncRequest, true)
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceProjectID, "proj-1")
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceProjectName, "Project One")
+	ctx.SetValue(schemas.BifrostContextKeySessionID, "session-no-pending-error")
 
 	statusCode := 500
 	bifrostErr := &schemas.BifrostError{
@@ -481,6 +482,9 @@ func TestPostLLMHookNoPendingErrorPreservesMetadata(t *testing.T) {
 	}
 	if logEntry.ProjectName == nil || *logEntry.ProjectName != "Project One" {
 		t.Fatalf("expected project name %q on the minimal-error entry, got %v", "Project One", logEntry.ProjectName)
+	}
+	if logEntry.SessionID == nil || *logEntry.SessionID != "session-no-pending-error" {
+		t.Fatalf("expected session ID on the minimal-error entry, got %v", logEntry.SessionID)
 	}
 }
 
@@ -861,6 +865,7 @@ func TestPostLLMHookCapturesComplexityRoutingContext(t *testing.T) {
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityTier, "COMPLEX")
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityMechanism, "semantic")
 	ctx.SetValue(schemas.BifrostContextKeyGovernanceComplexityScore, 0.42)
+	ctx.SetValue(schemas.BifrostContextKeySessionID, "session-log-123")
 
 	statusCode := 500
 	bifrostErr := &schemas.BifrostError{
@@ -893,6 +898,9 @@ func TestPostLLMHookCapturesComplexityRoutingContext(t *testing.T) {
 	}
 	if entry.ComplexityScore == nil || *entry.ComplexityScore != 0.42 {
 		t.Fatalf("expected complexity_score 0.42, got %v", entry.ComplexityScore)
+	}
+	if entry.SessionID == nil || *entry.SessionID != "session-log-123" {
+		t.Fatalf("expected session_id session-log-123, got %v", entry.SessionID)
 	}
 }
 

--- a/plugins/routing/complexity/extract.go
+++ b/plugins/routing/complexity/extract.go
@@ -68,10 +68,8 @@ var (
 )
 
 const (
-	codexTurnMetadataHeader      = "x-codex-turn-metadata"
-	claudeCodeSessionIDHeader    = "x-claude-code-session-id"
-	maxComplexitySessionIDLength = 255
-	claudeResumeRecapPrefix      = "The user stepped away and is coming back."
+	codexTurnMetadataHeader = "x-codex-turn-metadata"
+	claudeResumeRecapPrefix = "The user stepped away and is coming back."
 )
 
 type codexTurnMetadata struct {
@@ -200,7 +198,11 @@ func responsesHasTrailingContinuation(messages []schemas.ResponsesMessage, harne
 		case schemas.ResponsesInputMessageRoleUser:
 			text, ok := extractResponsesTextOnly(msg.Content)
 			if !ok {
-				return true
+				// The Anthropic-to-Responses conversion can emit one user item per
+				// block. A textless image or file may therefore follow text from the
+				// same human turn, or occur in older history. It is not classifiable
+				// on its own, but it must not hide the nearest human text item.
+				continue
 			}
 			_, kind := sanitizeUserText(text, harness)
 			if kind == complexityTextContextOnly || kind == complexityTextInvalid {
@@ -284,35 +286,11 @@ func extractFromResponsesRequest(req *schemas.BifrostResponsesRequest, harness c
 		input.SystemText = sanitizeSystemText(*req.Params.Instructions, harness)
 	}
 
-	var userTexts []string
-	lastRelevantUserKind := complexityTextInvalid
-	for _, msg := range req.Input {
-		if msg.Role == nil {
-			continue
-		}
-
-		switch *msg.Role {
-		case schemas.ResponsesInputMessageRoleSystem, schemas.ResponsesInputMessageRoleDeveloper:
-			input.SystemText = appendText(input.SystemText, sanitizeSystemText(extractResponsesText(msg.Content), harness))
-		case schemas.ResponsesInputMessageRoleUser:
-			text, ok := extractResponsesTextOnly(msg.Content)
-			if !ok {
-				return ComplexityInput{}, false
-			}
-			text, kind := sanitizeUserText(text, harness)
-			switch kind {
-			case complexityTextHuman:
-				userTexts = append(userTexts, text)
-				lastRelevantUserKind = kind
-			case complexityTextContextOnly:
-				continue
-			case complexityTextHousekeeping:
-				lastRelevantUserKind = kind
-			default:
-				return ComplexityInput{}, false
-			}
-		}
+	systemText, userTexts, lastRelevantUserKind, ok := collectResponsesInputText(req.Input, harness)
+	if !ok {
+		return ComplexityInput{}, false
 	}
+	input.SystemText = appendText(input.SystemText, systemText)
 
 	if lastRelevantUserKind == complexityTextHousekeeping || len(userTexts) == 0 {
 		return ComplexityInput{}, false
@@ -323,6 +301,51 @@ func extractFromResponsesRequest(req *schemas.BifrostResponsesRequest, harness c
 		input.PriorUserTexts = userTexts[:len(userTexts)-1]
 	}
 	return input, true
+}
+
+// collectResponsesInputText gathers system context and human user text without
+// treating textless multimodal fragments as complete conversational turns.
+func collectResponsesInputText(messages []schemas.ResponsesMessage, harness complexityHarness) (string, []string, complexityTextKind, bool) {
+	var systemText string
+	var userTexts []string
+	lastRelevantUserKind := complexityTextInvalid
+	for _, msg := range messages {
+		if msg.Role == nil {
+			continue
+		}
+
+		switch *msg.Role {
+		case schemas.ResponsesInputMessageRoleSystem, schemas.ResponsesInputMessageRoleDeveloper:
+			systemText = appendText(systemText, sanitizeSystemText(extractResponsesText(msg.Content), harness))
+		case schemas.ResponsesInputMessageRoleUser:
+			text, kind, hasText := classifyResponsesUserContent(msg.Content, harness)
+			if !hasText || kind == complexityTextContextOnly {
+				continue
+			}
+			if kind == complexityTextHuman {
+				userTexts = append(userTexts, text)
+				lastRelevantUserKind = kind
+				continue
+			}
+			if kind == complexityTextHousekeeping {
+				lastRelevantUserKind = kind
+				continue
+			}
+			return "", nil, complexityTextInvalid, false
+		}
+	}
+	return systemText, userTexts, lastRelevantUserKind, true
+}
+
+// classifyResponsesUserContent reports the text kind for one user item and
+// distinguishes a textless multimodal fragment from malformed text input.
+func classifyResponsesUserContent(content *schemas.ResponsesMessageContent, harness complexityHarness) (string, complexityTextKind, bool) {
+	text, ok := extractResponsesTextOnly(content)
+	if !ok {
+		return "", complexityTextInvalid, false
+	}
+	text, kind := sanitizeUserText(text, harness)
+	return text, kind, true
 }
 
 // extractChatText returns the text portions of chat content and ignores
@@ -451,45 +474,6 @@ func detectComplexityHarness(ctx *schemas.BifrostContext) complexityHarness {
 	default:
 		return complexityHarnessUnknown
 	}
-}
-
-// ResolveComplexitySessionID resolves the trusted session identity used only by
-// complexity routing. An explicit x-bf-session-id context value wins; otherwise
-// native harness metadata is accepted only when the User-Agent identifies the
-// corresponding Claude Code or Codex client.
-//
-// Native identities are not copied into BifrostContextKeySessionID because that
-// key also enables core provider-key stickiness, which is a separate feature.
-func ResolveComplexitySessionID(ctx *schemas.BifrostContext) (string, bool) {
-	if ctx == nil {
-		return "", false
-	}
-	if explicit, exists := ctx.Value(schemas.BifrostContextKeySessionID).(string); exists {
-		return normalizeComplexitySessionID(explicit)
-	}
-
-	headers, _ := ctx.Value(schemas.BifrostContextKeyRequestHeaders).(map[string]string)
-	switch detectComplexityHarness(ctx) {
-	case complexityHarnessClaudeCode:
-		return normalizeComplexitySessionID(headers[claudeCodeSessionIDHeader])
-	case complexityHarnessCodex:
-		metadata, ok := parseCodexTurnMetadata(ctx)
-		if !ok {
-			return "", false
-		}
-		return normalizeComplexitySessionID(metadata.SessionID)
-	default:
-		return "", false
-	}
-}
-
-func normalizeComplexitySessionID(raw string) (string, bool) {
-	value := strings.TrimSpace(raw)
-	if value == "" || len(value) > maxComplexitySessionIDLength ||
-		!utf8.ValidString(value) || strings.ContainsRune(value, '\x00') {
-		return "", false
-	}
-	return value, true
 }
 
 func isCodexBackgroundRequest(ctx *schemas.BifrostContext) bool {

--- a/plugins/routing/complexity/extract_test.go
+++ b/plugins/routing/complexity/extract_test.go
@@ -2,7 +2,6 @@ package complexity
 
 import (
 	"context"
-	"strings"
 	"testing"
 	"time"
 
@@ -685,6 +684,7 @@ func TestBuildComplexityInput_HarnessMarkersRequireMatchingUserAgent(t *testing.
 
 func TestBuildInputWithDisposition(t *testing.T) {
 	userRole := schemas.ResponsesInputMessageRoleUser
+	assistantRole := schemas.ResponsesInputMessageRoleAssistant
 	tests := []struct {
 		name string
 		ctx  *schemas.BifrostContext
@@ -697,6 +697,36 @@ func TestBuildInputWithDisposition(t *testing.T) {
 				RequestType: schemas.ChatCompletionRequest,
 				ChatRequest: &schemas.BifrostChatRequest{Input: []schemas.ChatMessage{
 					{Role: schemas.ChatMessageRoleUser, Content: complexityChatString("Explain vector clocks")},
+				}},
+			},
+			want: InputClassifiable,
+		},
+		{
+			name: "claude code history image does not hide a later human turn",
+			ctx:  complexityHarnessContext(schemas.ClaudeCLI.String(), nil),
+			req: &schemas.BifrostRequest{
+				RequestType: schemas.ResponsesRequest,
+				ResponsesRequest: &schemas.BifrostResponsesRequest{Input: []schemas.ResponsesMessage{
+					{Role: &userRole, Content: complexityResponsesString("Inspect the attached image")},
+					{Role: &userRole, Content: complexityResponsesBlocks(
+						schemas.ResponsesMessageContentBlock{Type: schemas.ResponsesInputMessageContentBlockTypeImage},
+					)},
+					{Role: &assistantRole, Content: complexityResponsesString("It contains a routing diagram.")},
+					{Role: &userRole, Content: complexityResponsesString("help can u reply to this text casually")},
+				}},
+			},
+			want: InputClassifiable,
+		},
+		{
+			name: "claude code text and image in one turn is classifiable",
+			ctx:  complexityHarnessContext(schemas.ClaudeCLI.String(), nil),
+			req: &schemas.BifrostRequest{
+				RequestType: schemas.ResponsesRequest,
+				ResponsesRequest: &schemas.BifrostResponsesRequest{Input: []schemas.ResponsesMessage{
+					{Role: &userRole, Content: complexityResponsesString("Inspect the attached image")},
+					{Role: &userRole, Content: complexityResponsesBlocks(
+						schemas.ResponsesMessageContentBlock{Type: schemas.ResponsesInputMessageContentBlockTypeImage},
+					)},
 				}},
 			},
 			want: InputClassifiable,
@@ -760,84 +790,6 @@ func TestBuildInputWithDisposition(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, got := BuildInputWithDisposition(tt.ctx, tt.req)
-			assert.Equal(t, tt.want, got)
-		})
-	}
-}
-
-func TestResolveComplexitySessionID(t *testing.T) {
-	tests := []struct {
-		name      string
-		ctx       *schemas.BifrostContext
-		want      string
-		wantFound bool
-	}{
-		{
-			name: "explicit bifrost session wins over native metadata",
-			ctx: func() *schemas.BifrostContext {
-				ctx := complexityHarnessContext(schemas.CodexCLI.String(), map[string]string{
-					codexTurnMetadataHeader: `{"request_kind":"turn","session_id":"native-session"}`,
-				})
-				ctx.SetValue(schemas.BifrostContextKeySessionID, " explicit-session ")
-				return ctx
-			}(),
-			want:      "explicit-session",
-			wantFound: true,
-		},
-		{
-			name: "claude native header is accepted for claude code",
-			ctx: complexityHarnessContext(schemas.ClaudeCLI.String(), map[string]string{
-				claudeCodeSessionIDHeader: "claude-session",
-			}),
-			want:      "claude-session",
-			wantFound: true,
-		},
-		{
-			name: "claude native header is rejected for a generic client",
-			ctx: complexityHarnessContext("generic-client/1.0", map[string]string{
-				claudeCodeSessionIDHeader: "spoofed-session",
-			}),
-		},
-		{
-			name: "codex native metadata is accepted for codex",
-			ctx: complexityHarnessContext(schemas.CodexDesktop.String(), map[string]string{
-				codexTurnMetadataHeader: `{"request_kind":"turn","session_id":"codex-session"}`,
-			}),
-			want:      "codex-session",
-			wantFound: true,
-		},
-		{
-			name: "invalid request kind does not invalidate codex session identity",
-			ctx: complexityHarnessContext(schemas.CodexCLI.String(), map[string]string{
-				codexTurnMetadataHeader: `{"request_kind":{},"session_id":"codex-session"}`,
-			}),
-			want:      "codex-session",
-			wantFound: true,
-		},
-		{
-			name: "oversized explicit identity is rejected without native fallback",
-			ctx: func() *schemas.BifrostContext {
-				ctx := complexityHarnessContext(schemas.CodexCLI.String(), map[string]string{
-					codexTurnMetadataHeader: `{"session_id":"native-session"}`,
-				})
-				ctx.SetValue(schemas.BifrostContextKeySessionID, strings.Repeat("x", maxComplexitySessionIDLength+1))
-				return ctx
-			}(),
-		},
-		{
-			name: "identity containing nul is rejected",
-			ctx: func() *schemas.BifrostContext {
-				ctx := complexityHarnessContext("", nil)
-				ctx.SetValue(schemas.BifrostContextKeySessionID, "session\x00suffix")
-				return ctx
-			}(),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, found := ResolveComplexitySessionID(tt.ctx)
-			assert.Equal(t, tt.wantFound, found)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/plugins/routing/complexity/semanticclassifier.go
+++ b/plugins/routing/complexity/semanticclassifier.go
@@ -349,6 +349,19 @@ func (c *SemanticClassifier) RearmForProvider(provider schemas.ModelProvider) {
 	c.requestWarmupLocked()
 }
 
+// RetryWarmup restarts a failed semantic warmup using the saved configuration.
+// It returns false unless the classifier is currently failed, which prevents an
+// operator retry from duplicating a healthy or in-flight embedding job.
+func (c *SemanticClassifier) RetryWarmup() (SemanticStatusInfo, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.config == nil || c.config.Semantic == nil || c.status.State != SemanticStatusFailed {
+		return c.status, false
+	}
+	c.restartPreparationLocked()
+	return c.status, true
+}
+
 // ValidateConfig is the seam for checks that depend on live process state
 // rather than the payload alone, run before a handler persists a configuration.
 // No semantic setting needs one today: neither vector_store mode can fail, since

--- a/plugins/routing/complexity/semanticclassifier_test.go
+++ b/plugins/routing/complexity/semanticclassifier_test.go
@@ -1039,6 +1039,39 @@ func TestSemanticClassifierRearmsForProviderOnlyWhenFailed(t *testing.T) {
 	assert.Equal(t, revisionBefore, revisionAfter, "a ready classifier must not re-embed on a provider change")
 }
 
+// TestSemanticClassifierRetryWarmupRetriesOnlyFailedState verifies an operator
+// retry shares the existing revision-safe recovery path without duplicating a
+// healthy or in-flight warmup.
+func TestSemanticClassifierRetryWarmupRetriesOnlyFailedState(t *testing.T) {
+	classifier := NewSemanticClassifier(context.Background(), bifrost.NewDefaultLogger(schemas.LogLevelError))
+	t.Cleanup(func() {
+		require.NoError(t, classifier.Close())
+	})
+
+	var serving atomic.Bool
+	classifier.SetEmbeddingFunc(func(_ context.Context, _ *SemanticConfig, _ string) ([]float32, error) {
+		if !serving.Load() {
+			return nil, errors.New("synthetic provider failure")
+		}
+		return []float32{1, 0}, nil
+	})
+	config := testSemanticClassifierConfig(configstore.ComplexitySemanticVectorStoreEmbedded)
+	classifier.Configure(&config)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusFailed
+	}, time.Second, 10*time.Millisecond)
+
+	serving.Store(true)
+	_, retried := classifier.RetryWarmup()
+	require.True(t, retried)
+	require.Eventually(t, func() bool {
+		return classifier.Status().State == SemanticStatusReady
+	}, time.Second, 10*time.Millisecond)
+
+	_, retried = classifier.RetryWarmup()
+	require.False(t, retried, "a ready classifier must not schedule another warmup")
+}
+
 // TestSemanticClassifierEmbedsOnlyNewPhrasesOnTierEdit pins the cost model of
 // editing a tier list. Generations stay content-addressed, so adding one phrase
 // still mints a new fingerprint and writes every exemplar into a fresh

--- a/plugins/routing/complexityrouting.go
+++ b/plugins/routing/complexityrouting.go
@@ -28,8 +28,8 @@ func (p *RoutingPlugin) computeComplexity(
 	virtualKeyID string,
 ) *complexity.ComplexityResult {
 	input, disposition := complexity.BuildInputWithDisposition(ctx, req)
-	sessionID, hasSessionID := complexity.ResolveComplexitySessionID(ctx)
-	sessionActive := p.sessionEnabled.Load() && hasSessionID && p.sessionStore != nil
+	sessionID, _ := ctx.Value(schemas.BifrostContextKeySessionID).(string)
+	sessionActive := p.sessionEnabled.Load() && sessionID != "" && p.sessionStore != nil
 
 	if disposition != complexity.InputClassifiable {
 		if sessionActive && disposition == complexity.InputContinuation {

--- a/plugins/routing/main.go
+++ b/plugins/routing/main.go
@@ -313,6 +313,15 @@ func (p *RoutingPlugin) ComplexitySemanticStatus() complexity.SemanticStatusInfo
 	return p.semanticClassifier.Status()
 }
 
+// RetryComplexitySemanticWarmup restarts the saved semantic classifier after
+// a failed warmup and reports whether a retry was actually started.
+func (p *RoutingPlugin) RetryComplexitySemanticWarmup() (complexity.SemanticStatusInfo, bool) {
+	if p.semanticClassifier == nil {
+		return complexity.SemanticStatusInfo{State: complexity.SemanticStatusDisabled}, false
+	}
+	return p.semanticClassifier.RetryWarmup()
+}
+
 // ListComplexityGenerations reports the exemplar generations held in the vector
 // store, flagging the one currently serving.
 func (p *RoutingPlugin) ListComplexityGenerations(ctx context.Context) ([]complexity.GenerationInfo, error) {

--- a/transports/bifrost-http/handlers/logging.go
+++ b/transports/bifrost-http/handlers/logging.go
@@ -313,9 +313,6 @@ func parseParentRequestIDFilter(ctx *fasthttp.RequestCtx) string {
 	if parentRequestID := string(ctx.QueryArgs().Peek("parent_request_id")); strings.TrimSpace(parentRequestID) != "" {
 		return parentRequestID
 	}
-	if sessionID := string(ctx.QueryArgs().Peek("session_id")); strings.TrimSpace(sessionID) != "" {
-		return sessionID
-	}
 	return ""
 }
 
@@ -666,6 +663,9 @@ func (h *LoggingHandler) getLogs(ctx *fasthttp.RequestCtx) {
 	if apps := string(ctx.QueryArgs().Peek("apps")); apps != "" {
 		filters.Apps = parseStringArrayParam(apps)
 	}
+	if sessionID := strings.TrimSpace(string(ctx.QueryArgs().Peek("session_id"))); sessionID != "" {
+		filters.SessionID = sessionID
+	}
 	parseComplexityFilters(ctx, filters)
 	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {
 		if t, err := time.Parse(time.RFC3339Nano, startTime); err == nil {
@@ -934,6 +934,9 @@ func (h *LoggingHandler) getLogsStats(ctx *fasthttp.RequestCtx) {
 	if apps := string(ctx.QueryArgs().Peek("apps")); apps != "" {
 		filters.Apps = parseStringArrayParam(apps)
 	}
+	if sessionID := strings.TrimSpace(string(ctx.QueryArgs().Peek("session_id"))); sessionID != "" {
+		filters.SessionID = sessionID
+	}
 	parseComplexityFilters(ctx, filters)
 	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {
 		if t, err := time.Parse(time.RFC3339Nano, startTime); err == nil {
@@ -1185,6 +1188,9 @@ func parseHistogramFilters(ctx *fasthttp.RequestCtx) *logstore.SearchFilters {
 	}
 	if apps := string(ctx.QueryArgs().Peek("apps")); apps != "" {
 		filters.Apps = parseStringArrayParam(apps)
+	}
+	if sessionID := strings.TrimSpace(string(ctx.QueryArgs().Peek("session_id"))); sessionID != "" {
+		filters.SessionID = sessionID
 	}
 	parseComplexityFilters(ctx, filters)
 	if startTime := string(ctx.QueryArgs().Peek("start_time")); startTime != "" {

--- a/transports/bifrost-http/handlers/logging_test.go
+++ b/transports/bifrost-http/handlers/logging_test.go
@@ -33,8 +33,10 @@ func TestShouldUseFilterDataCacheAllowsUnscopedEmptyQuery(t *testing.T) {
 	}
 }
 
+// TestParseComplexityFilters verifies complexity-specific query filters are
+// parsed independently from generic log filters.
 func TestParseComplexityFilters(t *testing.T) {
-	t.Run("parses tier and mechanism values", func(t *testing.T) {
+	t.Run("parses tier and mechanism", func(t *testing.T) {
 		ctx := &fasthttp.RequestCtx{}
 		ctx.QueryArgs().Set("complexity_tiers", "SIMPLE,COMPLEX")
 		ctx.QueryArgs().Set("complexity_mechanisms", "semantic,lexical")
@@ -65,6 +67,24 @@ func TestParseComplexityFilters(t *testing.T) {
 			t.Fatalf("complexity mechanisms = %#v, want %#v", got, want)
 		}
 	})
+}
+
+// TestParseParentRequestIDFilter verifies the explicit parent-request filter
+// does not consume the distinct generic session_id query parameter.
+func TestParseParentRequestIDFilter(t *testing.T) {
+	ctx := &fasthttp.RequestCtx{}
+	ctx.QueryArgs().Set("parent_request_id", "parent-abc")
+	ctx.QueryArgs().Set("session_id", "session-abc")
+
+	if got, want := parseParentRequestIDFilter(ctx), "parent-abc"; got != want {
+		t.Fatalf("parent request ID = %q, want %q", got, want)
+	}
+
+	ctx = &fasthttp.RequestCtx{}
+	ctx.QueryArgs().Set("session_id", "session-abc")
+	if got := parseParentRequestIDFilter(ctx); got != "" {
+		t.Fatalf("parent request ID = %q, want empty", got)
+	}
 }
 
 // TestShouldUseFilterDataCacheRejectsSearchQuery verifies search requests are

--- a/transports/bifrost-http/handlers/routing.go
+++ b/transports/bifrost-http/handlers/routing.go
@@ -49,6 +49,9 @@ type RoutingManager interface {
 	// semantic complexity routing so configuration clients can distinguish
 	// saved from ready.
 	GetComplexitySemanticStatus(ctx context.Context) (complexity.SemanticStatusInfo, error)
+	// RetryComplexitySemanticWarmup restarts a failed semantic warmup using the
+	// saved analyzer configuration. It returns false when no retry was started.
+	RetryComplexitySemanticWarmup(ctx context.Context) (complexity.SemanticStatusInfo, bool, error)
 	// GetComplexityLLMStatus returns the llm fallback classifier's readiness.
 	GetComplexityLLMStatus(ctx context.Context) (complexity.LLMStatusInfo, error)
 	// ListComplexityGenerations reports the exemplar generations the vector
@@ -120,6 +123,7 @@ func (h *RoutingHandler) RegisterRoutes(r *router.Router, middlewares ...schemas
 	register(fasthttp.MethodPost, "/api/routing/complexity-analyzer-config/reset", "/api/governance/complexity-analyzer-config/reset", h.resetComplexityAnalyzerConfig)
 	// Status never shipped under /api/governance, so it has no legacy alias.
 	r.Handle(fasthttp.MethodGet, "/api/routing/complexity-analyzer-status", lib.ChainMiddlewares(h.getComplexitySemanticStatus, middlewares...))
+	r.Handle(fasthttp.MethodPost, "/api/routing/complexity-analyzer-status/retry", lib.ChainMiddlewares(h.retryComplexitySemanticWarmup, middlewares...))
 	r.Handle(fasthttp.MethodGet, "/api/routing/complexity-analyzer-generations", lib.ChainMiddlewares(h.listComplexityGenerations, middlewares...))
 	r.Handle(fasthttp.MethodDelete, "/api/routing/complexity-analyzer-generations/{namespace}", lib.ChainMiddlewares(h.deleteComplexityGeneration, middlewares...))
 }
@@ -428,6 +432,21 @@ func (h *RoutingHandler) getComplexitySemanticStatus(ctx *fasthttp.RequestCtx) {
 		response.LLMDefaultPrompt = complexity.DefaultLLMClassifierGuidance()
 	}
 	SendJSON(ctx, response)
+}
+
+// retryComplexitySemanticWarmup restarts a failed semantic warmup without
+// changing the saved analyzer configuration.
+func (h *RoutingHandler) retryComplexitySemanticWarmup(ctx *fasthttp.RequestCtx) {
+	status, retried, err := h.routingManager.RetryComplexitySemanticWarmup(ctx)
+	if err != nil {
+		SendError(ctx, fasthttp.StatusServiceUnavailable, fmt.Sprintf("failed to retry semantic complexity warmup: %v", err))
+		return
+	}
+	if !retried {
+		SendError(ctx, fasthttp.StatusConflict, "semantic complexity warmup can only be retried after a failure")
+		return
+	}
+	SendJSONWithStatus(ctx, complexityStatusResponse{SemanticStatusInfo: status}, fasthttp.StatusAccepted)
 }
 
 // getRoutingRules retrieves all routing rules with optional filtering from database

--- a/transports/bifrost-http/handlers/routing_test.go
+++ b/transports/bifrost-http/handlers/routing_test.go
@@ -23,6 +23,9 @@ type mockRoutingManager struct {
 	reloadedConfig *complexity.AnalyzerConfig
 	reloadCalls    int
 	reloadErr      error
+	retryStatus    complexity.SemanticStatusInfo
+	retryStarted   bool
+	retryErr       error
 }
 
 func (m *mockRoutingManager) ValidateComplexityAnalyzerConfig(_ context.Context, _ *complexity.AnalyzerConfig) error {
@@ -31,6 +34,11 @@ func (m *mockRoutingManager) ValidateComplexityAnalyzerConfig(_ context.Context,
 
 func (m *mockRoutingManager) GetComplexitySemanticStatus(_ context.Context) (complexity.SemanticStatusInfo, error) {
 	return complexity.SemanticStatusInfo{State: complexity.SemanticStatusDisabled}, nil
+}
+
+// RetryComplexitySemanticWarmup records a retry request for routing handler tests.
+func (m *mockRoutingManager) RetryComplexitySemanticWarmup(_ context.Context) (complexity.SemanticStatusInfo, bool, error) {
+	return m.retryStatus, m.retryStarted, m.retryErr
 }
 
 func (m *mockRoutingManager) GetComplexityLLMStatus(_ context.Context) (complexity.LLMStatusInfo, error) {
@@ -135,6 +143,41 @@ func TestComplexityAnalyzerConfigGetReturnsDefaultsWhenUnset(t *testing.T) {
 	if len(resp.Keywords.MediumKeywords) == 0 {
 		t.Fatalf("expected default medium keywords")
 	}
+}
+
+// TestRetryComplexitySemanticWarmup verifies the retry endpoint accepts only a
+// failed classifier retry and returns the new asynchronous warmup state.
+func TestRetryComplexitySemanticWarmup(t *testing.T) {
+	SetLogger(&mockLogger{})
+	t.Run("accepts a failed warmup", func(t *testing.T) {
+		handler := &RoutingHandler{
+			configStore: setupPricingOverrideHandlerStore(t),
+			routingManager: &mockRoutingManager{
+				retryStarted: true,
+				retryStatus:  complexity.SemanticStatusInfo{State: complexity.SemanticStatusWarming, Total: 3},
+			},
+		}
+		ctx := newTestRequestCtx("")
+
+		handler.retryComplexitySemanticWarmup(ctx)
+
+		require.Equal(t, fasthttp.StatusAccepted, ctx.Response.StatusCode())
+		var status complexity.SemanticStatusInfo
+		require.NoError(t, json.Unmarshal(ctx.Response.Body(), &status))
+		require.Equal(t, complexity.SemanticStatusWarming, status.State)
+	})
+
+	t.Run("rejects a non-failed warmup", func(t *testing.T) {
+		handler := &RoutingHandler{
+			configStore:    setupPricingOverrideHandlerStore(t),
+			routingManager: &mockRoutingManager{retryStatus: complexity.SemanticStatusInfo{State: complexity.SemanticStatusReady}},
+		}
+		ctx := newTestRequestCtx("")
+
+		handler.retryComplexitySemanticWarmup(ctx)
+
+		require.Equal(t, fasthttp.StatusConflict, ctx.Response.StatusCode())
+	})
 }
 
 func TestComplexityAnalyzerConfigPutPersistsAndReloads(t *testing.T) {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -137,6 +137,7 @@ type ServerCallbacks interface {
 	ReloadComplexityAnalyzerConfig(ctx context.Context, config *complexity.AnalyzerConfig) error
 	ValidateComplexityAnalyzerConfig(ctx context.Context, config *complexity.AnalyzerConfig) error
 	GetComplexitySemanticStatus(ctx context.Context) (complexity.SemanticStatusInfo, error)
+	RetryComplexitySemanticWarmup(ctx context.Context) (complexity.SemanticStatusInfo, bool, error)
 	GetComplexityLLMStatus(ctx context.Context) (complexity.LLMStatusInfo, error)
 	ListComplexityGenerations(ctx context.Context) ([]complexity.GenerationInfo, error)
 	DeleteComplexityGeneration(ctx context.Context, namespace string) error
@@ -1149,6 +1150,17 @@ func (s *BifrostHTTPServer) GetComplexitySemanticStatus(_ context.Context) (comp
 		return complexity.SemanticStatusInfo{}, fmt.Errorf("routing plugin not found: %w", err)
 	}
 	return routingPlugin.ComplexitySemanticStatus(), nil
+}
+
+// RetryComplexitySemanticWarmup restarts a failed semantic warmup using its
+// saved configuration and reports whether the classifier accepted the retry.
+func (s *BifrostHTTPServer) RetryComplexitySemanticWarmup(_ context.Context) (complexity.SemanticStatusInfo, bool, error) {
+	routingPlugin, err := s.getRoutingPlugin()
+	if err != nil {
+		return complexity.SemanticStatusInfo{}, false, fmt.Errorf("routing plugin not found: %w", err)
+	}
+	status, retried := routingPlugin.RetryComplexitySemanticWarmup()
+	return status, retried, nil
 }
 
 // ListComplexityGenerations reports the exemplar generations held in the

--- a/ui/app/workspace/complexity-router/page.tsx
+++ b/ui/app/workspace/complexity-router/page.tsx
@@ -22,6 +22,7 @@ import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import {
 	useGetComplexityAnalyzerConfigQuery,
 	useGetComplexitySemanticStatusQuery,
+	useRetryComplexitySemanticWarmupMutation,
 	useResetComplexityAnalyzerConfigMutation,
 	useUpdateComplexityAnalyzerConfigMutation,
 } from "@/lib/store/apis/governanceApi";
@@ -107,6 +108,7 @@ export default function ComplexityRouterPage() {
 	const { data, isLoading, isFetching, error, refetch } = useGetComplexityAnalyzerConfigQuery();
 	const [updateConfig, { isLoading: isSaving }] = useUpdateComplexityAnalyzerConfigMutation();
 	const [resetConfig, { isLoading: isResetting }] = useResetComplexityAnalyzerConfigMutation();
+	const [retrySemanticWarmup, { isLoading: isRetryingWarmup }] = useRetryComplexitySemanticWarmupMutation();
 
 	const [submitError, setSubmitError] = useState<string | null>(null);
 	const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
@@ -326,6 +328,19 @@ export default function ComplexityRouterPage() {
 			});
 	};
 
+	const handleRetrySemanticWarmup = () => {
+		if (!canUpdate) return;
+		retrySemanticWarmup()
+			.unwrap()
+			.then(() => {
+				toast.success("Semantic warmup restarted", { position: "top-right" });
+				void refetchStatus();
+			})
+			.catch((err) => {
+				toast.error(`Couldn’t retry semantic warmup. ${getErrorMessage(err)}`, { position: "top-right" });
+			});
+	};
+
 	const onValid = (values: AnalyzerFormValues) => {
 		if (!canUpdate) return;
 		setSubmitError(null);
@@ -469,8 +484,11 @@ export default function ComplexityRouterPage() {
 									statusUnavailable={statusIsError && !semanticStatus}
 									statusRefreshFailed={statusIsError && Boolean(semanticStatus)}
 									isRetryingStatus={statusFetching}
+									canRetryWarmup={canUpdate}
+									isRetryingWarmup={isRetryingWarmup}
 									onConfigure={() => setEmbeddingSheetOpen(true)}
 									onRetryStatus={() => void refetchStatus()}
+									onRetryWarmup={handleRetrySemanticWarmup}
 								/>
 								<Button
 									type="button"

--- a/ui/app/workspace/complexity-router/views/classifierStatusBadge.tsx
+++ b/ui/app/workspace/complexity-router/views/classifierStatusBadge.tsx
@@ -71,8 +71,11 @@ export function ClassifierStatusBadge({
 	statusUnavailable,
 	statusRefreshFailed,
 	isRetryingStatus,
+	canRetryWarmup,
+	isRetryingWarmup,
 	onConfigure,
 	onRetryStatus,
+	onRetryWarmup,
 }: {
 	status: SemanticStatusInfo | undefined;
 	isLoading: boolean;
@@ -83,8 +86,11 @@ export function ClassifierStatusBadge({
 	statusUnavailable: boolean;
 	statusRefreshFailed: boolean;
 	isRetryingStatus: boolean;
+	canRetryWarmup: boolean;
+	isRetryingWarmup: boolean;
 	onConfigure: () => void;
 	onRetryStatus: () => void;
+	onRetryWarmup: () => void;
 }) {
 	const state: ClassifierState = isNotConfigured
 		? "not-configured"
@@ -156,6 +162,13 @@ export function ClassifierStatusBadge({
 					<p className={status.serving_previous ? "text-amber-700 dark:text-amber-400" : "text-destructive"}>
 						{semanticWarmupImpactMessage(status)}
 					</p>
+				)}
+
+				{state === "failed" && canRetryWarmup && !hasUnsavedChanges && (
+					<Button type="button" variant="outline" size="sm" className="w-full" onClick={onRetryWarmup} disabled={isRetryingWarmup}>
+						<RefreshCw className={cn("size-3.5", isRetryingWarmup && "animate-spin")} />
+						Retry warmup
+					</Button>
 				)}
 
 				{state === "unavailable" && (

--- a/ui/app/workspace/dashboard/page.tsx
+++ b/ui/app/workspace/dashboard/page.tsx
@@ -3,7 +3,7 @@ import { DateTimePickerWithRange } from "@/components/ui/datePickerWithRange";
 import { ScrollArea } from "@/components/ui/scrollArea";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTimezonePreference } from "@/lib/hooks/useTimezonePreference";
-import { parseAsSafeArrayOf } from "@/lib/queryParamsParser";
+import { parseAsSafeArrayOf, parseAsSafeString } from "@/lib/queryParamsParser";
 import { useGetMCPAvailableFilterDataQuery } from "@/lib/store";
 import type { LogFilters, MCPToolLogFilters } from "@/lib/types/logs";
 import { dateUtils } from "@/lib/types/logs";
@@ -82,6 +82,7 @@ export default function DashboardPage() {
 			mcp_tool_names: parseAsString.withDefault(""),
 			mcp_server_labels: parseAsString.withDefault(""),
 			parent_request_id: parseAsString.withDefault(""),
+			session_id: parseAsSafeString.withDefault(""),
 			user_ids: parseAsSafeArrayOf.withDefault([]),
 			team_ids: parseAsSafeArrayOf.withDefault([]),
 			customer_ids: parseAsSafeArrayOf.withDefault([]),
@@ -142,6 +143,7 @@ export default function DashboardPage() {
 					metadata_filters: metadataFilters,
 				}),
 			...(urlState.parent_request_id && { parent_request_id: urlState.parent_request_id }),
+			...(urlState.session_id && { session_id: urlState.session_id }),
 			...(urlState.user_ids.length > 0 && { user_ids: urlState.user_ids }),
 			...(urlState.team_ids.length > 0 && { team_ids: urlState.team_ids }),
 			...(urlState.customer_ids.length > 0 && { customer_ids: urlState.customer_ids }),
@@ -155,6 +157,7 @@ export default function DashboardPage() {
 			urlState.start_time,
 			urlState.end_time,
 			urlState.parent_request_id,
+			urlState.session_id,
 			urlState.providers,
 			urlState.models,
 			urlState.selected_key_ids,
@@ -375,6 +378,7 @@ export default function DashboardPage() {
 						? JSON.stringify(newFilters.metadata_filters)
 						: "",
 				parent_request_id: newFilters.parent_request_id || "",
+				session_id: newFilters.session_id || "",
 				user_ids: newFilters.user_ids || [],
 				team_ids: newFilters.team_ids || [],
 				customer_ids: newFilters.customer_ids || [],

--- a/ui/app/workspace/logs/page.tsx
+++ b/ui/app/workspace/logs/page.tsx
@@ -91,6 +91,7 @@ export default function LogsPage() {
 			user_agents: parseAsSafeArrayOf.withDefault([]),
 			complexity_tiers: parseAsSafeArrayOf.withDefault([]),
 			complexity_mechanisms: parseAsSafeArrayOf.withDefault([]),
+			session_id: parseAsSafeString.withDefault(""),
 			user_ids: parseAsSafeArrayOf.withDefault([]),
 			team_ids: parseAsSafeArrayOf.withDefault([]),
 			customer_ids: parseAsSafeArrayOf.withDefault([]),
@@ -124,7 +125,7 @@ export default function LogsPage() {
 	const polling = urlState.polling;
 	// Grouped view collapses fallback chains under their root. Disabled while a
 	// session filter is active — that view is already scoped to one chain/session.
-	const grouped = urlState.grouped && !urlState.parent_request_id;
+	const grouped = urlState.grouped && !urlState.parent_request_id && !urlState.session_id;
 
 	// Convert URL state to filters and pagination for API calls
 	const filters: LogFilters = useMemo(
@@ -144,6 +145,7 @@ export default function LogsPage() {
 			user_agents: urlState.user_agents,
 			complexity_tiers: urlState.complexity_tiers,
 			complexity_mechanisms: urlState.complexity_mechanisms,
+			session_id: urlState.session_id,
 			user_ids: urlState.user_ids,
 			team_ids: urlState.team_ids,
 			customer_ids: urlState.customer_ids,
@@ -186,6 +188,7 @@ export default function LogsPage() {
 			urlState.user_agents,
 			urlState.complexity_tiers,
 			urlState.complexity_mechanisms,
+			urlState.session_id,
 			urlState.user_ids,
 			urlState.team_ids,
 			urlState.customer_ids,
@@ -249,6 +252,7 @@ export default function LogsPage() {
 				user_agents: newFilters.user_agents || [],
 				complexity_tiers: newFilters.complexity_tiers || [],
 				complexity_mechanisms: newFilters.complexity_mechanisms || [],
+				session_id: newFilters.session_id || "",
 				user_ids: newFilters.user_ids || [],
 				team_ids: newFilters.team_ids || [],
 				customer_ids: newFilters.customer_ids || [],
@@ -427,6 +431,19 @@ export default function LogsPage() {
 			setFilters({
 				...filters,
 				parent_request_id: parentRequestId,
+			});
+		},
+		[filters, setFilters, setUrlState],
+	);
+
+	const handleFilterBySessionId = useCallback(
+		(sessionId: string) => {
+			setSelectedSessionId(null);
+			setSessionHighlightedLogId(null);
+			setUrlState({ selected_log: "" }, { history: "replace" });
+			setFilters({
+				...filters,
+				session_id: sessionId,
 			});
 		},
 		[filters, setFilters, setUrlState],
@@ -864,6 +881,7 @@ export default function LogsPage() {
 						hasPrev={selectedLogIndex > 0 || (selectedLogIndex !== -1 && pagination.offset > 0)}
 						hasNext={selectedLogIndex !== -1 && (selectedLogIndex < logs.length - 1 || pagination.offset + pagination.limit < totalItems)}
 						onFilterByParentRequestId={handleFilterByParentRequestId}
+						onFilterBySessionId={handleFilterBySessionId}
 						onViewSession={(sessionId, logId) => {
 							setUrlState({ selected_log: "" }, { history: "replace" });
 							setSessionHighlightedLogId(logId);

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1012,6 +1012,7 @@ interface LogDetailViewProps {
 	onClose?: () => void;
 	headerAction?: ReactNode;
 	onFilterByParentRequestId?: (parentRequestId: string) => void;
+	onFilterBySessionId?: (sessionId: string) => void;
 }
 
 // Explains an empty Raw JSON tab. Raw payloads are only persisted when the
@@ -1089,6 +1090,7 @@ export function LogDetailView({
 	onClose,
 	headerAction,
 	onFilterByParentRequestId,
+	onFilterBySessionId,
 }: LogDetailViewProps) {
 	const { copy: copyBody } = useCopyToClipboard({
 		successMessage: "Request body copied to clipboard",
@@ -1761,6 +1763,34 @@ export function LogDetailView({
 										) : (
 											<TruncatedLabel className="block max-w-full min-w-0 font-normal" tooltipSide="top">
 												{log.parent_request_id}
+											</TruncatedLabel>
+										)
+									}
+								/>
+							)}
+							{log.session_id && (
+								<LogEntryDetailsView
+									className="w-full"
+									label="Session ID"
+									value={
+										onFilterBySessionId ? (
+											<Tooltip>
+												<TooltipTrigger asChild>
+													<button
+														type="button"
+														className="block max-w-full min-w-0 cursor-pointer truncate bg-transparent p-0 text-left font-mono font-normal text-blue-600 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-blue-400"
+														onClick={() => onFilterBySessionId(log.session_id as string)}
+													>
+														{log.session_id}
+													</button>
+												</TooltipTrigger>
+												<TooltipContent sideOffset={6} className="max-w-md break-all">
+													{log.session_id} · Filter this session
+												</TooltipContent>
+											</Tooltip>
+										) : (
+											<TruncatedLabel className="block max-w-full min-w-0 font-normal" tooltipSide="top">
+												{log.session_id}
 											</TruncatedLabel>
 										)
 									}

--- a/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailsSheet.tsx
@@ -20,6 +20,7 @@ interface LogDetailSheetProps {
 	canReveal?: boolean;
 	onViewSession?: (sessionId: string, logId: string) => void;
 	onFilterByParentRequestId?: (parentRequestId: string) => void;
+	onFilterBySessionId?: (sessionId: string) => void;
 }
 
 export function LogDetailSheet({
@@ -33,6 +34,7 @@ export function LogDetailSheet({
 	canReveal = false,
 	onViewSession,
 	onFilterByParentRequestId,
+	onFilterBySessionId,
 }: LogDetailSheetProps) {
 	const [pollingInterval, setPollingInterval] = useState(0);
 	const {
@@ -87,6 +89,7 @@ export function LogDetailSheet({
 						canReveal={canReveal}
 						onClose={() => onOpenChange(false)}
 						onFilterByParentRequestId={onFilterByParentRequestId}
+						onFilterBySessionId={onFilterBySessionId}
 						headerAction={
 							<>
 								{displayLog.parent_request_id && onViewSession ? (

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -111,6 +111,7 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 					<RoutingRulesFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<ComplexityTierFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<ComplexityMechanismFilter filters={filters} onFiltersChange={onFiltersChange} />
+					<RequestSessionFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<LocalCachingFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<UserFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<TeamFilter filters={filters} onFiltersChange={onFiltersChange} />
@@ -932,13 +933,35 @@ function ComplexityMechanismFilter({ filters, onFiltersChange, defaultOpen }: Fi
 }
 
 // ---------------------------------------------------------------------------
+// RequestSessionFilter
+// ---------------------------------------------------------------------------
+
+function RequestSessionFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
+	const hasActive = !!filters.session_id;
+	return (
+		<FilterSection title="Session ID" defaultOpen={defaultOpen || hasActive} testId="request-session-filter-toggle">
+			<div className="relative">
+				<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
+				<Input
+					value={filters.session_id || ""}
+					onChange={(event) => onFiltersChange({ ...filters, session_id: event.target.value })}
+					placeholder="Exact session ID"
+					className="h-8 border-0 pl-8 text-sm"
+					data-testid="request-session-id-filter-input"
+				/>
+			</div>
+		</FilterSection>
+	);
+}
+
+// ---------------------------------------------------------------------------
 // SessionFilter
 // ---------------------------------------------------------------------------
 
 function SessionFilter({ filters, onFiltersChange, defaultOpen }: FilterComponentProps) {
 	const hasActive = !!filters.parent_request_id;
 	return (
-		<FilterSection title="Session" defaultOpen={defaultOpen || hasActive} testId="session-filter-toggle">
+		<FilterSection title="Parent request ID" defaultOpen={defaultOpen || hasActive} testId="session-filter-toggle">
 			<div className="relative">
 				<Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-2.5 size-3.5 -translate-y-1/2" />
 				<Input

--- a/ui/lib/store/apis/governanceApi.ts
+++ b/ui/lib/store/apis/governanceApi.ts
@@ -881,6 +881,13 @@ export const governanceApi = baseApi.injectEndpoints({
 			// page keeps showing the state the classifier was in before the edit.
 			providesTags: ["ComplexityAnalyzerConfig"],
 		}),
+		retryComplexitySemanticWarmup: builder.mutation<SemanticStatusInfo, void>({
+			query: () => ({
+				url: "/routing/complexity-analyzer-status/retry",
+				method: "POST",
+			}),
+			invalidatesTags: ["ComplexityAnalyzerConfig"],
+		}),
 		resetComplexityAnalyzerConfig: builder.mutation<AnalyzerConfig, void>({
 			query: () => ({
 				url: "/routing/complexity-analyzer-config/reset",
@@ -958,6 +965,7 @@ export const {
 	useUpdateComplexityAnalyzerConfigMutation,
 	useResetComplexityAnalyzerConfigMutation,
 	useGetComplexitySemanticStatusQuery,
+	useRetryComplexitySemanticWarmupMutation,
 
 	// Lazy queries
 	useLazyGetVirtualKeysQuery,

--- a/ui/lib/store/apis/logsApi.ts
+++ b/ui/lib/store/apis/logsApi.ts
@@ -69,6 +69,9 @@ function buildFilterParams(filters: LogFilters): Record<string, string | number>
 	if (filters.complexity_mechanisms && filters.complexity_mechanisms.length > 0) {
 		params.complexity_mechanisms = filters.complexity_mechanisms.join(",");
 	}
+	if (filters.session_id) {
+		params.session_id = filters.session_id;
+	}
 	if (filters.period) {
 		params.period = filters.period;
 	} else {

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -690,6 +690,7 @@ export interface LogEntry {
 	complexity_tier?: string; // Complexity tier used for routing ("SIMPLE", "MEDIUM", "COMPLEX"); absent when no routing rule referenced complexity_tier
 	complexity_mechanism?: string; // How the complexity tier was classified ("semantic", "llm", "session", "skipped"); absent when no routing rule referenced complexity_tier
 	complexity_score?: number; // Classifier score: the semantic classifier's similarity to the nearest reference phrase
+	session_id?: string; // Raw opaque session ID resolved by Bifrost for key stickiness and request correlation
 	routing_engine_logs?: string; // Human-readable routing decision logs
 	plugin_logs?: string; // JSON string of plugin execution logs grouped by plugin name
 	selected_key?: DBKey;
@@ -779,6 +780,7 @@ export interface LogFilters {
 	stop_reasons?: string[]; // For filtering by stop reason (stop, length, content_filter, refusal, tool_calls, etc.)
 	complexity_tiers?: string[]; // For filtering by routing complexity tier (SIMPLE, MEDIUM, COMPLEX)
 	complexity_mechanisms?: string[]; // For filtering by complexity decision mechanism (semantic, llm, session, skipped)
+	session_id?: string; // Exact session ID used for key stickiness and request correlation
 	objects?: string[]; // For filtering by request type (chat.completion, text.completion, embedding)
 	start_time?: string; // RFC3339 format
 	end_time?: string; // RFC3339 format


### PR DESCRIPTION
## Summary

Adds `complexity_session_id` as a first-class field across the full stack — from the routing plugin context key through log storage, filtering, and the UI — so that requests processed by session-aware complexity routing can be looked up and grouped by their opaque session identity.

## Changes

- Added `BifrostContextKeyGovernanceComplexitySessionID` context key to `bifrost.go` so the routing plugin can stamp the resolved session identity onto the request context when session-aware complexity routing is active.
- `computeComplexity` in `complexityrouting.go` now sets this context key when a session is active, making it available to downstream plugins.
- `ComplexitySessionID` column added to the `Log` struct with a partial index (`idx_logs_complexity_session_id`), a new migration (`migrationAddComplexitySessionIDColumn`), and a corresponding rollback path.
- `SearchFilters.ComplexitySessionID` added as an exact-match filter; `applyFilters` applies a `WHERE complexity_session_id = ?` clause, and `canUseMatViewFilters` forces the raw-table path when this filter is set (the materialized view does not carry this column).
- The logging plugin's `PostLLMHook` reads the new context key and writes it to the log entry in both the streaming and non-streaming paths.
- The HTTP transport's `parseComplexityFilters` parses the `complexity_session_id` query parameter (trimming whitespace) and populates the filter struct.
- `extractFromResponsesRequest` / `collectResponsesInputText` refactored so that textless multimodal fragments (e.g. image blocks emitted by the Anthropic-to-Responses conversion) are skipped rather than causing the entire input to be treated as unclassifiable, fixing a regression where a trailing image block in Claude Code history would hide a subsequent human text turn.
- UI: `complexity_session_id` added to URL state, `LogFilters`, `LogEntry`, and `buildFilterParams`. A `ComplexitySessionFilter` sidebar component provides an exact-match text input. The log detail view renders the session ID as a clickable link that sets the filter. The grouped view is disabled when a `complexity_session_id` filter is active (consistent with the existing `parent_request_id` behaviour). The `SessionFilter` sidebar section is renamed to "Parent request ID" to avoid ambiguity with the new complexity session concept.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/schemas/... ./framework/logstore/... ./plugins/logging/... ./plugins/routing/... ./transports/bifrost-http/handlers/...

# UI
cd ui
pnpm i
pnpm build
```

1. Issue a request through a routing rule that uses session-aware complexity routing (i.e. `complexity_tier` with a session-capable classifier). Confirm the resulting log row has a non-null `complexity_session_id`.
2. Query the logs API with `?complexity_session_id=<value>` and confirm only matching rows are returned.
3. In the UI, open a log with a `complexity_session_id`, click the session ID link in the detail panel, and confirm the filter sidebar populates and the log list narrows to that session.
4. Confirm the grouped view is automatically disabled when the `complexity_session_id` filter is active.

## Breaking changes

- [x] No

## Security considerations

The `complexity_session_id` value is an opaque caller-supplied string passed through context and stored as-is. It is not hashed or encrypted at rest. No credentials or PII are expected in this field by design, but operators should be aware it is stored in plaintext in the logs table and surfaced in the UI and API responses.

## Checklist

- [x] I added/updated tests where appropriate
- [x] I verified builds succeed (Go and UI)