### PR TITLE
[feat]: opt-in quota failover for session-sticky chat requests

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -100,6 +100,7 @@ type Bifrost struct {
 	keySelector         schemas.KeySelector                 // Custom key selector function
 	keyPoolFilter       schemas.KeyPoolFilter               // optional hook to veto keys before selection (nil = all eligible)
 	kvStore             schemas.KVStore                     // optional KV store for session stickiness (nil = disabled)
+	stickyQuotaFailover bool                                // trusted opt-in for process-local sticky chat quota migration
 }
 
 // ProviderQueue wraps a provider's request channel with lifecycle management
@@ -238,19 +239,20 @@ func Init(ctx context.Context, config schemas.BifrostConfig) (*Bifrost, error) {
 
 	bifrostCtx, cancel := schemas.NewBifrostContextWithCancel(ctx)
 	bifrost := &Bifrost{
-		ctx:           bifrostCtx,
-		cancel:        cancel,
-		account:       config.Account,
-		llmPlugins:    atomic.Pointer[[]schemas.LLMPlugin]{},
-		mcpPlugins:    atomic.Pointer[[]schemas.MCPPlugin]{},
-		requestQueues: sync.Map{},
-		waitGroups:    sync.Map{},
-		keySelector:   config.KeySelector,
-		keyPoolFilter: config.KeyPoolFilter,
-		mcpCredStore:  credstore.NewCredStore(config.OAuth2Provider, config.MCPHeadersProvider, config.Logger),
-		logger:        config.Logger,
-		kvStore:       config.KVStore,
-		modelCatalog:  config.ModelCatalog,
+		ctx:                 bifrostCtx,
+		cancel:              cancel,
+		account:             config.Account,
+		llmPlugins:          atomic.Pointer[[]schemas.LLMPlugin]{},
+		mcpPlugins:          atomic.Pointer[[]schemas.MCPPlugin]{},
+		requestQueues:       sync.Map{},
+		waitGroups:          sync.Map{},
+		keySelector:         config.KeySelector,
+		keyPoolFilter:       config.KeyPoolFilter,
+		mcpCredStore:        credstore.NewCredStore(config.OAuth2Provider, config.MCPHeadersProvider, config.Logger),
+		logger:              config.Logger,
+		kvStore:             config.KVStore,
+		stickyQuotaFailover: config.EnableStickyKeyQuotaFailover,
+		modelCatalog:        config.ModelCatalog,
 	}
 	bifrost.tracer.Store(&tracerWrapper{tracer: tracer})
 	if config.LLMPlugins == nil {
@@ -6124,6 +6126,7 @@ func executeRequestWithRetries[T any](
 	model string,
 	req *schemas.BifrostRequest,
 	logger schemas.Logger,
+	retryObservers ...stickyRetryObserver,
 ) (result T, bifrostError *schemas.BifrostError) {
 	var attempts int
 
@@ -6564,6 +6567,8 @@ func executeRequestWithRetries[T any](
 			logger.Debug("encountered error that should be retried: %s", errMessage)
 		}
 
+		quotaRetryEligible := isStickyQuotaRetry(bifrostError)
+
 		// Fill FailReason on any failed attempt (retryable or terminal). The trail field
 		// answers "why was this key skipped?", so for rotation-triggering status codes the
 		// status itself is the truthful answer — provider Type labels can be misleading
@@ -6573,7 +6578,7 @@ func executeRequestWithRetries[T any](
 		if trail, ok := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord); ok && len(trail) > 0 {
 			reason := "unknown"
 			switch {
-			case bifrostError.StatusCode != nil && *bifrostError.StatusCode == 429:
+			case quotaRetryEligible:
 				reason = "rate_limit_error"
 			case bifrostError.StatusCode != nil && (*bifrostError.StatusCode == 401 || *bifrostError.StatusCode == 403):
 				reason = "authentication_error"
@@ -6599,6 +6604,7 @@ func executeRequestWithRetries[T any](
 			stripUnverifiableReasoning(ctx, req) {
 			strippedEncryptedContent = true
 			lastWasEncryptedContentStrip = true
+			quotaRetryEligible = false
 			extraAttempts++
 			shouldRetry = true
 			logger.Warn("upstream rejected replayed encrypted reasoning content for %s/%s; retrying once without it: %s", providerKey, model, errMessage)
@@ -6607,6 +6613,11 @@ func executeRequestWithRetries[T any](
 
 		if !shouldRetry {
 			break
+		}
+		for _, observer := range retryObservers {
+			if observer != nil {
+				observer.observeRetry(bifrostError, quotaRetryEligible)
+			}
 		}
 
 		// Track key state so the next keyProvider call excludes this key. Permanent
@@ -6880,6 +6891,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		// It is nil when no key is required (e.g. providerRequiresKey=false) or for multi-key
 		// batch/file/container operations that manage their own key lists.
 		var keyProvider func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error)
+		var retryObserver stickyRetryObserver
 
 		if providerRequiresKey(config.CustomProviderConfig) {
 			// ListModels needs all enabled/supported keys so providers can aggregate
@@ -6965,74 +6977,83 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					// governance/alias resolution) is worker-side work; the per-attempt pick
 					// is the separate "key.selection" span.
 					keyPoolSpan := bifrost.startCoreSpan(req.Context, "key-pool")
-					supportedKeys, canRotate, keyPoolErr := bifrost.selectKeyFromProviderForModelWithPool(req.Context, req.RequestType, provider.GetProviderKey(), model, baseProvider)
-					bifrost.endCoreSpan(keyPoolSpan)
-					if keyPoolErr != nil {
-						bifrost.logger.Debug("error building key pool for model %s: %v", model, keyPoolErr)
-						req.Err <- schemas.BifrostError{
-							IsBifrostError: false,
-							Error: &schemas.ErrorField{
-								Message: keyPoolErr.Error(),
-								Error:   keyPoolErr,
-							},
-							ExtraFields: schemas.BifrostErrorExtraFields{
-								Provider:               provider.GetProviderKey(),
-								RequestType:            req.RequestType,
-								OriginalModelRequested: model,
-								ResolvedModelUsed:      model,
-							},
-						}
-						continue
+					var stickyPlan *stickyKeyPlan
+					var stickyHandled bool
+					var stickyPlanErr error
+					if bifrost.stickyQuotaFailover && stickyChatPayloadEligible(req.BifrostRequest.ChatRequest) {
+						stickyPlan, stickyHandled, stickyPlanErr = bifrost.buildStickyKeyPlan(req.Context, req.RequestType, provider.GetProviderKey(), model, baseProvider)
 					}
-
-					if len(supportedKeys) == 0 {
-						// SkipKeySelection path — keyProvider stays nil, zero Key is used.
-					} else if !canRotate {
-						// Fixed key (explicit ID/name, session stickiness): always
-						// return the same key — *unless* it has been marked permanently
-						// dead this request, in which case surface errAllKeysDead so the
-						// caller emits 502 upstream_credentials_exhausted instead of
-						// burning the remaining retries on the same bad credential.
-						fixedKey := supportedKeys[0]
-						keyProvider = func(_, deadKeyIDs map[string]bool) (schemas.Key, error) {
-							if deadKeyIDs[fixedKey.ID] {
-								return schemas.Key{}, errAllKeysDead
+					if stickyHandled {
+						bifrost.endCoreSpan(keyPoolSpan)
+						if stickyPlanErr != nil {
+							bifrost.logger.Debug("error building sticky key plan for model %s: %v", model, stickyPlanErr)
+							req.Err <- schemas.BifrostError{
+								IsBifrostError: false,
+								Error: &schemas.ErrorField{
+									Message: stickyPlanErr.Error(),
+									Error:   stickyPlanErr,
+								},
+								ExtraFields: schemas.BifrostErrorExtraFields{
+									Provider:               provider.GetProviderKey(),
+									RequestType:            req.RequestType,
+									OriginalModelRequested: model,
+									ResolvedModelUsed:      model,
+								},
 							}
-							return fixedKey, nil
+							continue
 						}
+						keyProvider = stickyPlan.keyProvider()
+						retryObserver = stickyPlan
 					} else {
-						// Rotating pool: weighted selection with per-cycle exclusion.
-						// Captures supportedKeys, bifrost.keySelector, provider/model by value.
-						pool := supportedKeys
-						provKey := provider.GetProviderKey()
-						mdl := model
-						keyProvider = func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error) {
-							available := make([]schemas.Key, 0, len(pool))
-							for _, k := range pool {
-								if deadKeyIDs[k.ID] || usedKeyIDs[k.ID] {
-									continue
-								}
-								available = append(available, k)
+						supportedKeys, canRotate, keyPoolErr := bifrost.selectKeyFromProviderForModelWithPool(req.Context, req.RequestType, provider.GetProviderKey(), model, baseProvider)
+						bifrost.endCoreSpan(keyPoolSpan)
+						if keyPoolErr != nil {
+							bifrost.logger.Debug("error building key pool for model %s: %v", model, keyPoolErr)
+							req.Err <- schemas.BifrostError{
+								IsBifrostError: false,
+								Error: &schemas.ErrorField{
+									Message: keyPoolErr.Error(),
+									Error:   keyPoolErr,
+								},
+								ExtraFields: schemas.BifrostErrorExtraFields{
+									Provider:               provider.GetProviderKey(),
+									RequestType:            req.RequestType,
+									OriginalModelRequested: model,
+									ResolvedModelUsed:      model,
+								},
 							}
-							if bifrost.keyPoolFilter != nil {
-								if filtered, err := bifrost.keyPoolFilter(req.Context, provKey, mdl, available); err != nil {
-									bifrost.logger.Warn("key pool filter failed for provider %s, using unfiltered keys: %v", provKey, err)
-								} else {
-									available = filtered
+							continue
+						}
+
+						if len(supportedKeys) == 0 {
+							// SkipKeySelection path — keyProvider stays nil, zero Key is used.
+						} else if !canRotate {
+							// Fixed key (explicit ID/name, session stickiness): always
+							// return the same key — *unless* it has been marked permanently
+							// dead this request, in which case surface errAllKeysDead so the
+							// caller emits 502 upstream_credentials_exhausted instead of
+							// burning the remaining retries on the same bad credential.
+							fixedKey := supportedKeys[0]
+							keyProvider = func(_, deadKeyIDs map[string]bool) (schemas.Key, error) {
+								if deadKeyIDs[fixedKey.ID] {
+									return schemas.Key{}, errAllKeysDead
 								}
+								return fixedKey, nil
 							}
-							if len(available) == 0 {
-								// No non-dead keys remain in this cycle. If every key has been
-								// marked permanently dead, give up — retrying won't help.
-								// Otherwise reset usedKeyIDs and start a fresh weighted round
-								// across the still-live (non-dead) keys; a previously
-								// rate-limited key may have free quota by now.
+						} else {
+							// Rotating pool: weighted selection with per-cycle exclusion.
+							// Captures supportedKeys, bifrost.keySelector, provider/model by value.
+							pool := supportedKeys
+							provKey := provider.GetProviderKey()
+							mdl := model
+							keyProvider = func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error) {
+								available := make([]schemas.Key, 0, len(pool))
 								for _, k := range pool {
-									if !deadKeyIDs[k.ID] {
-										available = append(available, k)
+									if deadKeyIDs[k.ID] || usedKeyIDs[k.ID] {
+										continue
 									}
+									available = append(available, k)
 								}
-								liveCount := len(available) // non-dead keys before the filter runs
 								if bifrost.keyPoolFilter != nil {
 									if filtered, err := bifrost.keyPoolFilter(req.Context, provKey, mdl, available); err != nil {
 										bifrost.logger.Warn("key pool filter failed for provider %s, using unfiltered keys: %v", provKey, err)
@@ -7041,16 +7062,36 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 									}
 								}
 								if len(available) == 0 {
-									if liveCount > 0 {
-										return schemas.Key{}, fmt.Errorf("%w: provider %s", errAllKeysFiltered, provKey)
+									// No non-dead keys remain in this cycle. If every key has been
+									// marked permanently dead, give up — retrying won't help.
+									// Otherwise reset usedKeyIDs and start a fresh weighted round
+									// across the still-live (non-dead) keys; a previously
+									// rate-limited key may have free quota by now.
+									for _, k := range pool {
+										if !deadKeyIDs[k.ID] {
+											available = append(available, k)
+										}
 									}
-									return schemas.Key{}, fmt.Errorf("%w: provider %s", errAllKeysDead, provKey)
+									liveCount := len(available) // non-dead keys before the filter runs
+									if bifrost.keyPoolFilter != nil {
+										if filtered, err := bifrost.keyPoolFilter(req.Context, provKey, mdl, available); err != nil {
+											bifrost.logger.Warn("key pool filter failed for provider %s, using unfiltered keys: %v", provKey, err)
+										} else {
+											available = filtered
+										}
+									}
+									if len(available) == 0 {
+										if liveCount > 0 {
+											return schemas.Key{}, fmt.Errorf("%w: provider %s", errAllKeysFiltered, provKey)
+										}
+										return schemas.Key{}, fmt.Errorf("%w: provider %s", errAllKeysDead, provKey)
+									}
+									for id := range usedKeyIDs {
+										delete(usedKeyIDs, id)
+									}
 								}
-								for id := range usedKeyIDs {
-									delete(usedKeyIDs, id)
-								}
+								return bifrost.keySelector(req.Context, available, provKey, mdl)
 							}
-							return bifrost.keySelector(req.Context, available, provKey, mdl)
 						}
 					}
 				}
@@ -7195,7 +7236,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 					})
 				}
 				return streamCh, streamErr
-			}, keyProvider, req.RequestType, provider.GetProviderKey(), model, &req.BifrostRequest, bifrost.logger)
+			}, keyProvider, req.RequestType, provider.GetProviderKey(), model, &req.BifrostRequest, bifrost.logger, retryObserver)
 		} else {
 			result, bifrostError = executeRequestWithRetries(req.Context, config, func(k schemas.Key) (*schemas.BifrostResponse, *schemas.BifrostError) {
 				if aliasConfig := k.Aliases.ResolveConfig(originalModelRequested); aliasConfig != nil {
@@ -7213,7 +7254,7 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 				applyRawCaptureSignals(req.Context, config)
 				attemptRoutingInfo = schemas.BuildRoutingInfo(req.Context, provider.GetProviderKey(), originalModelRequested, k)
 				return bifrost.handleProviderRequest(provider, config, req, k, keys)
-			}, keyProvider, req.RequestType, provider.GetProviderKey(), model, &req.BifrostRequest, bifrost.logger)
+			}, keyProvider, req.RequestType, provider.GetProviderKey(), model, &req.BifrostRequest, bifrost.logger, retryObserver)
 		}
 
 		// For streaming with an error, route release through the LAST attempt's

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+[feat]: opt in to quota failover for self-contained session-sticky chat requests [@Alex-wangyang](https://github.com/Alex-wangyang)
 - fix: give a Bedrock message a placeholder text block instead of a null `content` field when it has no text and no tool calls - `BedrockMessage.Content` has no `omitempty`, so a message with empty text and no tool calls (or an empty `tool_calls` array) serialized as `content:null`, which Converse rejects with "Member must not be null" (#2765)
 - [fix]: marshal required nullable response fields as null [@PSR94](https://github.com/PSR94)
 - fix: accept top-level arrays from OpenAI-compatible model APIs [@dani29](https://github.com/dani29)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -36,7 +36,13 @@ type BifrostConfig struct {
 	KeySelector        KeySelector   // Custom key selector function
 	KeyPoolFilter      KeyPoolFilter // Optional hook to filter available keys before selection; nil = all keys eligible
 	KVStore            KVStore       // shared KV store for clustering/session stickiness; nil = disabled
-	ModelCatalog       ModelInfoProvider
+	// EnableStickyKeyQuotaFailover opts trusted callers into process-local
+	// failover for self-contained session-sticky chat requests after quota errors.
+	// It is disabled by default and requires the optional conditional KV store
+	// capability; it is not a cluster-wide guarantee.
+	// This is an initialization-only option; ReloadConfig does not change it.
+	EnableStickyKeyQuotaFailover bool
+	ModelCatalog                 ModelInfoProvider
 }
 
 // ModelProvider represents the different AI model providers supported by Bifrost.

--- a/core/schemas/kvstore.go
+++ b/core/schemas/kvstore.go
@@ -12,6 +12,18 @@ type KVStore interface {
 	Delete(key string) (bool, error)
 }
 
+// ConditionalStringKVStore is an optional process-local compare-and-swap
+// capability for string bindings. Implementations must only replace an
+// existing, unexpired value that equals expected; a missing or expired value
+// must never be resurrected by a conditional write.
+//
+// The capability is intentionally separate from KVStore. A KVStore may be
+// backed by a delegated cluster implementation whose local CAS cannot provide
+// the process-local semantics required by sticky-key failover.
+type ConditionalStringKVStore interface {
+	CompareAndSwapStringWithTTL(key, expected, replacement string, ttl time.Duration) (bool, error)
+}
+
 const (
 	DefaultSessionStickyTTL = time.Hour
 )

--- a/core/stickykeys.go
+++ b/core/stickykeys.go
@@ -1,0 +1,524 @@
+package bifrost
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/bytedance/sonic"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+const stickyQuotaKeyPrefix = "sticky-quota:"
+
+// stickyRetryObserver is deliberately narrow: retry orchestration reports only
+// whether the failed attempt is eligible for sticky-key quota rotation. It
+// does not carry request bodies or other per-request state through the retry
+// loop.
+type stickyRetryObserver interface {
+	observeRetry(*schemas.BifrostError, bool)
+}
+
+// stickyKeyPlan owns one request's fixed binding and its optional quota
+// migration. The plan's pool is captured once, before the first attempt, so a
+// concurrent provider/key update cannot broaden a retry's eligibility.
+type stickyKeyPlan struct {
+	mu sync.Mutex
+
+	ctx      *schemas.BifrostContext
+	store    schemas.KVStore
+	cas      schemas.ConditionalStringKVStore
+	key      string
+	ttl      time.Duration
+	provider schemas.ModelProvider
+	model    string
+	pool     []schemas.Key
+	selector schemas.KeySelector
+	filter   schemas.KeyPoolFilter
+	current  schemas.Key
+	casReady bool
+	rotate   bool
+}
+
+// buildStickyQuotaKey uses a dedicated namespace. Legacy session stickiness
+// remains authoritative for non-chat requests and for callers without the
+// opt-in, so a chat quota migration cannot move another request type's
+// continuation.
+func buildStickyQuotaKey(provider schemas.ModelProvider, sessionID, model string) string {
+	return stickyQuotaKeyPrefix + buildSessionKey(provider, sessionID, model)
+}
+
+// stickyChatPayloadEligible is the replay-safety boundary for opt-in sticky
+// quota migration. A quota retry can resend the exact typed request to another
+// credential, so only payloads whose state is fully present in the neutral Chat
+// schema may enter that path. Unsupported or opaque payloads fall back to the
+// existing strict key selector.
+func stickyChatPayloadEligible(req *schemas.BifrostChatRequest) bool {
+	if req == nil || req.Input == nil || req.RawRequestBody != nil {
+		return false
+	}
+
+	if params := req.Params; params != nil {
+		if params.Container != nil || len(params.ContextManagement) > 0 || len(params.MCPServers) > 0 || len(params.ExtraParams) > 0 {
+			return false
+		}
+		if params.Store != nil && *params.Store {
+			return false
+		}
+		if params.Audio != nil || stickyHasAudioModality(params.Modalities) {
+			return false
+		}
+		if params.IncludeServerSideToolInvocations != nil && *params.IncludeServerSideToolInvocations {
+			return false
+		}
+		if params.WebSearchOptions != nil {
+			return false
+		}
+		for _, tool := range params.Tools {
+			if tool.Type != schemas.ChatToolTypeFunction || tool.Function == nil || strings.TrimSpace(tool.Function.Name) == "" {
+				return false
+			}
+			if tool.Annotations != nil || tool.DeferLoading != nil || len(tool.AllowedCallers) > 0 || len(tool.InputExamples) > 0 || tool.EagerInputStreaming != nil {
+				return false
+			}
+		}
+	}
+
+	for _, message := range req.Input {
+		if !stickyChatMessageEligible(message) {
+			return false
+		}
+	}
+	return true
+}
+
+func stickyHasAudioModality(modalities []string) bool {
+	for _, modality := range modalities {
+		if strings.EqualFold(strings.TrimSpace(modality), "audio") {
+			return true
+		}
+	}
+	return false
+}
+
+func stickyChatMessageEligible(message schemas.ChatMessage) bool {
+	switch message.Role {
+	case schemas.ChatMessageRoleAssistant, schemas.ChatMessageRoleDeveloper, schemas.ChatMessageRoleSystem, schemas.ChatMessageRoleTool, schemas.ChatMessageRoleUser:
+	default:
+		return false
+	}
+	if message.ChatToolMessage != nil && message.ChatAssistantMessage != nil {
+		return false
+	}
+	if message.ChatToolMessage != nil && message.ChatToolMessage.IsError != nil {
+		return false
+	}
+	if message.Content != nil && !stickyChatContentEligible(message.Content) {
+		return false
+	}
+	if message.ChatAssistantMessage != nil && !stickyChatAssistantMessageEligible(message.ChatAssistantMessage) {
+		return false
+	}
+	return message.Content != nil || message.ChatToolMessage != nil || message.ChatAssistantMessage != nil
+}
+
+func stickyChatContentEligible(content *schemas.ChatMessageContent) bool {
+	if content == nil || (content.ContentStr != nil && content.ContentBlocks != nil) {
+		return false
+	}
+	if content.ContentStr != nil {
+		return true
+	}
+	if content.ContentBlocks == nil || len(content.ContentBlocks) == 0 {
+		return false
+	}
+	for _, block := range content.ContentBlocks {
+		if block.Citations != nil {
+			return false
+		}
+		switch block.Type {
+		case schemas.ChatContentBlockTypeText:
+			if block.Text == nil || block.Refusal != nil || block.ImageURLStruct != nil || block.InputAudio != nil || block.File != nil {
+				return false
+			}
+		case schemas.ChatContentBlockTypeImage:
+			if block.ImageURLStruct == nil || block.Text != nil || block.Refusal != nil || block.InputAudio != nil || block.File != nil {
+				return false
+			}
+			image := block.ImageURLStruct
+			if image.FileID != nil || strings.TrimSpace(image.URL) == "" || !stickyIsInlineDataURL(image.URL) {
+				return false
+			}
+		case schemas.ChatContentBlockTypeInputAudio:
+			if block.InputAudio == nil || strings.TrimSpace(block.InputAudio.Data) == "" || block.Text != nil || block.Refusal != nil || block.ImageURLStruct != nil || block.File != nil {
+				return false
+			}
+		case schemas.ChatContentBlockTypeFile:
+			if block.File == nil || block.Text != nil || block.Refusal != nil || block.ImageURLStruct != nil || block.InputAudio != nil {
+				return false
+			}
+			file := block.File
+			if file.FileID != nil || file.FileURL != nil || file.FileData == nil || strings.TrimSpace(*file.FileData) == "" {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func stickyIsInlineDataURL(value string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(value)), "data:")
+}
+
+func stickyChatAssistantMessageEligible(message *schemas.ChatAssistantMessage) bool {
+	if message.Audio != nil && strings.TrimSpace(message.Audio.ID) != "" {
+		return false
+	}
+	if message.Refusal != nil || message.Reasoning != nil || len(message.ReasoningDetails) > 0 || len(message.Annotations) > 0 {
+		return false
+	}
+	for _, call := range message.ToolCalls {
+		if call.Type != nil && strings.TrimSpace(*call.Type) != "" && !strings.EqualFold(strings.TrimSpace(*call.Type), string(schemas.ChatToolTypeFunction)) {
+			return false
+		}
+		if len(call.ExtraContent) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// SupportsProcessLocalCAS is an optional discriminator implemented by the
+// framework store. A delegated cluster store returns false because its local
+// mutex does not establish a cluster-wide CAS guarantee.
+type processLocalCASDiscriminator interface {
+	SupportsProcessLocalCAS() bool
+}
+
+// buildStickyKeyPlan returns handled=false when the feature is not applicable
+// or its KV store cannot prove process-local CAS support. The caller then uses
+// the existing selector path unchanged.
+func (bifrost *Bifrost) buildStickyKeyPlan(ctx *schemas.BifrostContext, requestType schemas.RequestType, providerKey schemas.ModelProvider, model string, baseProviderType schemas.ModelProvider) (*stickyKeyPlan, bool, error) {
+	if !bifrost.stickyQuotaFailover || bifrost.kvStore == nil || ctx == nil {
+		return nil, false, nil
+	}
+	if requestType != schemas.ChatCompletionRequest && requestType != schemas.ChatCompletionStreamRequest {
+		return nil, false, nil
+	}
+	if _, ok := ctx.Value(schemas.BifrostContextKeyDirectKey).(schemas.Key); ok {
+		return nil, false, nil
+	}
+	if skip, _ := ctx.Value(schemas.BifrostContextKeySkipKeySelection).(bool); skip && isKeySkippingAllowed(baseProviderType) {
+		return nil, false, nil
+	}
+	if raw, _ := ctx.Value(schemas.BifrostContextKeyUseRawRequestBody).(bool); raw {
+		return nil, false, nil
+	}
+	if keyID, _ := ctx.Value(schemas.BifrostContextKeyAPIKeyID).(string); strings.TrimSpace(keyID) != "" {
+		return nil, false, nil
+	}
+	if keyName, _ := ctx.Value(schemas.BifrostContextKeyAPIKeyName).(string); strings.TrimSpace(keyName) != "" {
+		return nil, false, nil
+	}
+	sessionID, _ := ctx.Value(schemas.BifrostContextKeySessionID).(string)
+	if sessionID == "" {
+		return nil, false, nil
+	}
+	fallbackIndex, _ := ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int)
+	if fallbackIndex != 0 {
+		return nil, false, nil
+	}
+
+	cas, ok := bifrost.kvStore.(schemas.ConditionalStringKVStore)
+	if !ok {
+		return nil, false, nil
+	}
+	if discriminator, ok := cas.(processLocalCASDiscriminator); ok && !discriminator.SupportsProcessLocalCAS() {
+		return nil, false, nil
+	}
+
+	keys, err := bifrost.account.GetKeysForProvider(ctx, providerKey)
+	if err != nil {
+		return nil, true, err
+	}
+	pool := eligibleStickyKeys(bifrost, keys, model, baseProviderType, providerKey)
+	if len(pool) < 2 {
+		return nil, false, nil
+	}
+
+	ttl, _ := ctx.Value(schemas.BifrostContextKeySessionTTL).(time.Duration)
+	if ttl <= 0 {
+		ttl = schemas.DefaultSessionStickyTTL
+	}
+	plan := &stickyKeyPlan{
+		ctx:      ctx,
+		store:    bifrost.kvStore,
+		cas:      cas,
+		key:      buildStickyQuotaKey(providerKey, sessionID, model),
+		ttl:      ttl,
+		provider: providerKey,
+		model:    model,
+		pool:     pool,
+		selector: bifrost.keySelector,
+		filter:   bifrost.keyPoolFilter,
+		casReady: true,
+	}
+	if err := plan.initialize(); err != nil {
+		return nil, true, err
+	}
+	return plan, true, nil
+}
+
+func eligibleStickyKeys(bifrost *Bifrost, keys []schemas.Key, model string, baseProviderType, providerKey schemas.ModelProvider) []schemas.Key {
+	pool := make([]schemas.Key, 0, len(keys))
+	for _, key := range keys {
+		if key.Enabled != nil && !*key.Enabled {
+			continue
+		}
+		if err := validateKey(baseProviderType, &key); err != nil {
+			bifrost.logger.Warn("error validating key %s (%s) for provider %s: %s, skipping key", key.Name, key.ID, providerKey, err.Error())
+			continue
+		}
+		hasValue := strings.TrimSpace(key.Value.GetValue()) != "" || CanProviderKeyValueBeEmpty(baseProviderType)
+		if !hasValue || !key.Models.IsAllowed(model) || key.BlacklistedModels.IsBlocked(model) {
+			continue
+		}
+		if baseProviderType == schemas.VLLM && key.VLLMKeyConfig != nil && key.VLLMKeyConfig.ModelName != "" && key.VLLMKeyConfig.ModelName != model {
+			continue
+		}
+		pool = append(pool, key)
+	}
+	return pool
+}
+
+func (p *stickyKeyPlan) initialize() error {
+	value, err := p.store.Get(p.key)
+	if err == nil {
+		if bound, ok := stickyKeyByID(value, p.pool); ok {
+			p.current = bound
+			p.refreshExisting()
+			return nil
+		}
+		// An invalid dedicated winner is left untouched. Selecting a fixed
+		// key keeps this request safe without overwriting a newer/unknown
+		// binding.
+		p.current = p.pool[0]
+		p.casReady = false
+		return nil
+	}
+
+	// Seed the dedicated namespace from the legacy session binding when it is
+	// still an eligible key. This read preserves existing affinity while never
+	// mutating or deleting the legacy namespace.
+	legacyValue, legacyErr := p.store.Get(strings.TrimPrefix(p.key, stickyQuotaKeyPrefix))
+	if legacyErr == nil {
+		if bound, ok := stickyKeyByID(legacyValue, p.pool); ok {
+			p.current = bound
+		} else {
+			p.current = p.pool[0]
+			p.casReady = false
+			return nil
+		}
+	} else {
+		selected, selectErr := p.selector(p.ctx, p.pool, p.provider, p.model)
+		if selectErr != nil {
+			return selectErr
+		}
+		canonical, ok := stickyKeyByID(selected.ID, p.pool)
+		if !ok {
+			p.current = p.pool[0]
+			p.casReady = false
+			return nil
+		}
+		p.current = canonical
+	}
+
+	wasSet, setErr := p.store.SetNXWithTTL(p.key, p.current.ID, p.ttl)
+	if setErr != nil {
+		p.casReady = false
+		return nil
+	}
+	if wasSet {
+		return nil
+	}
+	if winner, ok := stickyKeyByIDFromStore(p.store, p.key, p.pool); ok {
+		p.current = winner
+		return nil
+	}
+	// SetNX lost to an invalid winner; keep the selected key fixed and do not
+	// overwrite the store.
+	p.casReady = false
+	return nil
+}
+
+func (p *stickyKeyPlan) refreshExisting() {
+	swapped, err := p.cas.CompareAndSwapStringWithTTL(p.key, p.current.ID, p.current.ID, p.ttl)
+	if err != nil {
+		p.casReady = false
+		return
+	}
+	if swapped {
+		return
+	}
+	if winner, ok := stickyKeyByIDFromStore(p.store, p.key, p.pool); ok {
+		p.current = winner
+		return
+	}
+	p.casReady = false
+}
+
+func stickyKeyByID(raw any, pool []schemas.Key) (schemas.Key, bool) {
+	id := ""
+	switch value := raw.(type) {
+	case string:
+		id = value
+	case []byte:
+		if err := sonic.Unmarshal(value, &id); err != nil {
+			id = string(value)
+		}
+	}
+	for _, key := range pool {
+		if key.ID == id {
+			return key, true
+		}
+	}
+	return schemas.Key{}, false
+}
+
+func stickyKeyByIDFromStore(store schemas.KVStore, key string, pool []schemas.Key) (schemas.Key, bool) {
+	raw, err := store.Get(key)
+	if err != nil {
+		return schemas.Key{}, false
+	}
+	return stickyKeyByID(raw, pool)
+}
+
+func (p *stickyKeyPlan) keyProvider() func(map[string]bool, map[string]bool) (schemas.Key, error) {
+	return func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error) {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if deadKeyIDs != nil && deadKeyIDs[p.current.ID] {
+			return schemas.Key{}, errAllKeysDead
+		}
+		if !p.rotate || !p.casReady {
+			p.rotate = false
+			return p.current, nil
+		}
+		p.rotate = false
+
+		alternatives := make([]schemas.Key, 0, len(p.pool)-1)
+		for _, key := range p.pool {
+			if key.ID == p.current.ID || (deadKeyIDs != nil && deadKeyIDs[key.ID]) || (usedKeyIDs != nil && usedKeyIDs[key.ID]) {
+				continue
+			}
+			alternatives = append(alternatives, key)
+		}
+		if len(alternatives) == 0 {
+			return p.current, nil
+		}
+		if p.filter != nil {
+			filtered, err := p.filter(p.ctx, p.provider, p.model, alternatives)
+			if err != nil || len(filtered) == 0 {
+				return p.current, nil
+			}
+			filteredSet := make(map[string]schemas.Key, len(alternatives))
+			for _, key := range alternatives {
+				filteredSet[key.ID] = key
+			}
+			canonical := make([]schemas.Key, 0, len(filtered))
+			seen := make(map[string]struct{}, len(filtered))
+			for _, key := range filtered {
+				original, ok := filteredSet[key.ID]
+				if !ok {
+					return p.current, nil
+				}
+				if _, duplicate := seen[key.ID]; duplicate {
+					continue
+				}
+				seen[key.ID] = struct{}{}
+				canonical = append(canonical, original)
+			}
+			if len(canonical) == 0 {
+				return p.current, nil
+			}
+			alternatives = canonical
+		}
+
+		next, err := p.selector(p.ctx, alternatives, p.provider, p.model)
+		if err != nil {
+			return p.current, nil
+		}
+		canonicalNext, valid := stickyKeyByID(next.ID, alternatives)
+		if !valid {
+			return p.current, nil
+		}
+		won, err := p.cas.CompareAndSwapStringWithTTL(p.key, p.current.ID, canonicalNext.ID, p.ttl)
+		if err != nil {
+			return p.current, nil
+		}
+		if won {
+			p.current = canonicalNext
+			return canonicalNext, nil
+		}
+		if winner, ok := stickyKeyByIDFromStore(p.store, p.key, alternatives); ok {
+			p.current = winner
+			return winner, nil
+		}
+		return p.current, nil
+	}
+}
+
+func (p *stickyKeyPlan) observeRetry(err *schemas.BifrostError, eligible bool) {
+	p.mu.Lock()
+	p.rotate = eligible && isStickyQuotaRetry(err)
+	p.mu.Unlock()
+}
+
+// isStickyQuotaRetry deliberately excludes permanent credential failures,
+// transport/server failures, and misleading quota text on those failures.
+func isStickyQuotaRetry(err *schemas.BifrostError) bool {
+	if err == nil || err.IsBifrostError {
+		return false
+	}
+	// A recognized transport or credential classification wins over incidental
+	// quota text (and even a contradictory 429 supplied by an adapter).
+	if err.Error != nil {
+		if err.Error.Message == schemas.ErrProviderDoRequest || err.Error.Message == schemas.ErrProviderNetworkError {
+			return false
+		}
+		for _, classification := range []*string{err.Error.Type, err.Error.Code} {
+			if classification == nil {
+				continue
+			}
+			value := strings.TrimSpace(*classification)
+			if strings.EqualFold(value, schemas.ErrProviderDoRequest) || strings.EqualFold(value, schemas.ErrProviderNetworkError) {
+				return false
+			}
+			switch strings.ToLower(value) {
+			case "authentication_error", "invalid_api_key", "unauthorized", "forbidden", "permission_error", "permission_denied", "insufficient_permissions", "access_denied", "billing_error", "billing_not_active", "network_error", "connection_error", "timeout_error":
+				return false
+			}
+		}
+	}
+	if err.StatusCode != nil {
+		switch *err.StatusCode {
+		case 401, 402, 403:
+			return false
+		case 429:
+			return true
+		}
+		if *err.StatusCode >= 500 && *err.StatusCode <= 599 {
+			return false
+		}
+	}
+	if err.Error == nil {
+		return false
+	}
+	return IsRateLimitErrorMessage(err.Error.Message) ||
+		(err.Error.Type != nil && IsRateLimitErrorMessage(*err.Error.Type)) ||
+		(err.Error.Code != nil && IsRateLimitErrorMessage(*err.Error.Code))
+}
+
+var _ stickyRetryObserver = (*stickyKeyPlan)(nil)

--- a/core/stickykeys.go
+++ b/core/stickykeys.go
@@ -1,6 +1,7 @@
 package bifrost
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -38,6 +39,9 @@ type stickyKeyPlan struct {
 	current  schemas.Key
 	casReady bool
 	rotate   bool
+	// Deferred to keyProvider so the retry engine maps rejected pools to the
+	// same 503/no_eligible_keys response for ordinary and streaming requests.
+	selectionErr error
 }
 
 // buildStickyQuotaKey uses a dedicated namespace. Legacy session stickiness
@@ -247,6 +251,35 @@ func (bifrost *Bifrost) buildStickyKeyPlan(ctx *schemas.BifrostContext, requestT
 	if len(pool) < 2 {
 		return nil, false, nil
 	}
+	if bifrost.keyPoolFilter != nil {
+		// Filter before both cached-binding lookup and initial selection. Keep
+		// the captured keys canonical even if the hook edits its input slice.
+		filtered, filterErr := bifrost.keyPoolFilter(ctx, providerKey, model, append([]schemas.Key(nil), pool...))
+		if filterErr != nil {
+			// Match normal initial selection's fail-open handling. Quota
+			// migration still keeps the current key when its filter fails.
+			bifrost.logger.Warn("key pool filter failed for provider %s, using unfiltered keys: %v", providerKey, filterErr)
+		} else {
+			canonical := make([]schemas.Key, 0, len(filtered))
+			seen := make(map[string]bool, len(filtered))
+			for _, key := range filtered {
+				original, valid := stickyKeyByID(key.ID, pool)
+				if !valid {
+					return &stickyKeyPlan{selectionErr: fmt.Errorf("%w: provider %s", errAllKeysFiltered, providerKey)}, true, nil
+				}
+				if !seen[key.ID] {
+					canonical = append(canonical, original)
+					seen[key.ID] = true
+				}
+			}
+			if len(canonical) == 0 {
+				return &stickyKeyPlan{selectionErr: fmt.Errorf("%w: provider %s", errAllKeysFiltered, providerKey)}, true, nil
+			}
+			// Keep a one-key filtered plan handled: falling back to the legacy
+			// selector would rebuild an unfiltered pool and undo the veto.
+			pool = canonical
+		}
+	}
 
 	ttl, _ := ctx.Value(schemas.BifrostContextKeySessionTTL).(time.Duration)
 	if ttl <= 0 {
@@ -399,6 +432,9 @@ func (p *stickyKeyPlan) keyProvider() func(map[string]bool, map[string]bool) (sc
 	return func(usedKeyIDs, deadKeyIDs map[string]bool) (schemas.Key, error) {
 		p.mu.Lock()
 		defer p.mu.Unlock()
+		if p.selectionErr != nil {
+			return schemas.Key{}, p.selectionErr
+		}
 		if deadKeyIDs != nil && deadKeyIDs[p.current.ID] {
 			return schemas.Key{}, errAllKeysDead
 		}

--- a/core/stickykeys_test.go
+++ b/core/stickykeys_test.go
@@ -1,0 +1,784 @@
+package bifrost
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+type stickyTestKVStore struct {
+	mu       sync.Mutex
+	data     map[string]any
+	casError error
+}
+
+func newStickyTestKVStore() *stickyTestKVStore {
+	return &stickyTestKVStore{data: make(map[string]any)}
+}
+
+func (s *stickyTestKVStore) Get(key string) (any, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	v, ok := s.data[key]
+	if !ok {
+		return nil, errors.New("missing")
+	}
+	return v, nil
+}
+
+func (s *stickyTestKVStore) SetWithTTL(key string, value any, _ time.Duration) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[key] = value
+	return nil
+}
+
+func (s *stickyTestKVStore) SetNXWithTTL(key string, value any, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.data[key]; ok {
+		return false, nil
+	}
+	s.data[key] = value
+	return true, nil
+}
+
+func (s *stickyTestKVStore) Delete(key string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.data[key]
+	delete(s.data, key)
+	return ok, nil
+}
+
+func (s *stickyTestKVStore) CompareAndSwapStringWithTTL(key, expected, replacement string, _ time.Duration) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.casError != nil {
+		return false, s.casError
+	}
+	v, ok := s.data[key]
+	if !ok || v != expected {
+		return false, nil
+	}
+	s.data[key] = replacement
+	return true, nil
+}
+
+func stickyTestKeys() []schemas.Key {
+	return []schemas.Key{
+		{ID: "key-a", Name: "A", Value: *schemas.NewSecretVar("sk-a"), Models: schemas.WhiteList{"*"}, Weight: 1},
+		{ID: "key-b", Name: "B", Value: *schemas.NewSecretVar("sk-b"), Models: schemas.WhiteList{"*"}, Weight: 1},
+	}
+}
+
+func newStickyTestBifrost(t *testing.T, store schemas.KVStore, filter schemas.KeyPoolFilter) *Bifrost {
+	t.Helper()
+	account := NewMockAccount()
+	account.AddProvider(schemas.OpenAI, 1, 8)
+	account.SetKeysForProvider(schemas.OpenAI, stickyTestKeys())
+	bf, err := Init(context.Background(), schemas.BifrostConfig{
+		Account:                      account,
+		KVStore:                      store,
+		KeyPoolFilter:                filter,
+		EnableStickyKeyQuotaFailover: true,
+		KeySelector: func(_ *schemas.BifrostContext, keys []schemas.Key, _ schemas.ModelProvider, _ string) (schemas.Key, error) {
+			return keys[0], nil
+		},
+		Logger: NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(bf.Shutdown)
+	return bf
+}
+
+func stickyTestContext() *schemas.BifrostContext {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeySessionID, "session-1")
+	ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+	return ctx
+}
+
+func TestStickyKeyPlanQuotaFailoverPersistsWinner(t *testing.T) {
+	store := newStickyTestKVStore()
+	bf := newStickyTestBifrost(t, store, nil)
+	ctx := stickyTestContext()
+
+	plan, handled, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil || !handled || plan == nil {
+		t.Fatalf("expected enabled sticky plan, handled=%v plan=%v err=%v", handled, plan, err)
+	}
+
+	provider := plan.keyProvider()
+	first, err := provider(nil, nil)
+	if err != nil || first.ID != "key-a" {
+		t.Fatalf("attempt 0 should use bound key-a, got %q err=%v", first.ID, err)
+	}
+	plan.observeRetry(createBifrostError("quota exceeded", Ptr(429), nil, false), true)
+	second, err := provider(map[string]bool{"key-a": true}, nil)
+	if err != nil || second.ID != "key-b" {
+		t.Fatalf("quota retry should rotate to key-b, got %q err=%v", second.ID, err)
+	}
+
+	raw, err := store.Get(buildStickyQuotaKey(schemas.OpenAI, "session-1", "gpt-4"))
+	if err != nil || raw != "key-b" {
+		t.Fatalf("expected winner key-b persisted, got %v err=%v", raw, err)
+	}
+
+	next, handled, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil || !handled || next == nil {
+		t.Fatalf("expected second sticky plan, handled=%v plan=%v err=%v", handled, next, err)
+	}
+	selected, err := next.keyProvider()(nil, nil)
+	if err != nil || selected.ID != "key-b" {
+		t.Fatalf("next request should use persisted winner key-b, got %q err=%v", selected.ID, err)
+	}
+}
+
+func TestChatCompletionRequestStickyQuotaFailoverUsesAndPersistsWinner(t *testing.T) {
+	var mu sync.Mutex
+	var auths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		auths = append(auths, r.Header.Get("Authorization"))
+		mu.Unlock()
+		if r.Header.Get("Authorization") == "Bearer sk-a" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = fmt.Fprint(w, `{"error":{"message":"quota exceeded","type":"rate_limit_error"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, chatCompletionBody)
+	}))
+	defer server.Close()
+
+	store := newStickyTestKVStore()
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 8, server.URL)
+	account.configs[schemas.OpenAI].NetworkConfig.MaxRetries = 1
+	account.configs[schemas.OpenAI].NetworkConfig.RetryBackoffInitial = 0
+	account.configs[schemas.OpenAI].NetworkConfig.RetryBackoffMax = 0
+	account.SetKeysForProvider(schemas.OpenAI, stickyTestKeys())
+	bf, err := Init(context.Background(), schemas.BifrostConfig{
+		Account:                      account,
+		KVStore:                      store,
+		EnableStickyKeyQuotaFailover: true,
+		KeySelector: func(_ *schemas.BifrostContext, keys []schemas.Key, _ schemas.ModelProvider, _ string) (schemas.Key, error) {
+			return keys[0], nil
+		},
+		Logger: NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(bf.Shutdown)
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	ctx.SetValue(schemas.BifrostContextKeySessionID, "request-session")
+	response, bifrostErr := bf.ChatCompletionRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}}},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("chat completion should recover on quota failover: %v", bifrostErr)
+	}
+	if response == nil {
+		t.Fatal("expected chat response")
+	}
+	nextCtx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
+	nextCtx.SetValue(schemas.BifrostContextKeySessionID, "request-session")
+	if _, e := bf.ChatCompletionRequest(nextCtx, &schemas.BifrostChatRequest{Provider: schemas.OpenAI, Model: "gpt-4o-mini", Input: []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("again")}}}}); e != nil {
+		t.Fatalf("next request failed: %v", e)
+	}
+	mu.Lock()
+	gotAuths := append([]string(nil), auths...)
+	mu.Unlock()
+	if len(gotAuths) != 3 || gotAuths[0] != "Bearer sk-a" || gotAuths[1] != "Bearer sk-b" || gotAuths[2] != "Bearer sk-b" {
+		t.Fatalf("expected first key then persisted alternative, got auth sequence %v", gotAuths)
+	}
+	if raw, err := store.Get(buildStickyQuotaKey(schemas.OpenAI, "request-session", "gpt-4o-mini")); err != nil || raw != "key-b" {
+		t.Fatalf("expected key-b winner binding, got %v err=%v", raw, err)
+	}
+}
+
+func TestChatCompletionRequestStickyQuotaFailoverSkipsUnsafeTypedPayloads(t *testing.T) {
+	tests := []struct {
+		name  string
+		apply func(*schemas.BifrostChatRequest)
+	}{
+		{name: "raw request body", apply: func(req *schemas.BifrostChatRequest) {
+			req.RawRequestBody = []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+		}},
+		{name: "container", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{Container: &schemas.ChatContainer{ContainerStr: schemas.Ptr("container-1")}}
+		}},
+		{name: "context management", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{ContextManagement: []byte(`{"clear_at_turn":3}`)}
+		}},
+		{name: "mcp server", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{MCPServers: []schemas.ChatMCPServer{{Type: "url", URL: "https://mcp.example.test", Name: "mcp"}}}
+		}},
+		{name: "extra params", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{ExtraParams: map[string]interface{}{"provider_state": "opaque"}}
+		}},
+		{name: "store", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{Store: schemas.Ptr(true)}
+		}},
+		{name: "audio generation", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{Audio: &schemas.ChatAudioParameters{Format: "wav", Voice: "alloy"}}
+		}},
+		{name: "audio modality", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{Modalities: []string{"text", "audio"}}
+		}},
+		{name: "server-side tool", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{Tools: []schemas.ChatTool{{Type: schemas.ChatToolType("web_search_20260209")}}}
+		}},
+		{name: "web search options", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{WebSearchOptions: &schemas.ChatWebSearchOptions{SearchContextSize: schemas.Ptr("low")}}
+		}},
+		{name: "server-side invocations", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{IncludeServerSideToolInvocations: schemas.Ptr(true)}
+		}},
+		{name: "custom tool", apply: func(req *schemas.BifrostChatRequest) {
+			req.Params = &schemas.ChatParameters{Tools: []schemas.ChatTool{{
+				Type:   schemas.ChatToolTypeCustom,
+				Custom: &schemas.ChatToolCustom{},
+			}}}
+		}},
+		{name: "image file id", apply: func(req *schemas.BifrostChatRequest) {
+			fileID := "file-image-1"
+			req.Input[0].Content = &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{{Type: schemas.ChatContentBlockTypeImage, ImageURLStruct: &schemas.ChatInputImage{FileID: &fileID}}}}
+		}},
+		{name: "remote image url", apply: func(req *schemas.BifrostChatRequest) {
+			req.Input[0].Content = &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{{Type: schemas.ChatContentBlockTypeImage, ImageURLStruct: &schemas.ChatInputImage{URL: "https://example.test/image.png"}}}}
+		}},
+		{name: "assistant audio", apply: func(req *schemas.BifrostChatRequest) {
+			req.Input[0] = schemas.ChatMessage{Role: schemas.ChatMessageRoleAssistant, ChatAssistantMessage: &schemas.ChatAssistantMessage{Audio: &schemas.ChatAudioMessageAudio{ID: "audio-issued", Data: "inline"}}}
+		}},
+		{name: "assistant reasoning", apply: func(req *schemas.BifrostChatRequest) {
+			req.Input[0] = schemas.ChatMessage{Role: schemas.ChatMessageRoleAssistant, ChatAssistantMessage: &schemas.ChatAssistantMessage{Reasoning: schemas.Ptr("opaque reasoning")}}
+		}},
+		{name: "assistant reasoning signature", apply: func(req *schemas.BifrostChatRequest) {
+			req.Input[0] = schemas.ChatMessage{Role: schemas.ChatMessageRoleAssistant, ChatAssistantMessage: &schemas.ChatAssistantMessage{ReasoningDetails: []schemas.ChatReasoningDetails{{Type: schemas.BifrostReasoningDetailsTypeEncrypted, Signature: schemas.Ptr("sig"), Data: schemas.Ptr("ciphertext")}}}}
+		}},
+		{name: "assistant refusal", apply: func(req *schemas.BifrostChatRequest) {
+			req.Input[0] = schemas.ChatMessage{Role: schemas.ChatMessageRoleAssistant, ChatAssistantMessage: &schemas.ChatAssistantMessage{Refusal: schemas.Ptr("refused")}}
+		}},
+		{name: "assistant annotation", apply: func(req *schemas.BifrostChatRequest) {
+			req.Input[0] = schemas.ChatMessage{Role: schemas.ChatMessageRoleAssistant, ChatAssistantMessage: &schemas.ChatAssistantMessage{Annotations: []schemas.ChatAssistantMessageAnnotation{{Type: "url_citation"}}}}
+		}},
+		{name: "tool extra content", apply: func(req *schemas.BifrostChatRequest) {
+			name := "lookup"
+			req.Input[0] = schemas.ChatMessage{Role: schemas.ChatMessageRoleAssistant, ChatAssistantMessage: &schemas.ChatAssistantMessage{ToolCalls: []schemas.ChatAssistantMessageToolCall{{
+				Type:         schemas.Ptr("function"),
+				Function:     schemas.ChatAssistantMessageToolCallFunction{Name: &name, Arguments: `{}`},
+				ExtraContent: []byte(`{"thought_signature":"opaque"}`),
+			}}}}
+		}},
+		{name: "unknown content block", apply: func(req *schemas.BifrostChatRequest) {
+			req.Input[0].Content = &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{{Type: schemas.ChatContentBlockType("provider_result")}}}
+		}},
+	}
+
+	var mu sync.Mutex
+	var auths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		auths = append(auths, r.Header.Get("Authorization"))
+		mu.Unlock()
+		if r.Header.Get("Authorization") == "Bearer sk-a" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = fmt.Fprint(w, `{"error":{"message":"quota exceeded","type":"rate_limit_error"}}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, chatCompletionBody)
+	}))
+	defer server.Close()
+
+	store := newStickyTestKVStore()
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 8, server.URL)
+	account.configs[schemas.OpenAI].NetworkConfig.MaxRetries = 1
+	account.configs[schemas.OpenAI].NetworkConfig.RetryBackoffInitial = 0
+	account.configs[schemas.OpenAI].NetworkConfig.RetryBackoffMax = 0
+	account.SetKeysForProvider(schemas.OpenAI, stickyTestKeys())
+	bf, err := Init(context.Background(), schemas.BifrostConfig{
+		Account:                      account,
+		KVStore:                      store,
+		EnableStickyKeyQuotaFailover: true,
+		KeySelector: func(_ *schemas.BifrostContext, keys []schemas.Key, _ schemas.ModelProvider, _ string) (schemas.Key, error) {
+			return keys[0], nil
+		},
+		Logger: NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(bf.Shutdown)
+
+	for i, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mu.Lock()
+			auths = nil
+			mu.Unlock()
+			sessionID := fmt.Sprintf("unsafe-session-%d", i)
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			ctx.SetValue(schemas.BifrostContextKeySessionID, sessionID)
+			req := &schemas.BifrostChatRequest{
+				Provider: schemas.OpenAI,
+				Model:    "gpt-4o-mini",
+				Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}}},
+			}
+			tc.apply(req)
+			if _, bifrostErr := bf.ChatCompletionRequest(ctx, req); bifrostErr == nil {
+				t.Fatal("unsafe payload unexpectedly recovered through key-b")
+			}
+			mu.Lock()
+			gotAuths := append([]string(nil), auths...)
+			mu.Unlock()
+			if len(gotAuths) == 0 {
+				t.Fatal("expected upstream attempt")
+			}
+			for _, auth := range gotAuths {
+				if auth != "Bearer sk-a" {
+					t.Fatalf("unsafe payload contacted alternate key: auth sequence %v", gotAuths)
+				}
+			}
+			if _, err := store.Get(buildStickyQuotaKey(schemas.OpenAI, sessionID, req.Model)); err == nil {
+				t.Fatal("unsafe payload persisted a sticky quota winner")
+			}
+		})
+	}
+}
+
+func TestStickyChatPayloadPredicateAllowsFunctionTranscriptsAndInlineMedia(t *testing.T) {
+	callName := "lookup"
+	toolCallID := "call-1"
+	imageData := "data:image/png;base64,AAAA"
+	fileData := "SGVsbG8="
+	toolRequest := &schemas.ChatTool{
+		Type:     schemas.ChatToolTypeFunction,
+		Function: &schemas.ChatToolFunction{Name: callName},
+	}
+	req := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Params: &schemas.ChatParameters{
+			Tools: []schemas.ChatTool{*toolRequest},
+		},
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{
+				{Type: schemas.ChatContentBlockTypeImage, ImageURLStruct: &schemas.ChatInputImage{URL: imageData}},
+				{Type: schemas.ChatContentBlockTypeFile, File: &schemas.ChatInputFile{FileData: &fileData}},
+				{Type: schemas.ChatContentBlockTypeInputAudio, InputAudio: &schemas.ChatInputAudio{Data: "data:audio/wav;base64,AAAA"}},
+			}}},
+			{Role: schemas.ChatMessageRoleAssistant, ChatAssistantMessage: &schemas.ChatAssistantMessage{ToolCalls: []schemas.ChatAssistantMessageToolCall{{
+				Type: schemas.Ptr("function"), ID: &toolCallID,
+				Function: schemas.ChatAssistantMessageToolCallFunction{Name: &callName, Arguments: `{}`},
+			}}}},
+			{Role: schemas.ChatMessageRoleTool, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr(`{"ok":true}`)}, ChatToolMessage: &schemas.ChatToolMessage{ToolCallID: &toolCallID}},
+		},
+	}
+	if !stickyChatPayloadEligible(req) {
+		t.Fatal("function tool transcript and inline media should remain eligible for sticky quota rotation")
+	}
+}
+
+func TestStickyChatPayloadPredicateRejectsRemoteFileURL(t *testing.T) {
+	remote := "https://example.test/file.pdf"
+	req := &schemas.BifrostChatRequest{
+		Input: []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentBlocks: []schemas.ChatContentBlock{{
+			Type: schemas.ChatContentBlockTypeFile,
+			File: &schemas.ChatInputFile{FileURL: &remote},
+		}}}}},
+	}
+	if stickyChatPayloadEligible(req) {
+		t.Fatal("remote file URLs must not enter sticky quota rotation")
+	}
+}
+
+func TestChatCompletionStreamStickyQuotaFailoverSkipsUnsafeTypedPayload(t *testing.T) {
+	var mu sync.Mutex
+	var auths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		auths = append(auths, r.Header.Get("Authorization"))
+		mu.Unlock()
+		quota := `{"error":{"message":"quota exceeded","type":"rate_limit_error"}}`
+		if r.Header.Get("Authorization") == "Bearer sk-a" {
+			sseHandler(quota)(w, r)
+			return
+		}
+		sseHandler(`{"id":"s1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"}}]}`)(w, r)
+	}))
+	defer server.Close()
+
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 8, server.URL)
+	account.configs[schemas.OpenAI].NetworkConfig.MaxRetries = 1
+	account.configs[schemas.OpenAI].NetworkConfig.RetryBackoffInitial = 0
+	account.configs[schemas.OpenAI].NetworkConfig.RetryBackoffMax = 0
+	account.SetKeysForProvider(schemas.OpenAI, stickyTestKeys())
+	bf, err := Init(context.Background(), schemas.BifrostConfig{
+		Account:                      account,
+		KVStore:                      newStickyTestKVStore(),
+		EnableStickyKeyQuotaFailover: true,
+		KeySelector: func(_ *schemas.BifrostContext, keys []schemas.Key, _ schemas.ModelProvider, _ string) (schemas.Key, error) {
+			return keys[0], nil
+		},
+		Logger: NewDefaultLogger(schemas.LogLevelError),
+	})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(bf.Shutdown)
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
+	ctx.SetValue(schemas.BifrostContextKeySessionID, "unsafe-stream-session")
+	request := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o-mini",
+		Params:   &schemas.ChatParameters{Store: schemas.Ptr(true)},
+		Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}}},
+	}
+	ch, bifrostErr := bf.ChatCompletionStreamRequest(ctx, request)
+	if bifrostErr == nil {
+		_, errs := drainChatStream(ch)
+		if len(errs) == 0 {
+			t.Fatal("unsafe stream unexpectedly recovered through key-b")
+		}
+	}
+	mu.Lock()
+	gotAuths := append([]string(nil), auths...)
+	mu.Unlock()
+	for _, auth := range gotAuths {
+		if auth != "Bearer sk-a" {
+			t.Fatalf("unsafe stream contacted alternate key: auth sequence %v", gotAuths)
+		}
+	}
+}
+
+func TestStickyQuotaRetryStrictNegatives(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *schemas.BifrostError
+	}{
+		{name: "429 network sentinel", err: createBifrostError(schemas.ErrProviderNetworkError, Ptr(429), nil, false)},
+		{name: "auth code without status", err: &schemas.BifrostError{Error: &schemas.ErrorField{Message: "quota exceeded", Code: Ptr("invalid_api_key")}}},
+		{name: "auth type without status", err: createBifrostError("quota exceeded", nil, Ptr("authentication_error"), false)},
+		{name: "billing type without status", err: createBifrostError("quota exceeded", nil, Ptr("billing_error"), false)},
+		{name: "permission type without status", err: createBifrostError("quota exceeded", nil, Ptr("permission_denied"), false)},
+		{name: "401 with quota text", err: createBifrostError("quota exceeded", Ptr(401), nil, false)},
+		{name: "402 with quota text", err: createBifrostError("rate limit", Ptr(402), nil, false)},
+		{name: "403 with quota text", err: createBifrostError("rate limit", Ptr(403), nil, false)},
+		{name: "500 with quota text", err: createBifrostError("rate limit", Ptr(500), nil, false)},
+		{name: "501 with quota text", err: createBifrostError("rate limit", Ptr(501), nil, false)},
+		{name: "network with quota text", err: createBifrostError(schemas.ErrProviderDoRequest, nil, Ptr("rate limit"), false)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if isStickyQuotaRetry(tc.err) {
+				t.Fatalf("must not classify %s as sticky quota rotation", tc.name)
+			}
+		})
+	}
+	if !isStickyQuotaRetry(createBifrostError("quota exceeded", Ptr(429), nil, false)) {
+		t.Fatal("429 must enable sticky quota rotation")
+	}
+	if !isStickyQuotaRetry(createBifrostError("quota exceeded", nil, nil, false)) {
+		t.Fatal("recognized quota text must enable sticky quota rotation")
+	}
+}
+
+func TestStickyKeyPlanFilterErrorKeepsBinding(t *testing.T) {
+	store := newStickyTestKVStore()
+	bf := newStickyTestBifrost(t, store, func(_ *schemas.BifrostContext, _ schemas.ModelProvider, _ string, _ []schemas.Key) ([]schemas.Key, error) {
+		return nil, errors.New("filter unavailable")
+	})
+	ctx := stickyTestContext()
+	plan, handled, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil || !handled || plan == nil {
+		t.Fatalf("expected sticky plan, handled=%v plan=%v err=%v", handled, plan, err)
+	}
+	first, err := plan.keyProvider()(nil, nil)
+	if err != nil || first.ID != "key-a" {
+		t.Fatalf("expected key-a, got %q err=%v", first.ID, err)
+	}
+	plan.observeRetry(createBifrostError("quota exceeded", Ptr(429), nil, false), true)
+	second, err := plan.keyProvider()(map[string]bool{"key-a": true}, nil)
+	if err != nil || second.ID != "key-a" {
+		t.Fatalf("filter error must keep fixed key-a, got %q err=%v", second.ID, err)
+	}
+}
+
+func TestStickyKeyPlanCASFailureKeepsBinding(t *testing.T) {
+	store := newStickyTestKVStore()
+	store.casError = errors.New("cas unavailable")
+	bf := newStickyTestBifrost(t, store, nil)
+	ctx := stickyTestContext()
+	plan, handled, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil || !handled || plan == nil {
+		t.Fatalf("expected sticky plan, handled=%v plan=%v err=%v", handled, plan, err)
+	}
+	first, err := plan.keyProvider()(nil, nil)
+	if err != nil || first.ID != "key-a" {
+		t.Fatalf("expected key-a, got %q err=%v", first.ID, err)
+	}
+	plan.observeRetry(createBifrostError("quota exceeded", Ptr(429), nil, false), true)
+	second, err := plan.keyProvider()(map[string]bool{"key-a": true}, nil)
+	if err != nil || second.ID != "key-a" {
+		t.Fatalf("CAS error must keep fixed key-a, got %q err=%v", second.ID, err)
+	}
+}
+
+func TestStickyKeyPlanDefaultOffAndRequestScope(t *testing.T) {
+	store := newStickyTestKVStore()
+	account := NewMockAccount()
+	account.AddProvider(schemas.OpenAI, 1, 8)
+	account.SetKeysForProvider(schemas.OpenAI, stickyTestKeys())
+	bf, err := Init(context.Background(), schemas.BifrostConfig{Account: account, KVStore: store, Logger: NewDefaultLogger(schemas.LogLevelError)})
+	if err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	t.Cleanup(bf.Shutdown)
+	ctx := stickyTestContext()
+	if plan, handled, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI); err != nil || handled || plan != nil {
+		t.Fatalf("default-off must not build a plan: handled=%v plan=%v err=%v", handled, plan, err)
+	}
+	for _, requestType := range []schemas.RequestType{schemas.TextCompletionRequest, schemas.ResponsesRequest, schemas.EmbeddingRequest} {
+		if plan, handled, err := newStickyTestBifrost(t, store, nil).buildStickyKeyPlan(ctx, requestType, schemas.OpenAI, "gpt-4", schemas.OpenAI); err != nil || handled || plan != nil {
+			t.Fatalf("request type %s must not build a sticky plan: handled=%v plan=%v err=%v", requestType, handled, plan, err)
+		}
+	}
+}
+
+func TestStickyKeyPlanNoRetryDoesNotMutateBinding(t *testing.T) {
+	store := newStickyTestKVStore()
+	bf := newStickyTestBifrost(t, store, nil)
+	ctx := stickyTestContext()
+	plan, handled, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil || !handled || plan == nil {
+		t.Fatalf("expected sticky plan, handled=%v plan=%v err=%v", handled, plan, err)
+	}
+	keyProvider := plan.keyProvider()
+	first, err := keyProvider(nil, nil)
+	if err != nil || first.ID != "key-a" {
+		t.Fatalf("expected key-a, got %q err=%v", first.ID, err)
+	}
+	if _, err := store.Get(buildStickyQuotaKey(schemas.OpenAI, "session-1", "gpt-4")); err != nil {
+		t.Fatalf("initial binding should exist: %v", err)
+	}
+	plan.observeRetry(createBifrostError("invalid request", Ptr(400), nil, false), false)
+	second, err := keyProvider(nil, nil)
+	if err != nil || second.ID != "key-a" {
+		t.Fatalf("non-retryable outcome must keep key-a, got %q err=%v", second.ID, err)
+	}
+	raw, err := store.Get(buildStickyQuotaKey(schemas.OpenAI, "session-1", "gpt-4"))
+	if err != nil || raw != "key-a" {
+		t.Fatalf("non-retryable outcome must not mutate binding, got %v err=%v", raw, err)
+	}
+}
+
+func TestStickyKeyPlanMaxRetriesZeroDoesNotMigrateBinding(t *testing.T) {
+	store := newStickyTestKVStore()
+	bf := newStickyTestBifrost(t, store, nil)
+	ctx := stickyTestContext()
+	plan, handled, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil || !handled || plan == nil {
+		t.Fatalf("expected sticky plan, handled=%v plan=%v err=%v", handled, plan, err)
+	}
+	config := createTestConfig(0, 0, 0)
+	_, retryErr := executeRequestWithRetries(ctx, config, func(_ schemas.Key) (string, *schemas.BifrostError) {
+		return "", createBifrostError("quota exceeded", Ptr(429), nil, false)
+	}, plan.keyProvider(), schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", nil, NewDefaultLogger(schemas.LogLevelError), plan)
+	if retryErr == nil {
+		t.Fatal("expected terminal quota error with zero retry budget")
+	}
+	if raw, err := store.Get(buildStickyQuotaKey(schemas.OpenAI, "session-1", "gpt-4")); err != nil || raw != "key-a" {
+		t.Fatalf("zero retry budget must keep key-a binding, got %v err=%v", raw, err)
+	}
+}
+
+var _ schemas.ConditionalStringKVStore = (*stickyTestKVStore)(nil)
+
+// A losing migration and an old refresh must converge without touching the
+// legacy binding used by stateful request types.
+func TestStickyConcurrentMigrationAndStaleRefresh(t *testing.T) {
+	store := newStickyTestKVStore()
+	bf := newStickyTestBifrost(t, store, nil)
+	legacy := buildSessionKey(schemas.OpenAI, "session-1", "gpt-4")
+	_ = store.SetWithTTL(legacy, "key-a", time.Hour)
+	plans := make([]*stickyKeyPlan, 3)
+	for i := range plans {
+		p, handled, err := bf.buildStickyKeyPlan(stickyTestContext(), schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+		if err != nil || !handled {
+			t.Fatalf("plan: %v", err)
+		}
+		plans[i] = p
+	}
+	extra := stickyTestKeys()[1]
+	extra.ID = "key-c"
+	for _, p := range plans {
+		p.pool = append(p.pool, extra)
+	}
+	plans[1].selector = func(_ *schemas.BifrostContext, keys []schemas.Key, _ schemas.ModelProvider, _ string) (schemas.Key, error) {
+		return keys[len(keys)-1], nil
+	}
+	start := make(chan struct{})
+	results := make(chan string, 2)
+	for _, p := range plans[:2] {
+		p.observeRetry(createBifrostError("quota exceeded", Ptr(429), nil, false), true)
+		go func(p *stickyKeyPlan) {
+			<-start
+			k, e := p.keyProvider()(map[string]bool{"key-a": true}, nil)
+			if e != nil {
+				results <- "error"
+			} else {
+				results <- k.ID
+			}
+		}(p)
+	}
+	close(start)
+	a, b := <-results, <-results
+	if a != b || (a != "key-b" && a != "key-c") {
+		t.Fatalf("concurrent requests disagree: %q %q", a, b)
+	}
+	plans[2].refreshExisting()
+	raw, _ := store.Get(plans[0].key)
+	if raw != a || plans[2].current.ID != a {
+		t.Fatalf("stale refresh reverted winner: %v / %s", raw, plans[2].current.ID)
+	}
+	raw, _ = store.Get(legacy)
+	if raw != "key-a" {
+		t.Fatalf("legacy stateful binding changed: %v", raw)
+	}
+	keys, rotate, err := bf.selectKeyFromProviderForModelWithPool(stickyTestContext(), schemas.ResponsesRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil || rotate || len(keys) != 1 || keys[0].ID != "key-a" {
+		t.Fatalf("stateful selection moved: %v %v %v", keys, rotate, err)
+	}
+}
+
+func TestStickyExplicitPinsAndUnsupportedStore(t *testing.T) {
+	bf := newStickyTestBifrost(t, newStickyTestKVStore(), nil)
+	for _, tc := range []struct {
+		key   schemas.BifrostContextKey
+		value any
+	}{
+		{schemas.BifrostContextKeyAPIKeyID, "key-a"},
+		{schemas.BifrostContextKeyAPIKeyName, "A"},
+		{schemas.BifrostContextKeyDirectKey, stickyTestKeys()[0]},
+		{schemas.BifrostContextKeyUseRawRequestBody, true},
+	} {
+		ctx := stickyTestContext()
+		ctx.SetValue(tc.key, tc.value)
+		_, handled, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+		if err != nil || handled {
+			t.Fatalf("strict %s entered migration: %v", tc.key, err)
+		}
+	}
+	bf.kvStore = &legacyStickyTestStore{newStickyTestKVStore()}
+	_, handled, err := bf.buildStickyKeyPlan(stickyTestContext(), schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil || handled {
+		t.Fatalf("unsupported store entered migration: %v", err)
+	}
+}
+
+// Embed only the old interface so the optional capability is absent.
+type legacyStickyTestStore struct{ schemas.KVStore }
+
+func TestStickyStreamQuotaBoundary(t *testing.T) {
+	for _, late := range []bool{false, true} {
+		t.Run(fmt.Sprint("late=", late), func(t *testing.T) {
+			var mu sync.Mutex
+			var auths []string
+			data := `{"id":"s1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"hello"}}]}`
+			quota := `{"error":{"message":"quota exceeded","type":"rate_limit_error"}}`
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				auth := r.Header.Get("Authorization")
+				mu.Lock()
+				auths = append(auths, auth)
+				mu.Unlock()
+				if auth == "Bearer sk-a" {
+					if late {
+						sseHandler(data, quota)(w, r)
+					} else {
+						sseHandler(quota)(w, r)
+					}
+					return
+				}
+				sseHandler(data)(w, r)
+			}))
+			defer server.Close()
+			account := NewMockAccount()
+			account.AddProviderWithBaseURL(schemas.OpenAI, 1, 8, server.URL)
+			account.SetKeysForProvider(schemas.OpenAI, stickyTestKeys())
+			account.configs[schemas.OpenAI].NetworkConfig.MaxRetries = 1
+			account.configs[schemas.OpenAI].NetworkConfig.RetryBackoffInitial = time.Millisecond
+			store := newStickyTestKVStore()
+			bf, err := Init(context.Background(), schemas.BifrostConfig{Account: account, KVStore: store, EnableStickyKeyQuotaFailover: true, Logger: NewDefaultLogger(schemas.LogLevelError), KeySelector: func(_ *schemas.BifrostContext, keys []schemas.Key, _ schemas.ModelProvider, _ string) (schemas.Key, error) {
+				return keys[0], nil
+			}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(bf.Shutdown)
+			ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(10*time.Second))
+			ctx.SetValue(schemas.BifrostContextKeySessionID, "stream-session")
+			ch, be := bf.ChatCompletionStreamRequest(ctx, &schemas.BifrostChatRequest{Provider: schemas.OpenAI, Model: "gpt-4", Input: []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}}}})
+			if be != nil {
+				t.Fatalf("stream setup: %v", be)
+			}
+			content, errs := drainChatStream(ch)
+			if content != "hello" {
+				t.Fatalf("content=%q", content)
+			}
+			mu.Lock()
+			got := append([]string(nil), auths...)
+			mu.Unlock()
+			if late {
+				if len(got) != 1 || len(errs) == 0 {
+					t.Fatalf("late error replayed or lost: attempts=%v errors=%v", got, errs)
+				}
+			} else {
+				if len(got) != 2 || got[1] != "Bearer sk-b" || len(errs) != 0 {
+					t.Fatalf("quota did not migrate: attempts=%v errors=%v", got, errs)
+				}
+			}
+		})
+	}
+}
+
+func TestStickyTextQuotaAttribution(t *testing.T) {
+	bf := newStickyTestBifrost(t, newStickyTestKVStore(), nil)
+	ctx := stickyTestContext()
+	plan, _, err := bf.buildStickyKeyPlan(ctx, schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, be := executeRequestWithRetries(ctx, createTestConfig(1, 0, 0), func(k schemas.Key) (string, *schemas.BifrostError) {
+		if k.ID == "key-a" {
+			return "", createBifrostError("quota exceeded", nil, nil, false)
+		}
+		return "ok", nil
+	}, plan.keyProvider(), schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", nil, NewDefaultLogger(schemas.LogLevelError), plan)
+	if be != nil {
+		t.Fatal(be)
+	}
+	trail, _ := ctx.Value(schemas.BifrostContextKeyAttemptTrail).([]schemas.KeyAttemptRecord)
+	if len(trail) != 2 || trail[0].FailReason == nil || *trail[0].FailReason != "rate_limit_error" || !trail[0].TriggeredRotation {
+		t.Fatalf("quota route attribution missing: %+v", trail)
+	}
+}

--- a/core/stickykeys_test.go
+++ b/core/stickykeys_test.go
@@ -503,6 +503,118 @@ func TestStickyQuotaRetryStrictNegatives(t *testing.T) {
 	}
 }
 
+func TestChatCompletionStickyInitialFilterRejectsWithServiceUnavailable(t *testing.T) {
+	for _, stream := range []bool{false, true} {
+		t.Run(fmt.Sprintf("stream=%v", stream), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				t.Error("an empty filtered pool must not contact an upstream")
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			t.Cleanup(server.Close)
+			account := NewMockAccount()
+			account.AddProviderWithBaseURL(schemas.OpenAI, 1, 8, server.URL)
+			account.SetKeysForProvider(schemas.OpenAI, stickyTestKeys())
+			bf, err := Init(context.Background(), schemas.BifrostConfig{
+				Account: account, KVStore: newStickyTestKVStore(), EnableStickyKeyQuotaFailover: true,
+				KeyPoolFilter: func(_ *schemas.BifrostContext, _ schemas.ModelProvider, _ string, _ []schemas.Key) ([]schemas.Key, error) {
+					return nil, nil
+				},
+				Logger: NewDefaultLogger(schemas.LogLevelError),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(bf.Shutdown)
+			request := &schemas.BifrostChatRequest{
+				Provider: schemas.OpenAI, Model: "gpt-4",
+				Input: []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")}}},
+			}
+			var be *schemas.BifrostError
+			if stream {
+				ch, streamErr := bf.ChatCompletionStreamRequest(stickyTestContext(), request)
+				be = streamErr
+				if ch != nil {
+					for range ch {
+					}
+					t.Error("rejected key selection must not start a stream")
+				}
+			} else {
+				_, be = bf.ChatCompletionRequest(stickyTestContext(), request)
+			}
+			if be == nil || be.StatusCode == nil || *be.StatusCode != 503 || be.Type == nil || *be.Type != "no_eligible_keys" {
+				t.Fatalf("expected 503/no_eligible_keys from filtered key selection, got %v", be)
+			}
+		})
+	}
+}
+
+func TestStickyKeyPlanInitialFilter(t *testing.T) {
+	for _, seed := range []string{"fresh", "legacy", "dedicated"} {
+		for _, mode := range []string{"veto", "empty", "error", "foreign", "modified"} {
+			t.Run(seed+"/"+mode, func(t *testing.T) {
+				store := newStickyTestKVStore()
+				binding := ""
+				if seed == "legacy" {
+					binding = buildSessionKey(schemas.OpenAI, "session-1", "gpt-4")
+				} else if seed == "dedicated" {
+					binding = buildStickyQuotaKey(schemas.OpenAI, "session-1", "gpt-4")
+				}
+				if binding != "" {
+					if err := store.SetWithTTL(binding, "key-a", time.Hour); err != nil {
+						t.Fatal(err)
+					}
+				}
+				bf := newStickyTestBifrost(t, store, func(_ *schemas.BifrostContext, _ schemas.ModelProvider, _ string, keys []schemas.Key) ([]schemas.Key, error) {
+					switch mode {
+					case "empty":
+						return nil, nil
+					case "error":
+						return nil, errors.New("filter unavailable")
+					case "foreign":
+						return []schemas.Key{{ID: "outside-pool"}}, nil
+					case "modified":
+						key := keys[1]
+						key.Value = *schemas.NewSecretVar("sk-replaced")
+						return []schemas.Key{key}, nil
+					default:
+						return keys[1:], nil
+					}
+				})
+				plan, handled, err := bf.buildStickyKeyPlan(stickyTestContext(), schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4", schemas.OpenAI)
+				if err != nil || !handled || plan == nil {
+					t.Fatalf("expected handled filtered plan, handled=%v hasPlan=%v err=%v", handled, plan != nil, err)
+				}
+				if mode == "empty" || mode == "foreign" {
+					if _, err := plan.keyProvider()(nil, nil); !errors.Is(err, errAllKeysFiltered) {
+						t.Fatalf("expected filtered-pool error without selector fallback, err=%v", err)
+					}
+				} else {
+					wantID, wantValue := "key-b", "sk-b"
+					if mode == "error" {
+						wantID, wantValue = "key-a", "sk-a"
+					}
+					key, err := plan.keyProvider()(nil, nil)
+					if err != nil || key.ID != wantID || key.Value.GetValue() != wantValue {
+						t.Fatalf("initial key must respect filter and canonical credentials: got ID=%q want=%q err=%v", key.ID, wantID, err)
+					}
+					if seed == "fresh" {
+						stored, err := store.Get(buildStickyQuotaKey(schemas.OpenAI, "session-1", "gpt-4"))
+						if err != nil || stored != wantID {
+							t.Fatalf("unexpected initial binding: %v err=%v", stored, err)
+						}
+					}
+				}
+				if binding != "" {
+					stored, err := store.Get(binding)
+					if err != nil || stored != "key-a" {
+						t.Fatalf("filtering must not overwrite existing binding: %v err=%v", stored, err)
+					}
+				}
+			})
+		}
+	}
+}
+
 func TestStickyKeyPlanFilterErrorKeepsBinding(t *testing.T) {
 	store := newStickyTestKVStore()
 	bf := newStickyTestBifrost(t, store, func(_ *schemas.BifrostContext, _ schemas.ModelProvider, _ string, _ []schemas.Key) ([]schemas.Key, error) {

--- a/docs/features/keys-management.mdx
+++ b/docs/features/keys-management.mdx
@@ -28,6 +28,43 @@ Random selection ensures statistical distribution over time
 3. Select key based on cumulative weight ranges
 4. If selected key fails, automatic fallback to next available key
 
+## Session stickiness and quota failover
+
+Send `x-bf-session-id` to reuse a provider key for a session. By default, retries keep
+the same key, preserving affinity even when another key has available quota.
+
+Operators can opt in to quota-driven key migration for self-contained Chat
+Completions requests:
+
+```bash
+BIFROST_ENABLE_STICKY_KEY_QUOTA_FAILOVER=true
+```
+
+Set this environment variable on the HTTP gateway process and restart it. It defaults
+to `false`; invalid boolean values prevent startup. Request headers and configuration
+reloads cannot change the setting. Go SDK callers can set
+`BifrostConfig.EnableStickyKeyQuotaFailover` when calling `bifrost.Init`.
+
+When an eligible request encounters a rate-limit or quota failure and has a retry
+remaining, Bifrost can move its binding to another eligible key in the same provider
+and model pool. Later eligible requests reuse the winning key. This requires at least
+two eligible keys, a positive retry budget, and a KV store implementing the optional
+conditional string-update capability. The built-in store supports this locally;
+a delegated cluster store retains strict selection. This is not cluster-wide failover.
+
+Eligibility is deliberately conservative. Plain text, function-tool transcripts,
+inline media and ordinary cache hints are supported. Explicit key pins, raw or opaque
+payloads, remote files/images, provider-issued resource references, reasoning history,
+refusals, annotations and server-side tools retain the existing selection path.
+Responses and Anthropic Messages are excluded. Authentication, billing, permission,
+network and server errors do not cause this migration. A stream that has already
+exposed valid data is never replayed by this feature.
+
+Opt-in Chat bindings use a separate namespace, so their migration does not move
+legacy bindings used by other request types. The first eligible request may seed its
+binding from an existing legacy session key. Disabling the option restores strict
+legacy selection; it does not copy the migrated binding back.
+
 ## Model Whitelisting and Filtering
 
 Keys can be restricted to specific models for access control and cost management:

--- a/framework/changelog.md
+++ b/framework/changelog.md
@@ -1,3 +1,4 @@
+[feat]: add optional process-local conditional KV updates for sticky key migration [@Alex-wangyang](https://github.com/Alex-wangyang)
 ## ✨ Features
 
 - **Virtual Key Rotation Grace Period** - New rotation-state columns on `governance_virtual_keys` (`previous_value`, `previous_value_hash`, `previous_value_expires_at`, `rotated_at`) with encryption support, plus a `vk_rotation_cooldown` client config setting (duration string, default 0 = immediate flip) controlling how long a rotated-out key value keeps authenticating.

--- a/framework/kvstore/kvstore.go
+++ b/framework/kvstore/kvstore.go
@@ -11,10 +11,11 @@ import (
 )
 
 var (
-	ErrClosed     = errors.New("kvstore is closed")
-	ErrEmptyKey   = errors.New("key cannot be empty")
-	ErrNotFound   = errors.New("key not found")
-	ErrInvalidTTL = errors.New("ttl cannot be negative")
+	ErrClosed                 = errors.New("kvstore is closed")
+	ErrEmptyKey               = errors.New("key cannot be empty")
+	ErrNotFound               = errors.New("key not found")
+	ErrInvalidTTL             = errors.New("ttl cannot be negative")
+	ErrConditionalUnsupported = errors.New("conditional string CAS is unsupported")
 )
 
 const (
@@ -51,9 +52,16 @@ type Store struct {
 	stopOnce  sync.Once
 	cleanupWg sync.WaitGroup
 
-	delegate  SyncDelegate
+	delegate  atomic.Pointer[delegateHolder]
 	decoders  map[string]TypeDecoder
 	decoderMu sync.RWMutex
+}
+
+// SupportsProcessLocalCAS reports whether conditional string writes are safe
+// for the process-local sticky-key feature. Delegated stores are deliberately
+// excluded because their local mutex does not coordinate cluster writers.
+func (s *Store) SupportsProcessLocalCAS() bool {
+	return s.delegate.Load() == nil
 }
 
 // SyncDelegate is notified of all mutations, enabling cross-node replication.
@@ -72,8 +80,18 @@ type TypeDecoder func(data []byte) (any, error)
 
 // SetDelegate plugs in the cluster sync implementation.
 func (s *Store) SetDelegate(d SyncDelegate) {
-	s.delegate = d
+	// Serialize attachment with conditional writes, then publish an immutable
+	// holder for lock-free callback snapshots. Callbacks still run outside mu.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if d == nil {
+		s.delegate.Store(nil)
+	} else {
+		s.delegate.Store(&delegateHolder{d})
+	}
 }
+
+type delegateHolder struct{ SyncDelegate }
 
 // RegisterDecoder registers a decoder for keys matching the given prefix.
 // Used by the receiving side to reconstruct concrete types from gossip payloads.
@@ -116,6 +134,7 @@ func (s *Store) Set(key string, value any) error {
 // SetWithTTL stores a value with an explicit TTL.
 // ttl=0 means no expiration.
 func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
+	delegate := s.delegate.Load()
 	if err := s.validateMutable(key, ttl); err != nil {
 		return err
 	}
@@ -129,7 +148,7 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	var valueJSON []byte
 	var err error
 
-	if s.delegate != nil {
+	if delegate != nil {
 		valueJSON, err = sonic.Marshal(value)
 		if err != nil {
 			return err
@@ -144,8 +163,8 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 	}
 	s.mu.Unlock()
 
-	if s.delegate != nil {
-		s.delegate.OnSet(key, valueJSON, now, expiresAt)
+	if delegate != nil {
+		delegate.OnSet(key, valueJSON, now, expiresAt)
 	}
 
 	return nil
@@ -155,6 +174,7 @@ func (s *Store) SetWithTTL(key string, value any, ttl time.Duration) error {
 // Returns true if the key was set, false if the key already existed.
 // ttl=0 means no expiration.
 func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, error) {
+	delegate := s.delegate.Load()
 	if err := s.validateMutable(key, ttl); err != nil {
 		return false, err
 	}
@@ -168,7 +188,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	var valueJSON []byte
 	var err error
 
-	if s.delegate != nil {
+	if delegate != nil {
 		valueJSON, err = sonic.Marshal(value)
 		if err != nil {
 			return false, err
@@ -176,7 +196,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	}
 
 	s.mu.Lock()
-	
+
 	// Check if key exists and is not expired
 	if existing, ok := s.data[key]; ok {
 		if !isExpired(existing, now) {
@@ -185,7 +205,7 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 		}
 		// Key exists but is expired, allow overwrite
 	}
-	
+
 	// Key doesn't exist or is expired, set it
 	s.data[key] = entry{
 		value:     value,
@@ -194,10 +214,58 @@ func (s *Store) SetNXWithTTL(key string, value any, ttl time.Duration) (bool, er
 	}
 	s.mu.Unlock()
 
-	if s.delegate != nil {
-		s.delegate.OnSet(key, valueJSON, now, expiresAt)
+	if delegate != nil {
+		delegate.OnSet(key, valueJSON, now, expiresAt)
 	}
 
+	return true, nil
+}
+
+// CompareAndSwapStringWithTTL replaces an existing, unexpired string value
+// only when it equals expected. Missing and expired entries are never
+// resurrected. This capability is process-local; delegated stores fail closed
+// because local CAS cannot establish a cluster-wide ordering guarantee.
+func (s *Store) CompareAndSwapStringWithTTL(key, expected, replacement string, ttl time.Duration) (bool, error) {
+	if err := s.validateMutable(key, ttl); err != nil {
+		return false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.delegate.Load() != nil {
+		return false, ErrConditionalUnsupported
+	}
+	if s.closed.Load() {
+		return false, ErrClosed
+	}
+	now := time.Now().UnixNano()
+	e, ok := s.data[key]
+	if !ok || isExpired(e, now) {
+		if ok && isExpired(e, now) {
+			delete(s.data, key)
+		}
+		return false, nil
+	}
+
+	var current string
+	switch value := e.value.(type) {
+	case string:
+		current = value
+	case []byte:
+		if err := sonic.Unmarshal(value, &current); err != nil {
+			current = string(value)
+		}
+	default:
+		return false, nil
+	}
+	if current != expected {
+		return false, nil
+	}
+
+	expiresAt := int64(0)
+	if ttl > 0 {
+		expiresAt = now + int64(ttl)
+	}
+	s.data[key] = entry{value: replacement, writtenAt: now, expiresAt: expiresAt}
 	return true, nil
 }
 
@@ -257,6 +325,7 @@ func (s *Store) Get(key string) (any, error) {
 
 // GetAndDelete retrieves and deletes a key atomically.
 func (s *Store) GetAndDelete(key string) (any, error) {
+	delegate := s.delegate.Load()
 	if key == "" {
 		return nil, ErrEmptyKey
 	}
@@ -276,14 +345,15 @@ func (s *Store) GetAndDelete(key string) (any, error) {
 	if !ok || isExpired(e, now) {
 		return nil, ErrNotFound
 	}
-	if s.delegate != nil {
-		s.delegate.OnDelete(key, now)
+	if delegate != nil {
+		delegate.OnDelete(key, now)
 	}
 	return e.value, nil
 }
 
 // Delete removes a key.
 func (s *Store) Delete(key string) (bool, error) {
+	delegate := s.delegate.Load()
 	if key == "" {
 		return false, ErrEmptyKey
 	}
@@ -303,8 +373,8 @@ func (s *Store) Delete(key string) (bool, error) {
 	if !ok {
 		return false, nil
 	}
-	if s.delegate != nil {
-		s.delegate.OnDelete(key, deletedAt)
+	if delegate != nil {
+		delegate.OnDelete(key, deletedAt)
 	}
 	return true, nil
 }

--- a/framework/kvstore/kvstore_test.go
+++ b/framework/kvstore/kvstore_test.go
@@ -98,3 +98,104 @@ func TestStoreClose(t *testing.T) {
 		t.Fatalf("expected ErrClosed on get, got: %v", err)
 	}
 }
+
+func TestStoreCompareAndSwapStringWithTTL(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if err := store.SetWithTTL("binding", "a", time.Hour); err != nil {
+		t.Fatalf("set failed: %v", err)
+	}
+	if swapped, err := store.CompareAndSwapStringWithTTL("binding", "wrong", "b", time.Hour); err != nil || swapped {
+		t.Fatalf("mismatched CAS should lose without error, swapped=%v err=%v", swapped, err)
+	}
+	if swapped, err := store.CompareAndSwapStringWithTTL("binding", "a", "b", time.Hour); err != nil || !swapped {
+		t.Fatalf("matching CAS should win, swapped=%v err=%v", swapped, err)
+	}
+	if value, err := store.Get("binding"); err != nil || value != "b" {
+		t.Fatalf("expected replacement b, got %v err=%v", value, err)
+	}
+}
+
+func TestStoreCompareAndSwapStringWithTTLDoesNotResurrectMissingOrExpired(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	if swapped, err := store.CompareAndSwapStringWithTTL("missing", "a", "b", time.Hour); err != nil || swapped {
+		t.Fatalf("missing CAS should lose without error, swapped=%v err=%v", swapped, err)
+	}
+	if err := store.SetWithTTL("expired", "a", time.Nanosecond); err != nil {
+		t.Fatalf("set expired failed: %v", err)
+	}
+	time.Sleep(time.Millisecond)
+	if swapped, err := store.CompareAndSwapStringWithTTL("expired", "a", "b", time.Hour); err != nil || swapped {
+		t.Fatalf("expired CAS should lose without resurrection, swapped=%v err=%v", swapped, err)
+	}
+}
+
+func TestStoreCompareAndSwapStringWithTTLHandlesJSONBytes(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+
+	store.mu.Lock()
+	store.data["json"] = entry{value: []byte(`"a"`), writtenAt: time.Now().UnixNano()}
+	store.mu.Unlock()
+	if swapped, err := store.CompareAndSwapStringWithTTL("json", "a", "b", time.Hour); err != nil || !swapped {
+		t.Fatalf("JSON string CAS should win, swapped=%v err=%v", swapped, err)
+	}
+}
+
+func TestStoreCompareAndSwapStringWithTTLRejectsDelegatedStore(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatalf("failed to create store: %v", err)
+	}
+	defer store.Close()
+	store.SetDelegate(testSyncDelegate{})
+	if swapped, err := store.CompareAndSwapStringWithTTL("binding", "a", "b", time.Hour); !errors.Is(err, ErrConditionalUnsupported) || swapped {
+		t.Fatalf("delegated CAS should fail closed, swapped=%v err=%v", swapped, err)
+	}
+}
+
+type testSyncDelegate struct{}
+
+func (testSyncDelegate) OnSet(string, []byte, int64, int64) {}
+func (testSyncDelegate) OnDelete(string, int64)             {}
+
+func TestStoreDelegateAttachConcurrentWithCAS(t *testing.T) {
+	store, err := New(Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	_ = store.Set("binding", "a")
+	start := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		<-start
+		for i := 0; i < 1000; i++ {
+			store.SetDelegate(testSyncDelegate{})
+			store.SetDelegate(nil)
+		}
+	}()
+	close(start)
+	for i := 0; i < 1000; i++ {
+		store.SupportsProcessLocalCAS()
+		store.CompareAndSwapStringWithTTL("binding", "a", "a", time.Hour)
+	}
+	<-done
+	store.SetDelegate(testSyncDelegate{})
+	if ok, e := store.CompareAndSwapStringWithTTL("binding", "a", "b", time.Hour); ok || !errors.Is(e, ErrConditionalUnsupported) {
+		t.Fatalf("CAS accepted delegated store: %v %v", ok, e)
+	}
+}

--- a/framework/kvstore/kvstore_test.go
+++ b/framework/kvstore/kvstore_test.go
@@ -191,7 +191,10 @@ func TestStoreDelegateAttachConcurrentWithCAS(t *testing.T) {
 	close(start)
 	for i := 0; i < 1000; i++ {
 		store.SupportsProcessLocalCAS()
-		store.CompareAndSwapStringWithTTL("binding", "a", "a", time.Hour)
+		// Delegate attachment may reject CAS; other errors are unexpected.
+		if _, err := store.CompareAndSwapStringWithTTL("binding", "a", "a", time.Hour); err != nil && !errors.Is(err, ErrConditionalUnsupported) {
+			t.Errorf("unexpected CAS error during delegate attachment: %v", err)
+		}
 	}
 	<-done
 	store.SetDelegate(testSyncDelegate{})

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -140504,6 +140504,202 @@
           ]
         }
       ]
+    },
+    {
+      "name": "69. Sticky quota failover (isolated opt-in fixture)",
+      "description": "Opt-in HTTP regression contract for typed chat sticky-key quota migration. SKIPPED unless stickyFailoverFixture=enabled. Requires an isolated SDK-initialized gateway with trusted sticky-key failover enabled, local atomic KV with no cluster delegate, max_retries>=1, deterministic initial selector choosing key A, and two eligible keys. Configure stickyFailoverModel as provider/model and stickyFailoverPinnedKeyID as A. Mock upstream A returns HTTP 429 sticky-quota-error (also as first SSE error for streaming); B returns valid OpenAI chat/SSE with marker sticky-healthy-key. Use no real provider credentials. A missing fixture is a skip, not a pass. Do not skip 429/5xx after opt-in: those are regression outcomes. The standard HTTP gateway exposes the initialization-only operator flag BIFROST_ENABLE_STICKY_KEY_QUOTA_FAILOVER=true; SDK fixtures can also initialize the flag directly. Core tests cover concurrency, persistence and negative paths; this collection adds a wire-contract template, not evidence of a live fixture run.",
+      "item": [
+        {
+          "name": "openai fixture chat - sticky-quota-failover",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.variables.get('stickyFailoverFixture') !== 'enabled') { pm.execution.skipRequest(); return; }",
+                  "if (!pm.variables.get('stickyFailoverModel') || !pm.variables.get('stickyFailoverPinnedKeyID')) { throw new Error('isolated sticky failover fixture variables required'); }",
+                  "pm.variables.set('stickyFailoverSession', 'harness-sticky-' + pm.variables.replaceIn('{{$guid}}'));"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('sticky quota migrates to healthy key - sticky-quota-failover', function () {",
+                  "  pm.expect(pm.response.code, pm.response.text()).to.equal(200);",
+                  "  pm.expect(pm.response.json().choices[0].message.content).to.equal('sticky-healthy-key');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-session-id",
+                "value": "{{stickyFailoverSession}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{stickyFailoverModel}}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Return the fixture marker.\"\n    }\n  ],\n  \"max_tokens\": 8\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai fixture stream - sticky-quota-failover",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.variables.get('stickyFailoverFixture') !== 'enabled') { pm.execution.skipRequest(); return; }",
+                  "if (!pm.variables.get('stickyFailoverModel') || !pm.variables.get('stickyFailoverPinnedKeyID')) { throw new Error('isolated sticky failover fixture variables required'); }",
+                  "pm.variables.set('stickyFailoverSession', 'harness-sticky-' + pm.variables.replaceIn('{{$guid}}'));"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('quota first chunk migrates before output - sticky-quota-failover', function () {",
+                  "  pm.expect(pm.response.code, pm.response.text()).to.equal(200);",
+                  "  pm.expect(pm.response.text()).to.include('data:');",
+                  "  pm.expect(pm.response.text()).to.include('sticky-healthy-key');",
+                  "  pm.expect(pm.response.text()).to.include('[DONE]');",
+                  "  pm.expect(pm.response.text()).to.not.include('sticky-quota-error');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-session-id",
+                "value": "{{stickyFailoverSession}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{stickyFailoverModel}}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Return the fixture marker.\"\n    }\n  ],\n  \"max_tokens\": 8,\n  \"stream\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai fixture pin - sticky-quota-failover [EXPECT-4XX]",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.variables.get('stickyFailoverFixture') !== 'enabled') { pm.execution.skipRequest(); return; }",
+                  "if (!pm.variables.get('stickyFailoverModel') || !pm.variables.get('stickyFailoverPinnedKeyID')) { throw new Error('isolated sticky failover fixture variables required'); }",
+                  "pm.variables.set('stickyFailoverSession', 'harness-sticky-' + pm.variables.replaceIn('{{$guid}}'));"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('explicit pin retains quota failure - sticky-quota-failover', function () {",
+                  "  pm.expect(pm.response.code, pm.response.text()).to.equal(429);",
+                  "  pm.expect(pm.response.text()).to.not.include('sticky-healthy-key');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-session-id",
+                "value": "{{stickyFailoverSession}}"
+              },
+              {
+                "key": "x-bf-api-key-id",
+                "value": "{{stickyFailoverPinnedKeyID}}"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"{{stickyFailoverModel}}\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Return the fixture marker.\"\n    }\n  ],\n  \"max_tokens\": 8\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -2668,6 +2668,15 @@ func startSkillsOrphanCleanupWorker(ctx context.Context, config *lib.Config, sho
 //   - GET /metrics: For Prometheus metrics
 func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	var err error
+	// This is an operator-only, process-lifetime opt-in. Request headers and
+	// database config reloads cannot broaden which requests may migrate keys.
+	stickyQuotaFailover := false
+	if raw := os.Getenv("BIFROST_ENABLE_STICKY_KEY_QUOTA_FAILOVER"); raw != "" {
+		stickyQuotaFailover, err = strconv.ParseBool(raw)
+		if err != nil {
+			return fmt.Errorf("BIFROST_ENABLE_STICKY_KEY_QUOTA_FAILOVER must be a boolean")
+		}
+	}
 	ctx = context.WithValue(ctx, schemas.BifrostContextKeyRuntimeVersion, s.Version)
 	s.Ctx, s.cancel = schemas.NewBifrostContextWithCancel(ctx)
 	handlers.SetVersion(s.Version)
@@ -2782,22 +2791,23 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	// The account interface now benefits from ultra-fast config access times via in-memory storage
 	account := lib.NewBaseAccount(s.Config)
 	s.Client, err = bifrost.Init(ctx, schemas.BifrostConfig{
-		Account:            account,
-		InitialPoolSize:    s.Config.ClientConfig.InitialPoolSize,
-		DropExcessRequests: s.Config.ClientConfig.DropExcessRequests,
-		LLMPlugins:         s.Config.GetLoadedLLMPlugins(),
-		MCPPlugins:         s.Config.GetLoadedMCPPlugins(),
-		MCPConfig:          mcpConfig,
-		OAuth2Provider:     s.Config.OAuthProvider,
-		MCPHeadersProvider: s.Config.MCPHeadersProvider,
-		Logger:             logger,
-		KVStore:            s.Config.KVStore,
-		ModelCatalog:       s.Config.ModelCatalog,
+		Account:                      account,
+		InitialPoolSize:              s.Config.ClientConfig.InitialPoolSize,
+		DropExcessRequests:           s.Config.ClientConfig.DropExcessRequests,
+		LLMPlugins:                   s.Config.GetLoadedLLMPlugins(),
+		MCPPlugins:                   s.Config.GetLoadedMCPPlugins(),
+		MCPConfig:                    mcpConfig,
+		OAuth2Provider:               s.Config.OAuthProvider,
+		MCPHeadersProvider:           s.Config.MCPHeadersProvider,
+		Logger:                       logger,
+		KVStore:                      s.Config.KVStore,
+		ModelCatalog:                 s.Config.ModelCatalog,
+		EnableStickyKeyQuotaFailover: stickyQuotaFailover,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to initialize bifrost: %v", err)
 	}
-	logger.Info("bifrost client initialized")
+	logger.Info("bifrost client initialized (sticky quota failover: %t)", stickyQuotaFailover)
 	// Sync plugin execution order from config to core (defensive — Init receives sorted list,
 	// but this ensures order consistency if the loading path changes in the future)
 	s.Client.ReorderPlugins(s.Config.GetPluginOrder())

--- a/transports/changelog.md
+++ b/transports/changelog.md
@@ -1,3 +1,4 @@
+[feat]: add a restart-required operator flag for sticky chat quota failover [@Alex-wangyang](https://github.com/Alex-wangyang)
 ## ✨ Features
 
 - **Virtual Key Rotation Cooldown** - New `client.vk_rotation_cooldown` setting (duration string, e.g. "5m"): after a rotation the previous key value keeps authenticating until the grace window expires. config.json VK sync now treats a changed value as an explicit rotation (with console warning) and recognizes the previously rotated-out value as "no change".


### PR DESCRIPTION
## Summary

A session-bound key can exhaust its quota while another eligible key for the same provider and model remains usable. Today, strict session affinity keeps retrying the bound key. This PR adds a default-off operator opt-in that lets self-contained Chat requests move to another key after a quota failure, then reuse the winning key on subsequent eligible requests.

## Changes

- **Core:** add an initialization-only `BifrostConfig.EnableStickyKeyQuotaFailover` option, conservative payload eligibility checks, and quota-triggered migration within the existing retry budget.
- **Framework:** add an optional conditional string-update capability without changing the base `KVStore` interface. Local CAS prevents stale TTL refreshes and competing migrations from overwriting a newer binding. Delegated cluster stores retain existing selection behavior.
- **HTTP:** expose `BIFROST_ENABLE_STICKY_KEY_QUOTA_FAILOVER=true`. Absent/empty defaults to false; invalid boolean values fail Bootstrap before configuration loading. A restart is required to change it; request headers and config reloads cannot toggle it.
- **Tests/docs:** add Chat/SSE retry, persistence, concurrency, pin, filter, budget and payload-exclusion coverage; an opt-in provider-harness folder; operator documentation and package changelogs.

Opt-in bindings use a separate namespace, initially seeded from an eligible legacy binding when available. Migrating a Chat binding never changes a legacy protocol binding. This is process-local behavior, not cluster-wide failover.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

Also changes `framework/kvstore`.

## How to test

Use the repository's local Go workspace so framework and transports resolve the modified core package. From the repository root, with no existing `go.work`:

```sh
go work init ./core ./framework ./transports
go work use -r ./plugins
(cd core && go test -race . -run 'Test(Sticky|ChatCompletionRequestSticky|ChatCompletionStreamSticky)' -count=1)
(cd framework && go test -race ./kvstore -count=1)
(cd transports && go test ./bifrost-http/server -count=1)
```

The focused core tests use local mock HTTP/SSE upstreams, with no paid provider calls. They verify quota failure → alternate key → persisted winner, and strict behavior for unsafe payloads and already-started streams.

Validation on base `03ab39186`:

- Framework KV race suite and HTTP server suite passed.
- Full core race run had two failures, both reproduced with the unmodified upstream core sources: `TestEnrichmentRegistryDimsAllEmitted` (missing complexity/project enrichment registrations) and `TestValidateExternalURLBoundsDNSLookup` (local DNS resolved a `.invalid` name).
- Core race suite with exactly those two baseline failures excluded passed. The review follow-up also reproduced the initial-filter bug before the fix and passed all 15 filter scenarios afterward (fresh, legacy and dedicated bindings; veto, empty, error, foreign and modified-key results). Ordinary and streaming Chat API regressions also verify the established `503/no_eligible_keys` response and that a rejected pool never contacts an upstream; both reproduced missing status/type before the follow-up fix.
- Provider-harness augmentation and OpenAI/`sticky-quota-failover` filtering retained all three fixture requests. Structural validation only: the Postman collection was not executed. It skips unless its explicitly documented isolated fixture is configured.

The review follow-up exercises the Go embedding-only `KeyPoolFilter` callback. HTTP Bootstrap does not install that callback, so this particular regression cannot be configured through the stock HTTP provider harness; it is covered in the core Go suite. The existing Chat quota-failover harness cases remain unchanged.

No UI changes; a UI build and the full live-provider/service-dependent test matrix were not run for this PR.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

Default selection remains strict. Enabling the option changes affinity only for eligible requests; disabling it returns to legacy bindings without copying the migrated binding back.

## Related issues

Extends the session-key affinity introduced in #2021. This PR concerns keys within one provider/model pool, not weighted routing-target stickiness.

## Security considerations

Explicit key pins, raw/opaque payloads, remote media, provider resource references, reasoning history, refusals, annotations and server-side tools retain the existing selection path. Responses and Anthropic Messages remain excluded. Authentication, billing, permission, network and server errors do not trigger this migration. No replay occurs after valid stream data has been exposed. Alternative keys must remain eligible in the request's captured pool and pass its dynamic filter.

## Checklist

- [x] Read the current contributing guides (`raising-a-pr.mdx` and `code-conventions.mdx`; the template's `README.md` path is absent)
- [x] Added/updated relevant tests
- [x] Updated operator documentation and affected package changelogs
- [ ] Verified Go and UI builds (Go packages compiled via tests; UI unchanged and not rebuilt)
- [ ] Verified the full CI pipeline locally (targeted validation and baseline exceptions detailed above)
