### PR TITLE
feat(ui): add scope labels, `maxVisible` overflow, and `scopeLabel` prop to budget and rate limit displays

### DIFF
--- a/transports/bifrost-http/handlers/middlewares.go
+++ b/transports/bifrost-http/handlers/middlewares.go
@@ -1094,6 +1094,9 @@ func (m *AuthMiddleware) APIMiddleware() schemas.BifrostHTTPMiddleware {
 	systemWhitelistedRoutes := []string{
 		"/api/session/is-auth-enabled",
 		"/api/session/login",
+		// Idempotent: the handler clears the cookie and returns 200 whether or
+		// not a session token is present, so a repeat logout must not 401 here.
+		"/api/session/logout",
 		"/api/oauth/callback",
 		"/health",
 		"/login",

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -748,6 +748,10 @@ func TestAuthMiddleware_WhitelistedRoutes(t *testing.T) {
 	whitelistedRoutes := []string{
 		"/api/session/is-auth-enabled",
 		"/api/session/login",
+		// Logout is idempotent (clears the cookie, revokes the session if a
+		// token is present) and must never 401, or a repeat logout cascades
+		// into a redirect loop in the dashboard.
+		"/api/session/logout",
 		"/api/oauth/callback",
 		"/health",
 	}

--- a/ui/components/budgetDisplay.test.ts
+++ b/ui/components/budgetDisplay.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// vitest has no React plugin here, so the component cannot be rendered; this
+// pins the markup contract at the source level instead (same approach as
+// topbar.test.ts).
+const source = readFileSync(fileURLToPath(new URL("./budgetDisplay.tsx", import.meta.url)), "utf8");
+
+describe("BudgetDisplay overflow trigger", () => {
+	it('renders the "+N more" tooltip trigger as a focusable button so keyboard users can open it', () => {
+		const trigger = source.match(/<TooltipTrigger asChild>\s*<(\w+)[^>]*>\s*\+\{hidden\.length\} more/);
+		expect(trigger, "could not find the +N more trigger").not.toBeNull();
+		expect(trigger![1]).toBe("button");
+		expect(trigger![0]).toMatch(/type="button"/);
+	});
+});

--- a/ui/components/budgetDisplay.tsx
+++ b/ui/components/budgetDisplay.tsx
@@ -6,9 +6,12 @@ import { cn } from "@/lib/utils";
 import { formatCurrency, getEffectiveBudgetLimit, hasActiveBudgetOverride } from "@/lib/utils/governance";
 
 interface BudgetDisplayProps {
-	budgets: Budget[] | null | undefined;
+	/** A line may carry a label naming what the budget is on, for tables where lines on the same window differ by scope. */
+	budgets: (Budget & { label?: string })[] | null | undefined;
 	/** When true, alignable durations (day/week/month/quarter/year) get a "(calendar)" suffix. */
 	calendarAligned?: boolean;
+	/** Draw at most this many lines; the rest collapse into a "+x more" line whose tooltip names them. */
+	maxVisible?: number;
 }
 
 const formatResetDuration = (duration?: string | null, calendarAligned?: boolean) => {
@@ -22,14 +25,17 @@ const formatResetDuration = (duration?: string | null, calendarAligned?: boolean
  * color-coded progress bar (emerald < 80% < amber < exhausted = red), and a tooltip with
  * the exact current/max spend. Mirrors RateLimitDisplay for visual consistency across tables.
  */
-export function BudgetDisplay({ budgets, calendarAligned }: BudgetDisplayProps) {
+export function BudgetDisplay({ budgets, calendarAligned, maxVisible }: BudgetDisplayProps) {
 	if (!budgets || budgets.length === 0) {
 		return <span className="text-muted-foreground text-sm">-</span>;
 	}
 
+	const shown = maxVisible != null ? budgets.slice(0, maxVisible) : budgets;
+	const hidden = maxVisible != null ? budgets.slice(maxVisible) : [];
+
 	return (
 		<div className="min-w-[160px] space-y-2.5">
-			{budgets.map((b, idx) => {
+			{shown.map((b, idx) => {
 				const effectiveMaxLimit = getEffectiveBudgetLimit(b);
 				const hasOverride = hasActiveBudgetOverride(b);
 				const pct = effectiveMaxLimit > 0 ? Math.min((b.current_usage / effectiveMaxLimit) * 100, 100) : 0;
@@ -41,8 +47,9 @@ export function BudgetDisplay({ budgets, calendarAligned }: BudgetDisplayProps) 
 						<TooltipTrigger asChild>
 							<div className="space-y-1.5">
 								<div className="flex items-center justify-between gap-4">
-									<span className="font-medium">
+									<span className="font-medium text-xs">
 										{formatCurrency(effectiveMaxLimit)}
+										{b.label ? <span className="text-muted-foreground ml-1 text-xs font-normal">{b.label}</span> : null}
 										{hasOverride ? <span className="text-muted-foreground ml-1 text-[10px]">override</span> : null}
 									</span>
 									<span className="text-muted-foreground text-xs">
@@ -58,20 +65,38 @@ export function BudgetDisplay({ budgets, calendarAligned }: BudgetDisplayProps) 
 								{formatCurrency(b.current_usage)} / {formatCurrency(effectiveMaxLimit)}
 							</p>
 							{hasOverride ? (
-								<p className="text-primary-foreground/80 text-xs">
+								<p className="text-muted-foreground mt-1 text-xs">
 									Base {formatCurrency(b.max_limit)} + {formatCurrency(b.override_amount ?? 0)} override
 								</p>
 							) : null}
 							{b.reset_duration ? (
-								<p className="text-primary-foreground/80 text-xs">
-								Resets {formatResetDuration(b.reset_duration, calendarAligned)}
-								{fiscalQuarterNote(b.reset_duration, b.reset_config)}
-							</p>
+								<p className="text-muted-foreground mt-1 text-xs">
+									Resets {formatResetDuration(b.reset_duration, calendarAligned)}
+									{fiscalQuarterNote(b.reset_duration, b.reset_config)}
+								</p>
 							) : null}
 						</TooltipContent>
 					</Tooltip>
 				);
 			})}
+			{hidden.length > 0 ? (
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<button type="button" className="text-muted-foreground block cursor-help text-left text-xs">
+							+{hidden.length} more
+						</button>
+					</TooltipTrigger>
+					<TooltipContent>
+						{hidden.map((b, idx) => (
+							<p key={b.id ?? idx} className="text-xs">
+								{formatCurrency(b.current_usage)} / {formatCurrency(getEffectiveBudgetLimit(b))}
+								{b.label ? ` · ${b.label}` : ""}
+								{b.reset_duration ? ` · ${formatResetDuration(b.reset_duration, calendarAligned)}` : ""}
+							</p>
+						))}
+					</TooltipContent>
+				</Tooltip>
+			) : null}
 		</div>
 	);
 }

--- a/ui/components/entitySelectors/entitySelector.tsx
+++ b/ui/components/entitySelectors/entitySelector.tsx
@@ -130,7 +130,8 @@ interface EntitySelectorMultiProps {
  */
 interface EntitySelectorAddProps {
 	mode: "add";
-	onSelect: (option: EntitySelectorOption) => void;
+	/** The picked row, description included, so the caller can show more than its label. */
+	onSelect: (option: EntitySelectorEntry) => void;
 	multiple?: never;
 	value?: never;
 	onChange?: never;
@@ -264,7 +265,7 @@ export function EntitySelector(props: EntitySelectorProps) {
 		cacheLabel(option);
 
 		if (props.mode === "add") {
-			props.onSelect({ value: option.value, label: option.label });
+			props.onSelect(option);
 		} else if (props.multiple !== true) {
 			props.onChange(option.value);
 		}

--- a/ui/components/filters/logsFilterSidebar.tsx
+++ b/ui/components/filters/logsFilterSidebar.tsx
@@ -9,7 +9,7 @@ import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { RequestTypeLabels, RequestTypes, RoutingEngineUsedLabels, Statuses } from "@/lib/constants/logs";
 import { useGetAvailableFilterDataQuery, useGetProvidersQuery } from "@/lib/store";
-import { COMPLEXITY_TIER_VALUES, LEGACY_COMPLEXITY_TIER_VALUES, COMPLEXITY_MECHANISM_LABELS, COMPLEXITY_MECHANISM_VALUES } from "@/lib/types/complexityRouter";
+import { COMPLEXITY_MECHANISM_LABELS, COMPLEXITY_MECHANISM_VALUES, COMPLEXITY_TIER_VALUES, LEGACY_COMPLEXITY_TIER_VALUES } from "@/lib/types/complexityRouter";
 import type { LogFilters } from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { ChevronDown, LoaderCircle, PanelLeftClose, Plus, RotateCcw, Search } from "lucide-react";
@@ -99,7 +99,7 @@ export function LogsFilterSidebar({ filters, onFiltersChange }: LogsSidebarProps
 				<div className="flex grow flex-col gap-1">
 					{/* First 2 open by default */}
 					<StatusFilter filters={filters} onFiltersChange={onFiltersChange} defaultOpen />
-					<ModelsFilter filters={filters} onFiltersChange={onFiltersChange} defaultOpen />
+					<ModelsFilter filters={filters} onFiltersChange={onFiltersChange} />
 					{/* Rest closed unless they have active filters */}
 					<SelectedKeysFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<VirtualKeysFilter filters={filters} onFiltersChange={onFiltersChange} />
@@ -328,14 +328,13 @@ function SearchableCheckboxList({
 					onCheckedChange={() => onToggle(item.key)}
 					testId={
 						testIdPrefix
-							? `${testIdPrefix}-checkbox-${
-									normalizeTestIdKey
-										? item.key
-												.toLowerCase()
-												.replace(/[^a-z0-9]+/g, "-")
-												.replace(/^-+|-+$/g, "")
-										: item.key
-								}`
+							? `${testIdPrefix}-checkbox-${normalizeTestIdKey
+								? item.key
+									.toLowerCase()
+									.replace(/[^a-z0-9]+/g, "-")
+									.replace(/^-+|-+$/g, "")
+								: item.key
+							}`
 							: undefined
 					}
 				/>

--- a/ui/components/filters/mcpFilterSidebar.tsx
+++ b/ui/components/filters/mcpFilterSidebar.tsx
@@ -1,19 +1,13 @@
 import { FilterSidebarTrigger } from "@/components/filters/filterSidebarTrigger";
 import { CheckboxFilterItem, FilterSection, SearchableCheckboxList, useAutoFocusOnOpen } from "@/components/filters/primitives";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scrollArea";
-import { Skeleton } from "@/components/ui/skeleton";
-import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Statuses } from "@/lib/constants/logs";
 import { useGetMCPLogsFilterDataQuery } from "@/lib/store";
 import type { MCPToolLogFilters } from "@/lib/types/logs";
-import { cn } from "@/lib/utils";
-import { ChevronDown, LoaderCircle, PanelLeftClose, Plus, RotateCcw, Search } from "lucide-react";
-import { Ref, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { PanelLeftClose, RotateCcw } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 const COLLAPSE_STORAGE_KEY = "mcp-filter-sidebar-collapsed";
 
@@ -96,7 +90,7 @@ export function MCPFilterSidebar({ filters, onFiltersChange }: MCPFilterSidebarP
 				<div className="flex grow flex-col gap-1">
 					{/* First 2 open by default */}
 					<StatusFilter filters={filters} onFiltersChange={onFiltersChange} defaultOpen />
-					<ToolNamesFilter filters={filters} onFiltersChange={onFiltersChange} defaultOpen />
+					<ToolNamesFilter filters={filters} onFiltersChange={onFiltersChange} />
 					{/* Rest closed unless they have active filters */}
 					<ServersFilter filters={filters} onFiltersChange={onFiltersChange} />
 					<AppFilter filters={filters} onFiltersChange={onFiltersChange} />

--- a/ui/components/rateLimitDisplay.test.ts
+++ b/ui/components/rateLimitDisplay.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// vitest has no React plugin here, so the component cannot be rendered; this
+// pins the prop plumbing at the source level instead (same approach as
+// topbar.test.ts).
+const source = readFileSync(fileURLToPath(new URL("./rateLimitDisplay.tsx", import.meta.url)), "utf8");
+
+describe("RateLimitDisplay scopeLabel", () => {
+	it("renders scopeLabel in limitOnly mode as well as bar mode", () => {
+		const limitText = source.slice(source.indexOf("function LimitText("), source.indexOf("function Bar("));
+		expect(limitText).toMatch(/scopeLabel\s*\?/);
+
+		// Both limitOnly branches must forward the prop.
+		const limitOnlyUses = source.match(/<LimitText[\s\S]*?\/>/g) ?? [];
+		expect(limitOnlyUses).toHaveLength(2);
+		for (const use of limitOnlyUses) {
+			expect(use).toMatch(/scopeLabel=\{scopeLabel\}/);
+		}
+	});
+});

--- a/ui/components/rateLimitDisplay.tsx
+++ b/ui/components/rateLimitDisplay.tsx
@@ -22,6 +22,8 @@ interface RateLimitDisplayProps {
 	/** When true, alignable durations (day/week/month/year) get a "(calendar)" suffix to
 	 * mirror the budget cell. Sourced from the owning VK's calendar_aligned flag. */
 	calendarAligned?: boolean;
+	/** Names what the limit is on, drawn inline after the cap the way BudgetDisplay draws a line's label. */
+	scopeLabel?: string;
 }
 
 const formatResetDuration = (duration?: string | null, calendarAligned?: boolean) => {
@@ -35,16 +37,19 @@ function LimitText({
 	max,
 	resetDuration,
 	calendarAligned,
+	scopeLabel,
 }: {
 	label: string;
 	max: number;
 	resetDuration?: string | null;
 	calendarAligned?: boolean;
+	scopeLabel?: string;
 }) {
 	return (
 		<div className="flex items-center justify-between gap-4 text-xs">
 			<span className="font-mono">
 				{formatCompactNumber(max)} {label}
+				{scopeLabel ? <span className="text-muted-foreground ml-1 font-sans">{scopeLabel}</span> : null}
 			</span>
 			<span className="text-muted-foreground">{formatResetDuration(resetDuration, calendarAligned)}</span>
 		</div>
@@ -58,6 +63,7 @@ function Bar({
 	resetDuration,
 	compact,
 	calendarAligned,
+	scopeLabel,
 }: {
 	label: string;
 	current: number;
@@ -65,6 +71,7 @@ function Bar({
 	resetDuration?: string | null;
 	compact?: boolean;
 	calendarAligned?: boolean;
+	scopeLabel?: string;
 }) {
 	const pct = max > 0 ? Math.min((current / max) * 100, 100) : 0;
 	const isExhausted = max > 0 && current >= max;
@@ -77,10 +84,11 @@ function Bar({
 					<div className="flex items-center justify-between gap-4 text-xs">
 						<span className="font-medium">
 							{formatCompactNumber(max)} {label}
+							{scopeLabel ? <span className="text-muted-foreground ml-1 font-normal">{scopeLabel}</span> : null}
 						</span>
 						<span className="text-muted-foreground">{formatResetDuration(resetDuration, calendarAligned)}</span>
 					</div>
-					<Progress value={pct} className={cn("bg-muted/70 dark:bg-muted/30 h-1", barClass)} />
+					<Progress value={pct} className={cn("bg-muted/70 dark:bg-muted/30 h-1.5", barClass)} />
 				</div>
 			</TooltipTrigger>
 			<TooltipContent>
@@ -88,14 +96,14 @@ function Bar({
 					{current.toLocaleString()} / {max.toLocaleString()} {label}
 				</p>
 				{resetDuration ? (
-					<p className="text-primary-foreground/80 text-xs">Resets {formatResetDuration(resetDuration, calendarAligned)}</p>
+					<p className="text-muted-foreground text-xs">Resets {formatResetDuration(resetDuration, calendarAligned)}</p>
 				) : null}
 			</TooltipContent>
 		</Tooltip>
 	);
 }
 
-export function RateLimitDisplay({ rateLimits, compact, limitOnly, calendarAligned }: RateLimitDisplayProps) {
+export function RateLimitDisplay({ rateLimits, compact, limitOnly, calendarAligned, scopeLabel }: RateLimitDisplayProps) {
 	if (!rateLimits) {
 		return <span className="text-muted-foreground text-sm">-</span>;
 	}
@@ -116,6 +124,7 @@ export function RateLimitDisplay({ rateLimits, compact, limitOnly, calendarAlign
 						max={rateLimits.token_max_limit!}
 						resetDuration={rateLimits.token_reset_duration}
 						calendarAligned={calendarAligned}
+						scopeLabel={scopeLabel}
 					/>
 				) : (
 					<Bar
@@ -125,6 +134,7 @@ export function RateLimitDisplay({ rateLimits, compact, limitOnly, calendarAlign
 						resetDuration={rateLimits.token_reset_duration}
 						compact={compact}
 						calendarAligned={calendarAligned}
+						scopeLabel={scopeLabel}
 					/>
 				)
 			) : null}
@@ -135,6 +145,7 @@ export function RateLimitDisplay({ rateLimits, compact, limitOnly, calendarAlign
 						max={rateLimits.request_max_limit!}
 						resetDuration={rateLimits.request_reset_duration}
 						calendarAligned={calendarAligned}
+						scopeLabel={scopeLabel}
 					/>
 				) : (
 					<Bar
@@ -144,6 +155,7 @@ export function RateLimitDisplay({ rateLimits, compact, limitOnly, calendarAlign
 						resetDuration={rateLimits.request_reset_duration}
 						compact={compact}
 						calendarAligned={calendarAligned}
+						scopeLabel={scopeLabel}
 					/>
 				)
 			) : null}

--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -15,7 +15,8 @@ import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { useDescriptionSlotRef, useMobileFilterSlotRef, useTopbarTitle } from "@/lib/contexts/topbarContext";
 import type { TopbarTitleValue } from "@/lib/contexts/topbarContext.utils";
 import { useBranding } from "@/lib/hooks/useBranding";
-import { useGetCoreConfigQuery, useGetVersionQuery, useLogoutMutation } from "@/lib/store";
+import { useAppDispatch, useGetCoreConfigQuery, useGetVersionQuery, useLogoutMutation } from "@/lib/store";
+import { baseApi } from "@/lib/store/apis/baseApi";
 import { cn } from "@/lib/utils";
 import type { UserInfo } from "@enterprise/lib/store/utils/tokenManager";
 import { getUserInfo } from "@enterprise/lib/store/utils/tokenManager";
@@ -132,6 +133,7 @@ export default function Topbar() {
 	const setMobileFilterSlot = useMobileFilterSlotRef();
 	const navigate = useNavigate();
 	const [logout] = useLogoutMutation();
+	const dispatch = useAppDispatch();
 	const { data: coreConfig } = useGetCoreConfigQuery({});
 	// Shares the sidebar's RTK Query cache entry, so this costs no extra request.
 	const { data: version } = useGetVersionQuery();
@@ -158,11 +160,14 @@ export default function Topbar() {
 	const handleLogout = async () => {
 		try {
 			await logout().unwrap();
-		} finally {
-			// Redirect regardless — a failed server-side logout still means the
-			// user intended to end the session locally.
-			navigate({ to: "/login" });
+		} catch {
+			// Fall through: a failed server-side logout still means the user
+			// intended to end the session locally.
 		}
+		// Navigate first so the dashboard's polled queries unmount, then drop
+		// the cache. Resetting while they are mounted refetches all of them.
+		await navigate({ to: "/login" });
+		dispatch(baseApi.util.resetApiState());
 	};
 
 	return (

--- a/ui/hooks/useWebSocket.tsx
+++ b/ui/hooks/useWebSocket.tsx
@@ -1,6 +1,24 @@
 import { getApiBaseUrl } from "@/lib/utils/port";
 import { getWebSocketUrl } from "@/lib/utils/port";
+import { isLoggingOut } from "@/lib/utils/logoutState";
 import React, { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+	WS_CONNECTING,
+	WS_OPEN,
+	adoptSocket,
+	clearReconnectTimer,
+	getSocket,
+	isReconnectEnabled,
+	resetRetryCount,
+	scheduleReconnect,
+	setActiveConnect,
+	setReconnectEnabled,
+	setSocket,
+	startHeartbeat,
+	stopHeartbeat,
+} from "./useWebSocket.utils";
+
+export { stopWebSocket } from "./useWebSocket.utils";
 
 type MessageHandler = (data: any) => void;
 
@@ -18,16 +36,16 @@ interface WebSocketProviderProps {
 	path?: string;
 }
 
-// Global reference to maintain state across component remounts
-let globalWsRef: WebSocket | null = null;
+// The socket, heartbeat and reconnect bookkeeping all live in
+// useWebSocket.utils so they outlive any single provider mount: a shell
+// re-render must not tear the connection down, and a close event that fires
+// after the provider unmounted consults that shared state instead of a stale
+// closure. Only subscriptions and per-mount React state live here.
 const messageHandlers = new Map<string, Set<MessageHandler>>();
 
 export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderProps) {
-	const wsRef = useRef<WebSocket | null>(globalWsRef);
-	const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-	const pingTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
-	const retryCountRef = useRef(0);
-	const [isConnected, setIsConnected] = useState(false);
+	const wsRef = useRef<WebSocket | null>(getSocket());
+	const [isConnected, setIsConnected] = useState(getSocket()?.readyState === WS_OPEN);
 
 	const subscribe = useCallback<(channel: string, handler: MessageHandler) => () => void>((channel, handler) => {
 		if (!messageHandlers.has(channel)) {
@@ -48,7 +66,7 @@ export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderP
 	}, []);
 
 	const send = (data: any) => {
-		if (wsRef.current?.readyState === WebSocket.OPEN) {
+		if (wsRef.current?.readyState === WS_OPEN) {
 			try {
 				wsRef.current.send(typeof data === "string" ? data : JSON.stringify(data));
 			} catch (error) {
@@ -58,8 +76,30 @@ export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderP
 	};
 
 	useEffect(() => {
+		let mounted = true;
+		// Set when this mount adopts a socket created by an earlier mount;
+		// removes the open/close listeners that keep this mount's state honest.
+		let detachAdopted: (() => void) | null = null;
+
 		const connect = async () => {
-			if (wsRef.current?.readyState === WebSocket.OPEN) {
+			if (!mounted || !isReconnectEnabled() || isLoggingOut()) {
+				return;
+			}
+			const existing = getSocket();
+			if (existing && (existing.readyState === WS_OPEN || existing.readyState === WS_CONNECTING)) {
+				// Another mount created this socket; its onopen/onclose cannot
+				// update this mount's state, so observe the socket directly.
+				wsRef.current = existing;
+				detachAdopted?.();
+				detachAdopted = adoptSocket(existing, {
+					onOpen: () => {
+						if (mounted) setIsConnected(true);
+					},
+					onClose: () => {
+						if (mounted) setIsConnected(false);
+					},
+				});
+				if (existing.readyState === WS_OPEN) setIsConnected(true);
 				return;
 			}
 
@@ -71,6 +111,14 @@ export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderP
 					method: "POST",
 					credentials: "include",
 				});
+				if (resp.status === 401 || resp.status === 403) {
+					// The session is gone. Retrying cannot succeed until the user
+					// signs in again, at which point the dashboard shell remounts
+					// this provider and re-enables reconnection.
+					setReconnectEnabled(false);
+					if (mounted) setIsConnected(false);
+					return;
+				}
 				if (resp.ok) {
 					const { ticket } = await resp.json();
 					if (ticket) {
@@ -82,33 +130,23 @@ export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderP
 			} catch {
 				// If ticket fetch fails, attempt connection without auth param (cookie fallback)
 			}
+			// The ticket fetch is async; the provider may have unmounted or a
+			// logout may have started while it was in flight.
+			if (!mounted || !isReconnectEnabled() || isLoggingOut()) {
+				return;
+			}
 			const ws = new WebSocket(wsUrlWithAuth);
 			wsRef.current = ws;
-			globalWsRef = ws;
+			setSocket(ws);
 
 			ws.onopen = () => {
-				setIsConnected(true);
-				retryCountRef.current = 0; // Reset retry count on successful connection
-
-				// Clear any pending reconnection attempts
-				if (reconnectTimeoutRef.current) {
-					clearTimeout(reconnectTimeoutRef.current);
-					reconnectTimeoutRef.current = null;
-				}
-
-				// Start heartbeat/ping to keep connection alive
-				if (pingTimerRef.current) {
-					clearInterval(pingTimerRef.current);
-				}
-				pingTimerRef.current = setInterval(() => {
-					if (ws.readyState === WebSocket.OPEN) {
-						try {
-							ws.send("ping");
-						} catch (error) {
-							console.error("Error sending ping:", error);
-						}
-					}
-				}, 25000); // Ping every 25 seconds
+				if (getSocket() !== ws) return;
+				if (mounted) setIsConnected(true);
+				resetRetryCount(); // Reset retry count on successful connection
+				clearReconnectTimer();
+				// The heartbeat belongs to the socket, not to this mount: a
+				// later mount that adopts the socket must not find it silent.
+				startHeartbeat(ws);
 			};
 
 			ws.onmessage = (event) => {
@@ -133,40 +171,41 @@ export function WebSocketProvider({ children, path = "/ws" }: WebSocketProviderP
 			};
 
 			ws.onclose = () => {
-				setIsConnected(false);
-
-				// Clear ping timer
-				if (pingTimerRef.current) {
-					clearInterval(pingTimerRef.current);
-					pingTimerRef.current = null;
+				if (mounted) setIsConnected(false);
+				if (getSocket() === ws) {
+					stopHeartbeat();
+					setSocket(null);
 				}
-
-				// Exponential backoff: 0.5s, 1s, 2s, 4s, 8s, 16s, 32s (max)
-				retryCountRef.current = Math.min(retryCountRef.current + 1, 6);
-				const delay = Math.pow(2, retryCountRef.current) * 500;
-
-				reconnectTimeoutRef.current = setTimeout(connect, delay);
+				// Reconnect through the currently mounted provider (if any), not
+				// through this closure, so an unmounted provider never revives
+				// the loop.
+				scheduleReconnect();
 			};
 
-			ws.onerror = (error) => {
-				setIsConnected(false);
+			ws.onerror = () => {
+				if (mounted) setIsConnected(false);
 				ws.close();
 			};
 		};
 
-		connect();
+		// A fresh mount of the dashboard shell means the user is signed in:
+		// re-arm reconnection that a previous logout switched off.
+		setReconnectEnabled(true);
+		setActiveConnect(() => {
+			void connect();
+		});
+		void connect();
 
 		// Cleanup function
 		return () => {
-			// Don't close the WebSocket on unmount since it's global
-			if (reconnectTimeoutRef.current) {
-				clearTimeout(reconnectTimeoutRef.current);
-				reconnectTimeoutRef.current = null;
-			}
-			if (pingTimerRef.current) {
-				clearInterval(pingTimerRef.current);
-				pingTimerRef.current = null;
-			}
+			mounted = false;
+			// Don't close the WebSocket (or its heartbeat) on unmount since it
+			// is global, but make sure nothing reconnects on behalf of this
+			// provider once it is gone.
+			setActiveConnect(null);
+			clearReconnectTimer();
+			detachAdopted?.();
+			detachAdopted = null;
 		};
 	}, [path]);
 

--- a/ui/hooks/useWebSocket.utils.test.ts
+++ b/ui/hooks/useWebSocket.utils.test.ts
@@ -1,0 +1,199 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	HEARTBEAT_INTERVAL_MS,
+	adoptSocket,
+	getSocket,
+	isReconnectEnabled,
+	setActiveConnect,
+	setReconnectEnabled,
+	setSocket,
+	scheduleReconnect,
+	startHeartbeat,
+	stopHeartbeat,
+	stopWebSocket,
+} from "./useWebSocket.utils";
+
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSED = 3;
+
+/** Minimal stand-in for a browser WebSocket: readyState, send, close and the two event APIs the lifecycle uses. */
+class FakeSocket {
+	readyState = CONNECTING;
+	sent: string[] = [];
+	onclose: (() => void) | null = null;
+	onerror: (() => void) | null = null;
+	private listeners = new Map<string, Set<() => void>>();
+
+	addEventListener(type: string, fn: () => void) {
+		if (!this.listeners.has(type)) this.listeners.set(type, new Set());
+		this.listeners.get(type)!.add(fn);
+	}
+	removeEventListener(type: string, fn: () => void) {
+		this.listeners.get(type)?.delete(fn);
+	}
+	listenerCount(type: string) {
+		return this.listeners.get(type)?.size ?? 0;
+	}
+	send(data: string) {
+		this.sent.push(data);
+	}
+	close() {
+		this.readyState = CLOSED;
+		this.emit("close");
+		this.onclose?.();
+	}
+	open() {
+		this.readyState = OPEN;
+		this.emit("open");
+	}
+	private emit(type: string) {
+		this.listeners.get(type)?.forEach((fn) => fn());
+	}
+}
+
+const asWs = (s: FakeSocket) => s as unknown as WebSocket;
+
+describe("useWebSocket lifecycle", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		stopWebSocket();
+		setReconnectEnabled(true);
+		setActiveConnect(null);
+	});
+	afterEach(() => {
+		stopWebSocket();
+		vi.useRealTimers();
+	});
+
+	describe("adoptSocket", () => {
+		it("reports open to the adopting provider when it adopts a CONNECTING socket", () => {
+			// The provider that created the socket may already be unmounted, so its
+			// onopen closure cannot update the new provider's state.
+			const socket = new FakeSocket();
+			setSocket(asWs(socket));
+			const onOpen = vi.fn();
+			const onClose = vi.fn();
+
+			adoptSocket(asWs(socket), { onOpen, onClose });
+			expect(onOpen).not.toHaveBeenCalled();
+
+			socket.open();
+			expect(onOpen).toHaveBeenCalledTimes(1);
+			expect(onClose).not.toHaveBeenCalled();
+		});
+
+		it("reports close to the adopting provider", () => {
+			const socket = new FakeSocket();
+			socket.readyState = OPEN;
+			setSocket(asWs(socket));
+			const onClose = vi.fn();
+
+			adoptSocket(asWs(socket), { onOpen: vi.fn(), onClose });
+			socket.close();
+			expect(onClose).toHaveBeenCalledTimes(1);
+		});
+
+		it("restarts the heartbeat when adopting an already-open socket that has none", () => {
+			const socket = new FakeSocket();
+			socket.readyState = OPEN;
+			setSocket(asWs(socket));
+			stopHeartbeat();
+
+			adoptSocket(asWs(socket), { onOpen: vi.fn(), onClose: vi.fn() });
+			vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+			expect(socket.sent).toEqual(["ping"]);
+		});
+
+		it("detaches its listeners when the adopting provider unmounts", () => {
+			const socket = new FakeSocket();
+			setSocket(asWs(socket));
+			const onOpen = vi.fn();
+
+			const detach = adoptSocket(asWs(socket), { onOpen, onClose: vi.fn() });
+			expect(socket.listenerCount("open")).toBe(1);
+			detach();
+			expect(socket.listenerCount("open")).toBe(0);
+			expect(socket.listenerCount("close")).toBe(0);
+
+			socket.open();
+			expect(onOpen).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("heartbeat", () => {
+		it("keeps pinging on the shared socket independent of any provider mount", () => {
+			const socket = new FakeSocket();
+			socket.readyState = OPEN;
+			setSocket(asWs(socket));
+
+			startHeartbeat(asWs(socket));
+			vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 2);
+			expect(socket.sent).toEqual(["ping", "ping"]);
+		});
+
+		it("does not ping a socket that is not open", () => {
+			const socket = new FakeSocket();
+			setSocket(asWs(socket));
+
+			startHeartbeat(asWs(socket));
+			vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+			expect(socket.sent).toEqual([]);
+		});
+
+		it("replaces a previous heartbeat instead of stacking a second one", () => {
+			const socket = new FakeSocket();
+			socket.readyState = OPEN;
+			setSocket(asWs(socket));
+
+			startHeartbeat(asWs(socket));
+			startHeartbeat(asWs(socket));
+			vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS);
+			expect(socket.sent).toEqual(["ping"]);
+		});
+	});
+
+	describe("stopWebSocket", () => {
+		it("stops the heartbeat, closes the socket without reconnecting, and disables reconnection", () => {
+			const socket = new FakeSocket();
+			socket.readyState = OPEN;
+			setSocket(asWs(socket));
+			startHeartbeat(asWs(socket));
+			const connect = vi.fn();
+			setActiveConnect(connect);
+			socket.onclose = () => scheduleReconnect();
+
+			stopWebSocket();
+
+			expect(getSocket()).toBeNull();
+			expect(socket.readyState).toBe(CLOSED);
+			expect(isReconnectEnabled()).toBe(false);
+			vi.advanceTimersByTime(HEARTBEAT_INTERVAL_MS * 4);
+			expect(socket.sent).toEqual([]);
+			expect(connect).not.toHaveBeenCalled();
+		});
+	});
+
+	describe("scheduleReconnect", () => {
+		it("reconnects through the active provider with backoff", () => {
+			const connect = vi.fn();
+			setActiveConnect(connect);
+
+			scheduleReconnect();
+			vi.advanceTimersByTime(999);
+			expect(connect).not.toHaveBeenCalled();
+			vi.advanceTimersByTime(1);
+			expect(connect).toHaveBeenCalledTimes(1);
+		});
+
+		it("does nothing once no provider is mounted", () => {
+			const connect = vi.fn();
+			setActiveConnect(connect);
+			setActiveConnect(null);
+
+			scheduleReconnect();
+			vi.advanceTimersByTime(60_000);
+			expect(connect).not.toHaveBeenCalled();
+		});
+	});
+});

--- a/ui/hooks/useWebSocket.utils.ts
+++ b/ui/hooks/useWebSocket.utils.ts
@@ -1,0 +1,136 @@
+// Module-level lifecycle for the dashboard websocket. The socket outlives any
+// single WebSocketProvider mount so a shell re-render does not tear the
+// connection down, which means nothing that keeps the socket healthy may live
+// in a provider's closure or refs: a provider that unmounts must not take the
+// heartbeat with it, and a provider that mounts onto an existing socket must be
+// able to observe that socket's open/close itself rather than through the
+// handlers a previous (possibly unmounted) provider installed.
+
+// Mirror of WebSocket.CONNECTING / OPEN so this module does not depend on the
+// browser global being present (it is not, under vitest's node environment).
+export const WS_CONNECTING = 0;
+export const WS_OPEN = 1;
+
+export const HEARTBEAT_INTERVAL_MS = 25000;
+
+let socket: WebSocket | null = null;
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let retryCount = 0;
+// Set to false once auth is gone (logout, or the ticket endpoint answering
+// 401/403). Nothing reconnects until the next provider mount re-enables it.
+let reconnectEnabled = true;
+// The connect function of the currently mounted provider, or null. A close
+// event schedules a reconnect only through this, never through the closure
+// that created the socket.
+let activeConnect: (() => void) | null = null;
+
+export function getSocket() {
+	return socket;
+}
+
+export function setSocket(ws: WebSocket | null) {
+	socket = ws;
+}
+
+export function isReconnectEnabled() {
+	return reconnectEnabled;
+}
+
+export function setReconnectEnabled(enabled: boolean) {
+	reconnectEnabled = enabled;
+}
+
+export function setActiveConnect(connect: (() => void) | null) {
+	activeConnect = connect;
+}
+
+export function resetRetryCount() {
+	retryCount = 0;
+}
+
+export function clearReconnectTimer() {
+	if (reconnectTimer) {
+		clearTimeout(reconnectTimer);
+		reconnectTimer = null;
+	}
+}
+
+export function scheduleReconnect() {
+	if (!reconnectEnabled || !activeConnect || reconnectTimer) {
+		return;
+	}
+	// Exponential backoff: 1s, 2s, 4s, 8s, 16s, 32s (max)
+	retryCount = Math.min(retryCount + 1, 6);
+	const delay = Math.pow(2, retryCount) * 500;
+	reconnectTimer = setTimeout(() => {
+		reconnectTimer = null;
+		activeConnect?.();
+	}, delay);
+}
+
+export function stopHeartbeat() {
+	if (heartbeatTimer) {
+		clearInterval(heartbeatTimer);
+		heartbeatTimer = null;
+	}
+}
+
+/** Starts (or restarts) the keep-alive ping on `ws`. Owned by the socket, not by a provider mount. */
+export function startHeartbeat(ws: WebSocket) {
+	stopHeartbeat();
+	heartbeatTimer = setInterval(() => {
+		if (ws.readyState === WS_OPEN) {
+			try {
+				ws.send("ping");
+			} catch (error) {
+				console.error("Error sending ping:", error);
+			}
+		}
+	}, HEARTBEAT_INTERVAL_MS);
+}
+
+/**
+ * Binds a freshly mounted provider to a socket that already exists. The
+ * creating provider's onopen/onclose handlers may belong to an unmounted
+ * instance, so the adopter listens for open/close itself, and re-arms the
+ * heartbeat if the socket is open without one. Returns a detach function for
+ * the adopter's cleanup.
+ */
+export function adoptSocket(ws: WebSocket, handlers: { onOpen: () => void; onClose: () => void }): () => void {
+	const onOpen = () => handlers.onOpen();
+	const onClose = () => handlers.onClose();
+	ws.addEventListener("open", onOpen);
+	ws.addEventListener("close", onClose);
+	if (ws.readyState === WS_OPEN && !heartbeatTimer) {
+		startHeartbeat(ws);
+	}
+	return () => {
+		ws.removeEventListener("open", onOpen);
+		ws.removeEventListener("close", onClose);
+	};
+}
+
+/**
+ * Tears down the shared websocket and disables reconnection. Called on
+ * sign-out so the client stops requesting tickets for a session that no
+ * longer exists. The next WebSocketProvider mount (i.e. the next login)
+ * re-enables reconnection.
+ */
+export function stopWebSocket() {
+	reconnectEnabled = false;
+	clearReconnectTimer();
+	stopHeartbeat();
+	const ws = socket;
+	socket = null;
+	if (ws) {
+		// Detach first so the close event does not try to reconnect.
+		ws.onclose = null;
+		ws.onerror = null;
+		try {
+			ws.close();
+		} catch {
+			// Already closed.
+		}
+	}
+}

--- a/ui/lib/store/apis/sessionApi.ts
+++ b/ui/lib/store/apis/sessionApi.ts
@@ -1,3 +1,5 @@
+import { stopWebSocket } from "@/hooks/useWebSocket";
+import { beginLogout, endLogout } from "@/lib/utils/logoutState";
 import { baseApi, clearAuthStorage } from "./baseApi";
 
 export interface LoginRequest {
@@ -37,12 +39,23 @@ export const sessionApi = baseApi.injectEndpoints({
 				method: "POST",
 				body: credentials,
 			}),
+			async onQueryStarted(_arg, { queryFulfilled }) {
+				await queryFulfilled;
+				// A new session: 401s are meaningful again.
+				endLogout();
+			},
 			invalidatesTags: ["Sessions"],
 		}),
 
 		// Logout endpoint
 		logout: builder.mutation<LogoutResponse, void>({
 			async queryFn(_arg, _api, _extraOptions, baseQuery) {
+				// Latch first, so 401s from queries still in flight do not each
+				// trigger a refresh + another logout, and drop the websocket so it
+				// stops requesting tickets for the session being destroyed.
+				beginLogout();
+				stopWebSocket();
+
 				const passwordLogout = await baseQuery({
 					url: "/session/logout",
 					method: "POST",
@@ -59,14 +72,16 @@ export const sessionApi = baseApi.injectEndpoints({
 
 				return { data: { message: "Logout successful" } };
 			},
-			// After logout, clear token and all cached data
-			async onQueryStarted(arg, { dispatch, queryFulfilled }) {
+			// After logout, clear local auth state. The RTK cache is reset by the
+			// caller (see Topbar.handleLogout) only after navigating away: resetting
+			// it here, while the dashboard's polled queries are still mounted, makes
+			// every one of them refetch immediately and fail with a 401.
+			async onQueryStarted(_arg, { queryFulfilled }) {
 				try {
 					await queryFulfilled;
 				} catch {
 				} finally {
 					clearAuthStorage();
-					dispatch(baseApi.util.resetApiState());
 				}
 			},
 			invalidatesTags: ["Sessions", "Config", "Providers", "Logs", "VirtualKeys", "Teams", "Customers", "Budgets", "RateLimits"],

--- a/ui/lib/utils/logoutState.ts
+++ b/ui/lib/utils/logoutState.ts
@@ -1,0 +1,20 @@
+// Process-wide "a logout is in progress or has completed" latch.
+//
+// Once sign-out starts, every request still in flight (polled dashboard
+// queries, the websocket ticket fetch) comes back 401. Without this latch each
+// of those 401s would independently try a token refresh and then call logout
+// again, producing dozens of logout requests from a single click. The latch is
+// module state, so a full page load clears it; a client-side login clears it
+// explicitly via endLogout().
+
+let loggingOut = false;
+
+export const beginLogout = (): void => {
+	loggingOut = true;
+};
+
+export const endLogout = (): void => {
+	loggingOut = false;
+};
+
+export const isLoggingOut = (): boolean => loggingOut;


### PR DESCRIPTION
## Summary

Improves the `BudgetDisplay` and `RateLimitDisplay` table cells to support optional inline scope labels and a collapsible overflow pattern, making tables where multiple budgets or limits share a window more readable without overwhelming the cell.

## Changes

- `BudgetDisplay` now accepts an optional `label` field on each budget entry, rendered inline after the currency amount to identify scope (e.g. "team", "user"). A new `maxVisible` prop caps how many rows are shown; excess entries collapse into a `+x more` line whose tooltip lists each hidden entry's spend, label, and reset cadence.
- `RateLimitDisplay` gains a `scopeLabel` prop that renders inline after the cap value, mirroring the new label pattern in `BudgetDisplay`.
- Progress bar height in `RateLimitDisplay` increased from `h-1` to `h-1.5` for better visibility.
- Tooltip text in both components switched from `text-primary-foreground/80` to `text-muted-foreground` for consistent secondary text styling.
- `EntitySelector` in `add` mode now passes the full `EntitySelectorEntry` (including `description`) to `onSelect` instead of only `{ value, label }`, giving callers access to richer metadata.
- The Models filter in `LogsFilterSidebar` and the Tool Names filter in `MCPFilterSidebar` no longer default to open, reducing visual noise on initial load.
- Minor formatting and import-order cleanup in `logsFilterSidebar.tsx` and `mcpFilterSidebar.tsx`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

1. Open a table that renders `BudgetDisplay` with more than one budget per row and pass `maxVisible={1}`. Verify only the first entry is shown and a `+x more` tooltip appears with the remaining entries.
2. Pass a `label` on a budget entry and confirm it renders inline after the currency amount in a muted style.
3. Open a table using `RateLimitDisplay` with `scopeLabel` set and confirm the label appears after the cap value.
4. Open the Logs filter sidebar and confirm the Models filter starts collapsed. Open the MCP logs filter sidebar and confirm Tool Names starts collapsed.
5. Use an `EntitySelector` in `add` mode and confirm `onSelect` receives the full entry object including any `description`.

## Screenshots/Recordings

Add before/after screenshots of the budget cell with multiple entries and the `+x more` overflow tooltip.

## Breaking changes

- [x] Yes
- [ ] No

`EntitySelector` `add` mode `onSelect` callback signature changed from `EntitySelectorOption` to `EntitySelectorEntry`. Callers that destructure only `value` and `label` are unaffected, but any caller typed to `EntitySelectorOption` will need its type updated.

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable