### PR TITLE
fix: restore explicit opt-in for Infisical secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,18 +34,17 @@ USE_NODE = NVM_SH="$${NVM_DIR:-$$HOME/.nvm}/nvm.sh"; \
 	[ -s "$$NVM_SH" ] || NVM_SH="$$(brew --prefix nvm 2>/dev/null)/nvm.sh"; \
 	if [ -s "$$NVM_SH" ]; then . "$$NVM_SH" >/dev/null && nvm install >/dev/null 2>&1 && nvm use >/dev/null 2>&1; fi
 
-# Loads secrets into the current recipe shell. Infisical is the default source (Reads
-# USE_INFISICAL env var):
-#   USE_INFISICAL=0|n|N|no|NO|false|FALSE  -> source ./.env instead (explicit opt-out)
-#   anything else (including unset)        -> source secrets from Infisical (`infisical export --path <p>`)
+# Loads secrets into the current recipe shell. Reads USE_INFISICAL env var:
+#   USE_INFISICAL=1|y|Y|yes|YES|true|TRUE  -> source secrets from Infisical (`infisical export --path <p>`)
+#   anything else                          -> source ./.env
 # Honors INFISICAL_PATH (default /local) when sourcing from Infisical.
 # After invoking `$(EXPOSE_ENV);`, all subsequent commands inherit the secrets
 # - no per-command prefix needed.
 # Use as: `$(EXPOSE_ENV); <your command>`
 define EXPOSE_ENV
 	case "$$USE_INFISICAL" in \
-		0|n|N|no|NO|false|FALSE) USE_INFISICAL_RESOLVED=0 ;; \
-		*) USE_INFISICAL_RESOLVED=1 ;; \
+		1|y|Y|yes|YES|true|TRUE) USE_INFISICAL_RESOLVED=1 ;; \
+		*) USE_INFISICAL_RESOLVED=0 ;; \
 	esac; \
 	if [ "$$USE_INFISICAL_RESOLVED" = "1" ]; then \
 		if ! which infisical > /dev/null 2>&1; then \


### PR DESCRIPTION
## Summary

Restore explicit opt-in behavior for Infisical-backed development secrets.
Commands that use `EXPOSE_ENV`, including `make dev`, now load the repository's
`.env` file unless the caller enables Infisical with `USE_INFISICAL=1` or an
equivalent truthy value.

## Changes

- Changed `USE_INFISICAL` from opt-out to opt-in.
- Restored `.env` as the default secret source when `USE_INFISICAL` is unset.
- Kept the existing truthy forms `1`, `y`, `Y`, `yes`, `YES`, `true`, and `TRUE`
  for explicitly selecting Infisical.
- Updated the Makefile comments to match the behavior.

### Problem

The default was changed from `.env` to Infisical in #5856. As a result, an
ordinary local development command unexpectedly tried to access Infisical:

```sh
make dev LOCAL=1 LOG_STYLE=pretty
```

`LOCAL=1` controls use of the local Go workspace. It does not select a secret
source. With `USE_INFISICAL` unset, the previous catch-all branch still resolved
it as enabled:

```text
make dev
  |
  v
EXPOSE_ENV
  |
  +-- USE_INFISICAL is unset
  |
  +-- catch-all branch resolves to 1
  |
  v
infisical export --path /local
```

This made Infisical an implicit dependency for normal local development and
changed the established behavior from `transports/v1.6.6`.

### Solution

The selection logic now treats only explicit truthy values as enabling
Infisical:

```text
                  +---------------------------+
                  | USE_INFISICAL value       |
                  +-------------+-------------+
                                |
             +------------------+------------------+
             |                                     |
             v                                     v
1, y, Y, yes, YES, true, TRUE             unset or anything else
             |                                     |
             v                                     v
   load from Infisical                         load .env
```

Examples:

```sh
# Default local development: load .env
make dev LOCAL=1 LOG_STYLE=pretty

# Explicit Infisical use
make dev LOCAL=1 LOG_STYLE=pretty USE_INFISICAL=1

# Explicit false value also falls back to .env
make dev LOCAL=1 LOG_STYLE=pretty USE_INFISICAL=0
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

Build and test recipes that call the shared `EXPOSE_ENV` Makefile macro are
affected. Runtime transport behavior is unchanged.

## How to test

Validate Makefile parsing and whitespace:

```sh
git diff --cached --check
make -n help >/dev/null
```

Verify `.env` remains the default by running a command that uses `EXPOSE_ENV`
without setting `USE_INFISICAL`:

```sh
make dev LOCAL=1 LOG_STYLE=pretty
```

Expected result: the command prints `Loading environment variables from .env...`
and does not invoke `infisical export`.

Verify the explicit opt-in path:

```sh
make dev LOCAL=1 LOG_STYLE=pretty USE_INFISICAL=1
```

Expected result: the command prints
`Sourcing secrets from Infisical (path=/local)` and invokes the Infisical CLI.

No config or environment variable was added. This restores the earlier meaning
of `USE_INFISICAL`.

## Screenshots/Recordings

Not applicable. There are no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

This restores the behavior from `transports/v1.6.6`. Callers that currently
depend on implicit Infisical loading must set `USE_INFISICAL=1` explicitly.

## Related issues

- Regression introduced in #5856.

## Security considerations

This change prevents local commands from contacting an external secret manager
unless the caller explicitly requests it. Infisical secrets are still exported
into the recipe environment when enabled, and `.env` handling is unchanged.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
