### PR TITLE
[fix]: preserve GLM-5.3-Flash max reasoning effort

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+[fix]: preserve GLM-5.3-Flash max reasoning effort on OpenAI-compatible routes [@runbgp](https://github.com/runbgp)
 - fix: give a Bedrock message a placeholder text block instead of a null `content` field when it has no text and no tool calls - `BedrockMessage.Content` has no `omitempty`, so a message with empty text and no tool calls (or an empty `tool_calls` array) serialized as `content:null`, which Converse rejects with "Member must not be null" (#2765)
 - [fix]: marshal required nullable response fields as null [@PSR94](https://github.com/PSR94)
 - fix: accept top-level arrays from OpenAI-compatible model APIs [@dani29](https://github.com/dani29)

--- a/core/providers/openai/glmeffort_test.go
+++ b/core/providers/openai/glmeffort_test.go
@@ -1,0 +1,56 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercise the inbound OpenAI dialect and the outbound shared converter used
+// by vLLM, including Hugging Face namespaces and both streaming request shapes.
+func TestGLM53FlashReasoningEffortRoundTrip(t *testing.T) {
+	for _, model := range []string{"glm-5.3-flash", "zai-org/GLM-5.3-Flash"} {
+		for _, stream := range []bool{false, true} {
+			for _, effort := range []string{"", "low", "high", "max"} {
+				t.Run(model+"/"+effort+"/stream="+map[bool]string{false: "false", true: "true"}[stream], func(t *testing.T) {
+					payload := map[string]interface{}{
+						"model":       "vllm/" + model,
+						"messages":    []map[string]string{{"role": "user", "content": "What is 7 + 5?"}},
+						"stream":      stream,
+						"max_tokens":  100,
+						"temperature": 0.0,
+					}
+					if effort != "" {
+						payload["reasoning_effort"] = effort
+					}
+					raw, err := json.Marshal(payload)
+					require.NoError(t, err)
+					var inbound OpenAIChatRequest
+					require.NoError(t, sonic.Unmarshal(raw, &inbound))
+					ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+					request := inbound.ToBifrostChatRequest(ctx)
+					require.Equal(t, schemas.VLLM, request.Provider)
+					require.Equal(t, model, request.Model)
+					outbound := ToOpenAIChatRequest(ctx, request)
+					require.NotNil(t, outbound)
+					outbound.Stream = inbound.Stream
+					wire, err := json.Marshal(outbound)
+					require.NoError(t, err)
+					var body map[string]interface{}
+					require.NoError(t, json.Unmarshal(wire, &body))
+					if effort == "" {
+						require.NotContains(t, body, "reasoning_effort")
+					} else {
+						require.Equal(t, effort, body["reasoning_effort"])
+						require.Equal(t, effort, *request.Params.Reasoning.Effort, "conversion must not mutate input")
+					}
+					require.Equal(t, stream, body["stream"])
+					require.Equal(t, 0.0, body["temperature"])
+				})
+			}
+		}
+	}
+}

--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -179,6 +179,8 @@ func TestNormalizeOpenAIReasoningEffort(t *testing.T) {
 		{"provider-prefixed gpt-5.6 keeps max", "openai/gpt-5.6", "max", "max"},
 		{"deepseek-v4 keeps max", "deepseek-v4", "max", "max"},
 		{"glm-5.2 keeps max", "glm-5.2", "max", "max"},
+		{"glm-5.3-flash keeps max", "glm-5.3-flash", "max", "max"},
+		{"namespaced glm-5.3-flash keeps max", "vllm/zai-org/GLM-5.3-Flash", "max", "max"},
 		{"gpt-5.5 downgrades max to xhigh", "gpt-5.5", "max", "xhigh"},
 		{"gpt-5.2 downgrades max to xhigh", "gpt-5.2", "max", "xhigh"},
 		{"gpt-5.5 keeps xhigh", "gpt-5.5", "xhigh", "xhigh"},

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -114,7 +114,8 @@ func acceptsMaxEffort(model string) bool {
 	modelLower := bareModelLower(model)
 	return strings.Contains(modelLower, "gpt-5.6") ||
 		strings.Contains(modelLower, "deepseek-v4") ||
-		strings.Contains(modelLower, "glm-5.2")
+		strings.Contains(modelLower, "glm-5.2") ||
+		strings.Contains(modelLower, "glm-5.3-flash")
 }
 
 // bareModelLower strips any provider prefix and lowercases, so the effort

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140504,6 +140504,172 @@
           ]
         }
       ]
+    },
+    {
+      "name": "69. GLM-5.3-Flash max effort survives vLLM conversion",
+      "description": "Regression for GLM-5.3-Flash max being downgraded to high in the shared OpenAI converter. Requires a vllm key serving zai-org/GLM-5.3-Flash and client.allow_per_request_raw_override=true in the isolated harness gateway. Assert outbound raw_request, never infer effort from generated text or token counts. HF model card: https://huggingface.co/zai-org/GLM-5.3-Flash#note. Related: #6162 and #6054.",
+      "item": [
+        {
+          "name": "vllm/zai-org/GLM-5.3-Flash max effort chat completion",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vllm/zai-org/GLM-5.3-Flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 7 + 5? Answer with the number only.\"\n    }\n  ],\n  \"reasoning_effort\": \"max\",\n  \"max_tokens\": 100,\n  \"temperature\": 0,\n  \"stream\": false\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var txt = pm.response.text();",
+                  "pm.test('request succeeds', function () { pm.expect(pm.response.code, txt).to.be.below(400); });",
+                  "var chunks = [];",
+                  "chunks.push(pm.response.json());",
+                  "var rr;",
+                  "chunks.forEach(function (chunk) { var raw = (chunk.extra_fields || {}).raw_request; if (raw) { rr = typeof raw === 'string' ? JSON.parse(raw) : raw; } });",
+                  "pm.test('outbound reasoning effort is preserved', function () {",
+                  "  pm.expect(rr, 'raw_request missing; enable allow_per_request_raw_override in the harness gateway').to.be.an('object');",
+                  "  pm.expect(rr.reasoning_effort).to.eql('max');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "vllm/zai-org/GLM-5.3-Flash max effort streaming",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vllm/zai-org/GLM-5.3-Flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 7 + 5? Answer with the number only.\"\n    }\n  ],\n  \"reasoning_effort\": \"max\",\n  \"max_tokens\": 100,\n  \"temperature\": 0,\n  \"stream\": true\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var txt = pm.response.text();",
+                  "pm.test('request succeeds', function () { pm.expect(pm.response.code, txt).to.be.below(400); });",
+                  "var chunks = [];",
+                  "txt.split('\\n').forEach(function (line) { if (line.indexOf('data:') !== 0) { return; } var data = line.slice(5).trim(); if (data && data !== '[DONE]') { chunks.push(JSON.parse(data)); } });",
+                  "var rr;",
+                  "chunks.forEach(function (chunk) { var raw = (chunk.extra_fields || {}).raw_request; if (raw) { rr = typeof raw === 'string' ? JSON.parse(raw) : raw; } });",
+                  "pm.test('outbound reasoning effort is preserved', function () {",
+                  "  pm.expect(rr, 'raw_request missing; enable allow_per_request_raw_override in the harness gateway').to.be.an('object');",
+                  "  pm.expect(rr.reasoning_effort).to.eql('max');",
+                  "});",
+                  "pm.test('stream terminates', function () { pm.expect(txt).to.include('data: [DONE]'); });"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "vllm/zai-org/GLM-5.3-Flash low effort chat completion",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vllm/zai-org/GLM-5.3-Flash\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is 7 + 5? Answer with the number only.\"\n    }\n  ],\n  \"reasoning_effort\": \"low\",\n  \"max_tokens\": 100,\n  \"temperature\": 0,\n  \"stream\": false\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "var txt = pm.response.text();",
+                  "pm.test('request succeeds', function () { pm.expect(pm.response.code, txt).to.be.below(400); });",
+                  "var chunks = [];",
+                  "chunks.push(pm.response.json());",
+                  "var rr;",
+                  "chunks.forEach(function (chunk) { var raw = (chunk.extra_fields || {}).raw_request; if (raw) { rr = typeof raw === 'string' ? JSON.parse(raw) : raw; } });",
+                  "pm.test('outbound reasoning effort is preserved', function () {",
+                  "  pm.expect(rr, 'raw_request missing; enable allow_per_request_raw_override in the harness gateway').to.be.an('object');",
+                  "  pm.expect(rr.reasoning_effort).to.eql('low');",
+                  "});"
+                ]
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Bifrost changes `reasoning_effort: "max"` to `"high"` when routing `vllm/zai-org/GLM-5.3-Flash` through the OpenAI chat-completions integration. The model explicitly supports `low`, `high`, and `max`, with omitted effort defaulting to `max` ([official model card](https://huggingface.co/zai-org/GLM-5.3-Flash#note)). As a result, explicitly requesting the model's default produces a different outgoing request than omitting it.

This adds GLM-5.3-Flash to the shared converter's max-effort fallback. It preserves explicit `max`, including namespaced HF IDs, without changing `low`, `high`, or omitted effort.

## Changes

- Recognize `glm-5.3-flash` in `acceptsMaxEffort`.
- Add inbound OpenAI → Bifrost vLLM → outgoing OpenAI round-trip tests for bare/namespaced IDs, four effort settings, and both streaming request shapes.
- Add three provider-harness cases that assert the actual outgoing `raw_request.reasoning_effort`, including streaming. These do not infer correctness from generated text or token counts.
- Update the core changelog.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

Verified red before green: the four Go round-trip `max` subcases failed with actual `high`; the two HTTP `max` cases failed with the same mismatch. After the patch, all 16 round-trip subcases pass and the HTTP harness passes all 33 assertions.

```sh
make test-core PROVIDER=openai PATTERN=GLM53Flash
cd core
go test ./providers/openai ./providers/vllm ./providers/groq ./providers/cerebras ./providers/ollama ./providers/perplexity ./providers/openrouter ./providers/parasail ./providers/nebius ./providers/xai ./providers/sgl -run 'Test(To|Convert|Normalize|Filter|GLM53|OpenAIChatRequest|OpenAIResponsesRequest|Effort|Accepts)' -count=1
```

The latter command passes applicable converter tests and compiles the listed shared-converter consumers; some packages have no matching unit tests. The full paid-provider suite was not run.

The collection was structurally validated with `augment-provider-harness.mjs` and `filter-collection.mjs --feature GLM-5.3-Flash`. Its three new cases were also run through real Bifrost HTTP servers against a synthetic OpenAI backend: unmodified v2.0.0 versus v2.0.0 with the same narrow core v1.8.3 backport. The isolated gateway enabled `client.allow_per_request_raw_override`; production does not need that setting.

The backported image built successfully, including UI typechecking. Bounded live vLLM checks confirmed explicit max and omitted effort now agree, while low/high remain available. Streaming tool IDs, typed arguments, reasoning content, finish reasons, and SSE termination survived a two-tool conversation.

## Breaking changes

- [x] No

## Related issues

Related to #6162, closed into the broader #6054 provider addition. This is a narrow fix for the already-shipped vLLM path on current `dev`, limited to the officially released Flash model and with explicit HF namespace and HTTP regressions. It makes no assumptions about future GLM versions or coercion of unsupported effort levels.

## Security considerations

No configuration or credential changes. Raw-request inspection is confined to the isolated test gateway with synthetic credentials.

## Checklist

- [x] Read `AGENTS.md` and the current contribution guides (`raising-a-pr.mdx`, `code-conventions.mdx`; the template's README path no longer exists)
- [x] Added regression tests and updated the changelog
- [x] Verified relevant Go tests and the backported application build
- [ ] Full CI / paid-provider suite (not run locally)
