### PR TITLE
feat: add `ProviderScopedModelLimitsInScope` for named-scope provider-scoped model limits in load balancing

### DIFF
--- a/plugins/governance/loadbalance_test.go
+++ b/plugins/governance/loadbalance_test.go
@@ -393,3 +393,45 @@ func TestCandidateExclusionConsultsProviderScopedModelConfigs(t *testing.T) {
 	assert.Equal(t, DecisionAllow, decision,
 		"the spent budget covering every provider excludes no candidate; that refusal is the funnel's to state")
 }
+
+// TestProviderScopedModelLimitsInScopeNarrowsANamedScopeToTheProvider: the named-scope lookup is
+// ProviderScopedModelLimits for a scope no permit stands for. It reports the tiers that name the
+// provider, exact pair and all models on it, attributed to the kind it was handed, and leaves the
+// provider-less tiers to the funnel exactly as the permit-keyed lookup does. Naming no scope, or no
+// holder in it, selects nothing rather than falling through to the deployment's rows.
+func TestProviderScopedModelLimitsInScopeNarrowsANamedScopeToTheProvider(t *testing.T) {
+	openai := "openai"
+	const callerScope, callerID = "caller", "u-1"
+	kind := grant.LimitHolderKind("caller_model_config")
+	inCallerScope := func(mc *configstoreTables.TableModelConfig) configstoreTables.TableModelConfig {
+		mc.Scope, mc.ScopeID = callerScope, schemas.Ptr(callerID)
+		return *mc
+	}
+	pairBudget := buildBudgetWithUsage("pair-b", 100.0, 0, "1h")
+	allOnProviderBudget := buildBudgetWithUsage("all-on-openai-b", 100.0, 0, "1h")
+	anyProviderBudget := buildBudgetWithUsage("any-b", 100.0, 0, "1h")
+	store, err := NewLocalGovernanceStore(context.Background(), NewMockLogger(), nil, &configstore.GovernanceConfig{
+		ModelConfigs: []configstoreTables.TableModelConfig{
+			inCallerScope(buildModelConfig("pair", "gpt-5", &openai, pairBudget, nil)),
+			inCallerScope(buildModelConfig("all-on-openai", configstoreTables.ModelConfigAllModels, &openai, allOnProviderBudget, nil)),
+			inCallerScope(buildModelConfig("any", "gpt-5", nil, anyProviderBudget, nil)),
+		},
+		Budgets: []configstoreTables.TableBudget{*pairBudget, *allOnProviderBudget, *anyProviderBudget},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	budgets, _ := store.ProviderScopedModelLimitsInScope(context.Background(), callerScope, callerID, kind, "openai", "gpt-5")
+	var ids []string
+	for _, limit := range budgets {
+		ids = append(ids, limit.ID)
+		assert.Equal(t, string(kind), limit.HolderKind, "attributed to the kind the caller named")
+	}
+	assert.ElementsMatch(t, []string{"pair-b", "all-on-openai-b"}, ids,
+		"the tiers naming the provider are reported; the one covering every provider is the funnel's")
+
+	budgets, rateLimits := store.ProviderScopedModelLimitsInScope(context.Background(), callerScope, "", kind, "openai", "gpt-5")
+	assert.Empty(t, budgets, "no holder in the scope selects nothing")
+	assert.Empty(t, rateLimits)
+	budgets, _ = store.ProviderScopedModelLimitsInScope(context.Background(), "", callerID, kind, "openai", "gpt-5")
+	assert.Empty(t, budgets, "no scope selects nothing, not the deployment's rows")
+}

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -4690,17 +4690,35 @@ func (gs *LocalGovernanceStore) GlobalProviderLimits(ctx context.Context, provid
 // provider, exact pair and all-models-on-the-provider, in the scope the permit selects (the
 // deployment's own for nil, the holder's otherwise).
 //
-// The provider-less tiers are deliberately absent, and this method rather than
-// ProviderAndModelLimits is what routing asks so they stay absent: a limit covering every provider
+// The provider-less tiers are deliberately absent, and this method rather than GlobalModelLimits
+// or PermitModelLimits is what routing asks so they stay absent: a limit covering every provider
 // answers the same for every candidate, so it can only exclude all of them at once, which is a
 // refusal for the funnel to state with a reason rather than load balancing quietly running out of
 // options.
-//
-// The walk is collectModelConfigsFor's, filtered rather than reimplemented, so which configs cover
-// a pair has exactly one answer and routing's subset of it cannot drift from the funnel's.
 func (gs *LocalGovernanceStore) ProviderScopedModelLimits(ctx context.Context, permit schemas.Permit, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
+	return gs.providerScopedModelLimitsInScopes(ctx, modelConfigScopesFor(permit), provider, model)
+}
+
+// ProviderScopedModelLimitsInScope is ProviderScopedModelLimits over one named scope, attributed to
+// the given holder kind: the routing-side counterpart of ScopedModelLimits, and there for the same
+// reason. A store layered on this one may impose per-model limits on the caller themselves, under
+// a scope no permit stands for, and a provider-scoped one of those prices the caller out of that
+// provider exactly as a permit's would. Load balancing has to ask about it the same way, or it
+// routes to a provider the funnel then refuses.
+func (gs *LocalGovernanceStore) ProviderScopedModelLimitsInScope(ctx context.Context, scope, scopeID string, kind grant.LimitHolderKind, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
+	if scope == "" || scopeID == "" {
+		return nil, nil
+	}
+	return gs.providerScopedModelLimitsInScopes(ctx, []limitScope{{name: scope, id: scopeID, kind: kind}}, provider, model)
+}
+
+// providerScopedModelLimitsInScopes is modelLimitsInScopes narrowed to the configs that name the
+// provider. The walk is collectModelConfigsFor's, filtered rather than reimplemented, so which
+// configs cover a pair has exactly one answer and routing's subset of it cannot drift from the
+// funnel's.
+func (gs *LocalGovernanceStore) providerScopedModelLimitsInScopes(ctx context.Context, scopes []limitScope, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit) {
 	providerName := string(provider)
-	for _, scope := range modelConfigScopesFor(permit) {
+	for _, scope := range scopes {
 		for _, mc := range gs.collectModelConfigsFor(ctx, scope.name, scope.id, model, &providerName) {
 			if mc == nil || mc.Provider == nil {
 				continue


### PR DESCRIPTION
## Summary

Adds `ProviderScopedModelLimitsInScope`, a named-scope variant of `ProviderScopedModelLimits` for use when a store layered on top imposes per-model limits on a caller under a scope that no permit represents. Without this, load balancing has no way to ask about provider-scoped limits in those caller-owned scopes, causing it to route to a provider that the funnel then refuses.

## Changes

- Extracted the inner loop of `ProviderScopedModelLimits` into a shared `providerScopedModelLimitsInScopes` helper so both the permit-keyed and named-scope paths share the same walk logic, keeping routing's subset of covered configs consistent with the funnel's.
- Added `ProviderScopedModelLimitsInScope`, which accepts an explicit scope, scope ID, and holder kind. It returns nothing when either the scope or the scope ID is empty, rather than falling through to the deployment's rows.
- Added a test covering the new method: verifies that only tiers naming the provider (exact pair and all-models-on-provider) are returned, that provider-less tiers are left to the funnel, and that an empty scope or empty scope ID selects nothing.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/... -run TestProviderScopedModelLimitsInScopeNarrowsANamedScopeToTheProvider
```

The test asserts:
- Tiers naming the provider (`pair-b`, `all-on-openai-b`) are returned and attributed to the supplied holder kind.
- The provider-less tier (`any-b`) is absent from the result.
- Passing an empty scope ID returns no budgets or rate limits.
- Passing an empty scope returns no budgets or rate limits.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. The new method gates on both scope and scope ID being non-empty before performing any lookup, preventing unintended cross-scope access.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable