### PR TITLE
fix: don't serve disabled MCP clients or stale virtual MCP defs

### DIFF
--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -1459,6 +1459,13 @@ func (gs *LocalGovernanceStore) virtualMCPByID(id uint) *configstoreTables.Table
 	return nil
 }
 
+// GetVirtualMCPFromCache returns the live cached Virtual MCP definition for id, or nil. Enterprise
+// access-profile / project resolution uses this so it serves the current definition (Enabled and
+// tool specs) rather than a snapshot captured at propagate time, which goes stale on a vMCP edit.
+func (gs *LocalGovernanceStore) GetVirtualMCPFromCache(id uint) *configstoreTables.TableVirtualMCP {
+	return gs.virtualMCPByID(id)
+}
+
 // assignedVirtualMCPIDs returns a VK's assigned Virtual MCP IDs, or nil if none.
 func (gs *LocalGovernanceStore) assignedVirtualMCPIDs(vkID string) []uint {
 	if v, ok := gs.virtualMCPIDsByVK.Load(vkID); ok {

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -5662,7 +5662,8 @@ func (c *Config) GetMCPClientBySlug(slug string) (clientID, clientName string, o
 		return "", "", false
 	}
 	for _, client := range c.MCPConfig.ClientConfigs {
-		if client != nil && client.EndpointSlug == slug {
+		// Skip disabled clients so a disabled client's /mcp/<slug> endpoint is not served (admit 403).
+		if client != nil && client.EndpointSlug == slug && !client.Disabled {
 			return client.ID, client.Name, true
 		}
 	}

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -22322,3 +22322,24 @@ func TestUpdateClientConfig_PersistsExplicitZeroToolSyncInterval(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, persisted.MCPToolSyncInterval)
 }
+
+// TestGetMCPClientBySlugSkipsDisabled pins that a disabled MCP client's endpoint slug does not
+// resolve, so /mcp/<slug> is not served (admit returns 403) for a disabled direct client.
+func TestGetMCPClientBySlugSkipsDisabled(t *testing.T) {
+	c := &Config{
+		MCPConfig: &schemas.MCPConfig{
+			ClientConfigs: []*schemas.MCPClientConfig{
+				{ID: "enabled-id", Name: "Enabled", EndpointSlug: "live-slug"},
+				{ID: "disabled-id", Name: "Disabled", EndpointSlug: "dead-slug", Disabled: true},
+			},
+		},
+	}
+
+	id, name, ok := c.GetMCPClientBySlug("live-slug")
+	require.True(t, ok)
+	require.Equal(t, "enabled-id", id)
+	require.Equal(t, "Enabled", name)
+
+	_, _, ok = c.GetMCPClientBySlug("dead-slug")
+	require.False(t, ok, "a disabled client's slug must not resolve")
+}


### PR DESCRIPTION
## Summary

Disabled MCP clients were still resolvable by their endpoint slug, meaning `/mcp/<slug>` would be served even when a client was disabled. This PR fixes that by skipping disabled clients during slug resolution, causing the endpoint to return a 403. It also exposes a public accessor for the live Virtual MCP cache so that Enterprise access-profile and project resolution always reads the current vMCP definition rather than a stale snapshot captured at propagate time.

## Changes

- `GetMCPClientBySlug` now skips clients where `Disabled` is `true`, so a disabled direct client's slug no longer resolves and its `/mcp/<slug>` endpoint is not served.
- `GetVirtualMCPFromCache` is added as a public wrapper around `virtualMCPByID`, allowing Enterprise code to read the live cached Virtual MCP definition (including current `Enabled` state and tool specs) instead of a propagate-time snapshot that goes stale after a vMCP edit.
- A test `TestGetMCPClientBySlugSkipsDisabled` is added to pin that a disabled client's slug does not resolve while an enabled client's slug continues to resolve correctly.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/lib/... -run TestGetMCPClientBySlugSkipsDisabled
go test ./plugins/governance/...
go test ./...
```

1. Configure a disabled MCP client with a known slug.
2. Send a request to `/mcp/<slug>` — expect a 403 response.
3. Enable the client and repeat — expect the request to be admitted normally.
4. Edit a Virtual MCP definition and verify that access-profile resolution reflects the updated definition without requiring a re-propagation.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

Disabled MCP clients are now fully blocked at slug resolution, preventing any traffic from reaching a disabled client's endpoint. This closes a gap where a disabled client could still receive requests if its slug was known.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable