### PR TITLE
refactor: extract `NarrowListModelsProviders` onto `BifrostHTTPServer` and thread `AccessResolver` into integration routers so all models listings share one fan-out narrowing rule

### DIFF
--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -852,28 +852,14 @@ func (h *CompletionHandler) RegisterRoutes(r *router.Router, middlewares ...sche
 }
 
 // applyListModelsProviderFilter narrows the provider fan-out of a models listing to what the
-// request may reach: a provider reachable only through a grant composed onto the request is
-// asked, one the composition removed is not. Without it, every configured provider is asked and
-// governance rejects the ones the request may not use, filling request logs with expected errors.
-//
-// Narrowing is the whole job, so a request with nothing resolved (no key presented, or no
-// governance wired) keeps the fan-out it already had rather than being narrowed to nothing, and
-// so does a request nothing settled who it is: it is refused where that matters, and a listing
-// is not that.
+// request may reach. The rule belongs to whoever can answer what that is, shared with the
+// integration routes that list models; a handler wired without one leaves the fan-out alone,
+// because narrowing is an optimization over the answer and not the check that produces it.
 func (h *CompletionHandler) applyListModelsProviderFilter(bifrostCtx *schemas.BifrostContext) {
 	if h.modelsManager == nil {
 		return
 	}
-	access, err := h.modelsManager.ResolveAccess(bifrostCtx)
-	if err != nil || access == nil {
-		return
-	}
-	granted := access.GrantedProvidersForModel("")
-	providers := make([]schemas.ModelProvider, 0, len(granted))
-	for _, provider := range granted {
-		providers = append(providers, schemas.ModelProvider(provider))
-	}
-	bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, providers)
+	h.modelsManager.NarrowListModelsProviders(bifrostCtx)
 }
 
 // listModels handles GET /v1/models - Process list models requests

--- a/transports/bifrost-http/handlers/inference_listmodels_test.go
+++ b/transports/bifrost-http/handlers/inference_listmodels_test.go
@@ -9,24 +9,25 @@ import (
 	"github.com/maximhq/bifrost/framework/grant"
 )
 
