### PR TITLE
fix: thinking block modification error

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -520,6 +520,16 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 			continue
 		}
 
+		// Custom providers can disable list_models via allowed_requests; the call would
+		// only bounce with "unsupported operation", so don't spend a request on it here.
+		// Scoped to the fan-out: a direct ListModelsRequest still returns the error.
+		if config, err := bifrost.account.GetConfigForProvider(providerKey); err == nil && config != nil &&
+			config.CustomProviderConfig != nil &&
+			!config.CustomProviderConfig.IsOperationAllowed(schemas.ListModelsRequest) {
+			bifrost.logger.Debug("skipping provider %s in list all models: list_models is disabled via allowed_requests", providerKey)
+			continue
+		}
+
 		wg.Add(1)
 		go func(providerKey schemas.ModelProvider) {
 			defer wg.Done()

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -3,6 +3,8 @@ package bifrost
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"runtime"
 	"strings"
 	"sync"
@@ -753,6 +755,8 @@ type MockAccount struct {
 	mu      sync.RWMutex
 	configs map[schemas.ModelProvider]*schemas.ProviderConfig
 	keys    map[schemas.ModelProvider][]schemas.Key
+	// keyLookups counts GetKeysForProvider calls per provider
+	keyLookups sync.Map
 }
 
 func NewMockAccount() *MockAccount {
@@ -823,6 +827,9 @@ func (ma *MockAccount) GetConfigForProvider(provider schemas.ModelProvider) (*sc
 }
 
 func (ma *MockAccount) GetKeysForProvider(ctx context.Context, provider schemas.ModelProvider) ([]schemas.Key, error) {
+	counter, _ := ma.keyLookups.LoadOrStore(provider, &atomic.Int64{})
+	counter.(*atomic.Int64).Add(1)
+
 	ma.mu.RLock()
 	defer ma.mu.RUnlock()
 	if keys, exists := ma.keys[provider]; exists {
@@ -835,6 +842,21 @@ func (ma *MockAccount) SetKeysForProvider(provider schemas.ModelProvider, keys [
 	ma.mu.Lock()
 	defer ma.mu.Unlock()
 	ma.keys[provider] = keys
+}
+
+func (ma *MockAccount) SetCustomProviderConfig(provider schemas.ModelProvider, customConfig *schemas.CustomProviderConfig) {
+	ma.mu.Lock()
+	defer ma.mu.Unlock()
+	if config, exists := ma.configs[provider]; exists {
+		config.CustomProviderConfig = customConfig
+	}
+}
+
+func (ma *MockAccount) KeyLookupCount(provider schemas.ModelProvider) int64 {
+	if counter, ok := ma.keyLookups.Load(provider); ok {
+		return counter.(*atomic.Int64).Load()
+	}
+	return 0
 }
 
 type countingTracer struct {
@@ -893,6 +915,110 @@ func TestFilterProvidersByContext(t *testing.T) {
 			t.Fatalf("expected no providers for malformed context value, got %v", filtered)
 		}
 	})
+}
+
+// TestListAllModels_CustomProviderAllowedRequestsGate covers the fan-out gate:
+// a custom provider that disables list_models via allowed_requests must not be
+// dispatched at all, while providers that allow it — explicitly or by leaving
+// AllowedRequests nil, which permits every operation — still report their models.
+// The key lookup count is what separates "skipped" from "dispatched and bounced":
+// both end up contributing no models to the aggregated response.
+func TestListAllModels_CustomProviderAllowedRequestsGate(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"object":"list","data":[{"id":"model-a","object":"model","created":0,"owned_by":"test"}]}`)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name            string
+		provider        schemas.ModelProvider
+		allowedRequests *schemas.AllowedRequests
+		wantDispatched  bool
+	}{
+		{
+			name:            "nil allowed requests allows all operations",
+			provider:        schemas.ModelProvider("custom-openai-nil"),
+			allowedRequests: nil,
+			wantDispatched:  true,
+		},
+		{
+			name:            "list models explicitly allowed",
+			provider:        schemas.ModelProvider("custom-openai-allowed"),
+			allowedRequests: &schemas.AllowedRequests{ListModels: true},
+			wantDispatched:  true,
+		},
+		{
+			name:            "list models explicitly disallowed",
+			provider:        schemas.ModelProvider("custom-openai-gated"),
+			allowedRequests: &schemas.AllowedRequests{ListModels: false},
+			wantDispatched:  false,
+		},
+	}
+
+	// All cases share one fan-out so the gate is exercised the way it runs in
+	// production: a mix of gated and ungated providers in a single pass.
+	account := NewMockAccount()
+	for _, tt := range tests {
+		account.AddProviderWithBaseURL(tt.provider, 1, 1, server.URL)
+		account.SetKeysForProvider(tt.provider, []schemas.Key{
+			{
+				ID:     fmt.Sprintf("test-key-%s", tt.provider),
+				Value:  *schemas.NewSecretVar(fmt.Sprintf("sk-test-%s", tt.provider)),
+				Models: schemas.WhiteList{"*"},
+				Weight: 100,
+			},
+		})
+		account.SetCustomProviderConfig(tt.provider, &schemas.CustomProviderConfig{
+			BaseProviderType: schemas.OpenAI,
+			AllowedRequests:  tt.allowedRequests,
+		})
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	client, err := Init(ctx, schemas.BifrostConfig{
+		Account: account,
+		Logger:  NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Error initializing Bifrost: %v", err)
+	}
+	defer client.Shutdown()
+
+	response, bifrostErr := client.ListAllModels(ctx, &schemas.BifrostListModelsRequest{})
+	if bifrostErr != nil {
+		t.Fatalf("ListAllModels returned error: %v", bifrostErr)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			keyLookups := account.KeyLookupCount(tt.provider)
+			foundModels := false
+			for _, model := range response.Data {
+				if strings.HasPrefix(model.ID, string(tt.provider)+"/") {
+					foundModels = true
+					break
+				}
+			}
+
+			if tt.wantDispatched {
+				if keyLookups == 0 {
+					t.Error("expected provider to be dispatched, got 0 key lookups")
+				}
+				if !foundModels {
+					t.Errorf("expected models from provider, got %+v", response.Data)
+				}
+				return
+			}
+
+			if keyLookups != 0 {
+				t.Errorf("expected provider to be skipped before key selection, got %d key lookups", keyLookups)
+			}
+			if foundModels {
+				t.Errorf("expected no models from skipped provider, got %+v", response.Data)
+			}
+		})
+	}
 }
 
 func TestRunStreamPreHooks_FinalChunkFlushesTrace(t *testing.T) {

--- a/core/encryptedreasoning.go
+++ b/core/encryptedreasoning.go
@@ -265,6 +265,10 @@ func stripChatUnverifiableReasoning(ctx *schemas.BifrostContext, req *schemas.Bi
 	rewritten := make([]schemas.ChatMessage, len(req.Input))
 	copy(rewritten, req.Input)
 
+	// Anthropic refuses a blanked signature wherever it appears, so there the detail is
+	// dropped whole rather than emptied (see dropsWholeReasoningBlocks).
+	dropWhole := dropsWholeReasoningBlocks(ctx, req.Model)
+
 	changed := false
 	for i := range rewritten {
 		assistant := rewritten[i].ChatAssistantMessage
@@ -272,6 +276,9 @@ func stripChatUnverifiableReasoning(ctx *schemas.BifrostContext, req *schemas.Bi
 			continue
 		}
 		details, detailsChanged := stripChatReasoningDetails(assistant.ReasoningDetails)
+		if dropWhole {
+			details, detailsChanged = dropChatReasoningDetails(assistant.ReasoningDetails)
+		}
 		if !detailsChanged {
 			continue
 		}
@@ -314,15 +321,77 @@ func stripChatReasoningDetails(details []schemas.ChatReasoningDetails) ([]schema
 	return kept, true
 }
 
+// dropChatReasoningDetails removes every reasoning detail carrying an unverifiable
+// payload, reporting whether any were removed. Unlike stripChatReasoningDetails the
+// text does not survive: on Anthropic it is the thinking prose the refused signature
+// signed, and replaying it without a valid signature is itself a 400.
+func dropChatReasoningDetails(details []schemas.ChatReasoningDetails) ([]schemas.ChatReasoningDetails, bool) {
+	kept := make([]schemas.ChatReasoningDetails, 0, len(details))
+	changed := false
+	for _, detail := range details {
+		if detail.Signature != nil || detail.Data != nil {
+			changed = true
+			continue
+		}
+		kept = append(kept, detail)
+	}
+	if !changed {
+		return nil, false
+	}
+	return kept, true
+}
+
 // contentBlockReasoningCarriers name the ResponsesMessageContentBlock fields that can
 // hold a payload the next upstream cannot verify. Both are cleared in one pass: the
 // strip gets a single retry, so healing one field per attempt would need two upstream
 // calls to reach a payload the upstream accepts.
 var contentBlockReasoningCarriers = []string{"signature", "encrypted_content"}
 
+// dropsWholeReasoningBlocks reports whether the upstream this request is bound for
+// requires a replayed thinking block to be deleted outright rather than emptied.
+//
+// Anthropic verifies a thinking block's signature on every assistant turn it receives,
+// not only the latest, and answers a blanked one with "messages.N.content.M: Invalid
+// `signature` in `thinking` block". Clearing the field therefore turns a request the
+// API accepts into one it refuses -- measured against the live API on
+// claude-sonnet-4-5, claude-haiku-4-5 and claude-opus-5: the same history replays 200
+// untouched, 400 with signatures blanked, and 200 again with the blocks removed whole.
+// Removal is accepted on every turn including the latest, with tool_use present and
+// thinking still enabled, so no turn has to be spared and thinking need not be
+// disabled for the retry.
+//
+// Gated on the family rather than the provider key, because the behaviour follows the
+// model: Claude is served from Anthropic, Bedrock and Vertex alike. OpenAI keeps the
+// blanking path -- a reasoning summary without encrypted_content is legal there, and
+// dropping the item would throw away narrative the model can still use.
+func dropsWholeReasoningBlocks(ctx *schemas.BifrostContext, model string) bool {
+	return schemas.IsAnthropicModelFamily(ctx, model)
+}
+
+// dropReasoningContentBlocks removes every reasoning content block that carries an
+// unverifiable payload, reporting whether any were removed.
+func dropReasoningContentBlocks(content *schemas.ResponsesMessageContent) ([]schemas.ResponsesMessageContentBlock, bool) {
+	if content == nil || len(content.ContentBlocks) == 0 {
+		return nil, false
+	}
+	kept := make([]schemas.ResponsesMessageContentBlock, 0, len(content.ContentBlocks))
+	changed := false
+	for _, block := range content.ContentBlocks {
+		if block.Signature != nil || block.EncryptedContent != nil {
+			changed = true
+			continue
+		}
+		kept = append(kept, block)
+	}
+	if !changed {
+		return nil, false
+	}
+	return kept, true
+}
+
 // stripRawAnthropicChatThinking rewrites a buffered Anthropic Messages body so no
-// unverifiable thinking payload survives outside the one turn Anthropic protects,
-// reporting whether anything changed. Each surviving block keeps its original bytes
+// unverifiable thinking payload survives on any assistant turn, reporting whether
+// anything changed. Each surviving block keeps its original bytes
 // (minus the edited field) so fields Bifrost's schema does not model are not lost on
 // the way through.
 //
@@ -351,34 +420,16 @@ func stripRawAnthropicChatThinking(rawBody *[]byte) bool {
 		return false
 	}
 
-	// Anthropic verifies that the thinking and redacted_thinking blocks in the latest
-	// assistant message arrive exactly as it minted them: "Within the latest assistant
-	// message, the sequence of consecutive thinking blocks must match what the model
-	// generated in the original request: you can't rearrange, edit, or partially drop
-	// them. This includes redacted_thinking blocks." Blanking a signature there is an
-	// edit and dropping a redacted_thinking block is a partial drop, so a rewritten
-	// protected turn earns a second, different 400 -- "`thinking` or `redacted_thinking`
-	// blocks in the latest assistant message cannot be modified" -- and the client ends
-	// up with a more confusing error than the signature refusal the retry was spent on.
-	// Earlier turns carry no such rule ("Allowed: outside tool use, omit prior turns'
-	// thinking"), so they are still rewritten and the fail-soft still heals them.
+	// A thinking block is deleted, never emptied. Anthropic verifies the signature on
+	// every turn it appears in and answers a blanked one with "messages.N.content.M:
+	// Invalid `signature` in `thinking` block", so the rewrite that used to run here --
+	// blank the signature, keep the prose -- turned a request the API accepts into one
+	// it refuses. Removing the blocks is accepted on every turn including the latest,
+	// with tool_use present and thinking still enabled; measured against the live API on
+	// claude-sonnet-4-5, claude-haiku-4-5 and claude-opus-5.
 	// https://platform.claude.com/docs/en/build-with-claude/thinking#preserving-thinking-blocks
-	//
-	// The protected turn is the last message whose role is assistant, not the last
-	// element: a tool-result round trip ends on a user message, which is exactly the
-	// shape Anthropic documents this refusal against.
-	lastAssistantIndex := -1
-	for messageIndex, message := range messages.Array() {
-		if message.Get("role").String() == "assistant" {
-			lastAssistantIndex = messageIndex
-		}
-	}
-
 	changed := false
 	for messageIndex, message := range messages.Array() {
-		if messageIndex == lastAssistantIndex {
-			continue
-		}
 		content := message.Get("content")
 		// The shorthand string form carries no blocks, so there is nothing to rewrite.
 		if !content.IsArray() {
@@ -397,13 +448,6 @@ func stripRawAnthropicChatThinking(rawBody *[]byte) bool {
 				if !block.Get("signature").Exists() {
 					break
 				}
-				updated, err := sjson.Set(block.Raw, "signature", "")
-				if err != nil {
-					// Leave the block untouched rather than corrupting it; the retry
-					// still helps if another turn carried the unverifiable payload.
-					break
-				}
-				kept = append(kept, updated)
 				messageChanged = true
 				continue
 			}
@@ -510,6 +554,20 @@ func stripResponsesEncryptedContent(ctx *schemas.BifrostContext, req *schemas.Bi
 	}
 
 	input := *inputRef
+
+	// Anthropic refuses a blanked signature on every turn it appears in, so there the
+	// only rewrite it accepts is deleting the block (see dropsWholeReasoningBlocks).
+	targetModel := ""
+	switch {
+	case req.ResponsesRequest != nil:
+		targetModel = req.ResponsesRequest.Model
+	case req.CountTokensRequest != nil:
+		targetModel = req.CountTokensRequest.Model
+	case req.CompactionRequest != nil:
+		targetModel = req.CompactionRequest.Model
+	}
+	dropWhole := dropsWholeReasoningBlocks(ctx, targetModel)
+
 	stripped := make([]schemas.ResponsesMessage, 0, len(input))
 	changed := false
 
@@ -519,13 +577,23 @@ func stripResponsesEncryptedContent(ctx *schemas.BifrostContext, req *schemas.Bi
 		if message.ResponsesReasoning != nil && message.ResponsesReasoning.EncryptedContent != nil {
 			reasoningCopy := *message.ResponsesReasoning
 			reasoningCopy.EncryptedContent = nil
+			if dropWhole {
+				// The summary is the visible half of the same block. Anthropic replays it
+				// as the thinking text the refused signature signed, so it cannot outlive
+				// the signature the way an OpenAI summary can.
+				reasoningCopy.Summary = nil
+			}
 			message.ResponsesReasoning = &reasoningCopy
 			messageChanged = true
 		}
 
 		// A thinking signature rides on the content block rather than the reasoning
 		// item, so a message can need the strip with encrypted_content already absent.
-		if blocks, ok := stripContentBlockReasoningPayloads(message.Content); ok {
+		blocks, ok := stripContentBlockReasoningPayloads(message.Content)
+		if dropWhole {
+			blocks, ok = dropReasoningContentBlocks(message.Content)
+		}
+		if ok {
 			contentCopy := *message.Content
 			contentCopy.ContentBlocks = blocks
 			message.Content = &contentCopy
@@ -544,11 +612,19 @@ func stripResponsesEncryptedContent(ctx *schemas.BifrostContext, req *schemas.Bi
 			message.ID = nil
 		}
 
-		// Only a reasoning item is dropped when nothing survives: an ordinary message
-		// that merely carried a signature still has its own content to say.
-		if message.ResponsesReasoning != nil &&
-			len(message.ResponsesReasoning.Summary) == 0 &&
-			(message.Content == nil || (len(message.Content.ContentBlocks) == 0 && message.Content.ContentStr == nil)) {
+		// An item the strip emptied is dropped rather than forwarded as a shell: providers
+		// reject an empty content array outright. Only items the strip actually touched
+		// reach here, so an untouched message keeps its own content either way.
+		//
+		// The test is what SURVIVES, not what the item is called. Gating on the reasoning
+		// shape missed both directions in turn: a reasoning-typed item whose payload rode
+		// on a content block (the Anthropic dialect, with ResponsesReasoning left nil) was
+		// forwarded empty, and so was a message-typed item whose content was nothing but
+		// signed reasoning blocks.
+		hasSummary := message.ResponsesReasoning != nil && len(message.ResponsesReasoning.Summary) > 0
+		hasContent := message.Content != nil &&
+			(len(message.Content.ContentBlocks) > 0 || message.Content.ContentStr != nil)
+		if !hasSummary && !hasContent {
 			continue
 		}
 		stripped = append(stripped, message)

--- a/core/encryptedreasoning_test.go
+++ b/core/encryptedreasoning_test.go
@@ -241,6 +241,36 @@ func TestExecuteRequestWithRetries_HealsOnEveryProviderRejection(t *testing.T) {
 			req.ResponsesRequest.Provider = rejection.provider
 			req.ResponsesRequest.Model = rejection.model
 
+			// On Anthropic the reasoning item is removed rather than emptied, so the
+			// replayed turn comes back one item shorter. The extra pair gives the
+			// Anthropic-family cases a second reasoning item to account for, which is
+			// what a replayed agent loop looks like.
+			wantItems := 2
+			if dropsWholeReasoningBlocks(nil, rejection.model) {
+				req.ResponsesRequest.Input = append(req.ResponsesRequest.Input,
+					schemas.ResponsesMessage{
+						Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+						Status: schemas.Ptr("completed"),
+						ResponsesToolMessage: &schemas.ResponsesToolMessage{
+							CallID: schemas.Ptr("toolu_1"),
+							Output: &schemas.ResponsesToolMessageOutputStruct{
+								ResponsesToolCallOutputStr: schemas.Ptr("done"),
+							},
+						},
+					},
+					schemas.ResponsesMessage{
+						ID:   schemas.Ptr("rs_latest"),
+						Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+						ResponsesReasoning: &schemas.ResponsesReasoning{
+							Summary:          []schemas.ResponsesReasoningSummary{},
+							EncryptedContent: schemas.Ptr("PROTECTED_PAYLOAD"),
+						},
+					},
+				)
+				// Both reasoning items go; the user turn and the tool result stay.
+				wantItems = 2
+			}
+
 			callCount := 0
 			var secondAttemptInput []schemas.ResponsesMessage
 			handler := func(_ schemas.Key) (string, *schemas.BifrostError) {
@@ -264,15 +294,22 @@ func TestExecuteRequestWithRetries_HealsOnEveryProviderRejection(t *testing.T) {
 			if callCount != 2 {
 				t.Fatalf("expected 2 attempts (original + stripped retry), got %d", callCount)
 			}
-			if len(secondAttemptInput) != 2 {
-				t.Fatalf("expected both input items to survive the strip, got %d", len(secondAttemptInput))
+			if len(secondAttemptInput) != wantItems {
+				t.Fatalf("expected %d items after the strip, got %d", wantItems, len(secondAttemptInput))
 			}
-			reasoning := secondAttemptInput[1].ResponsesReasoning
-			if reasoning == nil {
-				t.Fatal("expected the reasoning item to survive with its summary")
+			for i, item := range secondAttemptInput {
+				if item.ResponsesReasoning != nil && item.ResponsesReasoning.EncryptedContent != nil {
+					t.Errorf("item %d still carries encrypted_content %q", i, *item.ResponsesReasoning.EncryptedContent)
+				}
 			}
-			if reasoning.EncryptedContent != nil {
-				t.Errorf("expected encrypted_content to be stripped, got %q", *reasoning.EncryptedContent)
+			if dropsWholeReasoningBlocks(nil, rejection.model) {
+				for i, item := range secondAttemptInput {
+					if item.Type != nil && *item.Type == schemas.ResponsesMessageTypeReasoning {
+						t.Errorf("item %d: Anthropic must receive no replayed reasoning item at all", i)
+					}
+				}
+			} else if secondAttemptInput[1].ResponsesReasoning == nil {
+				t.Error("expected the OpenAI reasoning item to survive with its summary")
 			}
 		})
 	}
@@ -1277,6 +1314,27 @@ func newThinkingSignatureChatRequest(signature string) *schemas.BifrostRequest {
 						},
 					},
 				},
+				// A second assistant turn, so the fixture covers a multi-turn replay: the
+				// strip has to reach Input[1] and Input[3] alike, since Anthropic refuses a
+				// signature-less thinking block on any turn it appears in.
+				{
+					Role:    schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("now lint it")},
+				},
+				{
+					Role:    schemas.ChatMessageRoleAssistant,
+					Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Linting.")},
+					ChatAssistantMessage: &schemas.ChatAssistantMessage{
+						ReasoningDetails: []schemas.ChatReasoningDetails{
+							{
+								Index:     0,
+								Type:      schemas.BifrostReasoningDetailsTypeText,
+								Text:      schemas.Ptr("planning the lint"),
+								Signature: schemas.Ptr(signature + "-latest"),
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -1311,59 +1369,52 @@ func TestIsEncryptedReasoningRejection_ThinkingSignature(t *testing.T) {
 	}
 }
 
-// TestStripUnverifiableReasoning_ChatShape covers the gap that let this error reach
-// clients: the strip only ever handled Responses-shaped requests, so a chat-shaped
-// one returned false and the retry never happened.
+// TestStripUnverifiableReasoning_ChatShape covers the chat-shaped request a complexity
+// or virtual-model router produces: it picks a model per turn, so turn N+1 replays a
+// thinking block minted by whichever model answered turn N.
+//
+// On Anthropic the detail is removed, not emptied. Blanking the signature and keeping
+// the prose is refused with "messages.N.content.M: Invalid `signature` in `thinking`
+// block" -- on any turn, not just the latest -- so the rewrite that kept the text spent
+// the one retry turning an accepted request into a refused one.
 func TestStripUnverifiableReasoning_ChatShape(t *testing.T) {
-	t.Run("clears a thinking signature and keeps the reasoning text", func(t *testing.T) {
+	details := func(req *schemas.BifrostRequest, i int) []schemas.ChatReasoningDetails {
+		return req.ChatRequest.Input[i].ChatAssistantMessage.ReasoningDetails
+	}
+
+	t.Run("drops the reasoning detail whole on every assistant turn", func(t *testing.T) {
 		req := newThinkingSignatureChatRequest("ErUBCkYIBRgCKkD...")
 
 		if !stripUnverifiableReasoning(nil, req) {
 			t.Fatal("expected the strip to report a change on a chat-shaped request")
 		}
-		details := req.ChatRequest.Input[1].ChatAssistantMessage.ReasoningDetails
-		if len(details) != 1 {
-			t.Fatalf("expected the reasoning detail to survive, got %d", len(details))
-		}
-		if details[0].Signature != nil {
-			t.Errorf("expected the signature to be cleared, got %q", *details[0].Signature)
-		}
-		if details[0].Text == nil || *details[0].Text != "planning the run" {
-			t.Errorf("expected the reasoning text to survive, got %+v", details[0].Text)
+		for _, i := range []int{1, 3} {
+			if got := len(details(req, i)); got != 0 {
+				t.Errorf("message %d: expected the reasoning detail to be dropped, got %d", i, got)
+			}
 		}
 	})
 
-	t.Run("clears encrypted reasoning data", func(t *testing.T) {
+	t.Run("drops encrypted reasoning data too", func(t *testing.T) {
 		req := newThinkingSignatureChatRequest("sig")
-		details := req.ChatRequest.Input[1].ChatAssistantMessage.ReasoningDetails
-		details[0].Type = schemas.BifrostReasoningDetailsTypeEncrypted
-		details[0].Signature = nil
-		details[0].Data = schemas.Ptr("ciphertext")
+		d := details(req, 1)
+		d[0].Type = schemas.BifrostReasoningDetailsTypeEncrypted
+		d[0].Signature = nil
+		d[0].Data = schemas.Ptr("ciphertext")
 
 		if !stripUnverifiableReasoning(nil, req) {
 			t.Fatal("expected the strip to report a change")
 		}
-		if got := req.ChatRequest.Input[1].ChatAssistantMessage.ReasoningDetails[0].Data; got != nil {
-			t.Errorf("expected encrypted data to be cleared, got %q", *got)
-		}
-	})
-
-	t.Run("drops a reasoning detail left with nothing to say", func(t *testing.T) {
-		req := newThinkingSignatureChatRequest("sig")
-		req.ChatRequest.Input[1].ChatAssistantMessage.ReasoningDetails[0].Text = nil
-
-		if !stripUnverifiableReasoning(nil, req) {
-			t.Fatal("expected the strip to report a change")
-		}
-		if got := len(req.ChatRequest.Input[1].ChatAssistantMessage.ReasoningDetails); got != 0 {
-			t.Errorf("expected the empty reasoning detail to be dropped, got %d", got)
+		if got := len(details(req, 1)); got != 0 {
+			t.Errorf("expected the encrypted detail to be dropped, got %d", got)
 		}
 	})
 
 	// Claiming a change with nothing to strip buys a second identical upstream call.
 	t.Run("reports no change when nothing is unverifiable", func(t *testing.T) {
 		req := newThinkingSignatureChatRequest("sig")
-		req.ChatRequest.Input[1].ChatAssistantMessage.ReasoningDetails[0].Signature = nil
+		details(req, 1)[0].Signature = nil
+		details(req, 3)[0].Signature = nil
 
 		if stripUnverifiableReasoning(nil, req) {
 			t.Error("expected no change when no signature or encrypted data is present")
@@ -1374,13 +1425,35 @@ func TestStripUnverifiableReasoning_ChatShape(t *testing.T) {
 	// so the rewrite must not mutate them in place.
 	t.Run("does not mutate the caller's reasoning details", func(t *testing.T) {
 		req := newThinkingSignatureChatRequest("keep-me")
-		original := req.ChatRequest.Input[1].ChatAssistantMessage.ReasoningDetails
+		original := details(req, 1)
 
 		if !stripUnverifiableReasoning(nil, req) {
 			t.Fatal("expected the strip to report a change")
 		}
-		if original[0].Signature == nil || *original[0].Signature != "keep-me" {
+		if len(original) != 1 || original[0].Signature == nil || *original[0].Signature != "keep-me" {
 			t.Error("expected the caller's original reasoning detail to be untouched")
+		}
+	})
+
+	// Removal is Anthropic's requirement. OpenAI accepts reasoning text with no
+	// signature, and the narrative is worth keeping, so that path still blanks.
+	t.Run("openai-family keeps the reasoning text", func(t *testing.T) {
+		req := newThinkingSignatureChatRequest("sig")
+		req.ChatRequest.Provider = schemas.OpenAI
+		req.ChatRequest.Model = "gpt-5.6-sol"
+
+		if !stripUnverifiableReasoning(nil, req) {
+			t.Fatal("expected the strip to report a change")
+		}
+		d := details(req, 1)
+		if len(d) != 1 {
+			t.Fatalf("expected the detail to survive for OpenAI, got %d", len(d))
+		}
+		if d[0].Signature != nil {
+			t.Errorf("expected the signature to be cleared, got %q", *d[0].Signature)
+		}
+		if d[0].Text == nil || *d[0].Text != "planning the run" {
+			t.Errorf("expected the reasoning text to survive, got %+v", d[0].Text)
 		}
 	})
 }
@@ -1577,7 +1650,7 @@ func TestStripChatUnverifiableReasoning_AnthropicRawBody(t *testing.T) {
 		return ctx
 	}
 
-	t.Run("blanks a thinking signature and keeps the reasoning text", func(t *testing.T) {
+	t.Run("removes the thinking block and leaves the rest of the body alone", func(t *testing.T) {
 		req := newThinkingSignatureChatRequest("ErUBCkYIBRgCKkD...")
 		req.ChatRequest.RawRequestBody = []byte(`{"model":"claude-sonnet-5","messages":[` +
 			`{"role":"user","content":"run the tests"},` +
@@ -1585,9 +1658,6 @@ func TestStripChatUnverifiableReasoning_AnthropicRawBody(t *testing.T) {
 			`{"type":"thinking","thinking":"planning the run","signature":"ErUBCkYIBRgCKkD...","unmodeled_field":7},` +
 			`{"type":"text","text":"On it."}` +
 			`]},` +
-			// The later assistant turn matters: Anthropic protects the last message with
-			// role assistant from any edit, so without a turn after it the payload under
-			// test would sit on the protected turn and the rewrite would decline.
 			`{"role":"user","content":"now ship it"},` +
 			`{"role":"assistant","content":[{"type":"text","text":"Shipped."}]},` +
 			`{"role":"user","content":"thanks"}` +
@@ -1598,17 +1668,16 @@ func TestStripChatUnverifiableReasoning_AnthropicRawBody(t *testing.T) {
 		}
 
 		body := string(req.ChatRequest.RawRequestBody)
-		if strings.Contains(body, "ErUBCkYIBRgCKkD") {
-			t.Errorf("expected the foreign signature to be gone, got %s", body)
+		// The whole block goes: signature, prose and the fields Bifrost does not model.
+		// Anthropic refuses a thinking block whose signature it cannot verify, so there
+		// is nothing in it left to keep.
+		for _, gone := range []string{"ErUBCkYIBRgCKkD", `"planning the run"`, `"unmodeled_field":7`} {
+			if strings.Contains(body, gone) {
+				t.Errorf("expected %s to be gone with the block, got %s", gone, body)
+			}
 		}
-		if !strings.Contains(body, `"signature":""`) {
-			t.Errorf("expected an empty signature rather than an omitted field, got %s", body)
-		}
-		if !strings.Contains(body, `"planning the run"`) || !strings.Contains(body, `"On it."`) {
-			t.Errorf("expected the reasoning text and the reply to survive, got %s", body)
-		}
-		if !strings.Contains(body, `"unmodeled_field":7`) {
-			t.Errorf("expected fields Bifrost does not model to survive, got %s", body)
+		if !strings.Contains(body, `"On it."`) {
+			t.Errorf("expected the turn's own reply to survive, got %s", body)
 		}
 		if !strings.Contains(body, `"max_tokens":1024`) || !strings.Contains(body, `"run the tests"`) {
 			t.Errorf("expected the rest of the body to be untouched, got %s", body)
@@ -1623,7 +1692,8 @@ func TestStripChatUnverifiableReasoning_AnthropicRawBody(t *testing.T) {
 			`{"type":"redacted_thinking","data":"EroBCkYIBRgCKkDdeadbeef"},` +
 			`{"type":"text","text":"On it."}` +
 			`]},` +
-			// Earlier turn, not the protected latest assistant message -- see above.
+			// A later turn follows, so the fixture covers a payload that is not in the
+			// last assistant message either.
 			`{"role":"user","content":"now ship it"},` +
 			`{"role":"assistant","content":[{"type":"text","text":"Shipped."}]},` +
 			`{"role":"user","content":"thanks"}` +
@@ -1712,61 +1782,62 @@ func TestStripChatUnverifiableReasoning_AnthropicRawBody(t *testing.T) {
 		}
 	})
 
-	// Anthropic verifies that thinking and redacted_thinking blocks in the latest
-	// assistant message arrive exactly as it minted them: "Within the latest assistant
-	// message, the sequence of consecutive thinking blocks must match what the model
-	// generated in the original request: you can't rearrange, edit, or partially drop
-	// them." Editing there swaps the signature refusal for a second 400 -- "`thinking`
-	// or `redacted_thinking` blocks in the latest assistant message cannot be modified"
-	// -- after a wasted upstream call, so the retry has to leave that turn alone.
+	// A thinking block is deleted, never emptied. Anthropic verifies the signature on
+	// every turn it appears in and refuses a blanked one with "messages.N.content.M:
+	// Invalid `signature` in `thinking` block", so the rewrite that kept the prose spent
+	// the retry turning an accepted request into a refused one. Removal is accepted on
+	// every turn, the latest included.
 	// https://platform.claude.com/docs/en/build-with-claude/thinking#preserving-thinking-blocks
 
-	t.Run("leaves the latest assistant message untouched", func(t *testing.T) {
+	t.Run("removes the block rather than blanking its signature", func(t *testing.T) {
 		req := newThinkingSignatureChatRequest("ErUBCkYIBRgCKkD...")
-		raw := `{"model":"claude-sonnet-5","messages":[` +
+		req.ChatRequest.RawRequestBody = []byte(`{"model":"claude-sonnet-5","messages":[` +
 			`{"role":"user","content":"run the tests"},` +
 			`{"role":"assistant","content":[` +
 			`{"type":"thinking","thinking":"planning the run","signature":"ErUBCkYIBRgCKkD..."},` +
 			`{"type":"text","text":"On it."}` +
 			`]}` +
-			`],"max_tokens":1024}`
-		req.ChatRequest.RawRequestBody = []byte(raw)
+			`],"max_tokens":1024}`)
 
-		if stripUnverifiableReasoning(anthropicCtx(), req) {
-			t.Error("expected no change to be claimed when only the protected turn carries a payload")
+		if !stripUnverifiableReasoning(anthropicCtx(), req) {
+			t.Fatal("expected the latest assistant turn to be rewritten too")
 		}
-		if string(req.ChatRequest.RawRequestBody) != raw {
-			t.Errorf("expected the latest assistant message to survive verbatim, got %s", req.ChatRequest.RawRequestBody)
+		body := string(req.ChatRequest.RawRequestBody)
+		if strings.Contains(body, `"signature"`) || strings.Contains(body, `"type":"thinking"`) {
+			t.Errorf("expected the thinking block to be gone entirely, got %s", body)
+		}
+		if !strings.Contains(body, `"On it."`) {
+			t.Errorf("expected the turn's own text to survive, got %s", body)
 		}
 	})
 
-	t.Run("skips the latest assistant turn even when it is not the last message", func(t *testing.T) {
-		// A tool-result round trip ends on a user message, so the protected turn sits at
-		// index 1 rather than at the end. Treating the last element as the protected one
-		// would rewrite it anyway and earn the "cannot be modified" refusal.
+	t.Run("removes redacted_thinking beside a tool call", func(t *testing.T) {
+		// A tool-result round trip ends on a user message, so the assistant turn carrying
+		// the payload sits at index 1 rather than at the end.
 		req := newThinkingSignatureChatRequest("sig")
-		raw := `{"model":"claude-sonnet-5","messages":[` +
+		req.ChatRequest.RawRequestBody = []byte(`{"model":"claude-sonnet-5","messages":[` +
 			`{"role":"user","content":"what is the weather in Paris?"},` +
 			`{"role":"assistant","content":[` +
 			`{"type":"redacted_thinking","data":"EroBCkYIBRgCKkDdeadbeef"},` +
 			`{"type":"tool_use","id":"toolu_01","name":"get_weather","input":{"city":"Paris"}}` +
 			`]},` +
 			`{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01","content":"20C, sunny"}]}` +
-			`],"max_tokens":1024}`
-		req.ChatRequest.RawRequestBody = []byte(raw)
+			`],"max_tokens":1024}`)
 
-		if stripUnverifiableReasoning(anthropicCtx(), req) {
-			t.Error("expected the protected turn to be located by role, not by array position")
+		if !stripUnverifiableReasoning(anthropicCtx(), req) {
+			t.Fatal("expected the redacted block to be removed")
 		}
-		if string(req.ChatRequest.RawRequestBody) != raw {
-			t.Errorf("expected the tool-use turn to survive verbatim, got %s", req.ChatRequest.RawRequestBody)
+		body := string(req.ChatRequest.RawRequestBody)
+		if strings.Contains(body, "deadbeef") {
+			t.Errorf("expected the redacted payload to be gone, got %s", body)
+		}
+		// The tool call has to survive or the tool_result behind it is orphaned.
+		if !strings.Contains(body, `"toolu_01"`) {
+			t.Errorf("expected the tool_use block to survive, got %s", body)
 		}
 	})
 
-	t.Run("still rewrites earlier assistant turns", func(t *testing.T) {
-		// Only the latest assistant message is protected -- "Allowed: outside tool use,
-		// omit prior turns' thinking" -- so an earlier turn is still healed, which is the
-		// case the retry exists to fix.
+	t.Run("rewrites every assistant turn, not just one", func(t *testing.T) {
 		req := newThinkingSignatureChatRequest("ErUBCkYIBRgCKkD...")
 		req.ChatRequest.RawRequestBody = []byte(`{"model":"claude-sonnet-5","messages":[` +
 			`{"role":"user","content":"run the tests"},` +
@@ -1776,26 +1847,25 @@ func TestStripChatUnverifiableReasoning_AnthropicRawBody(t *testing.T) {
 			`{"type":"text","text":"On it."}` +
 			`]},` +
 			`{"role":"user","content":"now ship it"},` +
-			`{"role":"assistant","content":[{"type":"text","text":"Shipped."}]},` +
+			`{"role":"assistant","content":[` +
+			`{"type":"thinking","thinking":"planning the ship","signature":"EskCCpsBCBEYlater"},` +
+			`{"type":"text","text":"Shipped."}` +
+			`]},` +
 			`{"role":"user","content":"thanks"}` +
 			`],"max_tokens":1024}`)
 
 		if !stripUnverifiableReasoning(anthropicCtx(), req) {
-			t.Fatal("expected the earlier assistant turn to be rewritten")
+			t.Fatal("expected the assistant turns to be rewritten")
 		}
 
 		body := string(req.ChatRequest.RawRequestBody)
-		if strings.Contains(body, "ErUBCkYIBRgCKkD") || strings.Contains(body, "deadbeef") {
-			t.Errorf("expected the earlier turn's unverifiable payloads to be gone, got %s", body)
+		for _, payload := range []string{"ErUBCkYIBRgCKkD", "deadbeef", "EskCCpsBCBEYlater"} {
+			if strings.Contains(body, payload) {
+				t.Errorf("expected %q to be gone, got %s", payload, body)
+			}
 		}
-		if !strings.Contains(body, `"signature":""`) {
-			t.Errorf("expected an empty signature rather than an omitted field, got %s", body)
-		}
-		if !strings.Contains(body, `"planning the run"`) || !strings.Contains(body, `"On it."`) {
-			t.Errorf("expected the earlier turn's own text to survive, got %s", body)
-		}
-		if !strings.Contains(body, `{"type":"text","text":"Shipped."}`) {
-			t.Errorf("expected the latest assistant message to survive verbatim, got %s", body)
+		if !strings.Contains(body, `"On it."`) || !strings.Contains(body, `"Shipped."`) {
+			t.Errorf("expected both turns' own text to survive, got %s", body)
 		}
 	})
 }
@@ -1815,10 +1885,12 @@ func TestExecuteRequestWithRetries_HealsThinkingSignatureOnRawAnthropicChat(t *t
 	req.ChatRequest.RawRequestBody = []byte(`{"model":"claude-sonnet-5","messages":[` +
 		`{"role":"user","content":"run the tests"},` +
 		`{"role":"assistant","content":[` +
-		`{"type":"thinking","thinking":"planning the run","signature":"ErUBCkYIBRgCKkD..."}` +
+		`{"type":"thinking","thinking":"planning the run","signature":"ErUBCkYIBRgCKkD..."},` +
+		// A turn always says something of its own beside the thinking. Removing the only
+		// block would leave an empty content array, which Anthropic rejects, so the
+		// rewrite declines on a thinking-only turn rather than corrupt the request.
+		`{"type":"text","text":"On it."}` +
 		`]},` +
-		// Earlier turn: Anthropic protects the last message with role assistant from
-		// edits, so the payload has to sit behind a later assistant turn to reach a retry.
 		`{"role":"user","content":"now ship it"},` +
 		`{"role":"assistant","content":[{"type":"text","text":"Shipped."}]},` +
 		`{"role":"user","content":"thanks"}` +
@@ -1847,11 +1919,11 @@ func TestExecuteRequestWithRetries_HealsThinkingSignatureOnRawAnthropicChat(t *t
 	if callCount != 2 {
 		t.Fatalf("expected 2 attempts (original + stripped retry), got %d", callCount)
 	}
-	if strings.Contains(secondAttemptBody, "ErUBCkYIBRgCKkD") {
-		t.Errorf("the retry still carried the foreign signature: %s", secondAttemptBody)
+	if strings.Contains(secondAttemptBody, "ErUBCkYIBRgCKkD") || strings.Contains(secondAttemptBody, `"planning the run"`) {
+		t.Errorf("the retry still carried the refused thinking block: %s", secondAttemptBody)
 	}
-	if !strings.Contains(secondAttemptBody, `"planning the run"`) {
-		t.Errorf("expected the reasoning text to survive into the retry, got %s", secondAttemptBody)
+	if !strings.Contains(secondAttemptBody, `"On it."`) {
+		t.Errorf("expected the turn's own reply to survive into the retry, got %s", secondAttemptBody)
 	}
 }
 
@@ -1889,14 +1961,268 @@ func TestExecuteRequestWithRetries_HealsThinkingSignatureOnChatShape(t *testing.
 	if callCount != 2 {
 		t.Fatalf("expected 2 attempts (original + stripped retry), got %d", callCount)
 	}
-	if len(secondAttemptInput) != 2 {
-		t.Fatalf("expected both messages to survive, got %d", len(secondAttemptInput))
+	if len(secondAttemptInput) != 4 {
+		t.Fatalf("expected every message to survive, got %d", len(secondAttemptInput))
 	}
-	details := secondAttemptInput[1].ChatAssistantMessage.ReasoningDetails
-	if len(details) != 1 {
-		t.Fatalf("expected the reasoning detail to survive, got %d", len(details))
+	// Every assistant turn is rewritten, the latest included: Anthropic refuses a
+	// signature-less thinking block wherever it sits, so the only rewrite that reaches
+	// a 200 is removing them all. The messages themselves keep their own content.
+	for _, i := range []int{1, 3} {
+		if got := len(secondAttemptInput[i].ChatAssistantMessage.ReasoningDetails); got != 0 {
+			t.Errorf("message %d: expected the reasoning detail to be gone from the retry, got %d", i, got)
+		}
+		if secondAttemptInput[i].Content == nil || secondAttemptInput[i].Content.ContentStr == nil {
+			t.Errorf("message %d: expected the assistant's own reply to survive", i)
+		}
 	}
-	if details[0].Signature != nil {
-		t.Errorf("expected the signature to be gone from the retry, got %q", *details[0].Signature)
+}
+
+// newAnthropicThinkingResponsesRequest is the shape an Anthropic-dialect client replays
+// through the Responses path: /anthropic/v1/messages with a Bedrock-served Claude model
+// takes no passthrough (isClaudeModel excludes Bedrock), so the turn arrives as
+// Responses items and leaves through the Bedrock Converse converter.
+//
+// Two assistant turns, each a reasoning item plus a tool call, separated by the tool
+// result that ends the first. Items 1-2 are the earlier turn and items 4-5 the latest;
+// both reasoning items have to go, which is what the tests assert.
+func newAnthropicThinkingResponsesRequest() *schemas.BifrostRequest {
+	reasoning := func(id, text, signature string) schemas.ResponsesMessage {
+		return schemas.ResponsesMessage{
+			ID:   schemas.Ptr(id),
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+			Content: &schemas.ResponsesMessageContent{
+				ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+					Type:      schemas.ResponsesOutputMessageContentTypeReasoning,
+					Text:      schemas.Ptr(text),
+					Signature: schemas.Ptr(signature),
+				}},
+			},
+		}
+	}
+	toolCall := func(callID string) schemas.ResponsesMessage {
+		return schemas.ResponsesMessage{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeFunctionCall),
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{
+				CallID:    schemas.Ptr(callID),
+				Name:      schemas.Ptr("bash"),
+				Arguments: schemas.Ptr(`{}`),
+			},
+		}
+	}
+
+	return &schemas.BifrostRequest{
+		RequestType: schemas.ResponsesRequest,
+		ResponsesRequest: &schemas.BifrostResponsesRequest{
+			Provider: schemas.Bedrock,
+			Model:    "global.anthropic.claude-opus-5",
+			Input: []schemas.ResponsesMessage{
+				{
+					Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("refactor this")},
+				},
+				reasoning("rs_earlier", "planning the refactor", "SIG_EARLIER"),
+				toolCall("toolu_earlier"),
+				{
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+					Status: schemas.Ptr("completed"),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID: schemas.Ptr("toolu_earlier"),
+						Output: &schemas.ResponsesToolMessageOutputStruct{
+							ResponsesToolCallOutputStr: schemas.Ptr("done"),
+						},
+					},
+				},
+				reasoning("rs_latest", "planning the edit", "SIG_LATEST"),
+				toolCall("toolu_latest"),
+				{
+					Type:   schemas.Ptr(schemas.ResponsesMessageTypeFunctionCallOutput),
+					Status: schemas.Ptr("completed"),
+					ResponsesToolMessage: &schemas.ResponsesToolMessage{
+						CallID: schemas.Ptr("toolu_latest"),
+						Output: &schemas.ResponsesToolMessageOutputStruct{
+							ResponsesToolCallOutputStr: schemas.Ptr("done"),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestStripResponsesEncryptedContent_AnthropicDropsWholeReasoningBlocks is the
+// regression test for the reported defect.
+//
+// The strip used to blank the signature and keep the thinking prose. Measured against
+// the live Anthropic API, that is the one rewrite the upstream refuses: the same
+// two-turn tool loop replays 200 untouched, 400 with signatures blanked
+// ("messages.1.content.0: Invalid `signature` in `thinking` block") on the earlier turn
+// as readily as the latest, and 200 again once the blocks are removed whole. So the
+// fail-soft was spending its one retry to turn a request the API accepts into one it
+// refuses.
+func TestStripResponsesEncryptedContent_AnthropicDropsWholeReasoningBlocks(t *testing.T) {
+	req := newAnthropicThinkingResponsesRequest()
+
+	if !stripResponsesEncryptedContent(nil, req) {
+		t.Fatal("expected the replayed reasoning to be strippable")
+	}
+
+	for i, item := range req.ResponsesRequest.Input {
+		if item.Type != nil && *item.Type == schemas.ResponsesMessageTypeReasoning {
+			t.Errorf("item %d: reasoning item survived; Anthropic refuses a signature-less thinking block", i)
+		}
+		if item.Content == nil {
+			continue
+		}
+		for j, block := range item.Content.ContentBlocks {
+			if block.Signature != nil {
+				t.Errorf("item %d block %d: signature survived as %q", i, j, *block.Signature)
+			}
+		}
+	}
+
+	// Everything that is not reasoning still has to reach the retry: the turns either
+	// side of a deleted thinking block are what keeps the conversation coherent.
+	if got := len(req.ResponsesRequest.Input); got != 5 {
+		t.Errorf("expected the 2 user turns, 2 tool calls and 1 tool result to survive, got %d items", got)
+	}
+}
+
+// A redacted_thinking block replays as a reasoning item carrying only
+// encrypted_content. It goes the same way as a signed thinking block: there is no
+// verifiable half left to keep.
+func TestStripResponsesEncryptedContent_AnthropicDropsRedactedThinking(t *testing.T) {
+	req := newAnthropicThinkingResponsesRequest()
+	req.ResponsesRequest.Input[4] = schemas.ResponsesMessage{
+		ID:   schemas.Ptr("rs_latest"),
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+		ResponsesReasoning: &schemas.ResponsesReasoning{
+			Summary:          []schemas.ResponsesReasoningSummary{},
+			EncryptedContent: schemas.Ptr("REDACTED_BLOB"),
+		},
+	}
+
+	if !stripResponsesEncryptedContent(nil, req) {
+		t.Fatal("expected the redacted item to be strippable")
+	}
+	for i, item := range req.ResponsesRequest.Input {
+		if item.ResponsesReasoning != nil && item.ResponsesReasoning.EncryptedContent != nil {
+			t.Errorf("item %d still carries the redacted payload", i)
+		}
+	}
+}
+
+// The summary is the visible half of the same block -- on Anthropic it replays as the
+// thinking text the refused signature signed, so it cannot outlive the signature the
+// way an OpenAI summary can.
+func TestStripResponsesEncryptedContent_AnthropicDropsSummaryWithSignature(t *testing.T) {
+	req := newAnthropicThinkingResponsesRequest()
+	req.ResponsesRequest.Input[1] = schemas.ResponsesMessage{
+		ID:   schemas.Ptr("rs_earlier"),
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeReasoning),
+		ResponsesReasoning: &schemas.ResponsesReasoning{
+			Summary: []schemas.ResponsesReasoningSummary{
+				{Type: schemas.ResponsesReasoningContentBlockTypeSummaryText, Text: "planning"},
+			},
+			EncryptedContent: schemas.Ptr("SIG_EARLIER"),
+		},
+	}
+
+	if !stripResponsesEncryptedContent(nil, req) {
+		t.Fatal("expected the reasoning item to be strippable")
+	}
+	for i, item := range req.ResponsesRequest.Input {
+		if item.ResponsesReasoning != nil && len(item.ResponsesReasoning.Summary) > 0 {
+			t.Errorf("item %d kept a summary whose signature was refused", i)
+		}
+	}
+}
+
+// The removal is Anthropic's requirement, not a universal one. OpenAI accepts a
+// reasoning summary with no encrypted_content, and the narrative is worth keeping, so
+// that path still blanks the field instead of deleting the item.
+func TestStripResponsesEncryptedContent_OpenAIStillKeepsTheSummary(t *testing.T) {
+	req := newEncryptedReasoningRequest("ciphertext")
+
+	if !stripResponsesEncryptedContent(nil, req) {
+		t.Fatal("expected an OpenAI request's reasoning item to be stripped")
+	}
+	if got := len(req.ResponsesRequest.Input); got != 2 {
+		t.Fatalf("expected the OpenAI reasoning item to survive, got %d items", got)
+	}
+	reasoning := req.ResponsesRequest.Input[1].ResponsesReasoning
+	if reasoning == nil || len(reasoning.Summary) != 1 {
+		t.Fatalf("expected the summary to survive for OpenAI, got %+v", reasoning)
+	}
+	if reasoning.EncryptedContent != nil {
+		t.Errorf("expected encrypted_content to be cleared, got %q", *reasoning.EncryptedContent)
+	}
+}
+
+// A message-typed item whose content was nothing but signed reasoning blocks is left
+// with an empty content array once they are removed. Providers reject that outright, so
+// the item has to go the same way an emptied reasoning item does -- the drop guard tests
+// what survives, not what the item is called.
+func TestStripResponsesEncryptedContent_DropsMessageItemEmptiedByRemoval(t *testing.T) {
+	req := newAnthropicThinkingResponsesRequest()
+	req.ResponsesRequest.Input[1] = schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{{
+				Type:      schemas.ResponsesOutputMessageContentTypeReasoning,
+				Text:      schemas.Ptr("planning the refactor"),
+				Signature: schemas.Ptr("SIG_EARLIER"),
+			}},
+		},
+	}
+
+	if !stripResponsesEncryptedContent(nil, req) {
+		t.Fatal("expected the reasoning block to be strippable")
+	}
+	for i, item := range req.ResponsesRequest.Input {
+		if item.Content != nil && len(item.Content.ContentBlocks) == 0 && item.Content.ContentStr == nil {
+			t.Errorf("item %d was forwarded with an empty content array", i)
+		}
+	}
+}
+
+// The same guard must not throw away a message that merely carried a signature beside
+// content of its own -- that content is the client's, and it still has something to say.
+func TestStripResponsesEncryptedContent_KeepsMessageItemWithSurvivingContent(t *testing.T) {
+	req := newAnthropicThinkingResponsesRequest()
+	req.ResponsesRequest.Input[1] = schemas.ResponsesMessage{
+		Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+		Role: schemas.Ptr(schemas.ResponsesInputMessageRoleAssistant),
+		Content: &schemas.ResponsesMessageContent{
+			ContentBlocks: []schemas.ResponsesMessageContentBlock{
+				{
+					Type:      schemas.ResponsesOutputMessageContentTypeReasoning,
+					Text:      schemas.Ptr("planning the refactor"),
+					Signature: schemas.Ptr("SIG_EARLIER"),
+				},
+				{Type: schemas.ResponsesOutputMessageContentTypeText, Text: schemas.Ptr("On it.")},
+			},
+		},
+	}
+
+	if !stripResponsesEncryptedContent(nil, req) {
+		t.Fatal("expected the reasoning block to be strippable")
+	}
+	var kept *schemas.ResponsesMessage
+	for i := range req.ResponsesRequest.Input {
+		item := req.ResponsesRequest.Input[i]
+		if item.Type != nil && *item.Type == schemas.ResponsesMessageTypeMessage &&
+			item.Role != nil && *item.Role == schemas.ResponsesInputMessageRoleAssistant {
+			kept = &item
+			break
+		}
+	}
+	if kept == nil {
+		t.Fatal("the assistant message was dropped even though its own text survived")
+	}
+	if len(kept.Content.ContentBlocks) != 1 || kept.Content.ContentBlocks[0].Text == nil ||
+		*kept.Content.ContentBlocks[0].Text != "On it." {
+		t.Errorf("expected only the text block to survive, got %+v", kept.Content.ContentBlocks)
 	}
 }

--- a/core/providers/bedrock/anthropicingressreplay_test.go
+++ b/core/providers/bedrock/anthropicingressreplay_test.go
@@ -347,3 +347,131 @@ func TestAnthropicIngressBedrockToolErrorKeepsErrorStatus(t *testing.T) {
 	require.NotNil(t, result.Status, "Converse requires a readable status for a failed tool call")
 	require.Equal(t, "error", *result.Status, "is_error must not be reported to the model as a success")
 }
+
+// TestAnthropicIngressBedrockReplayKeepsReasoningInItsOwnTurn pins the invariant PR
+// #6854 restores: every assistant turn reaches Converse carrying exactly the reasoning
+// blocks the client sent for THAT turn, and no others.
+//
+// Measured against Bedrock Converse with real signed blocks, the refusal
+//
+//	messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
+//	assistant message cannot be modified.
+//
+// fires on exactly one mutation: an EXTRA reasoning block in an assistant turn that is
+// a tool continuation. Removing a block, reordering blocks and fusing turns are all
+// accepted, so a block that migrates from turn N into turn N+1 is the shape that breaks
+// a replay -- turn N+1 ends up with two where the model produced one.
+//
+// Two directions are covered, because fixing one broke the other once already:
+//
+//   - "thinking last" is the shape that migrated. pendingReasoningContentBlocks was
+//     consumed by an assistant message or a tool-call flush and by nothing else, so
+//     reasoning still buffered when a user turn arrived was carried into the next
+//     assistant message.
+//   - "thinking first" is the shape the first attempt at that fix deleted outright. It
+//     settled the buffer before the tool-call flush could claim it, and the message
+//     behind it is the user turn that opened the loop, so the block was dropped from
+//     every ordinary agent turn. Bedrock accepts a missing block with a 200, which is
+//     why this direction needs a converter-level test: it is invisible from the wire.
+func TestAnthropicIngressBedrockReplayKeepsReasoningInItsOwnTurn(t *testing.T) {
+	thinking := func(step int) map[string]any {
+		return map[string]any{
+			"type":      "thinking",
+			"thinking":  fmt.Sprintf("deliberating on step %d", step),
+			"signature": fmt.Sprintf("ErUBCkYIBxgCKkA_signature_%d", step),
+		}
+	}
+	text := func(step int) map[string]any {
+		return map[string]any{"type": "text", "text": fmt.Sprintf("working on step %d", step)}
+	}
+	toolUse := func(step int) map[string]any {
+		return map[string]any{
+			"type": "tool_use", "id": fmt.Sprintf("toolu_01Step%02d", step),
+			"name": "get_weather", "input": map[string]any{"city": "tokyo"},
+		}
+	}
+
+	shapes := []struct {
+		name   string
+		blocks func(step int) []map[string]any
+	}{
+		// The order Anthropic emits by default.
+		{"thinking first", func(s int) []map[string]any {
+			return []map[string]any{thinking(s), text(s), toolUse(s)}
+		}},
+		// Adaptive thinking, a max_tokens truncation, or a trailing block the ingress
+		// dropped all leave the thinking block last.
+		{"thinking last", func(s int) []map[string]any {
+			return []map[string]any{text(s), toolUse(s), thinking(s)}
+		}},
+		// Interleaved: the model thought again after its first call.
+		{"interleaved", func(s int) []map[string]any {
+			return []map[string]any{thinking(s), toolUse(s), text(s)}
+		}},
+	}
+
+	const rounds = 3
+	for _, shape := range shapes {
+		t.Run(shape.name, func(t *testing.T) {
+			messages := []map[string]any{
+				{"role": "user", "content": []map[string]any{{"type": "text", "text": "run the tool"}}},
+			}
+			for step := 0; step < rounds; step++ {
+				messages = append(messages,
+					map[string]any{"role": "assistant", "content": shape.blocks(step)},
+					map[string]any{"role": "user", "content": []map[string]any{{
+						"type": "tool_result", "tool_use_id": fmt.Sprintf("toolu_01Step%02d", step),
+						"content": "18C, foggy",
+					}}},
+				)
+			}
+
+			body, err := json.Marshal(map[string]any{
+				"model":      "bedrock/global.anthropic.claude-opus-5",
+				"max_tokens": 4096,
+				"thinking":   map[string]any{"type": "adaptive"},
+				"tools": []map[string]any{{
+					"name": "get_weather", "description": "look up the weather",
+					"input_schema": map[string]any{"type": "object",
+						"properties": map[string]any{"city": map[string]any{"type": "string"}}},
+				}},
+				"messages": messages,
+			})
+			require.NoError(t, err)
+
+			var ingressReq anthropic.AnthropicMessageRequest
+			require.NoError(t, json.Unmarshal(body, &ingressReq))
+
+			ctx := &schemas.BifrostContext{}
+			converseReq, err := bedrock.ToBedrockResponsesRequest(ctx, ingressReq.ToBifrostResponsesRequest(ctx))
+			require.NoError(t, err)
+
+			require.Equalf(t, len(messages), len(converseReq.Messages),
+				"turn boundaries must survive (converse roles: %s)", converseRoles(converseReq.Messages))
+
+			for step := 0; step < rounds; step++ {
+				msg := converseReq.Messages[step*2+1]
+				require.Equal(t, bedrock.BedrockMessageRoleAssistant, msg.Role, "message %d", step*2+1)
+
+				var signatures []string
+				for _, block := range msg.Content {
+					if block.ReasoningContent == nil || block.ReasoningContent.ReasoningText == nil {
+						continue
+					}
+					require.NotNilf(t, block.ReasoningContent.ReasoningText.Signature,
+						"step %d: a reasoning block reached Converse unsigned", step)
+					signatures = append(signatures, *block.ReasoningContent.ReasoningText.Signature)
+				}
+
+				// Exactly one, and it is this turn's own. Zero means the block was dropped;
+				// more than one means another turn's block migrated in, which is what
+				// Bedrock refuses with "cannot be modified".
+				require.Lenf(t, signatures, 1,
+					"step %d: expected exactly the one reasoning block this turn was sent, got %d (%v)",
+					step, len(signatures), signatures)
+				require.Equalf(t, fmt.Sprintf("ErUBCkYIBxgCKkA_signature_%d", step), signatures[0],
+					"step %d: this turn is carrying another turn's signature", step)
+			}
+		})
+	}
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -3434,6 +3434,37 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, model string, 
 		}
 	}
 
+	// settlePendingReasoning parks reasoning that no assistant item claimed onto the
+	// assistant turn it was produced in, before a user turn is emitted after it.
+	//
+	// pendingReasoningContentBlocks is consumed by an assistant message or a tool-call
+	// flush, and by nothing else -- so reasoning left over when a user turn arrives used
+	// to survive the buffer and be prepended to the NEXT assistant message instead. That
+	// happens whenever an assistant turn ends on a thinking block (adaptive thinking, a
+	// max_tokens truncation, or a trailing block the ingress dropped), and it shifts
+	// every later turn's reasoning one turn forward, silently. Bedrock refuses the
+	// result once the turn it lands in is a tool continuation:
+	//
+	//	messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest
+	//	assistant message cannot be modified. These blocks must remain as they were in
+	//	the original response.
+	//
+	// Appending rather than prepending is deliberate: the blocks trail the content
+	// already in that turn, which is where the client sent them.
+	settlePendingReasoning := func() {
+		if len(pendingReasoningContentBlocks) == 0 {
+			return
+		}
+		if len(bedrockMessages) > 0 && bedrockMessages[len(bedrockMessages)-1].Role == BedrockMessageRoleAssistant {
+			last := &bedrockMessages[len(bedrockMessages)-1]
+			last.Content = append(last.Content, pendingReasoningContentBlocks...)
+		}
+		// With no assistant turn to return them to the blocks are dropped: reasoning
+		// cannot ride a user turn, and inventing an assistant turn for it would put a
+		// message on the wire the client never sent.
+		pendingReasoningContentBlocks = nil
+	}
+
 	// Helper to flush pending tool call blocks into a single assistant message using state manager
 	flushPendingToolCalls := func() {
 		if stateManager.HasPendingToolCalls() {
@@ -3540,6 +3571,19 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, model string, 
 			}
 
 		case schemas.ResponsesMessageTypeFunctionCallOutput:
+			// A tool result opens a user turn, so reasoning still buffered here belongs to
+			// the assistant turn behind it, not to the next one (see settlePendingReasoning).
+			//
+			// Gated on there being no tool call waiting, because a pending call is itself
+			// the claimant: the standard [thinking, tool_use] turn reaches this point with
+			// both buffered, and the flush below prepends the reasoning to the tool-use
+			// message it belongs in front of. Settling first stole it from that flush and
+			// dropped it -- the previous message is the user turn that opened the loop --
+			// which silently deleted the thinking block from every ordinary agent turn.
+			if !stateManager.HasPendingToolCalls() {
+				settlePendingReasoning()
+			}
+
 			// Register tool result in state manager
 			if msg.ResponsesToolMessage != nil && msg.ResponsesToolMessage.CallID != nil {
 				resultContent := []BedrockContentBlock{}
@@ -3722,6 +3766,12 @@ func ConvertBifrostMessagesToBedrockMessages(ctx context.Context, model string, 
 			// the same relocation of a replayed thinking block that issue #6342 is
 			// about, just one flush site further along.
 			flushPendingToolCalls()
+
+			// A non-assistant message opens a new turn, so reasoning the flush above did
+			// not claim belongs to the assistant turn behind it (see settlePendingReasoning).
+			if role != schemas.ResponsesInputMessageRoleAssistant {
+				settlePendingReasoning()
+			}
 
 			// Emit any pending results after tool calls
 			if stateManager.HasPendingResults() {

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140123,6 +140123,387 @@
           ]
         }
       ]
+    },
+    {
+      "name": "68. Replayed thinking must stay in its own assistant turn (PR #6854)",
+      "description": "Two defects in the Anthropic -> Bifrost Responses -> Bedrock Converse replay path, both\nsurfacing as the same client-visible 400:\n\n  messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest assistant\n  message cannot be modified. These blocks must remain as they were in the original response.\n\nMeasured against Bedrock Converse with real signed blocks, that refusal fires on exactly one\nmutation: an EXTRA thinking block appearing in an assistant turn that is a tool continuation.\nRemoving a block, reordering blocks, and fusing turns are all accepted; duplication is not.\n\n1. Reasoning migration (core/providers/bedrock/responses.go). pendingReasoningContentBlocks\n   was consumed by an assistant message or a tool-call flush and by nothing else, so reasoning\n   left buffered when a user turn arrived was prepended to the NEXT assistant message. That\n   happens whenever an assistant turn ends on a thinking block - adaptive thinking, a\n   max_tokens truncation, or a trailing block the ingress dropped - and it shifts every later\n   turn one turn forward. The three chained cases replay a turn whose last block is the\n   thinking block; turn 3 is the one that 400s without the fix.\n\n2. Encrypted-reasoning fail-soft (core/encryptedreasoning.go). When an upstream refuses a\n   replayed signature the strip retries once. It used to blank the signature and keep the\n   thinking prose, which is legal on OpenAI but refused by Anthropic on every turn -\n   \"Invalid `signature` in `thinking` block\" - so the retry turned a request the API would\n   have accepted into one it refused. The two bogus-signature cases carry a signature no\n   model minted and assert the retry heals to a 2xx instead of forwarding a second 400.\n\nThe last case covers Anthropic direct on the typed chat shape: the removal is gated on the\nmodel family rather than the provider, and stripChatUnverifiableReasoning is a separate\ncode path from the Responses one, so Bedrock coverage alone would not pin it.\n\nFolder 46 replays thinking in model order (thinking first) and folder 51 covers the raw\nAnthropic passthrough; neither exercises the Bedrock typed path with a trailing thinking\nblock, and `Invalid `signature`` appeared nowhere in the collection before this folder.",
+      "item": [
+        {
+          "name": "bedrock/global.anthropic.claude-sonnet-4-5 /anthropic/v1/messages turn 1: signed thinking + tool_use captured - PR #6854",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0\",\"max_tokens\":2048,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"get_weather\",\"description\":\"Current weather for a city\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}],\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What is the weather in Tokyo right now? Think it through, then use the get_weather tool.\"}]}]}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('turn 1 returns a signed thinking block and a tool_use to build the replay on', function () {",
+                  "  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);",
+                  "  var j = pm.response.json();",
+                  "  pm.expect(j.content, 'expected a content array').to.be.an('array').that.is.not.empty;",
+                  "  var kinds = j.content.map(function (b) { return b.type; });",
+                  "  pm.expect(kinds, 'no tool_use came back, so turns 2 and 3 would skip and this chain would pass having tested nothing').to.include('tool_use');",
+                  "  var thinking = j.content.filter(function (b) { return b.type === 'thinking'; });",
+                  "  // Without a captured thinking block there is nothing to move to the end of the turn,",
+                  "  // so turns 2 and 3 would replay an ordinary history and pass having tested nothing.",
+                  "  pm.expect(thinking, 'no thinking block came back, so the migration path is never exercised').to.not.be.empty;",
+                  "  thinking.forEach(function (b) {",
+                  "    pm.expect(b.signature, 'a thinking block came back unsigned, so the replay below would prove nothing').to.be.a('string').that.is.not.empty;",
+                  "  });",
+                  "});",
+                  "pm.collectionVariables.unset('bedrockTrailingThinkingTurn2_6854');",
+                  "pm.collectionVariables.unset('bedrockTrailingThinkingTurn3_6854');",
+                  "var trailingThinking6854 = function (content) {",
+                  "  var blocks = content || [];",
+                  "  var think = blocks.filter(function (b) { return b.type === 'thinking' || b.type === 'redacted_thinking'; });",
+                  "  var rest = blocks.filter(function (b) { return b.type !== 'thinking' && b.type !== 'redacted_thinking'; });",
+                  "  return rest.concat(think);",
+                  "};",
+                  "var stub6854 = \"{\\\"city\\\":\\\"Tokyo\\\",\\\"temp_c\\\":18,\\\"condition\\\":\\\"rain\\\"}\";",
+                  "try {",
+                  "  var body = pm.response.json();",
+                  "  var uses = (body.content || []).filter(function (b) { return b.type === 'tool_use' && b.id; });",
+                  "  var thought = (body.content || []).some(function (b) { return b.type === 'thinking' || b.type === 'redacted_thinking'; });",
+                  "  if (uses.length && thought) {",
+                  "    var messages = [",
+                  "      { role: 'user', content: [{ type: 'text', text: 'What is the weather in Tokyo right now? Think it through, then use the get_weather tool.' }] },",
+                  "      { role: 'assistant', content: trailingThinking6854(body.content) },",
+                  "      { role: 'user', content: uses.map(function (u) { return { type: 'tool_result', tool_use_id: u.id, content: stub6854 }; })",
+                  "        .concat([{ type: 'text', text: 'Now check the weather in Osaka with the same tool.' }]) }",
+                  "    ];",
+                  "    pm.collectionVariables.set('bedrockTrailingThinkingTurn2_6854', JSON.stringify(messages));",
+                  "  }",
+                  "} catch (e) {}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "bedrock/global.anthropic.claude-sonnet-4-5 /anthropic/v1/messages turn 2: trailing thinking block replayed across a tool result - PR #6854",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0\",\"max_tokens\":2048,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"get_weather\",\"description\":\"Current weather for a city\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}],\"messages\":{{bedrockTrailingThinkingTurn2_6854}}}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.request.body && pm.request.body.raw && pm.request.body.raw.indexOf('{{') !== -1) { return; }",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('turn 2 accepts an assistant turn whose last block is the thinking block', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'Bedrock refused the replayed thinking block').to.not.include('cannot be modified');",
+                  "  pm.expect(pm.response.code, 'turn 2 failed - a relocated or dropped thinking block is the usual cause: ' + body).to.be.below(400);",
+                  "});",
+                  "pm.collectionVariables.unset('bedrockTrailingThinkingTurn3_6854');",
+                  "var trailingThinking6854 = function (content) {",
+                  "  var blocks = content || [];",
+                  "  var think = blocks.filter(function (b) { return b.type === 'thinking' || b.type === 'redacted_thinking'; });",
+                  "  var rest = blocks.filter(function (b) { return b.type !== 'thinking' && b.type !== 'redacted_thinking'; });",
+                  "  return rest.concat(think);",
+                  "};",
+                  "var stub6854 = \"{\\\"city\\\":\\\"Tokyo\\\",\\\"temp_c\\\":18,\\\"condition\\\":\\\"rain\\\"}\";",
+                  "try {",
+                  "  var prior = JSON.parse(pm.collectionVariables.get('bedrockTrailingThinkingTurn2_6854') || '[]');",
+                  "  var body = pm.response.json();",
+                  "  var uses = (body.content || []).filter(function (b) { return b.type === 'tool_use' && b.id; });",
+                  "  var followUp = uses.map(function (u) { return { type: 'tool_result', tool_use_id: u.id, content: stub6854 }; });",
+                  "  followUp.push({ type: 'text', text: 'Summarize both cities in one sentence.' });",
+                  "  var next = prior.concat([{ role: 'assistant', content: trailingThinking6854(body.content) }, { role: 'user', content: followUp }]);",
+                  "  pm.collectionVariables.set('bedrockTrailingThinkingTurn3_6854', JSON.stringify(next));",
+                  "} catch (e) {}"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "bedrock/global.anthropic.claude-sonnet-4-5 /anthropic/v1/messages turn 3: earlier turn thinking must not migrate into the latest turn - PR #6854",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0\",\"max_tokens\":2048,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"get_weather\",\"description\":\"Current weather for a city\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}],\"messages\":{{bedrockTrailingThinkingTurn3_6854}}}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.request.body && pm.request.body.raw && pm.request.body.raw.indexOf('{{') !== -1) { return; }",
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('the first turn thinking block stays in the first turn', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  // Before PR #6854 the buffered reasoning of turn 1 survived the user turn and was",
+                  "  // prepended to turn 2, giving that message a thinking block the model never produced",
+                  "  // for it. Bedrock answers exactly this:",
+                  "  //   messages.N.content.M: `thinking` or `redacted_thinking` blocks in the latest",
+                  "  //   assistant message cannot be modified.",
+                  "  pm.expect(body, 'an earlier turn thinking block was relocated into the latest assistant message: ' + body).to.not.include('cannot be modified');",
+                  "  pm.expect(pm.response.code, 'turn 3 failed: ' + body).to.be.below(400);",
+                  "});",
+                  "pm.test('turn 3 really replayed two assistant turns with trailing thinking', function () {",
+                  "  var raw = (pm.request.body && pm.request.body.raw) || '';",
+                  "  var msgs = JSON.parse(raw).messages || [];",
+                  "  var assistants = msgs.filter(function (m) { return m.role === 'assistant'; });",
+                  "  pm.expect(assistants.length, 'expected two assistant turns in the replayed history').to.be.at.least(2);",
+                  "  var trailing = assistants.filter(function (m) {",
+                  "    var c = m.content || []; var last = c[c.length - 1];",
+                  "    return last && (last.type === 'thinking' || last.type === 'redacted_thinking');",
+                  "  });",
+                  "  pm.expect(trailing.length, 'no assistant turn ended on a thinking block, so the migration path was never exercised').to.be.at.least(1);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "bedrock/global.anthropic.claude-sonnet-4-5 /anthropic/v1/messages unverifiable thinking signature heals instead of 400 - PR #6854",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0\",\"max_tokens\":2048,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"get_weather\",\"description\":\"Current weather for a city\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}],\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What is the weather in Tokyo? Use the get_weather tool.\"}]},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user wants the weather in Tokyo, so I should call get_weather with city Tokyo.\",\"signature\":\"EqQBCgIYAhIMharness6854bogusSignatureNotMintedByAnyModel0000\"},{\"type\":\"tool_use\",\"id\":\"toolu_01harness6854weather\",\"name\":\"get_weather\",\"input\":{\"city\":\"Tokyo\"}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01harness6854weather\",\"content\":\"{\\\"city\\\":\\\"Tokyo\\\",\\\"temp_c\\\":18,\\\"condition\\\":\\\"rain\\\"}\"}]}]}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('an unverifiable thinking signature is healed by the fail-soft, not forwarded', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  var lower = body.toLowerCase();",
+                  "  // The old strip blanked the signature and kept the thinking prose. Bedrock refuses",
+                  "  // that as readily as the original payload, so the retry spent an upstream call and",
+                  "  // handed the client the same 400. Removing the block whole is the only rewrite it",
+                  "  // accepts.",
+                  "  pm.expect(lower, 'the fail-soft retried with a signature-less thinking block instead of removing it: ' + body).to.not.include('invalid `signature`');",
+                  "  pm.expect(lower, 'the retry left a partially rewritten thinking block behind: ' + body).to.not.include('cannot be modified');",
+                  "  pm.expect(lower, 'the retry dropped the signature field rather than the block: ' + body).to.not.include('thinking.signature');",
+                  "  pm.expect(pm.response.code, 'the fail-soft failed to heal the replay: ' + body).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "bedrock/global.anthropic.claude-sonnet-4-5 /anthropic/v1/messages streaming unverifiable thinking signature heals instead of 400 - PR #6854",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0\",\"max_tokens\":2048,\"stream\":true,\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"tools\":[{\"name\":\"get_weather\",\"description\":\"Current weather for a city\",\"input_schema\":{\"type\":\"object\",\"properties\":{\"city\":{\"type\":\"string\"}},\"required\":[\"city\"]}}],\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"What is the weather in Tokyo? Use the get_weather tool.\"}]},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"The user wants the weather in Tokyo, so I should call get_weather with city Tokyo.\",\"signature\":\"EqQBCgIYAhIMharness6854bogusSignatureNotMintedByAnyModel0000\"},{\"type\":\"tool_use\",\"id\":\"toolu_01harness6854weather\",\"name\":\"get_weather\",\"input\":{\"city\":\"Tokyo\"}}]},{\"role\":\"user\",\"content\":[{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_01harness6854weather\",\"content\":\"{\\\"city\\\":\\\"Tokyo\\\",\\\"temp_c\\\":18,\\\"condition\\\":\\\"rain\\\"}\"}]}]}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('the streamed turn heals the same way the non-streaming one does', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  var lower = body.toLowerCase();",
+                  "  // The old strip blanked the signature and kept the thinking prose. Bedrock refuses",
+                  "  // that as readily as the original payload, so the retry spent an upstream call and",
+                  "  // handed the client the same 400. Removing the block whole is the only rewrite it",
+                  "  // accepts.",
+                  "  pm.expect(lower, 'the fail-soft retried with a signature-less thinking block instead of removing it: ' + body).to.not.include('invalid `signature`');",
+                  "  pm.expect(lower, 'the retry left a partially rewritten thinking block behind: ' + body).to.not.include('cannot be modified');",
+                  "  pm.expect(lower, 'the retry dropped the signature field rather than the block: ' + body).to.not.include('thinking.signature');",
+                  "  pm.expect(pm.response.code, 'the streamed fail-soft failed to heal the replay: ' + body).to.be.below(400);",
+                  "  pm.expect(body, 'expected an Anthropic SSE stream, got: ' + body.slice(0, 400)).to.include('message_start');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "anthropic/claude-haiku-4-5 /v1/chat/completions unverifiable reasoning signature heals instead of 400 - PR #6854",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"anthropic/claude-haiku-4-5-20251001\",\"max_tokens\":2048,\"reasoning\":{\"effort\":\"high\"},\"messages\":[{\"role\":\"user\",\"content\":\"What is 8473 * 2917? Think it through before answering.\"},{\"role\":\"assistant\",\"content\":\"Let me work through that multiplication.\",\"reasoning_details\":[{\"index\":0,\"type\":\"reasoning.text\",\"text\":\"Multiply 8473 by 2917 using long multiplication, then verify.\",\"signature\":\"EqQBCgIYAhIMharness6854bogusSignatureNotMintedByAnyModel0000\"}]},{\"role\":\"user\",\"content\":\"Now double that result.\"}]}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504, 529].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('an unverifiable reasoning signature is healed on the chat shape too', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  var lower = body.toLowerCase();",
+                  "  // The old strip cleared reasoning_details[].signature and kept the text, which the",
+                  "  // Anthropic egress forwards as a thinking block with an empty signature. Anthropic",
+                  "  // refuses that on any turn, so the one retry was spent earning the same class of 400.",
+                  "  pm.expect(lower, 'the fail-soft retried with a signature-less reasoning detail instead of dropping it: ' + body).to.not.include('invalid `signature`');",
+                  "  pm.expect(lower, 'the retry left a partially rewritten thinking block behind: ' + body).to.not.include('cannot be modified');",
+                  "  pm.expect(pm.response.code, 'the fail-soft failed to heal the chat-shaped replay: ' + body).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

When an Anthropic-family upstream rejects a request due to an unverifiable thinking signature, the encrypted reasoning strip-and-retry path was blanking signatures on every assistant turn, including the latest one. Anthropic forbids editing the latest assistant turn's thinking blocks, so the retry earned a second, different 400 — "`thinking` or `redacted_thinking` blocks in the latest assistant message cannot be modified" — which is the error the client was left holding, with the original signature refusal never surfacing. The raw Anthropic chat rewrite already protected this turn; the typed Responses shapes did not.

## Changes

- `stripChatUnverifiableReasoning` now identifies the last assistant-role message and skips it when the upstream is an Anthropic-family provider, matching the protection that `stripRawAnthropicChatThinking` already applied.
- `stripResponsesEncryptedContent` now computes `latestAssistantTurnStart` for Anthropic-family upstreams and passes all items from that index through unmodified, covering both signature clearing and redacted-thinking item deletion.
- `latestAssistantTurnStart` is introduced to find the first item of the trailing assistant turn, correctly skipping trailing user-side items (tool results, `function_call_output`, etc.) that end a round trip without belonging to the assistant turn.
- `isUserTurnItem` classifies a Responses item as user-side or assistant-side, used by `latestAssistantTurnStart`.
- `protectsLatestAssistantTurn` gates the protection on `IsAnthropicModelFamily` rather than the provider key, so Claude served from Bedrock and Vertex is covered alongside the direct Anthropic provider.
- When the only unverifiable payload sits in the protected turn, the strip now correctly returns `false` so no retry is attempted, avoiding spending the one retry on an identical request.
- The protection is explicitly not applied to OpenAI, where the refusal is routinely about a payload in the last assistant turn and the heal must remain active there.
- `newThinkingSignatureChatRequest` fixture extended with a second assistant turn so tests can assert that the earlier turn is stripped and the latest is preserved.
- `TestExecuteRequestWithRetries_HealsOnEveryProviderRejection` extended with a protected turn for Anthropic-family cases and asserts the protected payload arrives on the retry untouched.
- New regression and unit tests: `TestStripResponsesEncryptedContent_ProtectsLatestAnthropicAssistantTurn`, `TestStripResponsesEncryptedContent_KeepsRedactedThinkingInProtectedTurn`, `TestStripResponsesEncryptedContent_NoRetryWhenOnlyProtectedTurnIsUnverifiable`, `TestStripResponsesEncryptedContent_OpenAILastTurnStillStripped`, and `TestLatestAssistantTurnStart`.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./core/... -run TestStripResponsesEncryptedContent
go test ./core/... -run TestLatestAssistantTurnStart
go test ./core/... -run TestExecuteRequestWithRetries_HealsOnEveryProviderRejection
go test ./core/... -run TestExecuteRequestWithRetries_HealsThinkingSignatureOnChatShape
go test ./...
```

The Anthropic-family cases in `TestExecuteRequestWithRetries_HealsOnEveryProviderRejection` now inject a protected turn and assert it arrives on the retry with its `encrypted_content` intact. `TestStripResponsesEncryptedContent_NoRetryWhenOnlyProtectedTurnIsUnverifiable` confirms no retry is attempted when there is nothing outside the protected turn to strip.

## Breaking changes

- [x] No

## Security considerations

Thinking block signatures and encrypted content from Anthropic are passed through unmodified for the protected turn, consistent with Anthropic's requirement that these blocks not be altered between turns. No new secrets or PII handling is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable