### PR TITLE
[fix]: preserve raw OpenAI Responses cache evidence

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- [fix]: preserve raw OpenAI Responses cache-counter presence [@valentinyanakiev](https://github.com/valentinyanakiev)
 - fix: give a Bedrock message a placeholder text block instead of a null `content` field when it has no text and no tool calls - `BedrockMessage.Content` has no `omitempty`, so a message with empty text and no tool calls (or an empty `tool_calls` array) serialized as `content:null`, which Converse rejects with "Member must not be null" (#2765)
 - [fix]: marshal required nullable response fields as null [@PSR94](https://github.com/PSR94)
 - fix: accept top-level arrays from OpenAI-compatible model APIs [@dani29](https://github.com/dani29)

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -19,6 +19,7 @@ import (
 
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
 	"github.com/valyala/fasthttp"
 )
 
@@ -1637,6 +1638,20 @@ func (provider *OpenAIProvider) Responses(ctx *schemas.BifrostContext, key schem
 	)
 }
 
+// rawResponsesCacheCountersKnown preserves one fact that
+// BifrostResponsesResponse.WithDefaults otherwise destroys: whether the raw
+// provider response actually contained an input-token detail object. Only the
+// closed boolean is retained in request context; raw content never
+// leaves this parser boundary.
+func rawResponsesCacheCountersKnown(body []byte, streaming bool) bool {
+	path := "usage.input_tokens_details"
+	if streaming {
+		path = "response.usage.input_tokens_details"
+	}
+	detail := gjson.GetBytes(body, path)
+	return detail.Exists() && detail.IsObject()
+}
+
 // HandleOpenAIResponsesRequest handles a responses request to OpenAI's API.
 func HandleOpenAIResponsesRequest(
 	ctx *schemas.BifrostContext,
@@ -1683,6 +1698,12 @@ func HandleOpenAIResponsesRequest(
 			return nil, lpErr
 		}
 		if len(lpResult.ResponseBody) > 0 {
+			// The large-request passthrough returns before the normal response parser
+			// below. Preserve the same raw presence fact at this boundary before the
+			// returned typed response can reach WithDefaults in the caller.
+			ctx.SetValue(schemas.BifrostContextKeyRawResponsesCacheCountersKnown,
+				rawResponsesCacheCountersKnown(lpResult.ResponseBody, false))
+
 			response := &schemas.BifrostResponsesResponse{}
 			if err := sonic.Unmarshal(lpResult.ResponseBody, response); err != nil {
 				return nil, providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseUnmarshal, err)
@@ -1750,6 +1771,11 @@ func HandleOpenAIResponsesRequest(
 			ExtraFields: schemas.BifrostResponseExtraFields{Latency: lpResult.Latency},
 		}, nil
 	}
+
+	// Preserve raw field presence before HandleProviderResponse / WithDefaults
+	// can materialize an empty InputTokensDetails object.
+	ctx.SetValue(schemas.BifrostContextKeyRawResponsesCacheCountersKnown,
+		rawResponsesCacheCountersKnown(body, false))
 
 	response := &schemas.BifrostResponsesResponse{}
 
@@ -2098,6 +2124,11 @@ func HandleOpenAIResponsesStreaming(
 
 			response.ExtraFields.ChunkIndex = response.SequenceNumber
 			if response.Type == schemas.ResponsesStreamResponseTypeCompleted || response.Type == schemas.ResponsesStreamResponseTypeIncomplete {
+				// The terminal event is the sole authoritative usage object. Preserve
+				// only raw presence before WithDefaults reaches plugin post hooks.
+				ctx.SetValue(schemas.BifrostContextKeyRawResponsesCacheCountersKnown,
+					rawResponsesCacheCountersKnown([]byte(jsonData), true))
+
 				// Set raw request if enabled
 				if sendBackRawRequest {
 					providerUtils.ParseAndSetRawRequest(&response.ExtraFields, jsonBody)

--- a/core/providers/openai/responses_cache_counter_presence_test.go
+++ b/core/providers/openai/responses_cache_counter_presence_test.go
@@ -1,0 +1,104 @@
+package openai
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
+)
+
+// TestRawResponsesCacheCountersKnown verifies that only a raw detail object
+// counts as observed cache-counter evidence.
+func TestRawResponsesCacheCountersKnown(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		streaming bool
+		want      bool
+	}{
+		{"unary present even when empty", `{"usage":{"input_tokens_details":{}}}`, false, true},
+		{"unary missing", `{"usage":{"input_tokens":10}}`, false, false},
+		{"unary null", `{"usage":{"input_tokens_details":null}}`, false, false},
+		{"unary scalar is not a detail object", `{"usage":{"input_tokens_details":0}}`, false, false},
+		{"stream present", `{"type":"response.completed","response":{"usage":{"input_tokens_details":{"cached_tokens":0}}}}`, true, true},
+		{"stream missing", `{"type":"response.completed","response":{"usage":{"input_tokens":10}}}`, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := rawResponsesCacheCountersKnown([]byte(tt.body), tt.streaming)
+			if got != tt.want {
+				t.Fatalf("knownness = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestLargeRequestPassthroughPreservesRawCacheCounterPresence exercises the
+// early-return boundary that bypasses the ordinary Responses parser.
+func TestLargeRequestPassthroughPreservesRawCacheCounterPresence(t *testing.T) {
+	tests := []struct {
+		name         string
+		usageDetails string
+		want         bool
+	}{
+		{"present even when empty", `,"input_tokens_details":{}`, true},
+		{"missing before defaults", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if _, err := io.Copy(io.Discard, r.Body); err != nil {
+					http.Error(w, "request read failed", http.StatusInternalServerError)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"resp_large_request","object":"response","status":"completed","model":"gpt-test","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2` + tt.usageDetails + `}}`))
+			}))
+			defer server.Close()
+
+			requestBody := `{"model":"gpt-test","input":"large request"}`
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeyLargePayloadMode, true)
+			ctx.SetValue(schemas.BifrostContextKeyLargePayloadReader, strings.NewReader(requestBody))
+			ctx.SetValue(schemas.BifrostContextKeyLargePayloadContentLength, len(requestBody))
+			ctx.SetValue(schemas.BifrostContextKeyLargePayloadContentType, "application/json")
+
+			response, bifrostErr := HandleOpenAIResponsesRequest(
+				ctx,
+				&fasthttp.Client{},
+				server.URL,
+				&schemas.BifrostResponsesRequest{Model: "gpt-test"},
+				nil,
+				nil,
+				false,
+				false,
+				schemas.OpenAI,
+				nil,
+				nil,
+				nil,
+				testNoopLogger{},
+			)
+			if bifrostErr != nil {
+				t.Fatalf("large-payload Responses request failed: %v", bifrostErr)
+			}
+			known, ok := ctx.Value(schemas.BifrostContextKeyRawResponsesCacheCountersKnown).(bool)
+			if !ok || known != tt.want {
+				t.Fatalf("raw cache-counter knownness = (%t, %t), want (%t, true)", known, ok, tt.want)
+			}
+			if response == nil {
+				t.Fatal("expected a typed response")
+			}
+			normalized := response.WithDefaults()
+			if normalized.Usage == nil || normalized.Usage.InputTokensDetails == nil {
+				t.Fatal("expected WithDefaults to materialize input token details")
+			}
+		})
+	}
+}

--- a/core/providers/openai/responses_cache_counter_presence_test.go
+++ b/core/providers/openai/responses_cache_counter_presence_test.go
@@ -39,6 +39,73 @@ func TestRawResponsesCacheCountersKnown(t *testing.T) {
 	}
 }
 
+// TestResponsesStreamCacheCounterKnownnessBoundary verifies that only a
+// terminal Responses event publishes cache-counter evidence to post hooks.
+func TestResponsesStreamCacheCounterKnownnessBoundary(t *testing.T) {
+	tests := []struct {
+		name        string
+		serve       func(*testing.T) *httptest.Server
+		wantPresent bool
+		wantKnown   bool
+	}{
+		{
+			name: "completed with details publishes known",
+			serve: func(t *testing.T) *httptest.Server {
+				return completeSSEServer(t, `data: {"type":"response.completed","sequence_number":1,"response":{"id":"r1","object":"response","created_at":1,"model":"repro-model","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2,"input_tokens_details":{"cached_tokens":0}}}}`+"\n\n")
+			},
+			wantPresent: true,
+			wantKnown:   true,
+		},
+		{
+			name: "incomplete without details publishes unknown",
+			serve: func(t *testing.T) *httptest.Server {
+				return completeSSEServer(t, `data: {"type":"response.incomplete","sequence_number":1,"response":{"id":"r2","object":"response","created_at":1,"model":"repro-model","status":"incomplete","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}`+"\n\n")
+			},
+			wantPresent: true,
+			wantKnown:   false,
+		},
+		{
+			name: "truncated before terminal publishes nothing",
+			serve: func(t *testing.T) *httptest.Server {
+				return truncatingSSEServer(t, `data: {"type":"response.output_text.delta","sequence_number":1,"delta":"partial"}`+"\n\n")
+			},
+			wantPresent: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := tt.serve(t)
+			defer server.Close()
+
+			ctx := newStreamTestContext()
+			provider := newStreamTestProvider(server.URL)
+			request := &schemas.BifrostResponsesRequest{
+				Provider: schemas.OpenAI,
+				Model:    "repro-model",
+				Input: []schemas.ResponsesMessage{{
+					Type:    schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+				}},
+			}
+			stream, bifrostErr := provider.ResponsesStream(ctx, passthroughPostHook, nil, testKey(), request)
+			if bifrostErr != nil {
+				t.Fatalf("stream setup failed: %v", bifrostErr)
+			}
+			collectChunks(t, stream)
+
+			known, present := ctx.Value(schemas.BifrostContextKeyRawResponsesCacheCountersKnown).(bool)
+			if present != tt.wantPresent {
+				t.Fatalf("raw cache-counter knownness present = %t, want %t", present, tt.wantPresent)
+			}
+			if present && known != tt.wantKnown {
+				t.Fatalf("raw cache-counter knownness = %t, want %t", known, tt.wantKnown)
+			}
+		})
+	}
+}
+
 // TestLargeRequestPassthroughPreservesRawCacheCounterPresence exercises the
 // early-return boundary that bypasses the ordinary Responses parser.
 func TestLargeRequestPassthroughPreservesRawCacheCounterPresence(t *testing.T) {

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -383,6 +383,7 @@ const (
 	BifrostContextKeyVideoOutputRequested                BifrostContextKey = "bifrost-video-output-requested"
 	BifrostContextKeyValidateKeys                        BifrostContextKey = "bifrost-validate-keys"                      // bool (triggers additional key validation during provider add/update)
 	BifrostContextKeyProviderResponseHeaders             BifrostContextKey = "bifrost-provider-response-headers"          // map[string]string (set by provider handlers for response header forwarding)
+	BifrostContextKeyRawResponsesCacheCountersKnown      BifrostContextKey = "bifrost-raw-responses-cache-counters-known" // bool (set by OpenAI Responses raw decoder; payload-blind field-presence evidence)
 	BifrostContextKeyDroppedUnsupportedTools             BifrostContextKey = "bifrost-dropped-unsupported-tools"          // []string (set by provider request builders — tool type strings silently dropped because the target provider/model doesn't support them)
 	BifrostContextKeyMCPAddedTools                       BifrostContextKey = "bifrost-mcp-added-tools"                    // []string (set by bifrost - DO NOT SET THIS MANUALLY)) - list of tools added to the request by MCP, all the tool are in the format "clientName-toolName"
 	BifrostContextKeyLargePayloadMode                    BifrostContextKey = "bifrost-large-payload-mode"                 // bool (set by bifrost - DO NOT SET THIS MANUALLY)) indicates large payload streaming mode is active


### PR DESCRIPTION
## Summary

Preserve whether raw OpenAI Responses usage included `input_tokens_details` before `WithDefaults` normalizes the response. This lets post hooks distinguish observed zero cache counters from missing telemetry.

Closes #6867.

## Changes

- Add one payload-blind `BifrostContext` boolean for raw Responses counter presence.
- Set it before normalization on ordinary unary responses.
- Set it before the large-request unary passthrough early return.
- Set it from terminal `response.completed` and `response.incomplete` SSE events.
- Leave the value absent when a stream truncates before a terminal event.
- Add parser table coverage for present-empty, missing, null, and scalar shapes.
- Add a real `httptest` upstream regression for the large-request boundary.
- Add table-driven streaming boundary coverage for completed-with-details, incomplete-without-details, and truncation.
- Add the required core changelog entry.

The implementation retains only a boolean. It does not retain raw bodies, prompts, outputs, response IDs, or arbitrary headers. A stream with no terminal usage event leaves the fact absent rather than reporting false.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

From `core`:

```sh
go test ./providers/openai -run "Test(RawResponsesCacheCountersKnown|ResponsesStreamCacheCounterKnownnessBoundary|LargeRequestPassthroughPreservesRawCacheCounterPresence)" -count=1
go test ./providers/openai -count=1
go test ./schemas -count=1
go vet ./providers/openai ./schemas
```

All commands pass on current `dev`. CodeRabbit approved current head `9f94efccc`.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The new context value is a closed boolean derived at the raw decoder boundary. Provider content, credentials, request content, response content, and response IDs are never copied into it.

## Checklist

- [x] I read the repository contribution guidance and followed it
- [x] I added tests for all changed execution paths
- [x] I updated the core changelog
- [x] I verified affected Go tests and vet locally