### PR TITLE
feat(ui): add guided migration dialog for custom Databricks providers to the first-party Databricks provider

### DIFF
--- a/ui/app/workspace/providers/dialogs/databricksMigrationDialog.tsx
+++ b/ui/app/workspace/providers/dialogs/databricksMigrationDialog.tsx
@@ -1,0 +1,525 @@
+"use client";
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+	AlertDialog,
+	AlertDialogAction,
+	AlertDialogCancel,
+	AlertDialogContent,
+	AlertDialogDescription,
+	AlertDialogFooter,
+	AlertDialogHeader,
+	AlertDialogTitle,
+} from "@/components/ui/alertDialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { SecretVarInput } from "@/components/ui/secretVarInput";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import {
+	getErrorMessage,
+	providersApi,
+	useAppDispatch,
+	useAppSelector,
+	useCreateProviderKeyMutation,
+	useCreateProviderMutation,
+	useDeleteProviderKeyMutation,
+	useDeleteProviderMutation,
+	useLazyGetProviderKeysQuery,
+	useLazyGetProviderQuery,
+	useRefreshProviderModelsMutation,
+	useUpdateProviderKeyMutation,
+	useUpdateProviderMutation,
+} from "@/lib/store";
+import { ModelProvider, ModelProviderName } from "@/lib/types/config";
+import { SecretVar } from "@/lib/types/schemas";
+import {
+	buildDatabricksMigrationPlan,
+	buildMigrationSteps,
+	DATABRICKS_PROVIDER,
+	DatabricksApiFormat,
+	ExistingTarget,
+	getErrorStatus,
+	isSecretVarSet,
+	maskSecret,
+	MigrationApi,
+	normalizeWorkspaceUrl,
+	MigrationPlan,
+	MigrationResult,
+	MigrationStep,
+	planNeedsInput,
+	runDatabricksMigration,
+} from "@/lib/utils/databricksMigration";
+import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
+import { AlertTriangle, Check, CircleDashed, Loader2, X } from "lucide-react";
+import { ReactNode, useEffect, useMemo, useState } from "react";
+
+interface Props {
+	show: boolean;
+	provider: ModelProvider;
+	onDeferred: () => void;
+	onMigrated: () => void;
+}
+
+type Stage = "intro" | "loading" | "preview" | "running" | "finished";
+
+const API_FORMAT_LABELS: Record<DatabricksApiFormat, string> = {
+	auto: "Auto-detect",
+	model_serving: "Model Serving",
+	ai_gateway: "AI Gateway",
+};
+
+/** Wraps an RTK error so the pure orchestrator can read a message and HTTP status. */
+const wrapError = (err: unknown): Error =>
+	Object.assign(new Error(getErrorMessage(err)), {
+		status: getErrorStatus(err),
+	});
+
+export default function DatabricksMigrationDialog({ show, provider, onDeferred, onMigrated }: Props) {
+	const dispatch = useAppDispatch();
+	const providerFormIsDirty = useAppSelector((state) => state.provider.isDirty);
+	const canCreate = useRbac(RbacResource.ModelProvider, RbacOperation.Create);
+	const canUpdate = useRbac(RbacResource.ModelProvider, RbacOperation.Update);
+	const canDelete = useRbac(RbacResource.ModelProvider, RbacOperation.Delete);
+	const hasAccess = canCreate && canUpdate && canDelete;
+
+	const [getProvider] = useLazyGetProviderQuery();
+	const [getProviderKeys] = useLazyGetProviderKeysQuery();
+	const [createProvider] = useCreateProviderMutation();
+	const [updateProvider] = useUpdateProviderMutation();
+	const [deleteProvider] = useDeleteProviderMutation();
+	const [createProviderKey] = useCreateProviderKeyMutation();
+	const [updateProviderKey] = useUpdateProviderKeyMutation();
+	const [deleteProviderKey] = useDeleteProviderKeyMutation();
+	const [refreshModels] = useRefreshProviderModelsMutation();
+
+	const [stage, setStage] = useState<Stage>("intro");
+	const [plan, setPlan] = useState<MigrationPlan | undefined>();
+	const [loadError, setLoadError] = useState<string | undefined>();
+	const [steps, setSteps] = useState<MigrationStep[]>([]);
+	const [result, setResult] = useState<MigrationResult | undefined>();
+
+	// Start over whenever a different provider is opened.
+	useEffect(() => {
+		setStage("intro");
+		setPlan(undefined);
+		setLoadError(undefined);
+		setSteps([]);
+		setResult(undefined);
+	}, [provider.name]);
+
+	const api = useMemo<MigrationApi>(
+		() => ({
+			getProvider: (name) =>
+				getProvider(name, false)
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+			getProviderKeys: (name) =>
+				getProviderKeys(name, false)
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+			createProvider: (body) =>
+				createProvider(body)
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+			updateProvider: (name, body) =>
+				updateProvider({ name: name as ModelProviderName, ...body })
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+			deleteProvider: (name) =>
+				deleteProvider(name)
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+			createProviderKey: (p, key) =>
+				createProviderKey({ provider: p, key })
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+			updateProviderKey: (p, keyId, key) =>
+				updateProviderKey({ provider: p, keyId, key })
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+			deleteProviderKey: (p, keyId) =>
+				deleteProviderKey({ provider: p, keyId })
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+			refreshModels: (p) =>
+				refreshModels(p)
+					.unwrap()
+					.catch((err) => Promise.reject(wrapError(err))),
+		}),
+		[
+			getProvider,
+			getProviderKeys,
+			createProvider,
+			updateProvider,
+			deleteProvider,
+			createProviderKey,
+			updateProviderKey,
+			deleteProviderKey,
+			refreshModels,
+		],
+	);
+
+	const loadPlan = async () => {
+		setStage("loading");
+		setLoadError(undefined);
+		try {
+			const [sourceProvider, sourceKeys] = await Promise.all([api.getProvider(provider.name), api.getProviderKeys(provider.name)]);
+			let existingTarget: ExistingTarget | undefined;
+			if (sourceProvider.name.trim().toLowerCase() !== DATABRICKS_PROVIDER) {
+				try {
+					const target = await api.getProvider(DATABRICKS_PROVIDER);
+					const targetKeys = await api.getProviderKeys(DATABRICKS_PROVIDER);
+					existingTarget = { provider: target, keys: targetKeys };
+				} catch (err) {
+					if (getErrorStatus(err) !== 404) throw err;
+				}
+			}
+			setPlan(buildDatabricksMigrationPlan(sourceProvider, sourceKeys, existingTarget));
+			setStage("preview");
+		} catch (err) {
+			setLoadError(err instanceof Error ? err.message : getErrorMessage(err));
+			setStage("intro");
+		}
+	};
+
+	const runMigration = async () => {
+		if (!plan) return;
+		setStage("running");
+		setSteps(buildMigrationSteps(plan));
+		const outcome = await runDatabricksMigration(plan, api, setSteps);
+		setResult(outcome);
+		setStage("finished");
+		if (outcome.ok) {
+			dispatch(providersApi.util.invalidateTags(["Providers", { type: "ProviderKeys", id: DATABRICKS_PROVIDER }, "DBKeys", "VirtualKeys"]));
+		}
+	};
+
+	const updateKeyValue = (tempId: string, value: SecretVar) => {
+		setPlan((prev) =>
+			prev
+				? {
+						...prev,
+						keys: prev.keys.map((k) => (k.tempId === tempId ? { ...k, value } : k)),
+					}
+				: prev,
+		);
+	};
+
+	const migrateDisabledReason = !hasAccess
+		? "Migrating requires create, update and delete access to providers."
+		: providerFormIsDirty
+			? "Save or discard your unsaved provider changes first."
+			: undefined;
+
+	const canMigrate = !!plan && !migrateDisabledReason && !planNeedsInput(plan);
+
+	return (
+		<AlertDialog open={show}>
+			<AlertDialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl" data-testid="databricks-migration-dialog">
+				<AlertDialogHeader>
+					<AlertDialogTitle className="flex items-center gap-2">
+						<RenderProviderIcon provider={DATABRICKS_PROVIDER as ProviderIconType} size="sm" className="h-5 w-5 shrink-0" />
+						{stage === "finished" && result ? (result.ok ? "Migration complete" : "Migration failed") : "Databricks is now a first-party provider"}
+					</AlertDialogTitle>
+					<AlertDialogDescription asChild>
+						<div className="space-y-2">
+							{(stage === "intro" || stage === "loading") && (
+								<>
+									<p>
+										<span className="text-foreground font-medium">{provider.name}</span> is a custom provider pointing at a Databricks workspace.
+										Bifrost now supports Databricks natively, with personal access tokens, OAuth service principals, Model Serving and AI Gateway
+										routing. Your existing configuration needs to be migrated to the official provider.
+									</p>
+									<p>
+										Nothing changes until you confirm. You will see exactly what will be copied before the migration runs, and the custom provider is
+										only removed after the new one is verified.
+									</p>
+								</>
+							)}
+							{stage === "preview" && <p>Review what will be migrated. Secrets are masked; anything that could not be read must be entered below.</p>}
+							{stage === "running" && <p>Migrating. Keep this window open until it finishes.</p>}
+							{stage === "finished" && result && <p>{result.message}</p>}
+						</div>
+					</AlertDialogDescription>
+				</AlertDialogHeader>
+
+				{loadError && (
+					<Alert variant="destructive">
+						<AlertTriangle className="h-4 w-4" />
+						<AlertTitle>Could not read the custom provider</AlertTitle>
+						<AlertDescription>{loadError}</AlertDescription>
+					</Alert>
+				)}
+
+				{stage === "preview" && plan && (
+					<MigrationPreview
+						plan={plan}
+						onWorkspaceUrlChange={(v) => setPlan({ ...plan, workspaceUrl: v })}
+						onApiFormatChange={(v) => setPlan({ ...plan, apiFormat: v })}
+						onKeyValueChange={updateKeyValue}
+					/>
+				)}
+
+				{(stage === "running" || stage === "finished") && <MigrationProgress steps={steps} />}
+
+				<AlertDialogFooter>
+					{(stage === "intro" || stage === "loading") && (
+						<>
+							<AlertDialogCancel onClick={onDeferred} disabled={stage === "loading"} data-testid="databricks-migration-not-now">
+								Not now
+							</AlertDialogCancel>
+							<DisabledTooltip reason={migrateDisabledReason}>
+								<Button onClick={loadPlan} disabled={!!migrateDisabledReason || stage === "loading"} data-testid="databricks-migration-start">
+									{stage === "loading" && <Loader2 className="h-4 w-4 animate-spin" />}
+									Let&apos;s migrate
+								</Button>
+							</DisabledTooltip>
+						</>
+					)}
+					{stage === "preview" && (
+						<>
+							<Button variant="ghost" onClick={() => setStage("intro")}>
+								Back
+							</Button>
+							<AlertDialogCancel onClick={onDeferred}>Not now</AlertDialogCancel>
+							<DisabledTooltip reason={migrateDisabledReason ?? (plan && planNeedsInput(plan) ? "Fill in the missing values above." : undefined)}>
+								<Button onClick={runMigration} disabled={!canMigrate} data-testid="databricks-migration-confirm">
+									Migrate
+								</Button>
+							</DisabledTooltip>
+						</>
+					)}
+					{stage === "finished" && result && (
+						<>
+							{!result.ok && (
+								<AlertDialogCancel onClick={onDeferred} data-testid="databricks-migration-close">
+									Close
+								</AlertDialogCancel>
+							)}
+							{result.ok && (
+								<AlertDialogAction onClick={onMigrated} data-testid="databricks-migration-done">
+									Go to Databricks
+								</AlertDialogAction>
+							)}
+						</>
+					)}
+				</AlertDialogFooter>
+			</AlertDialogContent>
+		</AlertDialog>
+	);
+}
+
+function DisabledTooltip({ reason, children }: { reason?: string; children: ReactNode }) {
+	if (!reason) return <>{children}</>;
+	return (
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<span tabIndex={0}>{children}</span>
+			</TooltipTrigger>
+			<TooltipContent>{reason}</TooltipContent>
+		</Tooltip>
+	);
+}
+
+interface PreviewProps {
+	plan: MigrationPlan;
+	onWorkspaceUrlChange: (value: string) => void;
+	onApiFormatChange: (value: DatabricksApiFormat) => void;
+	onKeyValueChange: (tempId: string, value: SecretVar) => void;
+}
+
+function MigrationPreview({ plan, onWorkspaceUrlChange, onApiFormatChange, onKeyValueChange }: PreviewProps) {
+	const net = plan.providerSettings.network_config;
+	const perf = plan.providerSettings.concurrency_and_buffer_size;
+	const otherHeaders = Object.keys(net.extra_headers ?? {});
+
+	return (
+		<div className="space-y-4 text-sm" data-testid="databricks-migration-preview">
+			<section className="space-y-2">
+				<SectionTitle>Workspace</SectionTitle>
+				<div className="grid gap-3 sm:grid-cols-[1fr_180px]">
+					<div className="space-y-1">
+						<Label htmlFor="databricks-migration-workspace-url">Workspace URL</Label>
+						<Input
+							id="databricks-migration-workspace-url"
+							data-testid="databricks-migration-workspace-url"
+							value={plan.workspaceUrl}
+							placeholder="https://adb-1234567890123456.7.azuredatabricks.net"
+							onChange={(e) => onWorkspaceUrlChange(e.target.value)}
+							onBlur={(e) => onWorkspaceUrlChange(normalizeWorkspaceUrl(e.target.value) || e.target.value)}
+						/>
+					</div>
+					<div className="space-y-1">
+						<Label>Inference surface</Label>
+						<Select value={plan.apiFormat} onValueChange={(v) => onApiFormatChange(v as DatabricksApiFormat)}>
+							<SelectTrigger data-testid="databricks-migration-api-format">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								{(Object.keys(API_FORMAT_LABELS) as DatabricksApiFormat[]).map((format) => (
+									<SelectItem key={format} value={format}>
+										{API_FORMAT_LABELS[format]}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					</div>
+				</div>
+			</section>
+
+			<section className="space-y-2">
+				<SectionTitle>
+					{plan.keys.length === 1 && plan.source.isKeyless ? "Authentication" : `Keys (${plan.keys.length})`}
+					{plan.targetExists && (
+						<Badge variant="secondary" className="ml-2">
+							added to existing provider
+						</Badge>
+					)}
+				</SectionTitle>
+				<div className="divide-y rounded-md border">
+					{plan.keys.map((key) => (
+						<div key={key.tempId} className="space-y-2 p-3" data-testid={`databricks-migration-key-${key.tempId}`}>
+							<div className="flex flex-wrap items-center gap-2">
+								<span className="font-medium">{key.name}</span>
+								{key.fromHeader && (
+									<Badge variant="outline" className="text-muted-foreground">
+										from Authorization header
+									</Badge>
+								)}
+								{key.createName !== key.name && (
+									<Badge variant="outline" className="text-muted-foreground">
+										created as {key.createName}, renamed after cleanup
+									</Badge>
+								)}
+							</div>
+							<div className="text-muted-foreground flex flex-wrap gap-x-4 gap-y-1 text-xs">
+								<span>Models: {key.models.length === 0 || key.models.includes("*") ? "all" : key.models.join(", ")}</span>
+								{key.blacklisted_models.length > 0 && <span>Blacklisted: {key.blacklisted_models.join(", ")}</span>}
+								<span>Weight: {key.weight}</span>
+								<span>Aliases: {Object.keys(key.aliases ?? {}).length}</span>
+								{!key.enabled && <span>Disabled</span>}
+							</div>
+							{key.needsValue || !isSecretVarSet(key.value) ? (
+								<div className="space-y-1">
+									<Label htmlFor={`databricks-migration-token-${key.tempId}`}>
+										Personal access token <span className="text-destructive">*</span>
+									</Label>
+									<SecretVarInput
+										id={`databricks-migration-token-${key.tempId}`}
+										data-testid={`databricks-migration-token-${key.tempId}`}
+										value={key.value ?? { value: "", ref: "" }}
+										onChange={(v) => onKeyValueChange(key.tempId, v)}
+										placeholder="dapi... or env.DATABRICKS_TOKEN"
+									/>
+									<p className="text-muted-foreground text-xs">
+										{key.fromHeader
+											? "The token could not be read from the custom provider."
+											: "Stored secrets are masked and cannot be copied; enter it again."}
+									</p>
+								</div>
+							) : (
+								<div className="text-xs">
+									<span className="text-muted-foreground">Personal access token: </span>
+									<code className="bg-muted rounded px-1 py-0.5 font-mono" data-testid={`databricks-migration-masked-${key.tempId}`}>
+										{maskSecret(key.value)}
+									</code>
+								</div>
+							)}
+						</div>
+					))}
+				</div>
+			</section>
+
+			<section className="space-y-2">
+				<SectionTitle>
+					Provider settings
+					{plan.targetExists && (
+						<Badge variant="secondary" className="ml-2">
+							existing settings kept
+						</Badge>
+					)}
+				</SectionTitle>
+				<dl className="text-muted-foreground grid grid-cols-2 gap-x-4 gap-y-1 text-xs sm:grid-cols-3">
+					<Stat label="Timeout" value={`${net.default_request_timeout_in_seconds}s`} />
+					<Stat label="Retries" value={String(net.max_retries)} />
+					<Stat label="Backoff" value={`${net.retry_backoff_initial}ms → ${net.retry_backoff_max}ms`} />
+					<Stat label="Concurrency" value={String(perf.concurrency)} />
+					<Stat label="Buffer size" value={String(perf.buffer_size)} />
+					<Stat label="Proxy" value={plan.providerSettings.proxy_config?.type ?? "none"} />
+					<Stat label="Extra headers" value={otherHeaders.length > 0 ? otherHeaders.join(", ") : "none"} />
+					<Stat label="Private network" value={net.allow_private_network ? "allowed" : "blocked"} />
+					<Stat
+						label="Raw request/response"
+						value={plan.providerSettings.send_back_raw_request || plan.providerSettings.send_back_raw_response ? "on" : "off"}
+					/>
+				</dl>
+			</section>
+
+			{plan.warnings.length > 0 && (
+				<Alert variant={plan.nameClash ? "destructive" : "default"} data-testid="databricks-migration-warnings">
+					<AlertTriangle className="h-4 w-4" />
+					<AlertTitle>Before you continue</AlertTitle>
+					<AlertDescription>
+						<ul className="list-disc space-y-1 pl-4">
+							{plan.warnings.map((warning) => (
+								<li key={warning}>{warning}</li>
+							))}
+						</ul>
+					</AlertDescription>
+				</Alert>
+			)}
+		</div>
+	);
+}
+
+function MigrationProgress({ steps }: { steps: MigrationStep[] }) {
+	return (
+		<ol className="space-y-2 text-sm" data-testid="databricks-migration-progress">
+			{steps.map((step) => (
+				<li key={step.id} className="flex items-start gap-2" data-testid={`databricks-migration-step-${step.id}`} data-status={step.status}>
+					<StepIcon status={step.status} />
+					<div className="min-w-0 flex-1">
+						<div className={step.status === "pending" ? "text-muted-foreground" : ""}>{step.label}</div>
+						{step.detail && (
+							<div className={`mt-0.5 text-xs whitespace-pre-line ${step.status === "failed" ? "text-destructive" : "text-muted-foreground"}`}>
+								{step.detail}
+							</div>
+						)}
+					</div>
+				</li>
+			))}
+		</ol>
+	);
+}
+
+function StepIcon({ status }: { status: MigrationStep["status"] }) {
+	switch (status) {
+		case "running":
+			return <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin" />;
+		case "done":
+			return <Check className="mt-0.5 h-4 w-4 shrink-0 text-green-600" />;
+		case "failed":
+			return <X className="text-destructive mt-0.5 h-4 w-4 shrink-0" />;
+		case "skipped":
+			return <CircleDashed className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />;
+		default:
+			return <CircleDashed className="text-muted-foreground/50 mt-0.5 h-4 w-4 shrink-0" />;
+	}
+}
+
+function SectionTitle({ children }: { children: ReactNode }) {
+	return <h4 className="flex items-center text-xs font-semibold tracking-wide uppercase">{children}</h4>;
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+	return (
+		<div className="min-w-0">
+			<dt className="inline">{label}: </dt>
+			<dd className="text-foreground inline break-all">{value}</dd>
+		</div>
+	);
+}

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -18,8 +18,9 @@ import {
 	useGetProvidersQuery,
 	useLazyGetProviderQuery,
 } from "@/lib/store";
-import { KnownProvider, ModelProviderName, ProviderStatus } from "@/lib/types/config";
+import { KnownProvider, ModelProvider, ModelProviderName, ProviderStatus } from "@/lib/types/config";
 import { cn } from "@/lib/utils";
+import { DATABRICKS_PROVIDER, isCustomDatabricksProvider } from "@/lib/utils/databricksMigration";
 import { findCustomProviderCollisions, normalizeProviderName } from "@/lib/utils/providerCollision";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { useNavigate } from "@tanstack/react-router";
@@ -30,6 +31,7 @@ import { toast } from "sonner";
 import AddCustomProviderSheet from "./dialogs/addNewCustomProviderSheet";
 import ConfirmDeleteProviderDialog from "./dialogs/confirmDeleteProviderDialog";
 import ConfirmRedirectionDialog from "./dialogs/confirmRedirection";
+import DatabricksMigrationDialog from "./dialogs/databricksMigrationDialog";
 import FirstPartyProviderAvailableDialog from "./dialogs/firstPartyProviderAvailableDialog";
 import { AddProviderDropdown } from "./views/addProviderDropdown";
 import { ProvidersEmptyState } from "./views/providersEmptyState";
@@ -60,6 +62,11 @@ export default function Providers() {
 	const [provider, setProvider] = useQueryState("provider");
 	const { dismissed: dismissedCollisions, dismiss: dismissCollision, hydrated: collisionsHydrated } = useDismissedProviderCollisions();
 	const [handledCollisions, setHandledCollisions] = useState<Set<string>>(() => new Set());
+	// Custom Databricks provider the user chose not to migrate for now; cleared on every re-selection.
+	const [migrationDeferredFor, setMigrationDeferredFor] = useState<string | undefined>(undefined);
+	// The migration dialog is pinned to the provider it opened for: the source disappears from the
+	// list mid-migration, and the dialog must survive that.
+	const [migrationSession, setMigrationSession] = useState<{ provider: ModelProvider } | undefined>(undefined);
 
 	const { data: savedProviders, isLoading: isLoadingProviders } = useGetProvidersQuery();
 	const [getProvider, { isLoading: isLoadingProvider }] = useLazyGetProviderQuery();
@@ -73,12 +80,25 @@ export default function Providers() {
 	const knownProviders = ProviderNames.map((name) => ({ name }));
 
 	// Custom providers whose name matches a provider that is now supported natively.
+	// Databricks is excluded: it gets the guided migration dialog below instead of the advisory one.
 	const activeCollision = collisionsHydrated
 		? findCustomProviderCollisions(configuredProviders).find((c) => {
 			const key = normalizeProviderName(c.customName);
-			return !dismissedCollisions.has(key) && !handledCollisions.has(key);
+			return c.knownProvider !== DATABRICKS_PROVIDER && !dismissedCollisions.has(key) && !handledCollisions.has(key);
 		})
 		: undefined;
+
+	// Open the migration dialog when the selected provider is a custom provider named exactly
+	// "databricks", unless the user deferred it for this selection.
+	useEffect(() => {
+		if (migrationSession || !selectedProvider || provider !== selectedProvider.name || isLoadingProvider) return;
+		if (migrationDeferredFor === selectedProvider.name) return;
+		if (isCustomDatabricksProvider(selectedProvider)) setMigrationSession({ provider: selectedProvider });
+	}, [migrationSession, selectedProvider, provider, isLoadingProvider, migrationDeferredFor]);
+
+	useEffect(() => {
+		setMigrationDeferredFor(undefined);
+	}, [provider]);
 
 	useEffect(() => {
 		if (!provider) return;
@@ -127,15 +147,16 @@ export default function Providers() {
 		}
 	}, [isMobile, provider]);
 
-	// When current provider is no longer configured (e.g. all keys deleted), switch to another configured provider
+	// When current provider is no longer configured (e.g. all keys deleted), switch to another configured provider.
+	// Held off while a Databricks migration is in progress: it removes the current provider on purpose.
 	useEffect(() => {
-		if (!provider || configuredProviderNamesArr.length === 0) return;
+		if (!provider || configuredProviderNamesArr.length === 0 || migrationSession) return;
 		const isCurrentConfigured = configuredProviderNamesArr.includes(provider as ModelProviderName);
 		if (!isCurrentConfigured) {
 			setProvider(configuredProviderNamesArr[0]);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [provider, configuredProviderNamesKey]);
+	}, [provider, configuredProviderNamesKey, migrationSession]);
 
 	if (!hasProvidersAccess && hasSettingsOnly) {
 		return <FullPageLoader />;
@@ -210,7 +231,23 @@ export default function Providers() {
 					setShowDeleteProviderDialog(false);
 				}}
 			/>
-			{activeCollision && (
+			{migrationSession && (
+				<DatabricksMigrationDialog
+					show
+					provider={migrationSession.provider}
+					onDeferred={() => {
+						setMigrationDeferredFor(migrationSession.provider.name);
+						setMigrationSession(undefined);
+					}}
+					onMigrated={() => {
+						setMigrationDeferredFor(undefined);
+						setMigrationSession(undefined);
+						setProvider(DATABRICKS_PROVIDER);
+						if (isMobile) setMobileDetailOpen(true);
+					}}
+				/>
+			)}
+			{activeCollision && !migrationSession && (
 				<FirstPartyProviderAvailableDialog
 					show
 					customProviderName={activeCollision.customName}

--- a/ui/lib/utils/databricksMigration.test.ts
+++ b/ui/lib/utils/databricksMigration.test.ts
@@ -1,0 +1,410 @@
+import { describe, expect, it } from "vitest";
+
+import { ModelProvider, ModelProviderKey } from "@/lib/types/config";
+import {
+	buildDatabricksMigrationPlan,
+	buildMigrationSteps,
+	deriveDatabricksWorkspace,
+	isCustomDatabricksProvider,
+	extractAuthFromHeaders,
+	maskSecret,
+	MigrationApi,
+	MigrationPlan,
+	planNeedsInput,
+	runDatabricksMigration,
+	toDatabricksKeyPayload,
+} from "./databricksMigration";
+
+const REDACTED = "dapi************************abcd";
+
+const custom = (name: string, overrides: Partial<ModelProvider> = {}): ModelProvider =>
+	({
+		name,
+		provider_status: "active",
+		custom_provider_config: { base_provider_type: "openai", is_key_less: true },
+		network_config: {
+			base_url: "https://adb-123.4.azuredatabricks.net/serving-endpoints",
+			extra_headers: { Authorization: "Bearer dapi1234567890secret" },
+			default_request_timeout_in_seconds: 60,
+			max_retries: 2,
+			retry_backoff_initial: 500,
+			retry_backoff_max: 5000,
+		},
+		concurrency_and_buffer_size: { concurrency: 10, buffer_size: 20 },
+		...overrides,
+	}) as ModelProvider;
+
+const key = (id: string, name: string, overrides: Partial<ModelProviderKey> = {}): ModelProviderKey => ({
+	id,
+	name,
+	value: { value: REDACTED, ref: "" },
+	models: ["a", "b"],
+	blacklisted_models: [],
+	weight: 0.5,
+	enabled: true,
+	...overrides,
+});
+
+describe("isCustomDatabricksProvider", () => {
+	it("matches only a custom provider named exactly databricks", () => {
+		expect(isCustomDatabricksProvider(custom("databricks"))).toBe(true);
+		expect(isCustomDatabricksProvider(custom("Databricks "))).toBe(true);
+		expect(isCustomDatabricksProvider(custom("databricks-bc"))).toBe(false);
+		expect(isCustomDatabricksProvider(custom("my-dbx"))).toBe(false);
+		expect(isCustomDatabricksProvider({ ...custom("databricks"), custom_provider_config: undefined })).toBe(false);
+	});
+});
+
+describe("deriveDatabricksWorkspace", () => {
+	it("derives the surface from the path", () => {
+		expect(deriveDatabricksWorkspace("https://h.cloud.databricks.com/serving-endpoints/")).toMatchObject({
+			workspaceUrl: "https://h.cloud.databricks.com",
+			apiFormat: "model_serving",
+		});
+		expect(deriveDatabricksWorkspace("https://h.cloud.databricks.com/ai-gateway/mlflow/v1").apiFormat).toBe("ai_gateway");
+		expect(deriveDatabricksWorkspace("https://h.cloud.databricks.com").apiFormat).toBe("auto");
+	});
+
+	it("warns on unknown paths and http, and keeps ports", () => {
+		const unknown = deriveDatabricksWorkspace("http://h.cloud.databricks.com:8443/v1");
+		expect(unknown.workspaceUrl).toBe("https://h.cloud.databricks.com:8443");
+		expect(unknown.apiFormat).toBe("auto");
+		expect(unknown.warnings).toHaveLength(2);
+	});
+
+	it("accepts a bare host and rejects garbage", () => {
+		expect(deriveDatabricksWorkspace("h.cloud.databricks.com/serving-endpoints").apiFormat).toBe("model_serving");
+		expect(deriveDatabricksWorkspace("").workspaceUrl).toBe("");
+	});
+});
+
+describe("extractAuthFromHeaders", () => {
+	it("reads bearer tokens case-insensitively", () => {
+		expect(extractAuthFromHeaders({ authorization: "bearer  tok" }).token).toEqual({ value: "tok", ref: "", type: undefined });
+		expect(extractAuthFromHeaders({ Authorization: "Bearer env.DBX" }).token).toMatchObject({ ref: "env.DBX", type: "env" });
+		expect(extractAuthFromHeaders({ Authorization: "vault.secret/dbx" }).token).toMatchObject({ ref: "vault.secret/dbx", type: "vault" });
+	});
+
+	it("reports missing or non-bearer headers", () => {
+		expect(extractAuthFromHeaders(undefined).problem).toBe("missing");
+		expect(extractAuthFromHeaders({ "X-Api-Key": "x" }).problem).toBe("missing");
+		expect(extractAuthFromHeaders({ Authorization: "Basic abc" }).problem).toBe("not_bearer");
+	});
+});
+
+describe("maskSecret", () => {
+	it("masks literals and shows refs", () => {
+		expect(maskSecret({ value: "dapi1234567890secret", ref: "" })).toBe("dapi****cret");
+		expect(maskSecret({ value: "short", ref: "" })).toBe("****");
+		expect(maskSecret({ value: "", ref: "env.X" })).toBe("env.X");
+	});
+});
+
+describe("buildDatabricksMigrationPlan", () => {
+	it("synthesizes one key from the header for a keyless source", () => {
+		const plan = buildDatabricksMigrationPlan(custom("my-dbx"), []);
+		expect(plan.keys).toHaveLength(1);
+		expect(plan.keys[0]).toMatchObject({
+			name: "my-dbx-token",
+			createName: "my-dbx-token",
+			fromHeader: true,
+			needsValue: false,
+			models: ["*"],
+		});
+		expect(plan.keys[0].value).toMatchObject({ value: "dapi1234567890secret" });
+		expect(plan.workspaceUrl).toBe("https://adb-123.4.azuredatabricks.net");
+		expect(plan.apiFormat).toBe("model_serving");
+		expect(plan.nameClash).toBe(false);
+		expect(planNeedsInput(plan)).toBe(false);
+	});
+
+	it("strips the Authorization header and base url from provider settings", () => {
+		const source = custom("my-dbx", {
+			network_config: {
+				...custom("x").network_config!,
+				extra_headers: { Authorization: "Bearer t", "X-Trace": "1" },
+			},
+			proxy_config: {
+				type: "http",
+				url: { value: "", ref: "env.PROXY" },
+				password: { value: "<REDACTED>", ref: "" },
+			},
+		});
+		const plan = buildDatabricksMigrationPlan(source, []);
+		expect(plan.providerSettings.network_config.extra_headers).toEqual({
+			"X-Trace": "1",
+		});
+		expect(plan.providerSettings.network_config.base_url).toBeUndefined();
+		expect(plan.providerSettings.network_config.default_request_timeout_in_seconds).toBe(60);
+		expect(plan.providerSettings.concurrency_and_buffer_size).toEqual({
+			concurrency: 10,
+			buffer_size: 20,
+		});
+		expect(plan.providerSettings.proxy_config).toEqual({
+			type: "http",
+			url: { value: "", ref: "env.PROXY" },
+		});
+		expect(plan.warnings.some((w) => w.includes("proxy password"))).toBe(true);
+	});
+
+	it("maps keyed sources, requiring re-entry for masked values and keeping refs", () => {
+		const keys = [
+			key("k1", "prod", { aliases: { alias: "real-model" } as never }),
+			key("k2", "ref", { value: { value: "", ref: "env.DBX", type: "env" } }),
+		];
+		const plan = buildDatabricksMigrationPlan(
+			custom("my-dbx", {
+				custom_provider_config: { base_provider_type: "openai" },
+			}),
+			keys,
+		);
+		expect(plan.source.isKeyless).toBe(false);
+		expect(plan.keys.map((k) => k.createName)).toEqual(["prod-migrating", "ref-migrating"]);
+		expect(plan.keys[0].needsValue).toBe(true);
+		expect(plan.keys[0].aliases).toEqual({ alias: { model_id: "real-model" } });
+		expect(plan.keys[1].needsValue).toBe(false);
+		expect(plan.keys[1].value).toMatchObject({ ref: "env.DBX", type: "env" });
+		expect(plan.warnings.some((w) => w.includes("Authorization header"))).toBe(true);
+		expect(planNeedsInput(plan)).toBe(true);
+	});
+
+	it("flags a name clash and does not suffix keys on that path", () => {
+		const plan = buildDatabricksMigrationPlan(
+			custom("databricks", {
+				custom_provider_config: { base_provider_type: "openai" },
+			}),
+			[key("k1", "prod")],
+		);
+		expect(plan.nameClash).toBe(true);
+		expect(plan.keys[0].createName).toBe("prod");
+		expect(buildMigrationSteps(plan).map((s) => s.id)[1]).toBe("delete-source");
+	});
+
+	it("keeps a permanent suffix when the existing target already has the key name", () => {
+		const target = {
+			provider: custom("databricks", { custom_provider_config: undefined }),
+			keys: [key("t1", "prod")],
+		};
+		const plan = buildDatabricksMigrationPlan(
+			custom("my-dbx", {
+				custom_provider_config: { base_provider_type: "openai" },
+			}),
+			[key("k1", "prod")],
+			target,
+		);
+		expect(plan.targetExists).toBe(true);
+		expect(plan.keys[0]).toMatchObject({
+			name: "prod-migrating",
+			createName: "prod-migrating",
+		});
+		expect(buildMigrationSteps(plan).some((s) => s.id === "rename-keys")).toBe(false);
+	});
+
+	it("warns about non-portable custom settings and config.json sources", () => {
+		const plan = buildDatabricksMigrationPlan(
+			custom("my-dbx", {
+				config_hash: "abc",
+				custom_provider_config: {
+					base_provider_type: "openai",
+					is_key_less: true,
+					allowed_requests: {
+						chat_completion: true,
+						embedding: false,
+					} as never,
+					request_path_overrides: { chat_completion: "/x" },
+				},
+			}),
+			[],
+		);
+		expect(plan.warnings.filter((w) => /Allowed request|path overrides|config\.json/.test(w))).toHaveLength(3);
+	});
+
+	it("enables migration once a masked key gets a value, and strips paths from an edited workspace url", () => {
+		const plan = buildDatabricksMigrationPlan(
+			custom("my-dbx", { custom_provider_config: { base_provider_type: "openai" } }),
+			[key("k1", "prod")],
+		);
+		expect(planNeedsInput(plan)).toBe(true);
+		const filled: MigrationPlan = {
+			...plan,
+			workspaceUrl: "https://dbc-ba56e0d8-0771.cloud.databricks.com/some_path/?x=1",
+			keys: plan.keys.map((k) => ({ ...k, value: { value: "dapi-new-token-value", ref: "" } })),
+		};
+		expect(planNeedsInput(filled)).toBe(false);
+		expect(toDatabricksKeyPayload(filled, filled.keys[0]).databricks_key_config?.workspace_url.value).toBe(
+			"https://dbc-ba56e0d8-0771.cloud.databricks.com",
+		);
+		expect(planNeedsInput({ ...filled, workspaceUrl: "not a url" })).toBe(true);
+	});
+
+	it("builds a databricks key payload with the workspace on every key", () => {
+		const plan = buildDatabricksMigrationPlan(custom("my-dbx"), []);
+		expect(toDatabricksKeyPayload(plan, plan.keys[0])).toMatchObject({
+			name: "my-dbx-token",
+			databricks_key_config: {
+				workspace_url: {
+					value: "https://adb-123.4.azuredatabricks.net",
+					ref: "",
+				},
+				api_format: "model_serving",
+			},
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+type Call = [string, ...unknown[]];
+
+interface FakeOptions {
+	failOn?: (call: Call) => Error | undefined;
+	providerStatus?: string;
+}
+
+const fakeApi = (opts: FakeOptions = {}) => {
+	const calls: Call[] = [];
+	const keysByProvider = new Map<string, ModelProviderKey[]>();
+	let nextId = 1;
+	const record = async <T>(call: Call, result: () => T): Promise<T> => {
+		calls.push(call);
+		const err = opts.failOn?.(call);
+		if (err) throw err;
+		return result();
+	};
+	const api: MigrationApi = {
+		getProvider: (name) =>
+			record(
+				["getProvider", name],
+				() =>
+					({
+						name,
+						provider_status: opts.providerStatus ?? "active",
+					}) as ModelProvider,
+			),
+		getProviderKeys: (name) => record(["getProviderKeys", name], () => keysByProvider.get(name) ?? []),
+		createProvider: (body) => record(["createProvider", body.provider], () => ({ name: body.provider, provider_status: "active" }) as ModelProvider),
+		updateProvider: (name) => record(["updateProvider", name], () => ({ name, provider_status: "active" }) as ModelProvider),
+		deleteProvider: (name) => record(["deleteProvider", name], () => undefined),
+		createProviderKey: (provider, k) =>
+			record(["createProviderKey", provider, k.name], () => {
+				const created = { ...k, id: `id-${nextId++}` };
+				keysByProvider.set(provider, [...(keysByProvider.get(provider) ?? []), created]);
+				return created;
+			}),
+		updateProviderKey: (provider, keyId, k) =>
+			record(["updateProviderKey", provider, keyId, k.name], () => ({
+				...k,
+				id: keyId,
+			})),
+		deleteProviderKey: (provider, keyId) => record(["deleteProviderKey", provider, keyId], () => undefined),
+		refreshModels: (provider) => record(["refreshModels", provider], () => undefined),
+	};
+	return { api, calls, names: () => calls.map((c) => c[0]) };
+};
+
+const withStatus = (message: string, status: number) => Object.assign(new Error(message), { status });
+
+const keyedPlan = (name = "my-dbx", existing?: Parameters<typeof buildDatabricksMigrationPlan>[2]): MigrationPlan =>
+	buildDatabricksMigrationPlan(
+		custom(name, { custom_provider_config: { base_provider_type: "openai" } }),
+		[
+			key("k1", "prod", { value: { value: "", ref: "env.A", type: "env" } }),
+			key("k2", "backup", { value: { value: "", ref: "env.B", type: "env" } }),
+		],
+		existing,
+	);
+
+describe("runDatabricksMigration", () => {
+	it("runs the normal path in order and only deletes the source after verification", async () => {
+		const { api, names, calls } = fakeApi();
+		const result = await runDatabricksMigration(keyedPlan(), api, () => {});
+		expect(result).toMatchObject({ ok: true, partial: false });
+		expect(names()).toEqual([
+			"createProvider",
+			"updateProvider",
+			"createProviderKey",
+			"createProviderKey",
+			"getProvider",
+			"getProviderKeys",
+			"deleteProvider",
+			"updateProviderKey",
+			"updateProviderKey",
+			"refreshModels",
+		]);
+		expect(calls.find((c) => c[0] === "deleteProvider")?.[1]).toBe("my-dbx");
+		expect(calls.filter((c) => c[0] === "updateProviderKey").map((c) => c[3])).toEqual(["prod", "backup"]);
+	});
+
+	it("rolls back created keys and the provider when a key fails, leaving the source untouched", async () => {
+		const { api, names, calls } = fakeApi({
+			failOn: (c) => (c[0] === "createProviderKey" && c[2] === "backup-migrating" ? new Error("boom") : undefined),
+		});
+		const steps: string[] = [];
+		const result = await runDatabricksMigration(keyedPlan(), api, (s) => steps.push(s.map((x) => x.status).join(",")));
+		expect(result.ok).toBe(false);
+		expect(names()).toEqual(["createProvider", "updateProvider", "createProviderKey", "createProviderKey", "deleteProviderKey", "deleteProvider"]);
+		expect(calls.find((c) => c[0] === "deleteProvider")?.[1]).toBe("databricks");
+		expect(steps.at(-1)).toContain("failed");
+	});
+
+	it("skips create and settings when the target already exists", async () => {
+		const target = {
+			provider: custom("databricks", { custom_provider_config: undefined }),
+			keys: [],
+		};
+		const { api, names } = fakeApi();
+		const result = await runDatabricksMigration(keyedPlan("my-dbx", target), api, () => {});
+		expect(result.ok).toBe(true);
+		expect(names()).not.toContain("createProvider");
+		expect(names()).not.toContain("updateProvider");
+	});
+
+	it("treats a 409 on create as an existing target", async () => {
+		const { api, names } = fakeApi({
+			failOn: (c) => (c[0] === "createProvider" ? withStatus("exists", 409) : undefined),
+		});
+		const result = await runDatabricksMigration(keyedPlan(), api, () => {});
+		expect(result.ok).toBe(true);
+		expect(names()).not.toContain("updateProvider");
+	});
+
+	it("deletes the source first on the name-clash path and restores it if create fails", async () => {
+		const { api, names, calls } = fakeApi({
+			failOn: (c) => (c[0] === "createProvider" && c[1] === "databricks" ? new Error("down") : undefined),
+		});
+		const result = await runDatabricksMigration(keyedPlan("databricks"), api, () => {});
+		expect(result.ok).toBe(false);
+		expect(names().slice(0, 2)).toEqual(["deleteProvider", "createProvider"]);
+		const restores = calls.filter((c) => c[0] === "createProvider" || c[0] === "createProviderKey");
+		expect(restores.map((c) => c[1])).toEqual(["databricks", "databricks", "databricks", "databricks"]);
+		expect(calls.filter((c) => c[0] === "createProviderKey").map((c) => c[2])).toEqual(["prod", "backup"]);
+	});
+
+	it("reports partial success when the source cannot be deleted", async () => {
+		const { api, names } = fakeApi({
+			failOn: (c) => (c[0] === "deleteProvider" ? new Error("locked") : undefined),
+		});
+		const result = await runDatabricksMigration(keyedPlan(), api, () => {});
+		expect(result).toMatchObject({ ok: true, partial: true });
+		expect(result.message).toContain("Delete it manually");
+		expect(names()).not.toContain("updateProviderKey");
+	});
+
+	it("ignores refresh-models failures", async () => {
+		const { api } = fakeApi({
+			failOn: (c) => (c[0] === "refreshModels" ? withStatus("busy", 409) : undefined),
+		});
+		const result = await runDatabricksMigration(keyedPlan(), api, () => {});
+		expect(result).toMatchObject({ ok: true, partial: false });
+	});
+
+	it("fails verification when the provider is not active", async () => {
+		const { api, names } = fakeApi({ providerStatus: "error" });
+		const result = await runDatabricksMigration(keyedPlan(), api, () => {});
+		expect(result.ok).toBe(false);
+		expect(names()).toContain("deleteProviderKey");
+		expect(names().filter((n) => n === "deleteProvider")).toHaveLength(1);
+	});
+});

--- a/ui/lib/utils/databricksMigration.ts
+++ b/ui/lib/utils/databricksMigration.ts
@@ -1,0 +1,789 @@
+import {
+	AddProviderRequest,
+	AliasConfig,
+	DatabricksKeyConfig,
+	ModelProvider,
+	ModelProviderKey,
+	ModelProviderName,
+	NetworkConfig,
+	ProxyConfig,
+	UpdateProviderRequest,
+} from "@/lib/types/config";
+import { DefaultNetworkConfig, DefaultPerformanceConfig } from "@/lib/constants/config";
+import { SecretVar } from "@/lib/types/schemas";
+import { toSecretVarFormValue } from "@/lib/utils/secretVarForm";
+import { isRedacted } from "@/lib/utils/validation";
+
+/**
+ * Frontend-only migration of a custom Databricks provider (created before Bifrost shipped
+ * first-party Databricks support) to the official `databricks` provider.
+ *
+ * This module is deliberately free of React and RTK so it can be unit tested. The dialog
+ * adapts RTK mutations into a `MigrationApi` and hands it to `runDatabricksMigration`.
+ */
+
+export const DATABRICKS_PROVIDER: ModelProviderName = "databricks";
+
+export type DatabricksApiFormat = NonNullable<DatabricksKeyConfig["api_format"]>;
+
+const MODEL_SERVING_PATH = "/serving-endpoints";
+const AI_GATEWAY_PATH = "/ai-gateway";
+const MIGRATING_SUFFIX = "-migrating";
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+const parseUrl = (raw: string | undefined): URL | undefined => {
+	const trimmed = (raw ?? "").trim();
+	if (!trimmed) return undefined;
+	const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+	try {
+		return new URL(withScheme);
+	} catch {
+		return undefined;
+	}
+};
+
+/**
+ * True for a custom provider named exactly "databricks" (case-insensitive). Only the exact name
+ * qualifies: a provider such as "databricks-bc" that points at a Databricks workspace is left
+ * alone, since it may be intentionally kept as a custom provider.
+ */
+export const isCustomDatabricksProvider = (provider: ModelProvider): boolean =>
+	Boolean(provider.custom_provider_config) && provider.name.trim().toLowerCase() === DATABRICKS_PROVIDER;
+
+// ---------------------------------------------------------------------------
+// Derivation helpers
+// ---------------------------------------------------------------------------
+
+export interface DerivedWorkspace {
+	workspaceUrl: string;
+	apiFormat: DatabricksApiFormat;
+	warnings: string[];
+}
+
+/**
+ * Splits a custom provider base URL into the workspace origin the first-party provider wants
+ * and the inference surface implied by its path.
+ */
+export const deriveDatabricksWorkspace = (baseUrl: string | undefined): DerivedWorkspace => {
+	const warnings: string[] = [];
+	const url = parseUrl(baseUrl);
+	if (!url) {
+		return { workspaceUrl: "", apiFormat: "auto", warnings };
+	}
+	if (url.protocol === "http:") {
+		warnings.push(`Base URL used http://; the workspace URL will use https:// (${url.host}).`);
+	}
+	const workspaceUrl = `https://${url.host}`;
+	const path = url.pathname.replace(/\/+$/, "");
+	let apiFormat: DatabricksApiFormat = "auto";
+	if (path === MODEL_SERVING_PATH) {
+		apiFormat = "model_serving";
+	} else if (path === AI_GATEWAY_PATH || path.startsWith(`${AI_GATEWAY_PATH}/`)) {
+		apiFormat = "ai_gateway";
+	} else if (path !== "") {
+		warnings.push(`Unrecognized base URL path "${path}"; inference surface set to auto-detect.`);
+	}
+	return { workspaceUrl, apiFormat, warnings };
+};
+
+export type AuthHeaderProblem = "missing" | "not_bearer";
+
+export interface ExtractedAuth {
+	token?: SecretVar;
+	problem?: AuthHeaderProblem;
+}
+
+const isSecretRef = (value: string): boolean => value.startsWith("env.") || value.startsWith("vault.");
+
+/** Pulls the personal access token out of an `Authorization: Bearer <token>` extra header. */
+export const extractAuthFromHeaders = (headers: Record<string, string> | undefined): ExtractedAuth => {
+	const entry = Object.entries(headers ?? {}).find(([key]) => key.trim().toLowerCase() === "authorization");
+	if (!entry) return { problem: "missing" };
+	const raw = entry[1].trim();
+	if (!raw) return { problem: "missing" };
+	// A whole-header secret reference (env.X / vault.X) is assumed to resolve to the raw token.
+	if (isSecretRef(raw)) return { token: toSecretVarFormValue(raw) };
+	const match = raw.match(/^bearer\s+(.+)$/i);
+	if (!match) return { problem: "not_bearer" };
+	const token = match[1].trim();
+	if (!token) return { problem: "not_bearer" };
+	return { token: toSecretVarFormValue(token) };
+};
+
+/** Masks a literal secret for display; secret references are shown as-is. */
+export const maskSecret = (secret: SecretVar | undefined): string => {
+	if (!secret) return "";
+	if (secret.ref?.trim()) return secret.ref.trim();
+	const value = (secret.value ?? "").trim();
+	if (!value) return "";
+	if (isRedacted(value)) return value;
+	if (value.length <= 8) return "****";
+	return `${value.slice(0, 4)}****${value.slice(-4)}`;
+};
+
+export const isSecretVarSet = (secret: SecretVar | undefined): boolean => Boolean(secret?.value?.trim() || secret?.ref?.trim());
+
+/** True when a secret came back from the API as a masked placeholder and cannot be re-sent. */
+const isMaskedLiteral = (secret: SecretVar | undefined): boolean => {
+	if (!secret) return false;
+	if (secret.ref?.trim()) return false;
+	const value = (secret.value ?? "").trim();
+	return value !== "" && isRedacted(value);
+};
+
+const normalizeAliases = (aliases: ModelProviderKey["aliases"] | undefined): Record<string, AliasConfig> | undefined => {
+	if (!aliases) return undefined;
+	const entries = Object.entries(aliases as Record<string, AliasConfig | string>);
+	if (entries.length === 0) return undefined;
+	return Object.fromEntries(entries.map(([alias, cfg]) => [alias, typeof cfg === "string" ? { model_id: cfg } : cfg]));
+};
+
+// ---------------------------------------------------------------------------
+// Plan
+// ---------------------------------------------------------------------------
+
+export interface PlannedKey {
+	tempId: string;
+	/** Name the key should end up with. */
+	name: string;
+	/** Name used when the key is created; may carry a temporary suffix while the source still exists. */
+	createName: string;
+	/** True when the key was synthesized from the Authorization header (keyless source). */
+	fromHeader: boolean;
+	value?: SecretVar;
+	/** The token could not be read (masked or absent); the user must enter it. */
+	needsValue: boolean;
+	models: string[];
+	blacklisted_models: string[];
+	weight: number;
+	enabled: boolean;
+	aliases?: Record<string, AliasConfig>;
+}
+
+export interface MigrationPlan {
+	source: {
+		name: string;
+		isKeyless: boolean;
+		fromConfigFile: boolean;
+	};
+	/** The custom provider is literally named "databricks", so it must be deleted before the first-party one can be created. */
+	nameClash: boolean;
+	/** A first-party Databricks provider is already configured; keys are merged into it. */
+	targetExists: boolean;
+	workspaceUrl: string;
+	apiFormat: DatabricksApiFormat;
+	providerSettings: UpdateProviderRequest;
+	keys: PlannedKey[];
+	warnings: string[];
+	/** Snapshot of the source, used to restore it if the name-clash path fails midway. */
+	snapshot: { provider: ModelProvider; keys: ModelProviderKey[] };
+}
+
+export interface ExistingTarget {
+	provider: ModelProvider;
+	keys: ModelProviderKey[];
+}
+
+const stripAuthorizationHeader = (headers: Record<string, string> | undefined): Record<string, string> | undefined => {
+	if (!headers) return undefined;
+	const rest = Object.fromEntries(Object.entries(headers).filter(([key]) => key.trim().toLowerCase() !== "authorization"));
+	return Object.keys(rest).length > 0 ? rest : undefined;
+};
+
+const portableSecret = (secret: SecretVar | undefined, label: string, warnings: string[]): SecretVar | undefined => {
+	if (!secret || !isSecretVarSet(secret)) return undefined;
+	if (isMaskedLiteral(secret)) {
+		warnings.push(`${label} is stored as a literal secret and cannot be copied; re-enter it on the Databricks provider after migrating.`);
+		return undefined;
+	}
+	return secret;
+};
+
+const buildProviderSettings = (source: ModelProvider, warnings: string[]): UpdateProviderRequest => {
+	const net = source.network_config;
+	const network_config: NetworkConfig = {
+		default_request_timeout_in_seconds: net?.default_request_timeout_in_seconds ?? DefaultNetworkConfig.default_request_timeout_in_seconds,
+		max_retries: net?.max_retries ?? DefaultNetworkConfig.max_retries,
+		retry_backoff_initial: net?.retry_backoff_initial ?? DefaultNetworkConfig.retry_backoff_initial,
+		retry_backoff_max: net?.retry_backoff_max ?? DefaultNetworkConfig.retry_backoff_max,
+	};
+	if (net) {
+		const extra_headers = stripAuthorizationHeader(net.extra_headers);
+		if (extra_headers) network_config.extra_headers = extra_headers;
+		if (net.insecure_skip_verify !== undefined) network_config.insecure_skip_verify = net.insecure_skip_verify;
+		if (net.stream_idle_timeout_in_seconds !== undefined) network_config.stream_idle_timeout_in_seconds = net.stream_idle_timeout_in_seconds;
+		if (net.keep_alive_timeout_in_seconds !== undefined) network_config.keep_alive_timeout_in_seconds = net.keep_alive_timeout_in_seconds;
+		if (net.max_conns_per_host !== undefined) network_config.max_conns_per_host = net.max_conns_per_host;
+		if (net.enforce_http2 !== undefined) network_config.enforce_http2 = net.enforce_http2;
+		if (net.http2_ping_interval_in_seconds !== undefined) network_config.http2_ping_interval_in_seconds = net.http2_ping_interval_in_seconds;
+		if (net.beta_header_overrides !== undefined) network_config.beta_header_overrides = net.beta_header_overrides;
+		if (net.allow_private_network !== undefined) network_config.allow_private_network = net.allow_private_network;
+		const caCert = portableSecret(net.ca_cert_pem, "The provider CA certificate", warnings);
+		if (caCert) network_config.ca_cert_pem = caCert;
+	}
+
+	let proxy_config: ProxyConfig | undefined;
+	if (source.proxy_config && source.proxy_config.type && source.proxy_config.type !== "none") {
+		proxy_config = { type: source.proxy_config.type };
+		const url = portableSecret(source.proxy_config.url, "The proxy URL", warnings);
+		if (url) proxy_config.url = url;
+		const username = portableSecret(source.proxy_config.username, "The proxy username", warnings);
+		if (username) proxy_config.username = username;
+		const password = portableSecret(source.proxy_config.password, "The proxy password", warnings);
+		if (password) proxy_config.password = password;
+		const caCert = portableSecret(source.proxy_config.ca_cert_pem, "The proxy CA certificate", warnings);
+		if (caCert) proxy_config.ca_cert_pem = caCert;
+	}
+
+	const settings: UpdateProviderRequest = {
+		network_config,
+		concurrency_and_buffer_size: source.concurrency_and_buffer_size ?? DefaultPerformanceConfig,
+	};
+	if (proxy_config) settings.proxy_config = proxy_config;
+	if (source.send_back_raw_request !== undefined) settings.send_back_raw_request = source.send_back_raw_request;
+	if (source.send_back_raw_response !== undefined) settings.send_back_raw_response = source.send_back_raw_response;
+	if (source.store_raw_request_response !== undefined) settings.store_raw_request_response = source.store_raw_request_response;
+	return settings;
+};
+
+const hasRestrictedRequests = (source: ModelProvider): boolean => {
+	const allowed = source.custom_provider_config?.allowed_requests;
+	if (!allowed) return false;
+	return Object.values(allowed as unknown as Record<string, boolean | undefined>).some((v) => v === false);
+};
+
+/**
+ * Builds the migration plan from the custom provider, its (redacted) keys and, when the
+ * first-party provider already exists, that provider and its keys.
+ */
+export const buildDatabricksMigrationPlan = (
+	source: ModelProvider,
+	sourceKeys: ModelProviderKey[],
+	existingTarget?: ExistingTarget,
+): MigrationPlan => {
+	const warnings: string[] = [];
+	const derived = deriveDatabricksWorkspace(source.network_config?.base_url);
+	warnings.push(...derived.warnings);
+	if (!derived.workspaceUrl) {
+		warnings.push("The base URL could not be parsed; enter the workspace URL below.");
+	}
+
+	const isKeyless = Boolean(source.custom_provider_config?.is_key_less) || sourceKeys.length === 0;
+	const nameClash = source.name.trim().toLowerCase() === DATABRICKS_PROVIDER;
+	const targetExists = Boolean(existingTarget);
+	const takenNames = new Set<string>();
+	if (!nameClash) sourceKeys.forEach((k) => takenNames.add(k.name));
+	existingTarget?.keys.forEach((k) => takenNames.add(k.name));
+
+	const auth = extractAuthFromHeaders(source.network_config?.extra_headers);
+	const keys: PlannedKey[] = [];
+
+	const pickCreateName = (name: string, permanent: boolean): string => {
+		if (!takenNames.has(name)) return name;
+		const suffixed = `${name}${MIGRATING_SUFFIX}`;
+		if (permanent) {
+			warnings.push(`A key named "${name}" already exists on the Databricks provider; the migrated key will be created as "${suffixed}".`);
+		}
+		return suffixed;
+	};
+
+	if (isKeyless) {
+		const name = `${source.name}-token`;
+		const clashesWithTarget = existingTarget?.keys.some((k) => k.name === name) ?? false;
+		const createName = pickCreateName(name, clashesWithTarget);
+		if (auth.problem === "missing") {
+			warnings.push("No Authorization header was found on the custom provider; enter the personal access token below.");
+		} else if (auth.problem === "not_bearer") {
+			warnings.push("The Authorization header is not a Bearer token; enter the personal access token below.");
+		}
+		keys.push({
+			tempId: "header",
+			name: clashesWithTarget ? createName : name,
+			createName,
+			fromHeader: true,
+			value: auth.token,
+			needsValue: !auth.token,
+			models: ["*"],
+			blacklisted_models: [],
+			weight: 1,
+			enabled: true,
+		});
+	} else {
+		if (auth.token) {
+			warnings.push("The custom provider also has an Authorization header; it will be dropped because the provider keys take precedence.");
+		}
+		for (const key of sourceKeys) {
+			const clashesWithTarget = existingTarget?.keys.some((k) => k.name === key.name) ?? false;
+			const createName = pickCreateName(key.name, clashesWithTarget);
+			const value = key.value && isSecretVarSet(key.value) && !isMaskedLiteral(key.value) ? toSecretVarFormValue(key.value) : undefined;
+			keys.push({
+				tempId: key.id,
+				name: clashesWithTarget ? createName : key.name,
+				createName,
+				fromHeader: false,
+				value,
+				needsValue: !value,
+				models: key.models ?? ["*"],
+				blacklisted_models: key.blacklisted_models ?? [],
+				weight: key.weight ?? 1,
+				enabled: key.enabled ?? true,
+				aliases: normalizeAliases(key.aliases),
+			});
+		}
+	}
+
+	if (hasRestrictedRequests(source)) {
+		warnings.push("Allowed request restrictions are specific to custom providers and will not be carried over.");
+	}
+	if (Object.keys(source.custom_provider_config?.request_path_overrides ?? {}).length > 0) {
+		warnings.push("Request path overrides are specific to custom providers and will not be carried over.");
+	}
+	if (source.config_hash) {
+		warnings.push("This provider is synced from config.json. Remove it there as well, or it may be re-added on the next restart.");
+	}
+	if (targetExists) {
+		warnings.push("A Databricks provider is already configured. Its settings will be kept and the migrated keys will be added to it.");
+	}
+	if (nameClash) {
+		warnings.push(
+			'The custom provider is named "databricks", so it has to be deleted before the official provider can be created. If a later step fails, it will be restored from a snapshot; key secrets that are stored as literals cannot be restored and would need to be re-entered.',
+		);
+	}
+
+	const providerSettings = buildProviderSettings(source, warnings);
+
+	return {
+		source: {
+			name: source.name,
+			isKeyless,
+			fromConfigFile: Boolean(source.config_hash),
+		},
+		nameClash,
+		targetExists,
+		workspaceUrl: derived.workspaceUrl,
+		apiFormat: derived.apiFormat,
+		providerSettings,
+		keys,
+		warnings,
+		snapshot: { provider: source, keys: sourceKeys },
+	};
+};
+
+/**
+ * Reduces any workspace URL a user may paste (with a scheme, path, query or trailing slash) to
+ * the bare origin the first-party provider expects. Returns "" when it cannot be parsed.
+ */
+export const normalizeWorkspaceUrl = (raw: string | undefined): string => {
+	const url = parseUrl(raw);
+	return url ? `https://${url.host}` : "";
+};
+
+/** True while the preview still lacks a usable workspace URL or a token for any key. */
+export const planNeedsInput = (plan: MigrationPlan): boolean =>
+	!normalizeWorkspaceUrl(plan.workspaceUrl) || plan.keys.some((k) => !isSecretVarSet(k.value));
+
+/** Builds the key payload sent to POST /api/providers/databricks/keys. */
+export const toDatabricksKeyPayload = (plan: MigrationPlan, key: PlannedKey): ModelProviderKey => ({
+	id: "",
+	name: key.createName,
+	value: key.value,
+	models: key.models,
+	blacklisted_models: key.blacklisted_models,
+	weight: key.weight,
+	enabled: key.enabled,
+	aliases: key.aliases,
+	databricks_key_config: {
+		workspace_url: { value: normalizeWorkspaceUrl(plan.workspaceUrl), ref: "" },
+		api_format: plan.apiFormat,
+		forward_gateway_tags: false,
+	},
+});
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+export interface MigrationApi {
+	getProvider(name: string): Promise<ModelProvider>;
+	getProviderKeys(name: string): Promise<ModelProviderKey[]>;
+	createProvider(body: AddProviderRequest): Promise<ModelProvider>;
+	updateProvider(name: string, body: UpdateProviderRequest): Promise<ModelProvider>;
+	deleteProvider(name: string): Promise<unknown>;
+	createProviderKey(provider: string, key: ModelProviderKey): Promise<ModelProviderKey>;
+	updateProviderKey(provider: string, keyId: string, key: ModelProviderKey): Promise<ModelProviderKey>;
+	deleteProviderKey(provider: string, keyId: string): Promise<unknown>;
+	refreshModels(provider: string): Promise<unknown>;
+}
+
+export type MigrationStepStatus = "pending" | "running" | "done" | "skipped" | "failed";
+
+export interface MigrationStep {
+	id: string;
+	label: string;
+	status: MigrationStepStatus;
+	detail?: string;
+}
+
+export interface MigrationResult {
+	ok: boolean;
+	/** The new provider is in place but cleanup did not fully complete. */
+	partial: boolean;
+	message: string;
+}
+
+export const getErrorStatus = (err: unknown): number | undefined => {
+	if (err && typeof err === "object" && "status" in err && typeof (err as { status: unknown }).status === "number") {
+		return (err as { status: number }).status;
+	}
+	return undefined;
+};
+
+const errorText = (err: unknown): string => {
+	if (err instanceof Error) return err.message;
+	if (typeof err === "string") return err;
+	return "Unknown error";
+};
+
+const STEP_IDS = {
+	snapshot: "snapshot",
+	deleteSource: "delete-source",
+	createProvider: "create-provider",
+	applySettings: "apply-settings",
+	createKeys: "create-keys",
+	verify: "verify",
+	renameKeys: "rename-keys",
+	refreshModels: "refresh-models",
+} as const;
+
+export const buildMigrationSteps = (plan: MigrationPlan): MigrationStep[] => {
+	const label = plan.source.name;
+	const keyCount = plan.keys.length;
+	const keysLabel = `Create ${keyCount} key${keyCount === 1 ? "" : "s"} on the Databricks provider`;
+	if (plan.nameClash) {
+		return [
+			{
+				id: STEP_IDS.snapshot,
+				label: `Snapshot custom provider "${label}"`,
+				status: "pending",
+			},
+			{
+				id: STEP_IDS.deleteSource,
+				label: `Delete custom provider "${label}"`,
+				status: "pending",
+			},
+			{
+				id: STEP_IDS.createProvider,
+				label: "Create the Databricks provider",
+				status: "pending",
+			},
+			{
+				id: STEP_IDS.applySettings,
+				label: "Apply network and performance settings",
+				status: "pending",
+			},
+			{ id: STEP_IDS.createKeys, label: keysLabel, status: "pending" },
+			{
+				id: STEP_IDS.verify,
+				label: "Verify the Databricks provider",
+				status: "pending",
+			},
+			{
+				id: STEP_IDS.refreshModels,
+				label: "Refresh models",
+				status: "pending",
+			},
+		];
+	}
+	const steps: MigrationStep[] = [
+		{
+			id: STEP_IDS.createProvider,
+			label: "Create the Databricks provider",
+			status: "pending",
+		},
+		{
+			id: STEP_IDS.applySettings,
+			label: "Apply network and performance settings",
+			status: "pending",
+		},
+		{ id: STEP_IDS.createKeys, label: keysLabel, status: "pending" },
+		{
+			id: STEP_IDS.verify,
+			label: "Verify the Databricks provider",
+			status: "pending",
+		},
+		{
+			id: STEP_IDS.deleteSource,
+			label: `Delete custom provider "${label}"`,
+			status: "pending",
+		},
+	];
+	if (plan.keys.some((k) => k.createName !== k.name)) {
+		steps.push({
+			id: STEP_IDS.renameKeys,
+			label: "Restore original key names",
+			status: "pending",
+		});
+	}
+	steps.push({
+		id: STEP_IDS.refreshModels,
+		label: "Refresh models",
+		status: "pending",
+	});
+	return steps;
+};
+
+class MigrationAbort extends Error {}
+
+/**
+ * Runs the migration. The normal path only deletes the custom provider once the new one is
+ * created and verified; the name-clash path deletes first and restores from a snapshot on
+ * failure. Every rollback call is best-effort and reported in the failed step's detail.
+ */
+export const runDatabricksMigration = async (
+	plan: MigrationPlan,
+	api: MigrationApi,
+	onProgress: (steps: MigrationStep[]) => void,
+): Promise<MigrationResult> => {
+	const steps = buildMigrationSteps(plan);
+	const emit = () => onProgress(steps.map((s) => ({ ...s })));
+	const step = (id: string) => steps.find((s) => s.id === id)!;
+	const start = (id: string) => {
+		step(id).status = "running";
+		emit();
+	};
+	const done = (id: string, detail?: string) => {
+		const s = step(id);
+		s.status = "done";
+		if (detail) s.detail = detail;
+		emit();
+	};
+	const skip = (id: string, detail: string) => {
+		const s = step(id);
+		s.status = "skipped";
+		s.detail = detail;
+		emit();
+	};
+	const fail = (id: string, detail: string) => {
+		const s = step(id);
+		s.status = "failed";
+		s.detail = detail;
+		emit();
+	};
+
+	const target = DATABRICKS_PROVIDER;
+	let createdProvider = false;
+	const createdKeys: ModelProviderKey[] = [];
+	let sourceDeleted = false;
+
+	const rollbackNotes: string[] = [];
+	const attempt = async (what: string, fn: () => Promise<unknown>) => {
+		try {
+			await fn();
+			rollbackNotes.push(`${what}: ok`);
+		} catch (err) {
+			rollbackNotes.push(`${what}: failed (${errorText(err)})`);
+		}
+	};
+
+	const rollbackTarget = async () => {
+		for (const key of createdKeys) {
+			await attempt(`Removed key "${key.name}"`, () => api.deleteProviderKey(target, key.id));
+		}
+		if (createdProvider) {
+			await attempt("Removed the Databricks provider", () => api.deleteProvider(target));
+		}
+	};
+
+	const restoreSnapshot = async () => {
+		if (!sourceDeleted) return;
+		const { provider, keys } = plan.snapshot;
+		await attempt(`Restored custom provider "${provider.name}"`, () =>
+			api.createProvider({
+				provider: provider.name,
+				network_config: provider.network_config,
+				concurrency_and_buffer_size: provider.concurrency_and_buffer_size,
+				proxy_config: provider.proxy_config,
+				send_back_raw_request: provider.send_back_raw_request,
+				send_back_raw_response: provider.send_back_raw_response,
+				store_raw_request_response: provider.store_raw_request_response,
+				custom_provider_config: provider.custom_provider_config,
+			}),
+		);
+		for (const key of keys) {
+			// Prefer what the user entered in the preview; a secret reference round-trips as-is.
+			const planned = plan.keys.find((k) => k.tempId === key.id);
+			const fromPlan = planned?.value && isSecretVarSet(planned.value) ? planned.value : undefined;
+			const fromSource = key.value && isSecretVarSet(key.value) && !isMaskedLiteral(key.value) ? key.value : undefined;
+			const value = fromPlan ?? fromSource;
+			if (!value) {
+				rollbackNotes.push(`Key "${key.name}" could not be restored: its secret is masked. Re-create it manually.`);
+				continue;
+			}
+			await attempt(`Restored key "${key.name}"`, () => api.createProviderKey(provider.name, { ...key, id: "", value }));
+		}
+	};
+
+	const abort = async (id: string, err: unknown, rollback: () => Promise<void>): Promise<never> => {
+		await rollback();
+		const detail = [errorText(err), ...rollbackNotes].join("\n");
+		fail(id, detail);
+		throw new MigrationAbort(errorText(err));
+	};
+
+	try {
+		if (plan.nameClash) {
+			start(STEP_IDS.snapshot);
+			done(STEP_IDS.snapshot, `${plan.snapshot.keys.length} key(s) captured`);
+
+			start(STEP_IDS.deleteSource);
+			try {
+				await api.deleteProvider(plan.source.name);
+				sourceDeleted = true;
+				done(STEP_IDS.deleteSource);
+			} catch (err) {
+				await abort(STEP_IDS.deleteSource, err, async () => {});
+			}
+		}
+
+		// Create provider
+		start(STEP_IDS.createProvider);
+		if (plan.targetExists && !plan.nameClash) {
+			skip(STEP_IDS.createProvider, "Already configured");
+		} else {
+			try {
+				await api.createProvider({
+					provider: target,
+					...plan.providerSettings,
+				});
+				createdProvider = true;
+				done(STEP_IDS.createProvider);
+			} catch (err) {
+				if (getErrorStatus(err) === 409 && !plan.nameClash) {
+					skip(STEP_IDS.createProvider, "Already configured");
+				} else {
+					await abort(STEP_IDS.createProvider, err, restoreSnapshot);
+				}
+			}
+		}
+
+		// Apply settings
+		start(STEP_IDS.applySettings);
+		if (!createdProvider) {
+			skip(STEP_IDS.applySettings, "Existing Databricks settings kept");
+		} else {
+			try {
+				await api.updateProvider(target, plan.providerSettings);
+				done(STEP_IDS.applySettings);
+			} catch (err) {
+				await abort(STEP_IDS.applySettings, err, async () => {
+					await rollbackTarget();
+					await restoreSnapshot();
+				});
+			}
+		}
+
+		// Create keys
+		start(STEP_IDS.createKeys);
+		for (const planned of plan.keys) {
+			try {
+				const created = await api.createProviderKey(target, toDatabricksKeyPayload(plan, planned));
+				createdKeys.push(created);
+			} catch (err) {
+				await abort(STEP_IDS.createKeys, new Error(`Failed to create key "${planned.createName}": ${errorText(err)}`), async () => {
+					await rollbackTarget();
+					await restoreSnapshot();
+				});
+			}
+		}
+		done(STEP_IDS.createKeys);
+
+		// Verify
+		start(STEP_IDS.verify);
+		try {
+			const provider = await api.getProvider(target);
+			if (provider.provider_status !== "active") {
+				throw new Error(`Provider status is "${provider.provider_status}"`);
+			}
+			const keys = await api.getProviderKeys(target);
+			const missing = createdKeys.filter((created) => !keys.some((k) => k.id === created.id));
+			if (missing.length > 0) {
+				throw new Error(`${missing.length} migrated key(s) are missing on the provider`);
+			}
+			done(STEP_IDS.verify, `Provider active with ${keys.length} key(s)`);
+		} catch (err) {
+			await abort(STEP_IDS.verify, err, async () => {
+				await rollbackTarget();
+				await restoreSnapshot();
+			});
+		}
+
+		let partial = false;
+		const partialNotes: string[] = [];
+
+		if (!plan.nameClash) {
+			start(STEP_IDS.deleteSource);
+			try {
+				await api.deleteProvider(plan.source.name);
+				sourceDeleted = true;
+				done(STEP_IDS.deleteSource);
+			} catch (err) {
+				partial = true;
+				partialNotes.push(`Could not delete custom provider "${plan.source.name}": ${errorText(err)}. Delete it manually.`);
+				fail(STEP_IDS.deleteSource, `${errorText(err)}. The Databricks provider was kept; delete "${plan.source.name}" manually.`);
+			}
+
+			const renames = plan.keys.filter((k) => k.createName !== k.name);
+			if (renames.length > 0) {
+				start(STEP_IDS.renameKeys);
+				if (!sourceDeleted) {
+					skip(STEP_IDS.renameKeys, "Custom provider still exists; key names keep the -migrating suffix");
+				} else {
+					const failures: string[] = [];
+					for (const planned of renames) {
+						const created = createdKeys.find((k) => k.name === planned.createName);
+						if (!created) continue;
+						try {
+							await api.updateProviderKey(target, created.id, {
+								...created,
+								name: planned.name,
+							});
+						} catch (err) {
+							failures.push(`"${planned.createName}" (${errorText(err)})`);
+						}
+					}
+					if (failures.length > 0) {
+						partial = true;
+						partialNotes.push(`Some keys kept their temporary name: ${failures.join(", ")}.`);
+						fail(STEP_IDS.renameKeys, `Could not rename: ${failures.join(", ")}`);
+					} else {
+						done(STEP_IDS.renameKeys);
+					}
+				}
+			}
+		}
+
+		start(STEP_IDS.refreshModels);
+		try {
+			await api.refreshModels(target);
+			done(STEP_IDS.refreshModels);
+		} catch (err) {
+			done(STEP_IDS.refreshModels, getErrorStatus(err) === 409 ? "A refresh is already running" : `Skipped: ${errorText(err)}`);
+		}
+
+		return {
+			ok: true,
+			partial,
+			message: partial
+				? `Databricks provider created with ${createdKeys.length} key(s), but cleanup did not fully complete. ${partialNotes.join(" ")}`
+				: `Migrated "${plan.source.name}" to the Databricks provider with ${createdKeys.length} key(s).`,
+		};
+	} catch (err) {
+		if (err instanceof MigrationAbort) {
+			return { ok: false, partial: false, message: err.message };
+		}
+		return { ok: false, partial: false, message: errorText(err) };
+	}
+};


### PR DESCRIPTION
## Summary

Bifrost now ships first-party Databricks support. This PR adds a guided, multi-step migration dialog that automatically detects when a user has a custom provider named `databricks` and walks them through converting it to the official Databricks provider — preserving keys, network settings, proxy config, and model aliases — without any manual copy-paste.

## Changes

- **`ui/lib/utils/databricksMigration.ts`** — Pure (React-free) orchestration module containing:
  - `isCustomDatabricksProvider` — detects a custom provider named exactly `databricks`
  - `deriveDatabricksWorkspace` — splits a custom base URL into a workspace origin and infers the inference surface (`model_serving`, `ai_gateway`, or `auto`)
  - `extractAuthFromHeaders` — reads a personal access token from an `Authorization: Bearer` extra header, including secret references (`env.*`, `vault.*`)
  - `buildDatabricksMigrationPlan` — constructs a full migration plan from the source provider, its keys, and an optional existing Databricks target; handles keyless providers, masked secrets, name clashes, and existing target merging
  - `runDatabricksMigration` — executes the plan step-by-step with rollback on failure; the normal path only deletes the custom provider after the new one is verified; the name-clash path (source is literally named `databricks`) deletes first and restores from a snapshot if a later step fails
  - `buildMigrationSteps` — produces the ordered step list shown in the progress UI, varying by whether a name clash or existing target is involved

- **`ui/app/workspace/providers/dialogs/databricksMigrationDialog.tsx`** — New dialog component with four stages (`intro → loading → preview → running → finished`):
  - Preview stage shows workspace URL, inference surface selector, per-key token inputs (masked or editable), and provider settings summary
  - Running stage shows live step-by-step progress with status icons
  - RBAC-gated: requires create + update + delete access; dirty-form guard prevents migration while unsaved changes exist

- **`ui/app/workspace/providers/page.tsx`** — Wires the dialog into the providers page:
  - Opens the migration dialog automatically when a custom `databricks` provider is selected, unless the user deferred it for that selection
  - Suppresses the existing "first-party provider available" advisory dialog for Databricks (it gets the richer migration dialog instead)
  - Holds off the "switch to another provider when current is unconfigured" effect while a migration session is active, since the migration intentionally removes the source provider mid-flight
  - On successful migration, navigates to the new Databricks provider and invalidates relevant RTK cache tags

- **`ui/lib/utils/databricksMigration.test.ts`** — Comprehensive unit tests covering detection, URL derivation, auth extraction, secret masking, plan building (keyless, keyed, name-clash, existing-target, warnings), and the full orchestrator (happy path, rollback on key failure, 409 handling, partial success on delete failure, verification failure, refresh-models tolerance).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm test
pnpm build
```

1. Configure a custom provider with the name `databricks` pointing at a Databricks workspace (with a base URL of `https://<workspace>.azuredatabricks.net/serving-endpoints` and an `Authorization: Bearer dapi...` extra header).
2. Select that provider in the UI — the migration dialog should open automatically.
3. Verify the preview shows the correct workspace URL, inferred inference surface, and masked or editable token fields.
4. Click **Migrate** and confirm all steps complete successfully.
5. Confirm the custom provider is removed and the UI navigates to the new first-party Databricks provider.
6. Repeat with a provider that has explicit keys (non-keyless) to verify token re-entry is required for masked secrets.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

- Personal access tokens stored as masked literals cannot be read back from the API and are never transmitted during migration; users must re-enter them.
- Secret references (`env.*`, `vault.*`) round-trip as-is and are never logged or displayed in plaintext.
- Proxy passwords and CA certificates that are stored as masked literals are explicitly dropped from the migrated settings with a warning, rather than silently omitted or sent as redacted placeholders.
- The name-clash rollback path restores the source provider from an in-memory snapshot; any key whose secret is masked and for which the user did not provide a value is skipped with an explicit note rather than restored with a broken placeholder.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable