### PR TITLE
chore: replace `FolderKanban` with `SquareKanban` icon and fix sidebar className indentation

### DIFF
--- a/ui/components/sidebar.tsx
+++ b/ui/components/sidebar.tsx
@@ -15,7 +15,7 @@ import {
 	DatabaseZap,
 	Flag,
 	FolderGit,
-	FolderKanban,
+	SquareKanban,
 	Gavel,
 	GitCompareArrows,
 	Globe,
@@ -254,12 +254,12 @@ const SidebarItemView = ({
 	const isHighlighted = !hasSubItems && highlightedUrl === item.url;
 
 	const buttonClassName = `group/nav-item relative h-7.5 cursor-pointer rounded-sm border px-3 transition-all duration-200 ${isHighlighted
-			? "bg-sidebar-accent text-accent-foreground border-primary/20"
-			: isActive || isAnySubItemActive
-				? "bg-sidebar-accent text-primary border-primary/20"
-				: item.hasAccess
-					? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
-					: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+		? "bg-sidebar-accent text-accent-foreground border-primary/20"
+		: isActive || isAnySubItemActive
+			? "bg-sidebar-accent text-primary border-primary/20"
+			: item.hasAccess
+				? "hover:bg-sidebar-accent hover:text-accent-foreground border-transparent text-slate-500 dark:text-zinc-400"
+				: "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
 		} `;
 
 	const innerContent = (
@@ -412,12 +412,12 @@ const SidebarItemView = ({
 						const isSubItemHighlighted = highlightedUrl ? subItemHref.startsWith(highlightedUrl) : false;
 						const SubItemIcon = subItem.icon;
 						const subItemClassName = `h-7 cursor-pointer rounded-sm px-2 transition-all duration-200 ${isSubItemHighlighted
-								? "bg-sidebar-accent text-accent-foreground"
-								: isSubItemActive
-									? "bg-sidebar-accent text-primary font-medium"
-									: subItem.hasAccess === false
-										? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
-										: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
+							? "bg-sidebar-accent text-accent-foreground"
+							: isSubItemActive
+								? "bg-sidebar-accent text-primary font-medium"
+								: subItem.hasAccess === false
+									? "hover:bg-destructive/5 hover:text-muted-foreground text-muted-foreground cursor-not-allowed border-transparent"
+									: "hover:bg-sidebar-accent hover:text-accent-foreground text-slate-500 dark:text-zinc-400"
 							}`;
 						const subInner = (
 							<div className="flex w-full items-center gap-2">
@@ -865,7 +865,7 @@ export default function AppSidebar() {
 					{
 						title: "Projects",
 						url: "/workspace/governance/projects",
-						icon: FolderKanban,
+						icon: SquareKanban,
 						description: "Scope requests to a project's access and budget",
 						hasAccess: hasProjectsAccess,
 					},


### PR DESCRIPTION
## Summary

Replaces the `FolderKanban` icon with `SquareKanban` for the Projects sidebar item and fixes indentation in the conditional class name strings for sidebar item styling.

## Changes

- Swapped the `FolderKanban` lucide icon for `SquareKanban` on the Projects governance sidebar entry
- Fixed indentation alignment in the `buttonClassName` and `subItemClassName` template literal conditionals to be consistent with the surrounding code style

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the governance Projects section in the sidebar and confirm the icon renders as `SquareKanban` instead of `FolderKanban`.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Before/after screenshots of the Projects sidebar icon would confirm the icon swap is visually correct.

## Breaking changes

- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable