### PR TITLE
complexity docs changes + openapi fix

### DIFF
--- a/docs/features/governance/complexity-router.mdx
+++ b/docs/features/governance/complexity-router.mdx
@@ -19,7 +19,7 @@ This lets you route simple greetings to a fast, cheap model and deep reasoning t
 Classification runs only when a routing rule actually references `complexity_tier`, so requests that never touch a complexity rule pay no embedding cost. Once semantic classification is configured, a request it cannot confidently match, such as a near miss or timeout, leaves `complexity_tier` unpublished. You can optionally configure an **LLM fallback classifier** to step in after semantic classification has run and returned no tier. See [LLM fallback classifier](#llm-fallback-classifier). Without semantic classification configured at all, Bifrost keeps the request on its existing routing path instead of guessing. When [session-aware routing](#session-aware-routing) is enabled and the request carries a recognized session identity, a turn that still produces no tier of its own reuses the tier already retained for that session, so `complexity_tier` goes unpublished only when neither classification nor session state supplies one.
 
 <Note>
-Complexity classification is **semantic** (embedding-based). The older lexical keyword scorer is retired. See [Lexical keyword classifier (retired)](#lexical-keyword-classifier-retired) for details and migration guidance.
+Complexity classification is **semantic** (embedding-based). The older lexical keyword scorer is retired. See [Lexical keyword classifier (retired)](#lexical-keyword-classifier-retired).
 </Note>
 
 ![Complexity Router](../../media/ui-complexity-router-semantic.png)
@@ -566,11 +566,6 @@ What this means for existing deployments:
 
 - **Boot is safe.** Legacy configurations still parse and validate, so upgrades never fail on startup because of an old complexity config. Until you configure an embedding provider and model, no tier is published (`complexity_mechanism: skipped`) and complexity rules simply fall through.
 - **Your keyword lists became phrase lists.** User-added entries are retained and mapped from four tiers to three: Simple stays Simple, Code and Technical become Medium, and Reasoning becomes Complex. They are now *reference phrases* to embed, not keywords to match. Short keywords like `"debug"` or `"api"` are weak exemplars and will produce poor classifications.
-- **Recommended migration:**
-  1. **Record any custom tier entries.** If you added entries beyond the built-in defaults, note them down in the UI or from `GET /api/routing/complexity-analyzer-config`. Legacy Simple entries map to Simple, Code and Technical entries map to Medium, and Reasoning entries map to Complex.
-  2. Click **Restore defaults** (or call `POST /api/routing/complexity-analyzer-config/reset`) to replace the phrase lists with the built-in semantic reference phrases. Your embedding provider, model, and storage setting are preserved.
-  3. Configure the embedding provider and model with **Edit embedding configuration**.
-  4. **Add your own examples back** as complete example requests in the appropriate tier. This preserves your routing policy.
 - **Historical logs are unchanged.** Earlier versions also had a fourth tier, **REASONING**, merged into **COMPLEX**; old `REASONING` rows stay reachable through the logs filter, but update any routing rules that still match on `"REASONING"`.
 
 ---

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -66236,6 +66236,105 @@
         }
       }
     },
+    "/api/routing/complexity-analyzer-status/retry": {
+      "post": {
+        "operationId": "retryComplexityAnalyzerWarmup",
+        "summary": "Retry failed complexity classifier warmup",
+        "description": "Restarts the saved semantic classifier warmup only when its current state is failed. The retry runs asynchronously and does not change the saved configuration.",
+        "tags": ["Routing"],
+        "responses": {
+          "202": {
+            "description": "Semantic warmup retry accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Runtime status of the semantic complexity classifier and, when configured, the LLM fallback classifier. Never contains phrases, embeddings, or provider secrets.",
+                  "properties": {
+                    "state": {
+                      "type": "string",
+                      "enum": ["disabled", "warming", "ready", "failed"],
+                      "description": "disabled = no embedding configuration; warming = reference phrases are being embedded; ready = serving the current configuration; failed = the desired configuration failed to warm"
+                    },
+                    "loaded": {
+                      "type": "integer",
+                      "description": "Reference phrases embedded so far in the current warmup"
+                    },
+                    "total": {
+                      "type": "integer",
+                      "description": "Total reference phrases to embed in the current warmup"
+                    },
+                    "serving_previous": {
+                      "type": "boolean",
+                      "description": "When true with state=failed, the previous generation is still serving while the new one failed to warm"
+                    },
+                    "failure_reason": {
+                      "type": "string",
+                      "enum": [
+                        "authentication",
+                        "model_unavailable",
+                        "rate_limited",
+                        "timeout",
+                        "provider_unavailable",
+                        "vector_store_unavailable",
+                        "invalid_response",
+                        "unknown"
+                      ],
+                      "description": "Category of a warmup failure when state=failed. Provider and backend error bodies stay in server logs; this bounded vocabulary is what status clients receive."
+                    },
+                    "error": {
+                      "type": "string",
+                      "description": "Warmup failure detail when state=failed"
+                    },
+                    "cached_phrases": {
+                      "type": "integer",
+                      "description": "How many phrase vectors the gateway currently holds in process for the configured provider and model. The cache is in-process only, since vectors cannot be read back out of a vector store, so a restart empties it while the saved phrases look unchanged. Zero means the next save re-embeds every phrase regardless of what changed."
+                    },
+                    "storage_mode": {
+                      "type": "string",
+                      "enum": ["embedded", "vector_store"],
+                      "description": "Where exemplar vectors are actually kept, which is not always what was configured. semantic.vector_store=vector_store degrades to embedded whenever no top-level vector store is configured, so this reports what is in force rather than what was asked for. Absent until a store has been resolved."
+                    },
+                    "namespace": {
+                      "type": "string",
+                      "description": "The fingerprinted namespace the serving generation queries, for example BifrostComplexityRouter_<hash>. The backend holds no phrase text, so this is the only handle on the records the classifier owns in a shared vector store. Absent while nothing is serving."
+                    },
+                    "llm": {
+                      "type": "object",
+                      "description": "Always present in the response. state is disabled when no llm block is configured.",
+                      "properties": {
+                        "state": {
+                          "type": "string",
+                          "enum": ["disabled", "ready"],
+                          "description": "disabled = no llm configuration; ready = the llm block is configured. The classifier has no warmup, so it is ready as soon as it is saved."
+                        }
+                      }
+                    },
+                    "llm_default_prompt": {
+                      "type": "string",
+                      "description": "The shipped classification guidance, served so a configuration client can seed its prompt editor and offer a reset without holding a copy that drifts from the gateway's. Always present in the response, regardless of whether an llm block is configured."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "The semantic classifier is not currently failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "503": {
+            "$ref": "#/components/responses/ConfigStoreUnavailable"
+          }
+        }
+      }
+    },
     "/api/routing/complexity-analyzer-generations": {
       "get": {
         "operationId": "listComplexityGenerations",


### PR DESCRIPTION
## Summary

Adds a new `POST /api/routing/complexity-analyzer-status/retry` endpoint that allows retrying a failed semantic complexity classifier warmup without requiring a configuration change. Also cleans up the complexity router documentation by removing the step-by-step migration guide and trimming a redundant note link.

## Changes

- Added the `/api/routing/complexity-analyzer-status/retry` endpoint to the OpenAPI spec. The endpoint accepts a `POST` request, runs the warmup retry asynchronously, and returns a `202` with the current classifier status. It returns `409` if the classifier is not currently in a failed state, preventing unnecessary retries.
- Removed the recommended migration steps from the lexical keyword classifier retirement section, leaving only the behavioral notes about what changed.
- Shortened the note in the complexity classification intro to remove the redundant "for details and migration guidance" text, since the migration steps no longer exist.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

1. Configure a semantic complexity classifier with an invalid embedding provider to force a `failed` state.
2. Call `POST /api/routing/complexity-analyzer-status/retry` and confirm a `202` response is returned with `state: warming` or `state: failed`.
3. Call `POST /api/routing/complexity-analyzer-status/retry` again while the classifier is not in a `failed` state and confirm a `409` response is returned.
4. Confirm that calling the endpoint does not alter the saved configuration.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The retry endpoint does not expose provider secrets, phrase text, or embeddings. The status response uses the same bounded vocabulary as the existing status endpoint.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable