### PR TITLE
handle azure providers for reasoning efforts

### DIFF
--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -355,7 +355,7 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 			// Handle OpenAI-specific parameter filtering
 			// Only o1/o3 series models support reasoning.effort
 			// Regular models like gpt-4o, gpt-4, gpt-3.5-turbo don't support it
-			if bifrostReq.Provider == schemas.OpenAI && !caps.SupportsReasoning(IsOpenAIReasoningModel(capModel)) {
+			if (bifrostReq.Provider == schemas.OpenAI || bifrostReq.Provider == schemas.Azure) && !caps.SupportsReasoning(IsOpenAIReasoningModel(capModel)) {
 				// Clear reasoning for non-reasoning OpenAI models to avoid API errors
 				req.ResponsesParameters.Reasoning = nil
 			}


### PR DESCRIPTION
## Summary

Fixes incorrect filtering of the `reasoning.effort` parameter for Azure-hosted OpenAI models. Previously, the check only applied to the `OpenAI` provider, causing Azure requests to non-reasoning models to potentially send unsupported `reasoning` parameters and result in API errors.

## Changes

- Extended the `reasoning.effort` filtering logic to also apply when the provider is `Azure`, ensuring non-reasoning models on Azure have the `Reasoning` field cleared before the request is sent.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Send a request through the Azure provider using a non-reasoning model (e.g., `gpt-4o`) with a `reasoning.effort` parameter set. Verify that the request succeeds without an API error and that the `reasoning` field is stripped before being forwarded.

```sh
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No security implications.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable