### PR TITLE
[fix]: recognize GPT-6 Astra in reasoning predicates and preserve xhigh effort

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+- [fix]: preserve reasoning parameters and xhigh effort for GPT-6 Astra
 - fix: map forced tool choice `any` to `required` on OpenAI Responses and Chat egress (#6887) [@Atharva-Kanherkar](https://github.com/Atharva-Kanherkar)
 - [fix]: preserve max reasoning effort for GPT-6 Astra [@nettee](https://github.com/nettee)
 - fix: give a Bedrock message a placeholder text block instead of a null `content` field when it has no text and no tool calls - `BedrockMessage.Content` has no `omitempty`, so a message with empty text and no tool calls (or an empty `tool_calls` array) serialized as `content:null`, which Converse rejects with "Member must not be null" (#2765)

--- a/core/gpt6astrae2e_test.go
+++ b/core/gpt6astrae2e_test.go
@@ -108,3 +108,81 @@ func TestGPT6AstraMaxReasoningEffortReachesOpenAIUpstream(t *testing.T) {
 			wire.Reasoning.Effort, schemas.ReasoningEffortMax)
 	}
 }
+
+// TestGPT6AstraReasoningPreservedWithoutDatasheet verifies that when no capability
+// resolver/datasheet entry is present, IsOpenAIReasoningModel ensures reasoning
+// parameters and xhigh effort are preserved rather than stripped or downgraded.
+func TestGPT6AstraReasoningPreservedWithoutDatasheet(t *testing.T) {
+	requests := make(chan astraUpstreamRequest, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		requests <- astraUpstreamRequest{
+			Method:  r.Method,
+			Path:    r.URL.Path,
+			Body:    body,
+			ReadErr: err,
+		}
+		writeJSON(w, http.StatusOK, `{"id":"resp_astra_2","object":"response","created_at":1,"status":"completed","model":"gpt-6-astra","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)
+	}))
+	t.Cleanup(upstream.Close)
+
+	// Ensure no capability resolver is set
+	schemas.SetCapabilityResolver(nil)
+
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(schemas.OpenAI, 1, 1, upstream.URL)
+	account.configs[schemas.OpenAI].NetworkConfig.MaxRetries = 0
+	account.SetKeysForProvider(schemas.OpenAI, []schemas.Key{{
+		ID:     "astra-e2e-key-fallback",
+		Value:  *schemas.NewSecretVar("sk-local-astra-e2e-fallback"),
+		Models: schemas.WhiteList{"gpt-6-astra"},
+		Weight: 100,
+	}})
+	client := newStreamTestClient(t, account)
+
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(5*time.Second))
+	response, bifrostErr := client.ResponsesRequest(ctx, &schemas.BifrostResponsesRequest{
+		Provider: schemas.OpenAI,
+		Model:    "gpt-6-astra",
+		Input: []schemas.ResponsesMessage{{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{
+				ContentStr: schemas.Ptr("Say hello"),
+			},
+		}},
+		Params: &schemas.ResponsesParameters{
+			Reasoning: &schemas.ResponsesParametersReasoning{
+				Effort: schemas.Ptr(schemas.ReasoningEffortXHigh),
+			},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ResponsesRequest failed before reaching the upstream: %v", bifrostErr)
+	}
+	if response == nil {
+		t.Fatal("ResponsesRequest returned a nil response")
+	}
+
+	observed := <-requests
+	if observed.ReadErr != nil {
+		t.Fatalf("read upstream request body: %v", observed.ReadErr)
+	}
+
+	var wire struct {
+		Model     string `json:"model"`
+		Reasoning struct {
+			Effort string `json:"effort"`
+		} `json:"reasoning"`
+	}
+	if err := json.Unmarshal(observed.Body, &wire); err != nil {
+		t.Fatalf("decode upstream request body %q: %v", observed.Body, err)
+	}
+	if wire.Model != "gpt-6-astra" {
+		t.Fatalf("upstream model = %q, want gpt-6-astra", wire.Model)
+	}
+	if wire.Reasoning.Effort != schemas.ReasoningEffortXHigh {
+		t.Fatalf("upstream reasoning.effort = %q, want %q; reasoning was stripped or downgraded without datasheet",
+			wire.Reasoning.Effort, schemas.ReasoningEffortXHigh)
+	}
+}

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -428,6 +428,8 @@ func TestToOpenAIResponsesRequest_ReasoningContentBlocksDropped(t *testing.T) {
 	})
 }
 
+// TestToOpenAIResponsesRequest_NormalizesReasoningEffort verifies that reasoning effort
+// normalization is correctly applied during ToOpenAIResponsesRequest conversion.
 func TestToOpenAIResponsesRequest_NormalizesReasoningEffort(t *testing.T) {
 	// Register the custom "deepseek" provider so ParseModelString strips its prefix.
 	schemas.RegisterKnownProvider(schemas.ModelProvider("deepseek"))

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -365,7 +365,7 @@ func TestToOpenAIResponsesRequest_ReasoningContentBlocksDropped(t *testing.T) {
 
 	// gpt-4o is not a reasoning model, so it additionally has cross-provider
 	// encrypted_content stripped (it could never decrypt it).
-	models := map[string]bool{"gpt-5.6-sol": true, "gpt-5.5": true, "o3": true, "gpt-4o": false}
+	models := map[string]bool{"gpt-6-astra": true, "gpt-5.6-sol": true, "gpt-5.5": true, "o3": true, "gpt-4o": false}
 	for model, keepsEncrypted := range models {
 		t.Run(model, func(t *testing.T) {
 			input := newReasoningItem()
@@ -484,6 +484,18 @@ func TestToOpenAIResponsesRequest_NormalizesReasoningEffort(t *testing.T) {
 			model:    "gpt-5.5",
 			effort:   "xhigh",
 			expected: "xhigh",
+		},
+		{
+			name:     "preserves xhigh for gpt-6-astra",
+			model:    "gpt-6-astra",
+			effort:   "xhigh",
+			expected: "xhigh",
+		},
+		{
+			name:     "preserves max for gpt-6-astra",
+			model:    "gpt-6-astra",
+			effort:   "max",
+			expected: "max",
 		},
 		{
 			name:     "maps xhigh to high for gpt-5",

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -157,6 +157,8 @@ func TestOpenAIResponsesRequest_MarshalJSON_ReasoningMaxTokensAbsent(t *testing.
 	}
 }
 
+// TestNormalizeOpenAIReasoningEffort verifies reasoning effort normalization across
+// OpenAI and third-party models, including minimal, xhigh, and max clamping.
 func TestNormalizeOpenAIReasoningEffort(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1165,6 +1167,8 @@ func TestEffortPredicatesAgainstCatalogIDs(t *testing.T) {
 	}
 }
 
+// TestIsOpenAIReasoningModel verifies that OpenAI reasoning models (including o-series,
+// GPT-5, GPT-6, and Astra families, with and without provider prefixes) are correctly identified.
 func TestIsOpenAIReasoningModel(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -176,6 +176,8 @@ func TestNormalizeOpenAIReasoningEffort(t *testing.T) {
 		{"maps minimal to low for gpt-oss", "gpt-oss", "minimal", "low"},
 		{"gpt-5.6 keeps max", "gpt-5.6", "max", "max"},
 		{"gpt-6-astra keeps max", "gpt-6-astra", "max", "max"},
+		{"gpt-6-astra keeps xhigh", "gpt-6-astra", "xhigh", "xhigh"},
+		{"maps minimal to low for gpt-6-astra", "gpt-6-astra", "minimal", "low"},
 		{"gpt-5.6 variant keeps max", "gpt-5.6-terra", "max", "max"},
 		{"gpt-5.6 keeps xhigh", "gpt-5.6", "xhigh", "xhigh"},
 		{"provider-prefixed gpt-5.6 keeps max", "openai/gpt-5.6", "max", "max"},
@@ -1142,6 +1144,9 @@ func TestEffortPredicatesAgainstCatalogIDs(t *testing.T) {
 		{"gpt-5.4", false, true, false},
 		{"gpt-5.6-terra", false, true, true},
 		{"openai.gpt-5.6-sol", false, true, true},
+		// gpt-6 family
+		{"gpt-6-astra", false, true, true},
+		{"azure/eu/gpt-6-astra", false, true, true},
 		// non-gpt families
 		{"deepseek-v4-pro", false, false, true},
 		{"glm-5.2", false, false, true},
@@ -1157,6 +1162,75 @@ func TestEffortPredicatesAgainstCatalogIDs(t *testing.T) {
 		if got := acceptsMaxEffort(c.model); got != c.max {
 			t.Errorf("max(%q) = %v, want %v", c.model, got, c.max)
 		}
+	}
+}
+
+func TestIsOpenAIReasoningModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  bool
+	}{
+		// gpt-6 and astra family
+		{"gpt-6 bare", "gpt-6", true},
+		{"gpt-6-mini", "gpt-6-mini", true},
+		{"gpt-6-astra", "gpt-6-astra", true},
+		{"astra bare", "astra", true},
+		{"astra-pro", "astra-pro", true},
+		{"openai/gpt-6-astra", "openai/gpt-6-astra", true},
+		{"azure/gpt-6-astra", "azure/gpt-6-astra", true},
+		{"azure/eu/gpt-6-astra", "azure/eu/gpt-6-astra", true},
+		{"azure/astra-preview", "azure/astra-preview", true},
+		{"databricks/gpt-6-astra", "databricks/gpt-6-astra", true},
+
+		// o-series reasoning models
+		{"o1", "o1", true},
+		{"o1-preview", "o1-preview", true},
+		{"o1-mini", "o1-mini", true},
+		{"o3", "o3", true},
+		{"o3-mini", "o3-mini", true},
+		{"o3-pro", "o3-pro", true},
+		{"o4", "o4", true},
+		{"o4-mini", "o4-mini", true},
+		{"openai/o3", "openai/o3", true},
+		{"azure/o1", "azure/o1", true},
+		{"azure/o3-mini", "azure/o3-mini", true},
+
+		// gpt-5 family
+		{"gpt-5", "gpt-5", true},
+		{"gpt-5-mini", "gpt-5-mini", true},
+		{"gpt-5.1", "gpt-5.1", true},
+		{"gpt-5.2", "gpt-5.2", true},
+		{"gpt-5.4", "gpt-5.4", true},
+		{"gpt-5.6", "gpt-5.6", true},
+		{"gpt-5.6-terra", "gpt-5.6-terra", true},
+		{"azure/gpt-5", "azure/gpt-5", true},
+		{"azure/eu/gpt-5.2", "azure/eu/gpt-5.2", true},
+
+		// gpt-oss family
+		{"gpt-oss", "gpt-oss", true},
+		{"gpt-oss-120b", "gpt-oss-120b", true},
+		{"azure/gpt-oss", "azure/gpt-oss", true},
+
+		// non-reasoning / negative cases
+		{"gpt-4o", "gpt-4o", false},
+		{"gpt-4o-mini", "gpt-4o-mini", false},
+		{"gpt-4-turbo", "gpt-4-turbo", false},
+		{"gpt-3.5-turbo", "gpt-3.5-turbo", false},
+		{"text-embedding-3-large", "text-embedding-3-large", false},
+		{"claude-3-5-sonnet", "claude-3-5-sonnet", false},
+		{"gemini-2.5-pro", "gemini-2.5-pro", false},
+		{"co1", "co1", false},
+		{"model-o3x", "model-o3x", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOpenAIReasoningModel(tt.model); got != tt.want {
+				t.Errorf("IsOpenAIReasoningModel(%q) = %v, want %v", tt.model, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -49,7 +49,9 @@ func IsOpenAIReasoningModel(model string) bool {
 			return true
 		}
 	}
-	return strings.Contains(modelLower, "gpt-5")
+	return strings.Contains(modelLower, "gpt-5") ||
+		strings.Contains(modelLower, "gpt-6") ||
+		strings.Contains(modelLower, "astra")
 }
 
 // defaultEffortControl widens the base low/medium/high ladder with the effort
@@ -86,7 +88,9 @@ func acceptsXHighEffort(model string) bool {
 		strings.Contains(modelLower, "gpt-5.3-codex") ||
 		strings.Contains(modelLower, "gpt-5.4") ||
 		strings.Contains(modelLower, "gpt-5.5") ||
-		strings.Contains(modelLower, "gpt-5.6")
+		strings.Contains(modelLower, "gpt-5.6") ||
+		strings.Contains(modelLower, "gpt-6") ||
+		strings.Contains(modelLower, "astra")
 }
 
 // acceptsMinimalEffort reports models that natively accept "minimal" effort:
@@ -113,7 +117,8 @@ func acceptsMinimalEffort(model string) bool {
 func acceptsMaxEffort(model string) bool {
 	modelLower := bareModelLower(model)
 	return strings.Contains(modelLower, "gpt-5.6") ||
-		strings.Contains(modelLower, "gpt-6-astra") ||
+		strings.Contains(modelLower, "gpt-6") ||
+		strings.Contains(modelLower, "astra") ||
 		strings.Contains(modelLower, "deepseek-v4") ||
 		strings.Contains(modelLower, "glm-5.2")
 }


### PR DESCRIPTION
## Summary

Follow-up to #6881.

PR #6881 by @nettee addressed the silent downgrade of `reasoning.effort: "max"` for `gpt-6-astra` on the Responses API when model capabilities are already resolved in the runtime datasheet. However, two related issues remained:

1. **`reasoning` parameter stripped on fallback**: `IsOpenAIReasoningModel` did not recognize `gpt-6` or `astra`. When running without an entry in the runtime datasheet (or during name-based capability fallback), `ToOpenAIResponsesRequest` (at `responses.go:358`) evaluated `caps.SupportsReasoning(IsOpenAIReasoningModel(capModel))` to `false` and cleared `req.ResponsesParameters.Reasoning = nil`. Because OpenAI upstream rejects `gpt-6-astra` requests that lack reasoning parameters with HTTP 400, these requests failed. Additionally, multi-turn `EncryptedContent` was stripped (at `responses.go:189, 233`).
2. **`xhigh` effort downgrade**: `acceptsXHighEffort` did not recognize `gpt-6` or `astra`, causing `reasoning.effort: "xhigh"` to be silently downgraded to `"high"` by `NormalizeReasoningEffort`.

This PR builds on #6881 to recognize `gpt-6-astra` across all reasoning predicates in `core/providers/openai/utils.go`, ensuring both reasoning parameters and `xhigh` effort are preserved regardless of datasheet status.

## Changes

- **Predicate Updates** (`core/providers/openai/utils.go`):
  - In `IsOpenAIReasoningModel`: add `strings.Contains(modelLower, "gpt-6") || strings.Contains(modelLower, "astra")`. Prevents clearing `req.ResponsesParameters.Reasoning` during fallback and preserves multi-turn `EncryptedContent`.
  - In `acceptsXHighEffort`: add `gpt-6` and `astra` substring matches to natively preserve `xhigh` effort.
  - In `acceptsMaxEffort`: broaden to `gpt-6` and `astra` substring matches.
- **Unit Tests** (`core/providers/openai/`):
  - In `responsesmarshal_test.go`:
    - Add direct table-driven test coverage in `TestIsOpenAIReasoningModel` across `gpt-6`, `gpt-6-astra`, `astra` variants, Azure prefixes (`azure/gpt-6-astra`, `azure/eu/gpt-6-astra`, `azure/astra-preview`), and existing reasoning/non-reasoning models.
    - Add `gpt-6-astra` normalization test cases for `xhigh` and `minimal` efforts in `TestNormalizeOpenAIReasoningEffort`.
    - Add catalog ID predicate checks in `TestEffortPredicatesAgainstCatalogIDs`.
  - In `responses_test.go`: verify `EncryptedContent` preservation in `TestToOpenAIResponsesRequest_ReasoningContentBlocksDropped`, and verify `xhigh`/`max` effort preservation in `TestToOpenAIResponsesRequest_NormalizesReasoningEffort`.
- **Wire-Level E2E Regression Test** (`core/gpt6astrae2e_test.go`):
  - Add `TestGPT6AstraReasoningPreservedWithoutDatasheet` alongside the test introduced in #6881 to verify that when no capability resolver / datasheet is configured, reasoning parameters and `xhigh` effort reach upstream intact.
- **Changelog** (`core/changelog.md`):
  - Add changelog entry for preserving reasoning parameters and xhigh effort.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```bash
# OpenAI provider unit tests
cd core
go test ./providers/openai -run 'TestIsOpenAIReasoningModel|TestNormalizeOpenAIReasoningEffort|TestEffortPredicatesAgainstCatalogIDs|TestToOpenAIResponsesRequest_ReasoningContentBlocksDropped|TestToOpenAIResponsesRequest_NormalizesReasoningEffort' -count=1

# Wire-level E2E recording-upstream regression tests
cd core
go test . -run '^TestGPT6Astra' -count=1 -v
```

Expected output:
```text
ok  	github.com/maximhq/bifrost/core/providers/openai	0.139s
=== RUN   TestGPT6AstraMaxReasoningEffortReachesOpenAIUpstream
--- PASS: TestGPT6AstraMaxReasoningEffortReachesOpenAIUpstream (0.08s)
=== RUN   TestGPT6AstraReasoningPreservedWithoutDatasheet
--- PASS: TestGPT6AstraReasoningPreservedWithoutDatasheet (0.00s)
PASS
ok  	github.com/maximhq/bifrost/core	0.215s
```

## Screenshots/Recordings

Not applicable (backend only).

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

- Follow-up to #6881
- Closes https://github.com/axsh/bifrost/issues/1

## Security considerations

None. No credentials or secrets are added. All tests use a local loopback `httptest.Server`.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