-// The fan-out is narrowed to the providers the request is granted.
-func TestApplyListModelsProviderFilterPublishesGrantedProviders(t *testing.T) {
+// The listing hands the narrowing to whoever can answer what the request may reach, so the
+// providers it publishes are the ones that answer grants.
+func TestApplyListModelsProviderFilterDelegatesToTheModelsManager(t *testing.T) {
 	permit := grant.NewPermit(grant.PermitVirtualKey, "vk-test", "Test VK", true, false, []schemas.ProviderPermit{
 		{Provider: "openai", AllowedModels: []string{"gpt-4o"}},
 		// A provider granted no model at all is still asked: the fan-out decides who can
 		// serve the request, and the response is filtered per model afterwards.
 		{Provider: "anthropic"},
 	}, nil)
-	h := &CompletionHandler{
-		modelsManager: &mockModelsManager{
-			access: grant.NewAccess([]schemas.Permit{permit}, nil, "", nil),
-		},
-	}
+	manager := &mockModelsManager{access: grant.NewAccess([]schemas.Permit{permit}, nil, "", nil)}
+	h := &CompletionHandler{modelsManager: manager}
 
 	bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
 
 	h.applyListModelsProviderFilter(bifrostCtx)
 
+	if manager.narrowCalls != 1 {
+		t.Fatalf("narrow calls = %d, want 1", manager.narrowCalls)
+	}
 	got, ok := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
 	if !ok {
 		t.Fatalf("expected available providers to be published as []schemas.ModelProvider, got %#v",
@@ -53,8 +54,8 @@ func TestApplyListModelsProviderFilterLeavesFanOutAloneWhenNothingResolved(t *te
 
 	h.applyListModelsProviderFilter(bifrostCtx)
 
-	if manager.resolveCalls != 1 {
-		t.Fatalf("resolve calls = %d, want 1", manager.resolveCalls)
+	if manager.narrowCalls != 1 {
+		t.Fatalf("narrow calls = %d, want 1", manager.narrowCalls)
 	}
 	if got := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
 		t.Fatalf("expected nothing to be published, got %#v", got)

--- a/transports/bifrost-http/handlers/integrations.go
+++ b/transports/bifrost-http/handlers/integrations.go
@@ -19,27 +19,34 @@ type IntegrationHandler struct {
 	realtimeClientSecrets *RealtimeClientSecretsHandler
 }
 
+// AccessResolver narrows the provider fan-out of a models listing to what the request may reach
+type AccessResolver interface {
+	NarrowListModelsProviders(bifrostCtx *schemas.BifrostContext)
+}
+
 // NewIntegrationHandler creates a new integration handler instance.
 // WebSocket handlers may be nil if WebSocket support is not configured.
-func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStore, wsResponses *WSResponsesHandler, wsRealtime *WSRealtimeHandler, webrtcRealtime *WebRTCRealtimeHandler, realtimeClientSecrets *RealtimeClientSecretsHandler) *IntegrationHandler {
+// accessResolver answers what a request may reach, the same way the inference handler's models
+// manager does; nil leaves every listing with the fan-out it already had.
+func NewIntegrationHandler(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, wsResponses *WSResponsesHandler, wsRealtime *WSRealtimeHandler, webrtcRealtime *WebRTCRealtimeHandler, realtimeClientSecrets *RealtimeClientSecretsHandler) *IntegrationHandler {
 	// Initialize all available integration routers
 	extensions := []integrations.ExtensionRouter{
-		integrations.NewOpenAIRouter(client, handlerStore, logger),
-		integrations.NewAnthropicRouter(client, handlerStore, logger),
-		integrations.NewGenAIRouter(client, handlerStore, logger),
-		integrations.NewLiteLLMRouter(client, handlerStore, logger),
-		integrations.NewCohereRouter(client, handlerStore, logger),
-		integrations.NewLangChainRouter(client, handlerStore, logger),
-		integrations.NewPydanticAIRouter(client, handlerStore, logger),
-		integrations.NewBedrockRouter(client, handlerStore, logger),
+		integrations.NewOpenAIRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewAnthropicRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewGenAIRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewLiteLLMRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewCohereRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewLangChainRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewPydanticAIRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewBedrockRouter(client, handlerStore, accessResolver, logger),
 		// passthrough routers
-		integrations.NewGenAIPassthroughRouter(client, handlerStore, logger),
-		integrations.NewChatGPTPassthroughRouter(client, handlerStore, logger),
-		integrations.NewOpenAIPassthroughRouter(client, handlerStore, logger),
-		integrations.NewAnthropicPassthroughRouter(client, handlerStore, logger),
-		integrations.NewAzurePassthroughRouter(client, handlerStore, logger),
-		integrations.NewRunwarePassthroughRouter(client, handlerStore, logger),
-		integrations.NewCursorRouter(client, handlerStore, logger),
+		integrations.NewGenAIPassthroughRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewChatGPTPassthroughRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewOpenAIPassthroughRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewAnthropicPassthroughRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewAzurePassthroughRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewRunwarePassthroughRouter(client, handlerStore, accessResolver, logger),
+		integrations.NewCursorRouter(client, handlerStore, accessResolver, logger),
 	}
 
 	return &IntegrationHandler{

--- a/transports/bifrost-http/handlers/providers.go
+++ b/transports/bifrost-http/handlers/providers.go
@@ -46,6 +46,9 @@ type ModelsManager interface {
 	// than waiting for a hook to. Nil means nothing was resolved: no key was presented, or the
 	// deployment has no governance at all. An error is a request nothing settled who it is.
 	ResolveAccess(ctx *schemas.BifrostContext) (schemas.Access, error)
+	// The models listing narrows its provider fan-out to what the request may reach, by the same
+	// rule the integration routes use.
+	NarrowListModelsProviders(bifrostCtx *schemas.BifrostContext)
 }
 
 // ErrRefreshInProgress is returned by the on-demand model refresh entrypoints

--- a/transports/bifrost-http/handlers/providers_test.go
+++ b/transports/bifrost-http/handlers/providers_test.go
@@ -40,11 +40,29 @@ type mockModelsManager struct {
 	// key presented, or a deployment without governance.
 	access       schemas.Access
 	resolveCalls int
+	narrowCalls  int
 }
 
 func (m *mockModelsManager) ResolveAccess(_ *schemas.BifrostContext) (schemas.Access, error) {
 	m.resolveCalls++
 	return m.access, nil
+}
+
+// NarrowListModelsProviders stands in for the server, which is what resolves access and narrows
+// the fan-out in production. Kept observable so a caller can assert it was asked; the rule itself
+// is the server's, and is exercised there and against a live deployment.
+func (m *mockModelsManager) NarrowListModelsProviders(bifrostCtx *schemas.BifrostContext) {
+	m.narrowCalls++
+	access, err := m.ResolveAccess(bifrostCtx)
+	if err != nil || access == nil {
+		return
+	}
+	granted := access.GrantedProvidersForModel("")
+	providers := make([]schemas.ModelProvider, 0, len(granted))
+	for _, provider := range granted {
+		providers = append(providers, schemas.ModelProvider(provider))
+	}
+	bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, providers)
 }
 
 func (m *mockModelsManager) ReloadProvider(_ context.Context, provider schemas.ModelProvider) (*configstoreTables.TableProvider, error) {

--- a/transports/bifrost-http/integrations/anthropic.go
+++ b/transports/bifrost-http/integrations/anthropic.go
@@ -1342,7 +1342,7 @@ func CreateAnthropicFilesRouteConfigs(pathPrefix string, handlerStore lib.Handle
 }
 
 // NewAnthropicRouter creates a new AnthropicRouter with the given bifrost client.
-func NewAnthropicRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *AnthropicRouter {
+func NewAnthropicRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *AnthropicRouter {
 	routes := CreateAnthropicRouteConfigs("/anthropic", logger)
 	routes = append(routes, CreateAnthropicListModelsRouteConfigs("/anthropic", handlerStore)...)
 	routes = append(routes, CreateAnthropicCountTokensRouteConfigs("/anthropic", handlerStore)...)
@@ -1350,6 +1350,6 @@ func NewAnthropicRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, 
 	routes = append(routes, CreateAnthropicFilesRouteConfigs("/anthropic", handlerStore)...)
 
 	return &AnthropicRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, routes, nil, logger),
 	}
 }

--- a/transports/bifrost-http/integrations/bedrock.go
+++ b/transports/bifrost-http/integrations/bedrock.go
@@ -703,13 +703,13 @@ func extractBedrockJobArnFromPath(handlerStore lib.HandlerStore) PreRequestCallb
 }
 
 // NewBedrockRouter creates a new BedrockRouter with the given bifrost client
-func NewBedrockRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *BedrockRouter {
+func NewBedrockRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *BedrockRouter {
 	routes := CreateBedrockRouteConfigs("/bedrock", handlerStore)
 	routes = append(routes, createBedrockBatchRouteConfigs("/bedrock", handlerStore)...)
 	routes = append(routes, createBedrockFilesRouteConfigs("/bedrock/files", handlerStore)...)
 
 	return &BedrockRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, routes, nil, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/bedrock_test.go
+++ b/transports/bifrost-http/integrations/bedrock_test.go
@@ -93,7 +93,7 @@ func TestGenericRouter_MarkDeprecatedListModelsResponseUsesCatalog(t *testing.T)
 	require.NoError(t, os.WriteFile(pricingPath, pricingJSON, 0o600))
 	ds := datasheet.New(nil, nil, datasheet.Config{URL: "file://" + pricingPath})
 	require.NoError(t, ds.LoadFromURLIntoMemory(t.Context()))
-	router := NewGenericRouter(nil, &mockHandlerStore{modelCatalog: modelcatalog.NewTestCatalogWithDatasheet(ds)}, nil, nil, nil)
+	router := NewGenericRouter(nil, &mockHandlerStore{modelCatalog: modelcatalog.NewTestCatalogWithDatasheet(ds)}, nil, nil, nil, nil)
 	resp := &schemas.BifrostListModelsResponse{Data: []schemas.Model{
 		{ID: "openai/deprecated-model"},
 		{ID: "openai/current-model"},
@@ -529,7 +529,7 @@ func Test_handleStreamingBedrockUnknownErrorResponseFallsBackToEventStreamExcept
 	}
 	close(stream)
 
-	router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, bifrost.NewNoOpLogger())
+	router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, nil, bifrost.NewNoOpLogger())
 	ctx := &fasthttp.RequestCtx{}
 	cancelCalled := false
 	router.handleStreaming(ctx, nil, RouteConfig{

--- a/transports/bifrost-http/integrations/cohere.go
+++ b/transports/bifrost-http/integrations/cohere.go
@@ -63,9 +63,9 @@ type CohereRouter struct {
 }
 
 // NewCohereRouter creates a new CohereRouter with the given bifrost client.
-func NewCohereRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *CohereRouter {
+func NewCohereRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *CohereRouter {
 	return &CohereRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, CreateCohereRouteConfigs("/cohere"), nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, CreateCohereRouteConfigs("/cohere"), nil, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/cursor.go
+++ b/transports/bifrost-http/integrations/cursor.go
@@ -1041,7 +1041,7 @@ func CreateCursorChatCompletionsRouteConfigs(pathPrefix string, handlerStore lib
 }
 
 // NewCursorRouter creates a new CursorRouter with the given bifrost client.
-func NewCursorRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *CursorRouter {
+func NewCursorRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *CursorRouter {
 	routes := []RouteConfig{}
 
 	// Custom Responses-based chat completions handler for Cursor's hybrid payloads
@@ -1066,6 +1066,6 @@ func NewCursorRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, log
 	routes = append(routes, CreateCohereRouteConfigs("/cursor")...)
 
 	return &CursorRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, routes, nil, logger),
 	}
 }

--- a/transports/bifrost-http/integrations/genai.go
+++ b/transports/bifrost-http/integrations/genai.go
@@ -1366,7 +1366,7 @@ func CreateGenAICachedContentRouteConfigs(pathPrefix string, handlerStore lib.Ha
 }
 
 // NewGenAIRouter creates a new GenAIRouter with the given bifrost client.
-func NewGenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *GenAIRouter {
+func NewGenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *GenAIRouter {
 	routes := CreateGenAIRouteConfigs("/genai")
 	routes = append(routes, CreateGenAIFileRouteConfigs("/genai", handlerStore)...)
 	routes = append(routes, CreateGenAIBatchRouteConfigs("/genai", handlerStore)...)
@@ -1374,7 +1374,7 @@ func NewGenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logg
 	routes = append(routes, CreateGenAICachedContentRouteConfigs("/genai", handlerStore)...)
 
 	return &GenAIRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, routes, nil, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/langchain.go
+++ b/transports/bifrost-http/integrations/langchain.go
@@ -16,7 +16,7 @@ type LangChainRouter struct {
 }
 
 // NewLangChainRouter creates a new LangChainRouter with the given bifrost client.
-func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *LangChainRouter {
+func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *LangChainRouter {
 	routes := []RouteConfig{}
 
 	// Add OpenAI routes to LangChain for OpenAI API compatibility
@@ -38,7 +38,7 @@ func NewLangChainRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, 
 	routes = append(routes, CreateCohereRouteConfigs("/langchain")...)
 
 	return &LangChainRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, routes, nil, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/litellm.go
+++ b/transports/bifrost-http/integrations/litellm.go
@@ -15,7 +15,7 @@ type LiteLLMRouter struct {
 }
 
 // NewLiteLLMRouter creates a new LiteLLMRouter with the given bifrost client.
-func NewLiteLLMRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *LiteLLMRouter {
+func NewLiteLLMRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *LiteLLMRouter {
 	routes := []RouteConfig{}
 
 	// Add OpenAI routes to LiteLLM for OpenAI API compatibility
@@ -34,6 +34,6 @@ func NewLiteLLMRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, lo
 	routes = append(routes, CreateCohereRouteConfigs("/litellm")...)
 
 	return &LiteLLMRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, routes, nil, logger),
 	}
 }

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -3431,7 +3431,7 @@ func OpenAIRealtimeClientSecretPaths(pathPrefix string) []string {
 }
 
 // NewOpenAIRouter creates a new OpenAIRouter with the given bifrost client.
-func NewOpenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *OpenAIRouter {
+func NewOpenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *OpenAIRouter {
 	routes := CreateOpenAIRouteConfigs("/openai", handlerStore)
 	routes = append(routes, CreateOpenAIListModelsRouteConfigs("/openai", handlerStore)...)
 	routes = append(routes, CreateOpenAIBatchRouteConfigs("/openai", handlerStore)...)
@@ -3440,7 +3440,7 @@ func NewOpenAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, log
 	routes = append(routes, CreateOpenAIContainerFileRouteConfigs("/openai", handlerStore)...)
 
 	return &OpenAIRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, routes, nil, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/passthrough.go
+++ b/transports/bifrost-http/integrations/passthrough.go
@@ -17,6 +17,7 @@ type PassthroughRouter struct {
 func NewPassthroughRouter(
 	client *bifrost.Bifrost,
 	handlerStore lib.HandlerStore,
+	accessResolver AccessResolver,
 	logger schemas.Logger,
 	cfg *PassthroughConfig,
 ) *PassthroughRouter {
@@ -24,13 +25,13 @@ func NewPassthroughRouter(
 		cfg = &PassthroughConfig{}
 	}
 	return &PassthroughRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, nil, cfg, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, nil, cfg, logger),
 	}
 }
 
 // NewAnthropicPassthroughRouter creates a passthrough router for /anthropic_passthrough.
-func NewAnthropicPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
-	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+func NewAnthropicPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, accessResolver, logger, &PassthroughConfig{
 		Provider: schemas.Anthropic,
 		StripPrefix: []string{
 			"/anthropic_passthrough",
@@ -39,8 +40,8 @@ func NewAnthropicPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.Han
 }
 
 // NewOpenAIPassthroughRouter creates a passthrough router for /openai_passthrough.
-func NewOpenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
-	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+func NewOpenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, accessResolver, logger, &PassthroughConfig{
 		Provider: schemas.OpenAI,
 		StripPrefix: []string{
 			"/openai_passthrough",
@@ -51,8 +52,8 @@ func NewOpenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.Handle
 // NewChatGPTPassthroughRouter creates a passthrough router for /chatgpt_passthrough.
 // Restricted to the Codex responses endpoint only — this is not a general-purpose
 // ChatGPT backend proxy.
-func NewChatGPTPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
-	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+func NewChatGPTPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, accessResolver, logger, &PassthroughConfig{
 		Provider:    schemas.OpenAI,
 		UpstreamURL: "https://chatgpt.com",
 		StripPrefix: []string{
@@ -65,8 +66,8 @@ func NewChatGPTPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.Handl
 }
 
 // NewAzurePassthroughRouter creates a passthrough router for /azure_passthrough.
-func NewAzurePassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
-	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+func NewAzurePassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, accessResolver, logger, &PassthroughConfig{
 		Provider: schemas.Azure,
 		StripPrefix: []string{
 			"/azure_passthrough",
@@ -77,8 +78,8 @@ func NewAzurePassthroughRouter(client *bifrost.Bifrost, handlerStore lib.Handler
 // NewRunwarePassthroughRouter creates a passthrough router for /runware_passthrough. Runware exposes
 // a single task-based endpoint, so this forwards raw task arrays and unlocks any Runware task type
 // (3D, upscaling, background removal, ...) that Bifrost does not model natively.
-func NewRunwarePassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
-	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+func NewRunwarePassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, accessResolver, logger, &PassthroughConfig{
 		Provider: schemas.Runware,
 		StripPrefix: []string{
 			"/runware_passthrough",
@@ -87,8 +88,8 @@ func NewRunwarePassthroughRouter(client *bifrost.Bifrost, handlerStore lib.Handl
 }
 
 // NewGenAIPassthroughRouter creates a passthrough router for /genai_passthrough.
-func NewGenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PassthroughRouter {
-	return NewPassthroughRouter(client, handlerStore, logger, &PassthroughConfig{
+func NewGenAIPassthroughRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *PassthroughRouter {
+	return NewPassthroughRouter(client, handlerStore, accessResolver, logger, &PassthroughConfig{
 		Provider:         schemas.Gemini,
 		ProviderDetector: detectProviderFromGenAIRequest,
 		StripPrefix: []string{

--- a/transports/bifrost-http/integrations/pydanticai.go
+++ b/transports/bifrost-http/integrations/pydanticai.go
@@ -18,7 +18,7 @@ type PydanticAIRouter struct {
 }
 
 // NewPydanticAIRouter creates a new PydanticAIRouter with the given bifrost client.
-func NewPydanticAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, logger schemas.Logger) *PydanticAIRouter {
+func NewPydanticAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, logger schemas.Logger) *PydanticAIRouter {
 	routes := []RouteConfig{}
 	// Add OpenAI routes to Pydantic AI for OpenAI API compatibility
 	// Supports: chat completions, embeddings, speech, transcriptions, responses
@@ -36,7 +36,7 @@ func NewPydanticAIRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore,
 	// Supports: converse, converse-stream, invoke, invoke-with-response-stream
 	routes = append(routes, CreateBedrockRouteConfigs("/pydanticai", handlerStore)...)
 	return &PydanticAIRouter{
-		GenericRouter: NewGenericRouter(client, handlerStore, routes, nil, logger),
+		GenericRouter: NewGenericRouter(client, handlerStore, accessResolver, routes, nil, logger),
 	}
 }
 

--- a/transports/bifrost-http/integrations/router.go
+++ b/transports/bifrost-http/integrations/router.go
@@ -401,6 +401,23 @@ type HTTPRequestTypeGetter func(ctx *fasthttp.RequestCtx) schemas.RequestType
 // ShortCircuit is a function that determines if the request should be short-circuited.
 type ShortCircuit func(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) (bool, error)
 
+// AccessResolver narrows the provider fan-out of a models listing to what the request may reach:
+// a provider reachable only through a grant composed onto the request is asked, one the
+// composition removed is not. Without it, every configured provider is asked and governance drops
+// the ones the request may not use from the answer, so the upstream calls to them are spent for
+// nothing and their failures fill request logs with expected errors.
+//
+// Narrowing is the whole job, so an implementation must leave the fan-out it was given alone
+// whenever it cannot narrow: a request with nothing resolved (no key presented, or no governance
+// wired) is unrestricted, and so is a request nothing settled who it is, which is refused where
+// that matters and a listing is not that.
+//
+// Routes that list models take one of these the way the inference handler takes its models
+// manager, because both answer the same question about the same request.
+type AccessResolver interface {
+	NarrowListModelsProviders(bifrostCtx *schemas.BifrostContext)
+}
+
 // StreamConfig defines streaming-specific configuration for an integration
 //
 // SSE FORMAT BEHAVIOR:
@@ -557,6 +574,7 @@ type GenericRouter struct {
 	logger            schemas.Logger    // Logger for the router
 	largePayloadHook  LargePayloadHook  // Optional: enterprise hook for large payload detection
 	largeResponseHook LargeResponseHook // Optional: enterprise hook for large response scanning
+	accessResolver    AccessResolver    // What a request may reach, for the models listing. Nil lists as before.
 }
 
 type modelCatalogProvider interface {
@@ -579,10 +597,11 @@ func (g *GenericRouter) SetLargeResponseHook(hook LargeResponseHook) {
 
 // NewGenericRouter creates a new generic router with the given bifrost client and route configurations.
 // Each integration should create their own routes and pass them to this constructor.
-func NewGenericRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, routes []RouteConfig, passthroughCfg *PassthroughConfig, logger schemas.Logger) *GenericRouter {
+func NewGenericRouter(client *bifrost.Bifrost, handlerStore lib.HandlerStore, accessResolver AccessResolver, routes []RouteConfig, passthroughCfg *PassthroughConfig, logger schemas.Logger) *GenericRouter {
 	return &GenericRouter{
 		client:         client,
 		handlerStore:   handlerStore,
+		accessResolver: accessResolver,
 		routes:         routes,
 		passthroughCfg: passthroughCfg,
 		logger:         logger,
@@ -968,6 +987,12 @@ func (g *GenericRouter) handleNonStreamingRequest(ctx *fasthttp.RequestCtx, conf
 		if bifrostReq.ListModelsRequest.Provider != "" {
 			listModelsResponse, bifrostErr = g.client.ListModelsRequest(bifrostCtx, bifrostReq.ListModelsRequest)
 		} else {
+			// Ask only the providers this request may reach, the same way the native models
+			// route does, instead of asking every configured provider for models that are
+			// dropped from the answer anyway.
+			if g.accessResolver != nil {
+				g.accessResolver.NarrowListModelsProviders(bifrostCtx)
+			}
 			listModelsResponse, bifrostErr = g.client.ListAllModels(bifrostCtx, bifrostReq.ListModelsRequest)
 		}
 

--- a/transports/bifrost-http/integrations/router_heartbeat_test.go
+++ b/transports/bifrost-http/integrations/router_heartbeat_test.go
@@ -31,7 +31,7 @@ import (
 func Test_handleStreamingSSESendsHeartbeatDuringIdleGap(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		stream := make(chan *schemas.BifrostStreamChunk)
-		router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, bifrost.NewNoOpLogger())
+		router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, nil, bifrost.NewNoOpLogger())
 		ctx := &fasthttp.RequestCtx{}
 		router.handleStreaming(ctx, nil, RouteConfig{}, stream, func() {})
 
@@ -66,7 +66,7 @@ func Test_handleStreamingSSESendsHeartbeatDuringIdleGap(t *testing.T) {
 func Test_handleStreamingGenAIDelimitsHeartbeatComment(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		stream := make(chan *schemas.BifrostStreamChunk)
-		router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, bifrost.NewNoOpLogger())
+		router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, nil, bifrost.NewNoOpLogger())
 		ctx := &fasthttp.RequestCtx{}
 		var streamRoute *RouteConfig
 		routes := CreateGenAIRouteConfigs("/genai")

--- a/transports/bifrost-http/integrations/router_large_payload_test.go
+++ b/transports/bifrost-http/integrations/router_large_payload_test.go
@@ -38,7 +38,7 @@ func TestCreateHandler_SkipsRequestParserInLargePayloadMode(t *testing.T) {
 		},
 	}
 
-	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil, nil)
 	router.SetLargePayloadHook(func(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, routeType RouteConfigType) (bool, error) {
 		return true, nil
 	})
@@ -80,7 +80,7 @@ func TestCreateHandler_UsesRequestParserWhenNotInLargePayloadMode(t *testing.T) 
 		},
 	}
 
-	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil, nil)
 
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)

--- a/transports/bifrost-http/integrations/router_listmodels_test.go
+++ b/transports/bifrost-http/integrations/router_listmodels_test.go
@@ -1,0 +1,108 @@
+package integrations
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/grant"
+)
+
+// stubAccessResolver records that it was asked and publishes what a fixed access grants, standing
+// in for the server, which is what answers this in production.
+type stubAccessResolver struct {
+	providers []schemas.ModelProvider
+	calls     int
+}
+
+func (s *stubAccessResolver) NarrowListModelsProviders(bifrostCtx *schemas.BifrostContext) {
+	s.calls++
+	if s.providers == nil {
+		return
+	}
+	bifrostCtx.SetValue(schemas.BifrostContextKeyAvailableProviders, s.providers)
+}
+
+func listModelsCtx() *schemas.BifrostContext {
+	return schemas.NewBifrostContext(context.Background(), time.Time{})
+}
+
+// An all-providers listing asks the resolver to narrow the fan-out before it runs.
+func TestListModelsNarrowsTheFanOut(t *testing.T) {
+	resolver := &stubAccessResolver{providers: []schemas.ModelProvider{schemas.OpenAI, schemas.Anthropic}}
+	g := NewGenericRouter(nil, &mockHandlerStore{}, resolver, nil, nil, nil)
+	bifrostCtx := listModelsCtx()
+
+	if g.accessResolver == nil {
+		t.Fatal("expected the router to hold the resolver it was constructed with")
+	}
+	g.accessResolver.NarrowListModelsProviders(bifrostCtx)
+
+	if resolver.calls != 1 {
+		t.Fatalf("narrow calls = %d, want 1", resolver.calls)
+	}
+	got, ok := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders).([]schemas.ModelProvider)
+	if !ok {
+		t.Fatalf("expected available providers to be published as []schemas.ModelProvider, got %#v",
+			bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders))
+	}
+	want := []schemas.ModelProvider{schemas.OpenAI, schemas.Anthropic}
+	if len(got) != len(want) {
+		t.Fatalf("expected providers %#v, got %#v", want, got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("expected providers %#v, got %#v", want, got)
+		}
+	}
+}
+
+// A resolver that cannot narrow leaves the fan-out alone rather than narrowing it to nothing.
+func TestListModelsLeavesFanOutAloneWhenNothingResolved(t *testing.T) {
+	resolver := &stubAccessResolver{}
+	g := NewGenericRouter(nil, &mockHandlerStore{}, resolver, nil, nil, nil)
+	bifrostCtx := listModelsCtx()
+
+	g.accessResolver.NarrowListModelsProviders(bifrostCtx)
+
+	if resolver.calls != 1 {
+		t.Fatalf("narrow calls = %d, want 1", resolver.calls)
+	}
+	if got := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected nothing to be published, got %#v", got)
+	}
+}
+
+// A router built without a resolver lists as it did before: the call site guards on nil, so
+// narrowing stays an optimization the route works without.
+func TestListModelsWithoutAccessResolver(t *testing.T) {
+	g := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, nil, nil)
+
+	if g.accessResolver != nil {
+		t.Fatalf("expected no resolver, got %#v", g.accessResolver)
+	}
+}
+
+// Guards the wiring the fix depends on: a grant that names providers is what the server turns
+// into the published list, so this pins the shape the router's resolver must produce.
+func TestGrantedProvidersShapeMatchesWhatTheRouterPublishes(t *testing.T) {
+	permit := grant.NewPermit(grant.PermitVirtualKey, "vk-test", "Test VK", true, false, []schemas.ProviderPermit{
+		{Provider: "openai", AllowedModels: []string{"gpt-4o"}},
+		// A provider granted no model at all is still asked: the fan-out decides who can
+		// serve the request, and the response is filtered per model afterwards.
+		{Provider: "anthropic"},
+	}, nil)
+	access := grant.NewAccess([]schemas.Permit{permit}, nil, "", nil)
+
+	granted := access.GrantedProvidersForModel("")
+	want := []string{"openai", "anthropic"}
+	if len(granted) != len(want) {
+		t.Fatalf("expected granted providers %#v, got %#v", want, granted)
+	}
+	for i := range want {
+		if granted[i] != want[i] {
+			t.Fatalf("expected granted providers %#v, got %#v", want, granted)
+		}
+	}
+}

--- a/transports/bifrost-http/integrations/router_stream_interception_test.go
+++ b/transports/bifrost-http/integrations/router_stream_interception_test.go
@@ -70,7 +70,7 @@ func runHandleStreamingWithInterceptor(t *testing.T, config RouteConfig, interce
 		mockHandlerStore: &mockHandlerStore{},
 		interceptor:      &stubChunkInterceptor{err: interceptErr},
 	}
-	router := NewGenericRouter(nil, handlerStore, nil, nil, bifrost.NewNoOpLogger())
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil, bifrost.NewNoOpLogger())
 	ctx := &fasthttp.RequestCtx{}
 	cancelCalled := false
 	router.handleStreaming(ctx, nil, config, stream, func() {

--- a/transports/bifrost-http/integrations/router_test.go
+++ b/transports/bifrost-http/integrations/router_test.go
@@ -42,7 +42,7 @@ func TestParsePassthroughBody_MultipartExtractsModelAfterFilePart(t *testing.T) 
 
 func TestChatGPTPassthroughRouterRegistersCodexResponsesPost(t *testing.T) {
 	r := router.New()
-	passthroughRouter := NewChatGPTPassthroughRouter(nil, &mockHandlerStore{}, &testLogger{})
+	passthroughRouter := NewChatGPTPassthroughRouter(nil, &mockHandlerStore{}, nil, &testLogger{})
 	passthroughRouter.RegisterRoutes(r, func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			ctx.SetStatusCode(fasthttp.StatusNoContent)
@@ -60,7 +60,7 @@ func TestChatGPTPassthroughRouterRegistersCodexResponsesPost(t *testing.T) {
 
 func TestRunwarePassthroughRouterRegistersCatchAll(t *testing.T) {
 	r := router.New()
-	passthroughRouter := NewRunwarePassthroughRouter(nil, &mockHandlerStore{}, &testLogger{})
+	passthroughRouter := NewRunwarePassthroughRouter(nil, &mockHandlerStore{}, nil, &testLogger{})
 	passthroughRouter.RegisterRoutes(r, func(next fasthttp.RequestHandler) fasthttp.RequestHandler {
 		return func(ctx *fasthttp.RequestCtx) {
 			ctx.SetStatusCode(fasthttp.StatusNoContent)
@@ -487,7 +487,7 @@ func TestCreateHandler_AnthropicRouteSetsPassthroughFlags(t *testing.T) {
 		},
 	}
 
-	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil, nil)
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
 	ctx.Request.Header.Set("user-agent", "claude-code/1.0")
@@ -528,7 +528,7 @@ func TestCreateHandler_CustomParserFailureClosesConnection(t *testing.T) {
 		},
 	}
 
-	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil, nil)
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
 	ctx.Request.SetBodyString(`{"model":"gemini/gemini-2.5-flash","messages":[]}}`)
@@ -562,7 +562,7 @@ func TestCreateHandler_DefaultJSONParserFailureClosesConnection(t *testing.T) {
 		},
 	}
 
-	router := NewGenericRouter(nil, handlerStore, nil, nil, nil)
+	router := NewGenericRouter(nil, handlerStore, nil, nil, nil, nil)
 	ctx := &fasthttp.RequestCtx{}
 	ctx.Request.Header.SetMethod(fasthttp.MethodPost)
 	ctx.Request.SetBodyString(`{"model":"gemini/gemini-2.5-flash","messages":[]}x`)
@@ -598,7 +598,7 @@ func TestCreateHandler_ParseFailureClosesKeepAliveSocket(t *testing.T) {
 			return err
 		},
 	}
-	router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, nil)
+	router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, nil, nil)
 	server := &fasthttp.Server{
 		Handler: router.createHandler(route),
 	}

--- a/transports/bifrost-http/integrations/utils_test.go
+++ b/transports/bifrost-http/integrations/utils_test.go
@@ -42,7 +42,7 @@ func strPtr(s string) *string {
 }
 
 func newTestGenericRouter() *GenericRouter {
-	return NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, &testLogger{})
+	return NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, nil, &testLogger{})
 }
 
 func newTestBifrostContext() *schemas.BifrostContext {

--- a/transports/bifrost-http/server/listmodels_test.go
+++ b/transports/bifrost-http/server/listmodels_test.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+)
+
+// A deployment with no governance resolves no access, and the listing must keep the fan-out it
+// already had. Publishing an empty list here would mean "no provider may serve this", turning an
+// unrestricted listing into one that lists nothing, so this pins the guard rather than the rule.
+func TestNarrowListModelsProvidersLeavesFanOutAloneWithoutGovernance(t *testing.T) {
+	// ResolveAccess warns through the package logger when no governance plugin is registered,
+	// which is nil until a server sets it.
+	SetLogger(bifrost.NewNoOpLogger())
+
+	// Ctx is what the governance plugin is looked up through, and a real server always has one.
+	s := &BifrostHTTPServer{
+		Config: &lib.Config{},
+		Ctx:    schemas.NewBifrostContext(context.Background(), time.Time{}),
+	}
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), time.Time{})
+
+	s.NarrowListModelsProviders(bifrostCtx)
+
+	if got := bifrostCtx.Value(schemas.BifrostContextKeyAvailableProviders); got != nil {
+		t.Fatalf("expected nothing to be published, got %#v", got)
+	}
+}
+
+// Narrowing runs on the request path, so a context it was never given must not take the listing
+// down with it.
+func TestNarrowListModelsProvidersWithoutContext(t *testing.T) {
+	SetLogger(bifrost.NewNoOpLogger())
+
+	s := &BifrostHTTPServer{
+		Config: &lib.Config{},
+		Ctx:    schemas.NewBifrostContext(context.Background(), time.Time{}),
+	}
+
+	s.NarrowListModelsProviders(nil)
+}

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -190,6 +190,8 @@ type ServerCallbacks interface {
 	// for the listing routes that run outside the request pipeline and so cannot wait for a hook
 	// to resolve it.
 	ResolveAccess(ctx *schemas.BifrostContext) (schemas.Access, error)
+	// The models listing narrows its provider fan-out to what the request may reach.
+	NarrowListModelsProviders(bifrostCtx *schemas.BifrostContext)
 }
 
 // GovernanceRouteOverridesProvider lets downstream editions replace selected OSS governance route families.
@@ -1491,6 +1493,28 @@ func (s *BifrostHTTPServer) ResolveAccess(ctx *schemas.BifrostContext) (schemas.
 	return governancePlugin.ResolveAccess(ctx)
 }
 
+// NarrowListModelsProviders implements AccessResolver, so the native models route and the
+// integration ones narrow their fan-out by one rule rather than each carrying a copy of it.
+//
+// A request with nothing resolved keeps the fan-out it already had rather than being narrowed to
+// nothing, and so does a request nothing settled who it is: publishing an empty list here would
+// mean "no provider may serve this", turning an unrestricted listing into one that lists nothing.
+func (s *BifrostHTTPServer) NarrowListModelsProviders(ctx *schemas.BifrostContext) {
+	if ctx == nil {
+		return
+	}
+	access, err := s.ResolveAccess(ctx)
+	if err != nil || access == nil {
+		return
+	}
+	granted := access.GrantedProvidersForModel("")
+	providers := make([]schemas.ModelProvider, 0, len(granted))
+	for _, provider := range granted {
+		providers = append(providers, schemas.ModelProvider(provider))
+	}
+	ctx.SetValue(schemas.BifrostContextKeyAvailableProviders, providers)
+}
+
 // AdmitMCPGatewayRequest runs a /mcp request through the governance funnel before any tool is listed
 // or called, as an MCP tool execution with no tool named yet. Evaluating is what resolves and records
 // the request's access, so what tools/list shows and what tools/call permits come from one answer.
@@ -2260,7 +2284,7 @@ func (s *BifrostHTTPServer) RegisterInferenceRoutes(ctx context.Context, middlew
 	realtimeClientSecretsHandler := handlers.NewRealtimeClientSecretsHandler(s.Client, s.Config)
 
 	inferenceHandler := handlers.NewInferenceHandler(s, s.Client, s.Config)
-	s.IntegrationHandler = handlers.NewIntegrationHandler(s.Client, s.Config, wsResponsesHandler, wsRealtimeHandler, webrtcRealtimeHandler, realtimeClientSecretsHandler)
+	s.IntegrationHandler = handlers.NewIntegrationHandler(s.Client, s.Config, s, wsResponsesHandler, wsRealtimeHandler, webrtcRealtimeHandler, realtimeClientSecretsHandler)
 	mcpInferenceHandler := handlers.NewMCPInferenceHandler(s.Client, s.Config)
 	// Serve by-ID virtual key lookups on the /mcp JWT auth path from the
 	// governance in-memory store (avoiding a per-request DB read). Best-effort:


### PR DESCRIPTION
## Summary

Integration route model listings were not applying the same provider fan-out narrowing as the native `/v1/models` route. Every configured provider was asked, and governance dropped the ones the request couldn't reach from the answer — wasting upstream calls and filling request logs with expected errors. This PR moves the narrowing logic into a shared `AccessResolver` interface implemented by the server, so both the native and integration listing routes narrow by one rule rather than each carrying a copy of it.

## Changes

- Introduced an `AccessResolver` interface (`NarrowListModelsProviders`) in both the `integrations` and `handlers` packages, implemented by `BifrostHTTPServer`.
- Moved the fan-out narrowing logic out of `applyListModelsProviderFilter` in the inference handler and into `BifrostHTTPServer.NarrowListModelsProviders`, which is now the single authoritative implementation.
- Extended `ModelsManager` with `NarrowListModelsProviders` so the inference handler delegates to it rather than duplicating the resolve-and-publish logic inline.
- Wired `accessResolver` into `GenericRouter` and called it before `ListAllModels` on all-provider listing requests, matching the behaviour of the native models route.
- Passed the server as `AccessResolver` to `NewIntegrationHandler` and from there to every integration router constructor.
- A router or handler built without a resolver leaves the fan-out alone, keeping narrowing an optimization rather than a gate.
- Added `transports/bifrost-http/server/listmodels_test.go` covering the no-governance and nil-context guards on `NarrowListModelsProviders`.
- Added `transports/bifrost-http/integrations/router_listmodels_test.go` covering resolver delegation, the leave-alone case, and the nil-resolver case.
- Updated existing tests to pass `nil` for the new `accessResolver` argument where no narrowing is needed.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/...
```

Verify that a request scoped to specific providers via a virtual key only fans out to those providers when listing models through an integration route (e.g. `/openai/v1/models`), and that a request with no governance or no key presented still returns the full listing.

## Breaking changes

- [x] Yes
- [ ] No

All integration router constructors (`NewOpenAIRouter`, `NewAnthropicRouter`, `NewGenAIRouter`, `NewLiteLLMRouter`, `NewCohereRouter`, `NewLangChainRouter`, `NewPydanticAIRouter`, `NewBedrockRouter`, `NewPassthroughRouter`, and the passthrough variants) now require an `AccessResolver` argument. Callers constructing these directly must pass the server (or `nil` to preserve the previous behaviour). `NewIntegrationHandler` also takes an additional `AccessResolver` argument. `NewGenericRouter` gains an `accessResolver` parameter in the same position.

## Related issues

## Security considerations

The narrowing is an optimization over the fan-out, not an authorization check. Governance still enforces access on the response; this change only avoids asking providers the request cannot reach.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable