### PR TITLE
[fix]: preserve GPT-6 Astra max reasoning effort

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- [fix]: preserve max reasoning effort for GPT-6 Astra [@nettee](https://github.com/nettee)
 - fix: give a Bedrock message a placeholder text block instead of a null `content` field when it has no text and no tool calls - `BedrockMessage.Content` has no `omitempty`, so a message with empty text and no tool calls (or an empty `tool_calls` array) serialized as `content:null`, which Converse rejects with "Member must not be null" (#2765)
 - [fix]: marshal required nullable response fields as null [@PSR94](https://github.com/PSR94)
 - fix: accept top-level arrays from OpenAI-compatible model APIs [@dani29](https://github.com/dani29)

--- a/core/gpt6astrae2e_test.go
+++ b/core/gpt6astrae2e_test.go
@@ -1,0 +1,110 @@
+package bifrost
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+type astraUpstreamRequest struct {
+	Method  string
+	Path    string
+	Body    []byte
+	ReadErr error
+}
+
+// TestGPT6AstraMaxReasoningEffortReachesOpenAIUpstream exercises the public
+// Responses API through provider selection, OpenAI conversion, JSON encoding,
+// and the real HTTP client. The fake upstream makes the silently rewritten
+// request observable without requiring a real OpenAI API key.
+func TestGPT6AstraMaxReasoningEffortReachesOpenAIUpstream(t *testing.T) {
+	requests := make(chan astraUpstreamRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		requests <- astraUpstreamRequest{
+			Method:  r.Method,
+			Path:    r.URL.Path,
+			Body:    body,
+			ReadErr: err,
+		}
+		writeJSON(w, http.StatusOK, `{"id":"resp_astra_1","object":"response","created_at":1,"status":"completed","model":"gpt-6-astra","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)
+	}))
+	t.Cleanup(upstream.Close)
+
+	// This is the capability information currently available to the Go runtime:
+	// the datasheet says Astra supports reasoning, but does not publish its
+	// reasoning_effort_levels ladder.
+	schemas.SetCapabilityResolver(func(provider schemas.ModelProvider, model string) *schemas.ModelCapabilities {
+		if provider == schemas.OpenAI && model == "gpt-6-astra" {
+			return &schemas.ModelCapabilities{SupportsReasoning: schemas.Ptr(true)}
+		}
+		return nil
+	})
+	t.Cleanup(func() { schemas.SetCapabilityResolver(nil) })
+
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 1, upstream.URL)
+	account.configs[schemas.OpenAI].NetworkConfig.MaxRetries = 0
+	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{{
+		ID:     "astra-e2e-key",
+		Value:  *schemas.NewSecretVar("sk-local-astra-e2e"),
+		Models: schemas.WhiteList{"gpt-6-astra"},
+		Weight: 100,
+	}})
+	client := newStreamTestClient(t, account)
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(5*time.Second))
+	response, bifrostErr := client.ResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-6-astra",
+		Input: []schemas.ResponsesMessage{{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{
+				ContentStr: schemas.Ptr("Say hello"),
+			},
+		}},
+		Params: &schemas.ResponsesParameters{
+			Reasoning: &schemas.ResponsesParametersReasoning{
+				Effort: schemas.Ptr(schemas.ReasoningEffortMax),
+			},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesRequest failed before reaching the upstream: %v", bifrostErr)
+	}
+	if response == nil {
+		t.Fatal("ResponsesRequest returned a nil response")
+	}
+
+	observed := <-requests
+	if observed.ReadErr != nil {
+		t.Fatalf("read upstream request body: %v", observed.ReadErr)
+	}
+	if observed.Method != http.MethodPost || observed.Path != "/v1/responses" {
+		t.Fatalf("upstream request = %s %s, want POST /v1/responses", observed.Method, observed.Path)
+	}
+
+	var wire struct {
+		Model     string `json:"model"`
+		Reasoning struct {
+			Effort string `json:"effort"`
+		} `json:"reasoning"`
+	}
+	if err := json.Unmarshal(observed.Body, &wire); err != nil {
+		t.Fatalf("decode upstream request body %q: %v", observed.Body, err)
+	}
+	if wire.Model != "gpt-6-astra" {
+		t.Fatalf("upstream model = %q, want gpt-6-astra", wire.Model)
+	}
+	if wire.Reasoning.Effort != schemas.ReasoningEffortMax {
+		t.Fatalf("upstream reasoning.effort = %q, want %q; Bifrost silently changed the requested effort on the wire",
+			wire.Reasoning.Effort, schemas.ReasoningEffortMax)
+	}
+}

--- a/core/providers/openai/responses_marshal_test.go
+++ b/core/providers/openai/responses_marshal_test.go
@@ -174,6 +174,7 @@ func TestNormalizeOpenAIReasoningEffort(t *testing.T) {
 		{"maps minimal to low for o4", "o4", "minimal", "low"},
 		{"maps minimal to low for gpt-oss", "gpt-oss", "minimal", "low"},
 		{"gpt-5.6 keeps max", "gpt-5.6", "max", "max"},
+		{"gpt-6-astra keeps max", "gpt-6-astra", "max", "max"},
 		{"gpt-5.6 variant keeps max", "gpt-5.6-terra", "max", "max"},
 		{"gpt-5.6 keeps xhigh", "gpt-5.6", "xhigh", "xhigh"},
 		{"provider-prefixed gpt-5.6 keeps max", "openai/gpt-5.6", "max", "max"},

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -113,6 +113,7 @@ func acceptsMinimalEffort(model string) bool {
 func acceptsMaxEffort(model string) bool {
 	modelLower := bareModelLower(model)
 	return strings.Contains(modelLower, "gpt-5.6") ||
+		strings.Contains(modelLower, "gpt-6-astra") ||
 		strings.Contains(modelLower, "deepseek-v4") ||
 		strings.Contains(modelLower, "glm-5.2")
 }


### PR DESCRIPTION
## Summary

Fixes the silent downgrade of `reasoning.effort: "max"` on OpenAI Responses requests targeting `gpt-6-astra`.

Bifrost currently builds Astra's fallback effort ladder as `low / medium / high`. As a result, `ModelCaps.NormalizeReasoningEffort` snaps a caller-selected `max` effort down to `high` before the request reaches OpenAI. The request can still return HTTP 200, which makes the behavior invisible to status-code-only checks.

This PR recognizes `gpt-6-astra` in the OpenAI max-effort fallback and verifies the final wire request with a local recording upstream.

## Changes

- Preserve `reasoning.effort: "max"` for `gpt-6-astra` in the OpenAI effort ladder.
- Add a focused normalization regression case.
- Add a Bifrost Core end-to-end regression test covering provider/key selection, OpenAI conversion, JSON serialization, and real HTTP dispatch.
- Add the required Core changelog entry.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

### OpenAI provider regression suite

```bash
cd core
go test ./providers/openai -count=1
```

Result:

```text
ok github.com/maximhq/bifrost/core/providers/openai
```

### Recording-upstream end-to-end regression

```bash
cd core
go test . -run '^TestGPT6AstraMaxReasoningEffortReachesOpenAIUpstream$' -count=1 -v
```

The test sends a request through the public `Bifrost.ResponsesRequest` API and records the JSON received by a local fake OpenAI server:

```text
Bifrost.ResponsesRequest
  -> provider and key selection
  -> OpenAI request conversion
  -> reasoning-effort normalization
  -> JSON serialization
  -> HTTP dispatch
  -> recording upstream
```

Base `dev@03ab391865`:

```text
upstream reasoning.effort = "high", want "max"
--- FAIL: TestGPT6AstraMaxReasoningEffortReachesOpenAIUpstream
```

With this commit:

```text
--- PASS: TestGPT6AstraMaxReasoningEffortReachesOpenAIUpstream
PASS
```

No OpenAI API key is required.

### Additional checks

- `git diff --check`: passed.
- Full `go test . -count=1` was attempted from `core/`. It reaches the pre-existing `TestEnrichmentRegistryDimsAllEmitted` failure for four tracing dimensions. The identical test fails on a clean detached `upstream/dev@03ab391865` worktree.
- `make fmt` could not complete because the optional `goimports` binary is not installed locally. The changed Go code was formatted with `gofmt`, and the repository-wide formatting side effects from the failed target were discarded.
- `golangci-lint` is not installed locally, so `make lint` was not run.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

The change only preserves an effort level supported by GPT-6 Astra. Existing effort normalization for other models is unchanged.

## Related issues

Closes #6880

## Security considerations

- No credentials or secret values are added.
- The end-to-end regression uses a fake local key and a loopback `httptest` upstream.
- No authentication, authorization, storage, or logging behavior changes.

## Checklist

- [x] I read the current contribution, code convention, issue, and PR guidelines.
- [x] I created an issue before opening the PR.
- [x] I added focused unit and end-to-end regression coverage.
- [x] I added the required Core changelog entry.
- [x] I verified the complete OpenAI provider test package passes.
- [x] I verified the Red-Green recording-upstream reproduction passes.
- [x] I reviewed the final diff for unrelated files and secrets.
- [x] Commit and PR titles follow the `[fix]: description` format.
- [x] All affected packages are listed in the commit message.
- [x] `git diff --check` passes.
- [ ] I ran the complete Core root package successfully (blocked by an upstream baseline test failure described above).
- [ ] I ran `make fmt` successfully (optional `goimports` unavailable).
- [ ] I ran `make lint` locally (`golangci-lint` unavailable).
