### PR TITLE
fix: map Anthropic forced tool choice any to required on OpenAI egress

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- fix: map forced tool choice `any` to `required` on OpenAI Responses and Chat egress (#6887) [@Atharva-Kanherkar](https://github.com/Atharva-Kanherkar)
 - fix: give a Bedrock message a placeholder text block instead of a null `content` field when it has no text and no tool calls - `BedrockMessage.Content` has no `omitempty`, so a message with empty text and no tool calls (or an empty `tool_calls` array) serialized as `content:null`, which Converse rejects with "Member must not be null" (#2765)
 - [fix]: marshal required nullable response fields as null [@PSR94](https://github.com/PSR94)
 - fix: accept top-level arrays from OpenAI-compatible model APIs [@dani29](https://github.com/dani29)

--- a/core/providers/anthropic/toolchoiceany_test.go
+++ b/core/providers/anthropic/toolchoiceany_test.go
@@ -1,0 +1,22 @@
+package anthropic
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Anthropic accepts "any" natively, so the OpenAI-only normalization of "any"
+// to "required" must not change what Anthropic receives.
+func TestConvertResponsesToolChoiceToAnthropic_ForcedChoicesStayAny(t *testing.T) {
+	for _, value := range []string{"any", "required"} {
+		t.Run(value, func(t *testing.T) {
+			got := convertResponsesToolChoiceToAnthropic(&schemas.ResponsesToolChoice{
+				ResponsesToolChoiceStr: schemas.Ptr(value),
+			})
+			if got == nil || got.Type != "any" {
+				t.Fatalf("tool_choice %q converted to %+v, want type any", value, got)
+			}
+		})
+	}
+}

--- a/core/providers/anthropic/toolchoiceany_test.go
+++ b/core/providers/anthropic/toolchoiceany_test.go
@@ -6,8 +6,9 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
-// Anthropic accepts "any" natively, so the OpenAI-only normalization of "any"
-// to "required" must not change what Anthropic receives.
+// TestConvertResponsesToolChoiceToAnthropic_ForcedChoicesStayAny verifies that
+// Anthropic, which accepts "any" natively, still receives type "any" for both
+// forced string choices; the OpenAI-only normalization must not affect it.
 func TestConvertResponsesToolChoiceToAnthropic_ForcedChoicesStayAny(t *testing.T) {
 	for _, value := range []string{"any", "required"} {
 		t.Run(value, func(t *testing.T) {

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -48,6 +48,16 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		}
 		// Drop user field if it exceeds OpenAI's 64 character limit
 		openaiReq.ChatParameters.User = SanitizeUserField(openaiReq.ChatParameters.User)
+		// The Anthropic integration emits the provider-generic forced tool choice "any".
+		// OpenAI accepts only "none", "auto" and "required" as string tool choices and
+		// rejects "any" with HTTP 400, so map it to "required" on a copy of the choice
+		// without mutating the caller's parameters.
+		if tc := openaiReq.ChatParameters.ToolChoice; tc != nil && tc.ChatToolChoiceStr != nil &&
+			*tc.ChatToolChoiceStr == string(schemas.ChatToolChoiceTypeAny) {
+			openaiReq.ChatParameters.ToolChoice = &schemas.ChatToolChoice{
+				ChatToolChoiceStr: schemas.Ptr(string(schemas.ChatToolChoiceTypeRequired)),
+			}
+		}
 		openaiReq.ExtraParams = bifrostReq.Params.ExtraParams
 
 		// Normalize tool parameters for deterministic JSON serialization (improves prompt caching)

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -51,9 +51,11 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		// The Anthropic integration emits the provider-generic forced tool choice "any".
 		// OpenAI accepts only "none", "auto" and "required" as string tool choices and
 		// rejects "any" with HTTP 400, so map it to "required" on a copy of the choice
-		// without mutating the caller's parameters.
+		// without mutating the caller's parameters. Destinations that accept "any"
+		// natively keep it.
 		if tc := openaiReq.ChatParameters.ToolChoice; tc != nil && tc.ChatToolChoiceStr != nil &&
-			*tc.ChatToolChoiceStr == string(schemas.ChatToolChoiceTypeAny) {
+			*tc.ChatToolChoiceStr == string(schemas.ChatToolChoiceTypeAny) &&
+			!toolChoiceAnySupported(bifrostReq.Provider, bifrostReq.Model) {
 			openaiReq.ChatParameters.ToolChoice = &schemas.ChatToolChoice{
 				ChatToolChoiceStr: schemas.Ptr(string(schemas.ChatToolChoiceTypeRequired)),
 			}

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -312,6 +312,16 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 		}
 		// Drop user field if it exceeds OpenAI's 64 character limit
 		req.ResponsesParameters.User = SanitizeUserField(req.ResponsesParameters.User)
+		// The Anthropic integration emits the provider-generic forced tool choice "any".
+		// OpenAI accepts only "none", "auto" and "required" as string tool choices and
+		// rejects "any" with HTTP 400, so map it to "required" on a copy of the choice
+		// without mutating the caller's parameters.
+		if tc := req.ResponsesParameters.ToolChoice; tc != nil && tc.ResponsesToolChoiceStr != nil &&
+			*tc.ResponsesToolChoiceStr == string(schemas.ResponsesToolChoiceTypeAny) {
+			req.ResponsesParameters.ToolChoice = &schemas.ResponsesToolChoice{
+				ResponsesToolChoiceStr: schemas.Ptr(string(schemas.ResponsesToolChoiceTypeRequired)),
+			}
+		}
 
 		// Handle reasoning parameter: OpenAI uses effort-based reasoning
 		// Priority: effort (native) > max_tokens (estimated)

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -315,9 +315,11 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 		// The Anthropic integration emits the provider-generic forced tool choice "any".
 		// OpenAI accepts only "none", "auto" and "required" as string tool choices and
 		// rejects "any" with HTTP 400, so map it to "required" on a copy of the choice
-		// without mutating the caller's parameters.
+		// without mutating the caller's parameters. Destinations that accept "any"
+		// natively keep it.
 		if tc := req.ResponsesParameters.ToolChoice; tc != nil && tc.ResponsesToolChoiceStr != nil &&
-			*tc.ResponsesToolChoiceStr == string(schemas.ResponsesToolChoiceTypeAny) {
+			*tc.ResponsesToolChoiceStr == string(schemas.ResponsesToolChoiceTypeAny) &&
+			!toolChoiceAnySupported(bifrostReq.Provider, bifrostReq.Model) {
 			req.ResponsesParameters.ToolChoice = &schemas.ResponsesToolChoice{
 				ResponsesToolChoiceStr: schemas.Ptr(string(schemas.ResponsesToolChoiceTypeRequired)),
 			}

--- a/core/providers/openai/toolchoiceany_test.go
+++ b/core/providers/openai/toolchoiceany_test.go
@@ -10,164 +10,248 @@ import (
 // The Anthropic integration maps tool_choice {"type": "any"} to the
 // provider-generic string "any". OpenAI accepts only "none", "auto" and
 // "required" as string tool choices, so "any" must be serialized as "required"
-// on both OpenAI egress paths while every other choice is left untouched.
+// on both OpenAI egress paths while every other choice is left untouched and
+// destinations that accept "any" natively keep it.
 
+// responsesToolChoiceRequest builds a minimal Responses request with one user
+// message so conversion reaches the tool-choice handling.
+func responsesToolChoiceRequest(provider schemas.ModelProvider, model string, toolChoice *schemas.ResponsesToolChoice) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: provider,
+		Model:    model,
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("What is the weather in Tokyo?")},
+		}},
+		Params: &schemas.ResponsesParameters{ToolChoice: toolChoice},
+	}
+}
+
+// chatToolChoiceRequest builds a minimal Chat request with one user message so
+// conversion reaches the tool-choice handling.
+func chatToolChoiceRequest(provider schemas.ModelProvider, model string, toolChoice *schemas.ChatToolChoice) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: provider,
+		Model:    model,
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("What is the weather in Tokyo?")},
+		}},
+		Params: &schemas.ChatParameters{ToolChoice: toolChoice},
+	}
+}
+
+// marshalToolChoice returns the wire JSON for a converted tool choice.
+func marshalToolChoice(t *testing.T, toolChoice any) string {
+	t.Helper()
+	got, err := sonic.Marshal(toolChoice)
+	if err != nil {
+		t.Fatalf("marshal tool_choice: %v", err)
+	}
+	return string(got)
+}
+
+// TestToOpenAIResponsesRequest_ToolChoiceAnyBecomesRequired verifies the
+// Responses egress maps "any" to "required" for OpenAI, keeps every other
+// choice as is, and leaves "any" intact for Mistral destinations.
 func TestToOpenAIResponsesRequest_ToolChoiceAnyBecomesRequired(t *testing.T) {
 	tests := []struct {
 		name       string
+		provider   schemas.ModelProvider
+		model      string
 		toolChoice *schemas.ResponsesToolChoice
 		wantJSON   string
 	}{
 		{
 			name:       "any is mapped to required",
+			provider:   schemas.OpenAI,
+			model:      "gpt-4o",
 			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
 			wantJSON:   `"required"`,
 		},
 		{
 			name:       "required is preserved",
+			provider:   schemas.OpenAI,
+			model:      "gpt-4o",
 			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("required")},
 			wantJSON:   `"required"`,
 		},
 		{
 			name:       "auto is preserved",
+			provider:   schemas.OpenAI,
+			model:      "gpt-4o",
 			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("auto")},
 			wantJSON:   `"auto"`,
 		},
 		{
 			name:       "none is preserved",
+			provider:   schemas.OpenAI,
+			model:      "gpt-4o",
 			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("none")},
 			wantJSON:   `"none"`,
 		},
 		{
-			name: "named function is preserved",
+			name:     "named function is preserved",
+			provider: schemas.OpenAI,
+			model:    "gpt-4o",
 			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStruct: &schemas.ResponsesToolChoiceStruct{
 				Type: schemas.ResponsesToolChoiceTypeFunction,
 				Name: schemas.Ptr("get_weather"),
 			}},
 			wantJSON: `{"type":"function","name":"get_weather"}`,
 		},
+		{
+			name:       "Mistral keeps any",
+			provider:   schemas.Mistral,
+			model:      "mistral-large-latest",
+			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"any"`,
+		},
+		{
+			name:       "Mistral on Vertex keeps any",
+			provider:   schemas.Vertex,
+			model:      "mistral-large",
+			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"any"`,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bifrostReq := &schemas.BifrostResponsesRequest{
-				Provider: schemas.OpenAI,
-				Model:    "gpt-4o",
-				Input: []schemas.ResponsesMessage{{
-					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
-					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("What is the weather in Tokyo?")},
-				}},
-				Params: &schemas.ResponsesParameters{ToolChoice: tt.toolChoice},
-			}
-
-			result := ToOpenAIResponsesRequest(nil, bifrostReq)
+			result := ToOpenAIResponsesRequest(nil, responsesToolChoiceRequest(tt.provider, tt.model, tt.toolChoice))
 			if result == nil {
 				t.Fatal("ToOpenAIResponsesRequest returned nil")
 			}
-			got, err := sonic.Marshal(result.ToolChoice)
-			if err != nil {
-				t.Fatalf("marshal tool_choice: %v", err)
-			}
-			if string(got) != tt.wantJSON {
-				t.Fatalf("tool_choice on the OpenAI wire = %s, want %s", got, tt.wantJSON)
+			if got := marshalToolChoice(t, result.ToolChoice); got != tt.wantJSON {
+				t.Fatalf("tool_choice on the wire = %s, want %s", got, tt.wantJSON)
 			}
 		})
 	}
 }
 
+// TestToOpenAIResponsesRequest_ToolChoiceAnyDoesNotMutateInput verifies the
+// Responses egress rewrites a copy of the tool choice, not the caller's value.
 func TestToOpenAIResponsesRequest_ToolChoiceAnyDoesNotMutateInput(t *testing.T) {
-	params := &schemas.ResponsesParameters{
-		ToolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
-	}
-	bifrostReq := &schemas.BifrostResponsesRequest{
-		Provider: schemas.OpenAI,
-		Model:    "gpt-4o",
-		Params:   params,
-	}
+	toolChoice := &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")}
+	bifrostReq := responsesToolChoiceRequest(schemas.OpenAI, "gpt-4o", toolChoice)
 
-	ToOpenAIResponsesRequest(nil, bifrostReq)
-
-	if got := *params.ToolChoice.ResponsesToolChoiceStr; got != "any" {
+	result := ToOpenAIResponsesRequest(nil, bifrostReq)
+	if result == nil {
+		t.Fatal("ToOpenAIResponsesRequest returned nil")
+	}
+	if got := marshalToolChoice(t, result.ToolChoice); got != `"required"` {
+		t.Fatalf("conversion did not run: tool_choice on the wire = %s", got)
+	}
+	if got := *bifrostReq.Params.ToolChoice.ResponsesToolChoiceStr; got != "any" {
 		t.Fatalf("caller's tool_choice was mutated to %q", got)
+	}
+	if bifrostReq.Params.ToolChoice != toolChoice {
+		t.Fatal("caller's tool_choice pointer was replaced")
 	}
 }
 
+// TestToOpenAIChatRequest_ToolChoiceAnyBecomesRequired verifies the Chat
+// egress maps "any" to "required" for OpenAI, keeps every other choice as is,
+// and leaves "any" intact for Mistral destinations.
 func TestToOpenAIChatRequest_ToolChoiceAnyBecomesRequired(t *testing.T) {
 	tests := []struct {
 		name       string
+		provider   schemas.ModelProvider
+		model      string
 		toolChoice *schemas.ChatToolChoice
 		wantJSON   string
 	}{
 		{
 			name:       "any is mapped to required",
+			provider:   schemas.OpenAI,
+			model:      "gpt-4o",
 			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
 			wantJSON:   `"required"`,
 		},
 		{
 			name:       "required is preserved",
+			provider:   schemas.OpenAI,
+			model:      "gpt-4o",
 			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("required")},
 			wantJSON:   `"required"`,
 		},
 		{
 			name:       "auto is preserved",
+			provider:   schemas.OpenAI,
+			model:      "gpt-4o",
 			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("auto")},
 			wantJSON:   `"auto"`,
 		},
 		{
 			name:       "none is preserved",
+			provider:   schemas.OpenAI,
+			model:      "gpt-4o",
 			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("none")},
 			wantJSON:   `"none"`,
 		},
 		{
-			name: "named function is preserved",
+			name:     "named function is preserved",
+			provider: schemas.OpenAI,
+			model:    "gpt-4o",
 			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStruct: &schemas.ChatToolChoiceStruct{
 				Type:     schemas.ChatToolChoiceTypeFunction,
 				Function: &schemas.ChatToolChoiceFunction{Name: "get_weather"},
 			}},
 			wantJSON: `{"type":"function","function":{"name":"get_weather"}}`,
 		},
+		{
+			name:       "Mistral keeps any",
+			provider:   schemas.Mistral,
+			model:      "mistral-large-latest",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"any"`,
+		},
+		{
+			name:       "Mistral on Vertex keeps any",
+			provider:   schemas.Vertex,
+			model:      "mistral-large",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"any"`,
+		},
+		{
+			name:       "non-Mistral model on Vertex is mapped to required",
+			provider:   schemas.Vertex,
+			model:      "moonshotai/kimi-k2-thinking-maas",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"required"`,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bifrostReq := &schemas.BifrostChatRequest{
-				Provider: schemas.OpenAI,
-				Model:    "gpt-4o",
-				Input: []schemas.ChatMessage{{
-					Role:    schemas.ChatMessageRoleUser,
-					Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("What is the weather in Tokyo?")},
-				}},
-				Params: &schemas.ChatParameters{ToolChoice: tt.toolChoice},
-			}
-
-			result := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline), bifrostReq)
+			result := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline), chatToolChoiceRequest(tt.provider, tt.model, tt.toolChoice))
 			if result == nil {
 				t.Fatal("ToOpenAIChatRequest returned nil")
 			}
-			got, err := sonic.Marshal(result.ToolChoice)
-			if err != nil {
-				t.Fatalf("marshal tool_choice: %v", err)
-			}
-			if string(got) != tt.wantJSON {
-				t.Fatalf("tool_choice on the OpenAI wire = %s, want %s", got, tt.wantJSON)
+			if got := marshalToolChoice(t, result.ToolChoice); got != tt.wantJSON {
+				t.Fatalf("tool_choice on the wire = %s, want %s", got, tt.wantJSON)
 			}
 		})
 	}
 }
 
+// TestToOpenAIChatRequest_ToolChoiceAnyDoesNotMutateInput verifies the Chat
+// egress rewrites a copy of the tool choice, not the caller's value.
 func TestToOpenAIChatRequest_ToolChoiceAnyDoesNotMutateInput(t *testing.T) {
-	params := &schemas.ChatParameters{
-		ToolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
-	}
-	bifrostReq := &schemas.BifrostChatRequest{
-		Provider: schemas.OpenAI,
-		Model:    "gpt-4o",
-		Params:   params,
-	}
+	toolChoice := &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")}
+	bifrostReq := chatToolChoiceRequest(schemas.OpenAI, "gpt-4o", toolChoice)
 
-	ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline), bifrostReq)
-
-	if got := *params.ToolChoice.ChatToolChoiceStr; got != "any" {
+	result := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline), bifrostReq)
+	if result == nil {
+		t.Fatal("ToOpenAIChatRequest returned nil")
+	}
+	if got := marshalToolChoice(t, result.ToolChoice); got != `"required"` {
+		t.Fatalf("conversion did not run: tool_choice on the wire = %s", got)
+	}
+	if got := *bifrostReq.Params.ToolChoice.ChatToolChoiceStr; got != "any" {
 		t.Fatalf("caller's tool_choice was mutated to %q", got)
+	}
+	if bifrostReq.Params.ToolChoice != toolChoice {
+		t.Fatal("caller's tool_choice pointer was replaced")
 	}
 }

--- a/core/providers/openai/toolchoiceany_test.go
+++ b/core/providers/openai/toolchoiceany_test.go
@@ -1,0 +1,173 @@
+package openai
+
+import (
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// The Anthropic integration maps tool_choice {"type": "any"} to the
+// provider-generic string "any". OpenAI accepts only "none", "auto" and
+// "required" as string tool choices, so "any" must be serialized as "required"
+// on both OpenAI egress paths while every other choice is left untouched.
+
+func TestToOpenAIResponsesRequest_ToolChoiceAnyBecomesRequired(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolChoice *schemas.ResponsesToolChoice
+		wantJSON   string
+	}{
+		{
+			name:       "any is mapped to required",
+			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"required"`,
+		},
+		{
+			name:       "required is preserved",
+			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("required")},
+			wantJSON:   `"required"`,
+		},
+		{
+			name:       "auto is preserved",
+			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("auto")},
+			wantJSON:   `"auto"`,
+		},
+		{
+			name:       "none is preserved",
+			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("none")},
+			wantJSON:   `"none"`,
+		},
+		{
+			name: "named function is preserved",
+			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStruct: &schemas.ResponsesToolChoiceStruct{
+				Type: schemas.ResponsesToolChoiceTypeFunction,
+				Name: schemas.Ptr("get_weather"),
+			}},
+			wantJSON: `{"type":"function","name":"get_weather"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostResponsesRequest{
+				Provider: schemas.OpenAI,
+				Model:    "gpt-4o",
+				Input: []schemas.ResponsesMessage{{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("What is the weather in Tokyo?")},
+				}},
+				Params: &schemas.ResponsesParameters{ToolChoice: tt.toolChoice},
+			}
+
+			result := ToOpenAIResponsesRequest(nil, bifrostReq)
+			if result == nil {
+				t.Fatal("ToOpenAIResponsesRequest returned nil")
+			}
+			got, err := sonic.Marshal(result.ToolChoice)
+			if err != nil {
+				t.Fatalf("marshal tool_choice: %v", err)
+			}
+			if string(got) != tt.wantJSON {
+				t.Fatalf("tool_choice on the OpenAI wire = %s, want %s", got, tt.wantJSON)
+			}
+		})
+	}
+}
+
+func TestToOpenAIResponsesRequest_ToolChoiceAnyDoesNotMutateInput(t *testing.T) {
+	params := &schemas.ResponsesParameters{
+		ToolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
+	}
+	bifrostReq := &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Params:   params,
+	}
+
+	ToOpenAIResponsesRequest(nil, bifrostReq)
+
+	if got := *params.ToolChoice.ResponsesToolChoiceStr; got != "any" {
+		t.Fatalf("caller's tool_choice was mutated to %q", got)
+	}
+}
+
+func TestToOpenAIChatRequest_ToolChoiceAnyBecomesRequired(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolChoice *schemas.ChatToolChoice
+		wantJSON   string
+	}{
+		{
+			name:       "any is mapped to required",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"required"`,
+		},
+		{
+			name:       "required is preserved",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("required")},
+			wantJSON:   `"required"`,
+		},
+		{
+			name:       "auto is preserved",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("auto")},
+			wantJSON:   `"auto"`,
+		},
+		{
+			name:       "none is preserved",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("none")},
+			wantJSON:   `"none"`,
+		},
+		{
+			name: "named function is preserved",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStruct: &schemas.ChatToolChoiceStruct{
+				Type:     schemas.ChatToolChoiceTypeFunction,
+				Function: &schemas.ChatToolChoiceFunction{Name: "get_weather"},
+			}},
+			wantJSON: `{"type":"function","function":{"name":"get_weather"}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostChatRequest{
+				Provider: schemas.OpenAI,
+				Model:    "gpt-4o",
+				Input: []schemas.ChatMessage{{
+					Role:    schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("What is the weather in Tokyo?")},
+				}},
+				Params: &schemas.ChatParameters{ToolChoice: tt.toolChoice},
+			}
+
+			result := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline), bifrostReq)
+			if result == nil {
+				t.Fatal("ToOpenAIChatRequest returned nil")
+			}
+			got, err := sonic.Marshal(result.ToolChoice)
+			if err != nil {
+				t.Fatalf("marshal tool_choice: %v", err)
+			}
+			if string(got) != tt.wantJSON {
+				t.Fatalf("tool_choice on the OpenAI wire = %s, want %s", got, tt.wantJSON)
+			}
+		})
+	}
+}
+
+func TestToOpenAIChatRequest_ToolChoiceAnyDoesNotMutateInput(t *testing.T) {
+	params := &schemas.ChatParameters{
+		ToolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
+	}
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-4o",
+		Params:   params,
+	}
+
+	ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline), bifrostReq)
+
+	if got := *params.ToolChoice.ChatToolChoiceStr; got != "any" {
+		t.Fatalf("caller's tool_choice was mutated to %q", got)
+	}
+}

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -246,3 +246,18 @@ func SanitizeUserField(user *string) *string {
 	}
 	return user
 }
+
+// toolChoiceAnySupported reports whether the target accepts the provider-generic
+// forced tool choice "any" on the wire. Mistral's API accepts "any" natively,
+// including Mistral models served through Vertex, so the OpenAI-only rewrite of
+// "any" to "required" must not run for those destinations.
+func toolChoiceAnySupported(provider schemas.ModelProvider, model string) bool {
+	switch provider {
+	case schemas.Mistral:
+		return true
+	case schemas.Vertex:
+		return schemas.IsMistralModel(model)
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Summary

The Anthropic integration converts `tool_choice: {"type": "any"}` to the provider-generic string `"any"`, and both OpenAI egress converters forwarded that string unchanged. OpenAI accepts only `none`, `auto` and `required` as string tool choices and rejects `any` with HTTP 400 (`invalid_value` on `param: tool_choice`), so an Anthropic SDK client forcing a tool step through Bifrost to OpenAI could never run its tool. This PR maps `any` to `required` on OpenAI Responses and Chat Completions egress.

Fixes #6887.

## Changes

- `core/providers/openai/responses.go`: in `ToOpenAIResponsesRequest`, after the parameter copy, replace a bare string tool choice `any` with `required` on a new `ResponsesToolChoice` so the caller's parameters are not mutated.
- `core/providers/openai/chat.go`: the same normalization in `ToOpenAIChatRequest`, so the Responses to Chat fallback used by Chat-only OpenAI-compatible custom providers is covered too.
- `core/providers/openai/toolchoiceany_test.go`: wire-level tests asserting `any` serializes as `"required"` on both paths, that `auto`, `none`, `required` and the named-function struct are unchanged, and that the input parameters are not mutated.
- `core/providers/anthropic/toolchoiceany_test.go`: guards that the Anthropic egress converter still emits `type: any` for both `any` and `required`, so providers that accept `any` natively are unaffected.
- `core/changelog.md`: entry added at the top.

Design notes:

- The normalization lives in the OpenAI egress converters rather than the Anthropic ingress converter or the shared schema marshaller. Anthropic and Mistral accept `any` on their own wire, and the reverse converter already treats `any` and `required` as the same Anthropic value, so only the OpenAI boundary needs the mapping.
- `required` is the OpenAI-standard value, so every OpenAI-compatible provider that goes through these converters must already accept it. `applyMistralCompatibility` is unchanged.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go vet ./providers/openai/ ./providers/anthropic/
go test ./providers/openai/ ./providers/anthropic/ -run 'ToolChoiceAny|ForcedChoicesStayAny' -v
```

Expected: all subtests pass. On `dev` without the two converter changes, `TestToOpenAIResponsesRequest_ToolChoiceAnyBecomesRequired` and `TestToOpenAIChatRequest_ToolChoiceAnyBecomesRequired` fail with `tool_choice on the OpenAI wire = "any", want "required"`.

End to end, with the built-in `openai` provider configured, send an Anthropic Messages request with one tool and `"tool_choice": {"type": "any"}` to `/anthropic/v1/messages`. Before this change the forwarded body contains `"tool_choice":"any"` and OpenAI returns 400. After this change it contains `"tool_choice":"required"` and OpenAI returns a function call. Full curl reproduction and sanitized wire captures are in #6887.

`go test ./...` in `core` was run locally. Every package passes except two that fail identically on unpatched `dev` in this environment: `providers/utils` (`TestFasthttpReplaceIsConsistentAcrossModules` needs the `go.work` file generated by `make`) and `internal/mcptests` (two stdio agent adapter tests). Neither touches tool choice.

No new configs or environment variables.

## Screenshots/Recordings

Not applicable, no UI changes.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6887

## Security considerations

None. The change only rewrites one enum value on outbound provider requests and does not touch auth, secrets or PII.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
