### PR TITLE
feat(logstore): add request-type visibility filtering

### DIFF
--- a/framework/logstore/config.go
+++ b/framework/logstore/config.go
@@ -19,6 +19,8 @@ type Config struct {
 	// ObjectStorageExcludeFields lists payload field names (DB column names) that
 	// should NOT be offloaded to object storage and instead remain in the database.
 	ObjectStorageExcludeFields []string `json:"object_storage_exclude_fields,omitempty"`
+	// HiddenRequestTypes excludes request types from dashboard reads, without changing log writes.
+	HiddenRequestTypes []string `json:"hidden_request_types,omitempty"`
 }
 
 const (
@@ -66,6 +68,7 @@ func (c *WriterConfig) WithDefaults() WriterConfig {
 func (c *Config) UnmarshalJSON(data []byte) error {
 	// First, unmarshal into a temporary struct to get the basic fields
 	type TempConfig struct {
+		HiddenRequestTypes         []string            `json:"hidden_request_types,omitempty"`
 		Enabled                    bool                `json:"enabled"`
 		Type                       LogStoreType        `json:"type"`
 		Config                     json.RawMessage     `json:"config"` // Keep as raw JSON
@@ -81,6 +84,7 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 	}
 
 	// Set basic fields
+	c.HiddenRequestTypes = temp.HiddenRequestTypes
 	c.Enabled = temp.Enabled
 	c.Type = temp.Type
 	c.RetentionDays = temp.RetentionDays

--- a/framework/logstore/matviews.go
+++ b/framework/logstore/matviews.go
@@ -1187,7 +1187,7 @@ func (s *RDBLogStore) getCountFromMatView(ctx context.Context, filters SearchFil
 	}
 
 	var interior int64
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, dimFilters)
 	q = applyInteriorBucketWindow(q, filters.StartTime, filters.EndTime)
 	if err := q.Select("COALESCE(SUM(count), 0)").Row().Scan(&interior); err != nil {
@@ -1257,7 +1257,7 @@ func isDegenerateHybridWindow(start, end *time.Time) bool {
 // counts sum a consistent population across the matview and raw halves.
 func (s *RDBLogStore) countRawTerminal(ctx context.Context, dimFilters SearchFilters, timePredicate string, timeArgs ...any) (int64, error) {
 	var count int64
-	q := s.ScopedDB(ctx).Model(&Log{})
+	q := s.scopedLogsDB(ctx).Model(&Log{})
 	q = s.applyFilters(q, dimFilters)
 	q = q.Where(timePredicate, timeArgs...)
 	if len(dimFilters.Status) == 0 {
@@ -1278,7 +1278,7 @@ func (s *RDBLogStore) countRawTerminal(ctx context.Context, dimFilters SearchFil
 // eligibility and excludes in-flight rows on every path.
 func (s *RDBLogStore) countRawNonTerminal(ctx context.Context, filters SearchFilters) (int64, error) {
 	var count int64
-	q := s.ScopedDB(ctx).Model(&Log{})
+	q := s.scopedLogsDB(ctx).Model(&Log{})
 	q = s.applyFilters(q, filters)
 	q = q.Where("status IN ?", nonTerminalLogStatuses)
 	if err := q.Count(&count).Error; err != nil {
@@ -1321,7 +1321,7 @@ func (a *matViewStatsAgg) add(b matViewStatsAgg) {
 // fully contained in the window.
 func (s *RDBLogStore) matViewInteriorStatsAgg(ctx context.Context, dimFilters SearchFilters, start, end *time.Time) (matViewStatsAgg, error) {
 	var agg matViewStatsAgg
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, dimFilters)
 	q = applyInteriorBucketWindow(q, start, end)
 	err := q.Select(`
@@ -1345,7 +1345,7 @@ func (s *RDBLogStore) matViewInteriorStatsAgg(ctx context.Context, dimFilters Se
 // halves of the hybrid aggregate the same population.
 func (s *RDBLogStore) rawTerminalStatsAgg(ctx context.Context, dimFilters SearchFilters, timePredicate string, timeArgs ...any) (matViewStatsAgg, error) {
 	var agg matViewStatsAgg
-	q := s.ScopedDB(ctx).Model(&Log{})
+	q := s.scopedLogsDB(ctx).Model(&Log{})
 	q = s.applyFilters(q, dimFilters)
 	q = q.Where(timePredicate, timeArgs...)
 	if len(dimFilters.Status) == 0 {
@@ -1492,7 +1492,7 @@ func (s *RDBLogStore) getHistogramFromMatView(ctx context.Context, filters Searc
 
 	rawBucketed := func(timePredicate string, timeArgs ...any) ([]histAgg, error) {
 		var rows []histAgg
-		q := s.ScopedDB(ctx).Model(&Log{})
+		q := s.scopedLogsDB(ctx).Model(&Log{})
 		q = s.applyFilters(q, dimFilters)
 		q = q.Where(timePredicate, timeArgs...)
 		q = q.Where("status IN ?", terminalLogStatuses)
@@ -1518,7 +1518,7 @@ func (s *RDBLogStore) getHistogramFromMatView(ctx context.Context, filters Searc
 		merge(rows)
 	} else {
 		var results []histAgg
-		q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+		q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 		q = s.applyMatViewFilters(q, dimFilters)
 		q = applyInteriorBucketWindow(q, filters.StartTime, filters.EndTime)
 		if err := q.Select(fmt.Sprintf(`
@@ -1590,7 +1590,7 @@ func (s *RDBLogStore) getTokenHistogramFromMatView(ctx context.Context, filters 
 		TotalTokens      int64 `gorm:"column:total_tkns"`
 		CachedReadTokens int64 `gorm:"column:cached_read_tokens"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
@@ -1634,7 +1634,7 @@ func (s *RDBLogStore) getCostHistogramFromMatView(ctx context.Context, filters S
 		Model           string  `gorm:"column:model"`
 		Cost            float64 `gorm:"column:cost"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
@@ -1690,7 +1690,7 @@ func (s *RDBLogStore) getModelHistogramFromMatView(ctx context.Context, filters 
 		ErrorCount      int64  `gorm:"column:error_count"`
 		CancelledCount  int64  `gorm:"column:cancelled_count"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
@@ -1757,7 +1757,7 @@ func (s *RDBLogStore) getLatencyHistogramFromMatView(ctx context.Context, filter
 		TotalRequests   int64   `gorm:"column:total_requests"`
 	}
 	// Weighted average of percentiles across hourly buckets
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
@@ -1815,7 +1815,7 @@ func (s *RDBLogStore) getThroughputHistogramFromMatView(ctx context.Context, fil
 		SumLatency       float64 `gorm:"column:sum_latency"`
 		TotalRequests    int64   `gorm:"column:total_requests"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	// Successful requests only: status is a matview dimension, so this restricts
 	// the summed tokens/latency/count to success rows (see GetThroughputHistogram).
@@ -1862,7 +1862,7 @@ func (s *RDBLogStore) getProviderThroughputHistogramFromMatView(ctx context.Cont
 		SumLatency       float64 `gorm:"column:sum_latency"`
 		TotalRequests    int64   `gorm:"column:total_requests"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	// Successful requests only — see getThroughputHistogramFromMatView.
 	q = q.Where("status = ?", "success")
@@ -1920,7 +1920,7 @@ func (s *RDBLogStore) getProviderCostHistogramFromMatView(ctx context.Context, f
 		Provider        string  `gorm:"column:provider"`
 		Cost            float64 `gorm:"column:cost"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
@@ -1975,7 +1975,7 @@ func (s *RDBLogStore) getProviderTokenHistogramFromMatView(ctx context.Context, 
 		CompletionTokens int64  `gorm:"column:completion_tokens"`
 		TotalTokens      int64  `gorm:"column:total_tkns"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
@@ -2049,7 +2049,7 @@ func (s *RDBLogStore) getProviderLatencyHistogramFromMatView(ctx context.Context
 		P99Latency      float64 `gorm:"column:p99_lat"`
 		TotalRequests   int64   `gorm:"column:total_requests"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	if err := q.Select(fmt.Sprintf(`
 		CAST(FLOOR(EXTRACT(EPOCH FROM hour) / %d) * %d AS BIGINT) AS bucket_timestamp,
@@ -2117,7 +2117,7 @@ func (s *RDBLogStore) getDimensionCostHistogramFromMatView(ctx context.Context, 
 		DimValue        string  `gorm:"column:dim_value"`
 		Cost            float64 `gorm:"column:cost"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	// Same ceiling as the raw path: bounded dimensions must not name ids the
 	// caller may not be shown, even when the aggregate is served pre-computed.
@@ -2179,7 +2179,7 @@ func (s *RDBLogStore) getDimensionTokenHistogramFromMatView(ctx context.Context,
 		CompletionTokens int64  `gorm:"column:completion_tokens"`
 		TotalTokens      int64  `gorm:"column:total_tkns"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	// Same ceiling as the raw path: bounded dimensions must not name ids the
 	// caller may not be shown, even when the aggregate is served pre-computed.
@@ -2258,7 +2258,7 @@ func (s *RDBLogStore) getDimensionLatencyHistogramFromMatView(ctx context.Contex
 		P99Latency      float64 `gorm:"column:p99_lat"`
 		TotalRequests   int64   `gorm:"column:total_requests"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	// Same ceiling as the raw path: bounded dimensions must not name ids the
 	// caller may not be shown, even when the aggregate is served pre-computed.
@@ -2331,7 +2331,7 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		TPCompletionTokens int64          `gorm:"column:tp_completion_tokens"`
 		TPLatencyMs        float64        `gorm:"column:tp_latency_ms"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	q = q.Where("model IS NOT NULL AND model != ''")
 	q = q.Select(`
@@ -2383,7 +2383,7 @@ func (s *RDBLogStore) getModelRankingsFromMatView(ctx context.Context, filters S
 		prevFilters := filters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
-		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
+		pq := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 		pq = s.applyMatViewFilters(pq, prevFilters)
 		pq = pq.Where("model IS NOT NULL AND model != ''")
 		if err := pq.Select(`
@@ -2454,7 +2454,7 @@ func (s *RDBLogStore) getUserRankingsFromMatView(ctx context.Context, filters Se
 		TotalTokens int64   `gorm:"column:total_tkns"`
 		TotalCost   float64 `gorm:"column:total_cost"`
 	}
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	q = q.Where("user_id != ''")
 	// Same ceiling as the raw path in GetUserRankings: the row scope alone does
@@ -2498,7 +2498,7 @@ func (s *RDBLogStore) getUserRankingsFromMatView(ctx context.Context, filters Se
 		prevFilters := filters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
-		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
+		pq := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 		pq = s.applyMatViewFilters(pq, prevFilters)
 		pq = pq.Where("user_id != ''")
 		pq = applyDimensionCeiling(ctx, pq, dimensionReadSource{}, "user_id")
@@ -2555,7 +2555,7 @@ func (s *RDBLogStore) getDimensionRankingsFromMatView(ctx context.Context, filte
 	}
 
 	var results []row
-	q := s.ScopedDB(ctx).Table("mv_logs_hourly")
+	q := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 	q = s.applyMatViewFilters(q, filters)
 	q = q.Where(fmt.Sprintf("%s != ''", idCol))
 	// Same ceiling as the raw path in GetDimensionRankings. Only non-bucketed
@@ -2584,7 +2584,7 @@ func (s *RDBLogStore) getDimensionRankingsFromMatView(ctx context.Context, filte
 			ID   string `gorm:"column:id"`
 			Name string `gorm:"column:name"`
 		}
-		if err := s.ScopedDB(ctx).Model(&Log{}).
+		if err := s.scopedLogsDB(ctx).Model(&Log{}).
 			Select(fmt.Sprintf("DISTINCT ON (%s) %s AS id, %s AS name", idCol, idCol, nameCol)).
 			Where(fmt.Sprintf("%s IN ?", idCol), ids).
 			Where(fmt.Sprintf("%s IS NOT NULL AND %s != ''", nameCol, nameCol)).
@@ -2616,7 +2616,7 @@ func (s *RDBLogStore) getDimensionRankingsFromMatView(ctx context.Context, filte
 		prevFilters := filters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
-		pq := s.ScopedDB(ctx).Table("mv_logs_hourly")
+		pq := s.scopedLogsDB(ctx).Table("mv_logs_hourly")
 		pq = s.applyMatViewFilters(pq, prevFilters)
 		pq = pq.Where(fmt.Sprintf("%s != ''", idCol))
 		pq = applyDimensionCeiling(ctx, pq, dimensionReadSource{}, idCol)
@@ -2668,7 +2668,7 @@ func (s *RDBLogStore) getDimensionRankingsFromMatView(ctx context.Context, filte
 // of which path served the request.
 func (s *RDBLogStore) getDistinctModelsFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var models []string
-	q := s.ScopedDB(ctx).Table("mv_filter_models").
+	q := s.scopedLogsDB(ctx).Table("mv_filter_models").
 		Distinct("model").
 		Where("model != ''")
 	if query != "" {
@@ -2683,7 +2683,7 @@ func (s *RDBLogStore) getDistinctModelsFromMatView(ctx context.Context, limit in
 // getDistinctAliasesFromMatView returns unique alias values from mv_filter_aliases.
 func (s *RDBLogStore) getDistinctAliasesFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var aliases []string
-	q := s.ScopedDB(ctx).Table("mv_filter_aliases").
+	q := s.scopedLogsDB(ctx).Table("mv_filter_aliases").
 		Distinct("alias").
 		Where("alias != ''")
 	if query != "" {
@@ -2698,7 +2698,7 @@ func (s *RDBLogStore) getDistinctAliasesFromMatView(ctx context.Context, limit i
 // getDistinctStopReasonsFromMatView returns unique stop reasons from mv_filter_stop_reasons.
 func (s *RDBLogStore) getDistinctStopReasonsFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var stopReasons []string
-	q := s.ScopedDB(ctx).Table("mv_filter_stop_reasons").
+	q := s.scopedLogsDB(ctx).Table("mv_filter_stop_reasons").
 		Distinct("stop_reason").
 		Where("stop_reason != ''")
 	if query != "" {
@@ -2713,7 +2713,7 @@ func (s *RDBLogStore) getDistinctStopReasonsFromMatView(ctx context.Context, lim
 // getDistinctUserAgentsFromMatView returns unique raw User-Agent strings from mv_filter_user_agents.
 func (s *RDBLogStore) getDistinctUserAgentsFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var userAgents []string
-	q := s.ScopedDB(ctx).Table("mv_filter_user_agents").
+	q := s.scopedLogsDB(ctx).Table("mv_filter_user_agents").
 		Distinct("user_agent").
 		Where("user_agent != ''")
 	if query != "" {
@@ -2728,7 +2728,7 @@ func (s *RDBLogStore) getDistinctUserAgentsFromMatView(ctx context.Context, limi
 // getDistinctAppsFromMatView returns unique backend-detected app labels from mv_filter_apps.
 func (s *RDBLogStore) getDistinctAppsFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var apps []string
-	q := s.ScopedDB(ctx).Table("mv_filter_apps").
+	q := s.scopedLogsDB(ctx).Table("mv_filter_apps").
 		Distinct("app").
 		Where("app != ''")
 	if query != "" {
@@ -2750,7 +2750,7 @@ func (s *RDBLogStore) getDistinctKeyPairsFromMatView(ctx context.Context, idCol,
 		return nil, false, nil
 	}
 	var results []KeyPairResult
-	q := s.ScopedDB(ctx).Table(view).Where("id != ''")
+	q := s.scopedLogsDB(ctx).Table(view).Where("id != ''")
 	// User matview stores name = id and the view-level WHERE already filters
 	// empty ids; other matviews include name and we additionally guard against
 	// stragglers with empty names.
@@ -2788,7 +2788,7 @@ func (s *RDBLogStore) getDistinctKeyPairsFromMatView(ctx context.Context, idCol,
 // mv_filter_routing_engines.
 func (s *RDBLogStore) getDistinctRoutingEnginesFromMatView(ctx context.Context, limit int, query string) ([]string, error) {
 	var rawValues []string
-	q := s.ScopedDB(ctx).Table("mv_filter_routing_engines").
+	q := s.scopedLogsDB(ctx).Table("mv_filter_routing_engines").
 		Distinct("routing_engines_used").
 		Where("routing_engines_used != ''")
 	if query != "" {

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -568,14 +568,14 @@ func (s *RDBLogStore) applyRootsOnlyFilter(baseQuery *gorm.DB, filters SearchFil
 		// once per query. The inherited filters (crucially the time window) bound
 		// it — an unfiltered `SELECT id FROM logs` would materialize every id in
 		// the table on every page load.
-		parents := s.applyFilters(s.ScopedDB(ctx).Model(&Log{}).Select("id"), parentFilters)
+		parents := s.applyFilters(s.scopedLogsDB(ctx).Model(&Log{}).Select("id"), parentFilters)
 		return baseQuery.Where("(parent_request_id IS NULL OR parent_request_id = id OR parent_request_id NOT IN (?))", parents)
 	}
 
 	// Correlated form elsewhere: the PK lookup on parent.id keeps this an index
 	// probe per candidate row rather than a materialized anti-join. Unqualified
 	// columns in the filter predicates bind to the inner `parent` scope.
-	parents := s.applyFilters(s.ScopedDB(ctx).Table("logs AS parent").Select("1"), parentFilters).
+	parents := s.applyFilters(s.scopedLogsDB(ctx).Table("logs AS parent").Select("1"), parentFilters).
 		Where("parent.id = logs.parent_request_id")
 	return baseQuery.Where("(parent_request_id IS NULL OR parent_request_id = id OR NOT EXISTS (?))", parents)
 }
@@ -994,13 +994,13 @@ func (s *RDBLogStore) searchLogs(ctx context.Context, filters SearchFilters, pag
 				return err
 			}
 		}
-		countQuery := s.ScopedDB(gCtx).Model(&Log{})
+		countQuery := s.scopedLogsDB(gCtx).Model(&Log{})
 		countQuery = s.applyFilters(countQuery, filters)
 		return countQuery.Count(&totalCount).Error
 	})
 
 	g.Go(func() error {
-		dataQuery := s.ScopedDB(gCtx).Model(&Log{})
+		dataQuery := s.scopedLogsDB(gCtx).Model(&Log{})
 		dataQuery = s.applyFilters(dataQuery, filters)
 		dataQuery = dataQuery.Order(orderClause).Select(selectColumns).Limit(limit)
 		if pagination.Offset > 0 {
@@ -1076,7 +1076,7 @@ func (s *RDBLogStore) attachChildAggregates(ctx context.Context, logs []Log, fil
 	childFilters.RootsOnly = false
 	childFilters.ParentRequestID = ""
 
-	err := s.applyFilters(s.ScopedDB(ctx).Model(&Log{}), childFilters).
+	err := s.applyFilters(s.scopedLogsDB(ctx).Model(&Log{}), childFilters).
 		Select("parent_request_id, COUNT(*) AS child_count, COALESCE(SUM(cost), 0) AS children_cost, COALESCE(SUM(total_tokens), 0) AS children_tokens").
 		Where("parent_request_id IN ? AND id <> parent_request_id", ids).
 		Group("parent_request_id").
@@ -1124,7 +1124,7 @@ func (s *RDBLogStore) GetSessionLogs(ctx context.Context, sessionID string, pagi
 	}
 	orderClause := "timestamp " + orderDir + ", id " + orderDir
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{}).Where("parent_request_id = ?", sessionID)
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{}).Where("parent_request_id = ?", sessionID)
 
 	var (
 		totalCount int64
@@ -1134,7 +1134,7 @@ func (s *RDBLogStore) GetSessionLogs(ctx context.Context, sessionID string, pagi
 	g, gCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		return s.ScopedDB(gCtx).Model(&Log{}).Where("parent_request_id = ?", sessionID).Count(&totalCount).Error
+		return s.scopedLogsDB(gCtx).Model(&Log{}).Where("parent_request_id = ?", sessionID).Count(&totalCount).Error
 	})
 
 	g.Go(func() error {
@@ -1187,7 +1187,7 @@ func (s *RDBLogStore) GetSessionSummary(ctx context.Context, sessionID string) (
 
 	// Single aggregate select keeps Count/SUM/MIN/MAX consistent against the same row snapshot
 	// and halves the round trips compared to running Count and the aggregate row in parallel.
-	row := s.ScopedDB(ctx).Model(&Log{}).
+	row := s.scopedLogsDB(ctx).Model(&Log{}).
 		Where("parent_request_id = ?", sessionID).
 		Select("COUNT(*) AS count, COALESCE(SUM(cost), 0) AS total_cost, COALESCE(SUM(total_tokens), 0) AS total_tokens, MIN(timestamp) AS started_at, MAX(timestamp) AS latest_at").
 		Row()
@@ -1455,7 +1455,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 			return stats, err
 		}
 	}
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 
 	// Get total count (includes processing status)
@@ -1480,7 +1480,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 			TotalCost        sql.NullFloat64 `gorm:"column:total_cost"`
 		}
 
-		statsQuery := s.ScopedDB(ctx).Model(&Log{})
+		statsQuery := s.scopedLogsDB(ctx).Model(&Log{})
 		statsQuery = s.applyFilters(statsQuery, filters)
 		statsQuery = statsQuery.Where("status IN ?", terminalLogStatuses)
 
@@ -1529,7 +1529,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 				TotalUserRequests      sql.NullInt64 `gorm:"column:total_user_requests"`
 				SuccessfulUserRequests sql.NullInt64 `gorm:"column:successful_user_requests"`
 			}
-			userFacingQuery := s.ScopedDB(ctx).Model(&Log{})
+			userFacingQuery := s.scopedLogsDB(ctx).Model(&Log{})
 			userFacingQuery = s.applyFilters(userFacingQuery, filters)
 			// Scope to root rows only so denominator and numerator are drawn from the same population.
 			// A chain is successful if the root itself succeeded or any of its fallbacks succeeded.
@@ -1545,6 +1545,10 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 				FROM logs
 				WHERE status = 'success' AND parent_request_id IS NOT NULL`
 			var innerArgs []interface{}
+			if hidden := HiddenRequestTypesFromContext(ctx); len(hidden) > 0 {
+				innerJoin += " AND object_type NOT IN ?"
+				innerArgs = append(innerArgs, hidden)
+			}
 			if filters.StartTime != nil {
 				innerJoin += " AND timestamp >= ?"
 				innerArgs = append(innerArgs, *filters.StartTime)
@@ -1572,7 +1576,7 @@ func (s *RDBLogStore) GetStats(ctx context.Context, filters SearchFilters) (*Sea
 	}
 
 	// Count cache hits by hit_type from cache_debug JSON
-	cacheBase := s.ScopedDB(ctx).Model(&Log{}).Where("status IN ?", terminalLogStatuses)
+	cacheBase := s.scopedLogsDB(ctx).Model(&Log{}).Where("status IN ?", terminalLogStatuses)
 	direct, semantic, err := s.aggregateCacheHits(ctx, cacheBase, filters)
 	if err != nil {
 		s.logger.Warn(fmt.Sprintf("logstore: failed to aggregate cache-hit stats, skipping: %s", err))
@@ -1641,7 +1645,7 @@ func (s *RDBLogStore) GetHistogram(ctx context.Context, filters SearchFilters, b
 	dialect := s.db.Dialector.Name()
 
 	// Build query with filters
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
@@ -1753,7 +1757,7 @@ func (s *RDBLogStore) GetTokenHistogram(ctx context.Context, filters SearchFilte
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	// Only count terminal requests for token stats
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
@@ -1874,7 +1878,7 @@ func (s *RDBLogStore) GetThroughputHistogram(ctx context.Context, filters Search
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	// Only successful requests contribute to throughput: failed/cancelled rows
 	// spend latency but produce no (or partial) completion tokens, which would
@@ -1963,7 +1967,7 @@ func (s *RDBLogStore) GetProviderThroughputHistogram(ctx context.Context, filter
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	// Successful requests only — see GetThroughputHistogram.
 	baseQuery = baseQuery.Where("status = ?", "success")
@@ -2058,7 +2062,7 @@ func (s *RDBLogStore) GetCostHistogram(ctx context.Context, filters SearchFilter
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	// Only count terminal requests with cost
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
@@ -2166,7 +2170,7 @@ func (s *RDBLogStore) GetModelHistogram(ctx context.Context, filters SearchFilte
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
@@ -2307,7 +2311,7 @@ func (s *RDBLogStore) GetLatencyHistogram(ctx context.Context, filters SearchFil
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
@@ -2633,7 +2637,7 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 		COALESCE(SUM(additional_cost), 0) as total_additional_cost`
 
 	// Query current period
-	currentQuery := s.ScopedDB(ctx).Model(&Log{})
+	currentQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
 	currentQuery = currentQuery.Where("model IS NOT NULL AND model != ''")
@@ -2677,7 +2681,7 @@ func (s *RDBLogStore) GetModelRankings(ctx context.Context, filters SearchFilter
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
 
-		prevQuery := s.ScopedDB(ctx).Model(&Log{})
+		prevQuery := s.scopedLogsDB(ctx).Model(&Log{})
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
 		prevQuery = prevQuery.Where("status IN ?", terminalLogStatuses)
 		prevQuery = prevQuery.Where("model IS NOT NULL AND model != ''")
@@ -2794,7 +2798,7 @@ func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters
 	`
 
 	// Query current period
-	currentQuery := s.ScopedDB(ctx).Model(&Log{})
+	currentQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
 	currentQuery = currentQuery.Where("user_id IS NOT NULL AND user_id != ''")
@@ -2829,7 +2833,7 @@ func (s *RDBLogStore) GetUserRankings(ctx context.Context, filters SearchFilters
 		prevFilters.StartTime = &prevStart
 		prevFilters.EndTime = &prevEnd
 
-		prevQuery := s.ScopedDB(ctx).Model(&Log{})
+		prevQuery := s.scopedLogsDB(ctx).Model(&Log{})
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
 		prevQuery = prevQuery.Where("status IN ?", terminalLogStatuses)
 		prevQuery = prevQuery.Where("user_id IS NOT NULL AND user_id != ''")
@@ -2934,7 +2938,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		COALESCE(SUM(cost), 0) as total_cost
 	`, groupExpr, nameExpr)
 
-	currentQuery := src.base(s.ScopedDB(ctx))
+	currentQuery := src.base(s.scopedLogsDB(ctx))
 	currentQuery = s.applyFilters(currentQuery, filters)
 	currentQuery = currentQuery.Where("status IN ?", terminalLogStatuses)
 	currentQuery = applyDimensionCeiling(ctx, currentQuery, src, idCol)
@@ -2981,7 +2985,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		AttributedRequests int64 `gorm:"column:attributed_requests"`
 	}
 	if src.Bucketed {
-		countQuery := s.ScopedDB(ctx).Model(&Log{})
+		countQuery := s.scopedLogsDB(ctx).Model(&Log{})
 		countQuery = s.applyFilters(countQuery, filters)
 		countQuery = countQuery.Where("status IN ?", terminalLogStatuses)
 		var total int64
@@ -2992,7 +2996,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		requestCounts.AttributedRequests = total
 
 		if src.FannedOut {
-			attributedQuery := src.base(s.ScopedDB(ctx))
+			attributedQuery := src.base(s.scopedLogsDB(ctx))
 			attributedQuery = s.applyFilters(attributedQuery, filters)
 			attributedQuery = attributedQuery.Where("status IN ?", terminalLogStatuses)
 			// Same ceiling as the rankings themselves: this total is the sum of
@@ -3020,7 +3024,7 @@ func (s *RDBLogStore) GetDimensionRankings(ctx context.Context, filters SearchFi
 		// Same relation as the current period: comparing a fanned-out current
 		// period against a scalar previous period would show a fake spike on
 		// every entity that only appears in the array columns.
-		prevQuery := src.base(s.ScopedDB(ctx))
+		prevQuery := src.base(s.scopedLogsDB(ctx))
 		prevQuery = s.applyFilters(prevQuery, prevFilters)
 		prevQuery = prevQuery.Where("status IN ?", terminalLogStatuses)
 		if !src.Bucketed {
@@ -3125,7 +3129,7 @@ func (s *RDBLogStore) GetProviderCostHistogram(ctx context.Context, filters Sear
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("cost IS NOT NULL AND cost > 0")
@@ -3222,7 +3226,7 @@ func (s *RDBLogStore) GetProviderTokenHistogram(ctx context.Context, filters Sea
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 
@@ -3331,7 +3335,7 @@ func (s *RDBLogStore) GetProviderLatencyHistogram(ctx context.Context, filters S
 
 	dialect := s.db.Dialector.Name()
 
-	baseQuery := s.ScopedDB(ctx).Model(&Log{})
+	baseQuery := s.scopedLogsDB(ctx).Model(&Log{})
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = baseQuery.Where("latency IS NOT NULL")
@@ -3693,7 +3697,7 @@ func (s *RDBLogStore) GetDimensionCostHistogram(ctx context.Context, filters Sea
 			return res, err
 		}
 	}
-	baseQuery := src.base(s.ScopedDB(ctx))
+	baseQuery := src.base(s.scopedLogsDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = applyDimensionCeiling(ctx, baseQuery, src, dimCol)
@@ -3796,7 +3800,7 @@ func (s *RDBLogStore) GetDimensionTokenHistogram(ctx context.Context, filters Se
 			return res, err
 		}
 	}
-	baseQuery := src.base(s.ScopedDB(ctx))
+	baseQuery := src.base(s.scopedLogsDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = applyDimensionCeiling(ctx, baseQuery, src, dimCol)
@@ -3920,7 +3924,7 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 		}
 	}
 	dialect := s.db.Dialector.Name()
-	baseQuery := src.base(s.ScopedDB(ctx))
+	baseQuery := src.base(s.scopedLogsDB(ctx))
 	baseQuery = s.applyFilters(baseQuery, filters)
 	baseQuery = baseQuery.Where("status IN ?", terminalLogStatuses)
 	baseQuery = applyDimensionCeiling(ctx, baseQuery, src, dimCol)
@@ -4000,7 +4004,7 @@ func (s *RDBLogStore) GetDimensionLatencyHistogram(ctx context.Context, filters 
 // HasLogs checks if there are any logs in the database.
 func (s *RDBLogStore) HasLogs(ctx context.Context) (bool, error) {
 	var log Log
-	err := s.db.WithContext(ctx).Select("id").Limit(1).Take(&log).Error
+	err := s.scopedLogsDB(ctx).Select("id").Limit(1).Take(&log).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil
@@ -4015,7 +4019,7 @@ func (s *RDBLogStore) HasLogs(ctx context.Context) (bool, error) {
 // IDs return ErrNotFound. Contexts without a QueryScope stay unscoped as before.
 func (s *RDBLogStore) FindByID(ctx context.Context, id string) (*Log, error) {
 	var log Log
-	if err := s.ScopedDB(ctx).Where("id = ?", id).First(&log).Error; err != nil {
+	if err := s.scopedLogsDB(ctx).Where("id = ?", id).First(&log).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, ErrNotFound
 		}
@@ -4080,14 +4084,14 @@ func (s *RDBLogStore) applyLikeFilter(q *gorm.DB, column, search string) *gorm.D
 // GetDistinctModels returns all unique non-empty model values using SELECT DISTINCT.
 // Scoped to recent data to avoid full table scans.
 func (s *RDBLogStore) GetDistinctModels(ctx context.Context, limit int, query string) ([]string, error) {
-	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
+	if s.canUseFilterMatView(ctx) {
 		if res, err := s.getDistinctModelsFromMatView(ctx, limit, query); !s.fallBackToRaw(err) {
 			return res, err
 		}
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var models []string
-	q := s.ScopedDB(ctx).Model(&Log{}).
+	q := s.scopedLogsDB(ctx).Model(&Log{}).
 		Where("model IS NOT NULL AND model != '' AND timestamp >= ?", cutoff).
 		Distinct("model")
 	if query != "" {
@@ -4104,14 +4108,14 @@ func (s *RDBLogStore) GetDistinctModels(ctx context.Context, limit int, query st
 // DAC-aware (see GetDistinctModels).
 // Scoped to recent data to avoid full table scans.
 func (s *RDBLogStore) GetDistinctAliases(ctx context.Context, limit int, query string) ([]string, error) {
-	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
+	if s.canUseFilterMatView(ctx) {
 		if res, err := s.getDistinctAliasesFromMatView(ctx, limit, query); !s.fallBackToRaw(err) {
 			return res, err
 		}
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var aliases []string
-	q := s.ScopedDB(ctx).Model(&Log{}).
+	q := s.scopedLogsDB(ctx).Model(&Log{}).
 		Where("alias IS NOT NULL AND alias != '' AND timestamp >= ?", cutoff).
 		Distinct("alias")
 	if query != "" {
@@ -4152,7 +4156,7 @@ var allowedKeyPairColumns = map[string]struct{}{
 // QueryScope on ctx applies on the matview directly. Until matViewsReady
 // the raw-table fallback (also ScopedDB-aware) serves requests.
 func (s *RDBLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol string, limit int, query string) ([]KeyPairResult, error) {
-	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
+	if s.canUseFilterMatView(ctx) {
 		results, served, err := s.getDistinctKeyPairsFromMatView(ctx, idCol, nameCol, limit, query)
 		if served && !s.fallBackToRaw(err) {
 			return results, err
@@ -4166,7 +4170,7 @@ func (s *RDBLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol st
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var results []KeyPairResult
-	q := s.ScopedDB(ctx).Model(&Log{}).
+	q := s.scopedLogsDB(ctx).Model(&Log{}).
 		Select(fmt.Sprintf("DISTINCT %s as id, %s as name", idCol, nameCol)).
 		Where(fmt.Sprintf("%s IS NOT NULL AND %s != '' AND %s IS NOT NULL AND %s != '' AND timestamp >= ?", idCol, idCol, nameCol, nameCol), cutoff)
 	if query != "" {
@@ -4187,14 +4191,14 @@ func (s *RDBLogStore) GetDistinctKeyPairs(ctx context.Context, idCol, nameCol st
 // DAC-aware (see GetDistinctModels).
 // Scoped to recent data to avoid full table scans.
 func (s *RDBLogStore) GetDistinctRoutingEngines(ctx context.Context, limit int, query string) ([]string, error) {
-	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
+	if s.canUseFilterMatView(ctx) {
 		if res, err := s.getDistinctRoutingEnginesFromMatView(ctx, limit, query); !s.fallBackToRaw(err) {
 			return res, err
 		}
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var rawValues []string
-	q := s.ScopedDB(ctx).Model(&Log{}).
+	q := s.scopedLogsDB(ctx).Model(&Log{}).
 		Where("routing_engines_used IS NOT NULL AND routing_engines_used != '' AND timestamp >= ?", cutoff).
 		Distinct("routing_engines_used")
 	if query != "" {
@@ -4229,14 +4233,14 @@ func (s *RDBLogStore) GetDistinctRoutingEngines(ctx context.Context, limit int, 
 // DAC-aware (see GetDistinctModels).
 // Scoped to recent data to avoid full table scans.
 func (s *RDBLogStore) GetDistinctStopReasons(ctx context.Context, limit int, query string) ([]string, error) {
-	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
+	if s.canUseFilterMatView(ctx) {
 		if res, err := s.getDistinctStopReasonsFromMatView(ctx, limit, query); !s.fallBackToRaw(err) {
 			return res, err
 		}
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var stopReasons []string
-	q := s.ScopedDB(ctx).Model(&Log{}).
+	q := s.scopedLogsDB(ctx).Model(&Log{}).
 		Where("stop_reason IS NOT NULL AND stop_reason != '' AND timestamp >= ?", cutoff).
 		Distinct("stop_reason")
 	if query != "" {
@@ -4252,12 +4256,12 @@ func (s *RDBLogStore) GetDistinctStopReasons(ctx context.Context, limit int, que
 // The UI maps each raw User-Agent to a client app. Matview path is DAC-aware
 // (see GetDistinctModels); falls back to a recency-scoped raw-table scan.
 func (s *RDBLogStore) GetDistinctUserAgents(ctx context.Context, limit int, query string) ([]string, error) {
-	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
+	if s.canUseFilterMatView(ctx) {
 		return s.getDistinctUserAgentsFromMatView(ctx, limit, query)
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var userAgents []string
-	q := s.ScopedDB(ctx).Model(&Log{}).
+	q := s.scopedLogsDB(ctx).Model(&Log{}).
 		Where("user_agent IS NOT NULL AND user_agent != '' AND timestamp >= ?", cutoff).
 		Distinct("user_agent")
 	if query != "" {
@@ -4271,12 +4275,12 @@ func (s *RDBLogStore) GetDistinctUserAgents(ctx context.Context, limit int, quer
 
 // GetDistinctApps returns all unique non-empty backend-detected app labels.
 func (s *RDBLogStore) GetDistinctApps(ctx context.Context, limit int, query string) ([]string, error) {
-	if s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() {
+	if s.canUseFilterMatView(ctx) {
 		return s.getDistinctAppsFromMatView(ctx, limit, query)
 	}
 	cutoff := time.Now().UTC().AddDate(0, 0, -defaultFilterDataCutoffDays)
 	var apps []string
-	q := s.ScopedDB(ctx).Model(&Log{}).
+	q := s.scopedLogsDB(ctx).Model(&Log{}).
 		Where("app IS NOT NULL AND app != '' AND timestamp >= ?", cutoff).
 		Distinct("app")
 	if query != "" {
@@ -4367,7 +4371,7 @@ func (s *RDBLogStore) GetDistinctMetadataKeys(ctx context.Context, limit int, qu
 	default:
 		metadataGuard = "metadata IS NOT NULL AND json_valid(metadata) AND json_type(metadata) = 'object' AND metadata != '{}' AND timestamp >= ?"
 	}
-	err := s.ScopedDB(ctx).Model(&Log{}).
+	err := s.scopedLogsDB(ctx).Model(&Log{}).
 		Where(metadataGuard, cutoff).
 		Order("timestamp DESC").
 		Limit(maxMetadataRows).

--- a/framework/logstore/visibility.go
+++ b/framework/logstore/visibility.go
@@ -1,0 +1,38 @@
+package logstore
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type visibilityContextKey string
+
+// HiddenRequestTypesContextKey carries []string request types on dashboard read
+// contexts. Writers and background jobs must not set this key.
+const HiddenRequestTypesContextKey visibilityContextKey = "logstore-hidden-request-types"
+
+// HiddenRequestTypesFromContext returns the request types excluded from a read.
+func HiddenRequestTypesFromContext(ctx context.Context) []string {
+	if ctx == nil {
+		return nil
+	}
+	types, _ := ctx.Value(HiddenRequestTypesContextKey).([]string)
+	return types
+}
+
+// scopedLogsDB composes dashboard visibility with the caller's access scope.
+// Only LLM log readers use it: MCP tables do not have an object_type column.
+// Filtering here keeps counts, aggregates and pagination on the same row set.
+func (s *RDBLogStore) scopedLogsDB(ctx context.Context) *gorm.DB {
+	db := s.ScopedDB(ctx)
+	if types := HiddenRequestTypesFromContext(ctx); len(types) > 0 {
+		db = db.Where("object_type NOT IN ?", types)
+	}
+	return db
+}
+
+func (s *RDBLogStore) canUseFilterMatView(ctx context.Context) bool {
+	// Filter-only materialized views omit object_type, unlike mv_logs_hourly.
+	return s.db.Dialector.Name() == "postgres" && s.matViewsReady.Load() && len(HiddenRequestTypesFromContext(ctx)) == 0
+}

--- a/framework/logstore/visibility_test.go
+++ b/framework/logstore/visibility_test.go
@@ -1,0 +1,183 @@
+package logstore
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/queryscope"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestHiddenRequestTypesConfig(t *testing.T) {
+	for _, backend := range []string{"sqlite", "postgres", "clickhouse"} {
+		t.Run(backend, func(t *testing.T) {
+			var config Config
+			require.NoError(t, json.Unmarshal([]byte(`{"enabled":true,"type":"`+backend+`","config":{},"hidden_request_types":["count_tokens","embedding"]}`), &config))
+			require.Equal(t, []string{"count_tokens", "embedding"}, config.HiddenRequestTypes)
+			data, err := json.Marshal(config)
+			require.NoError(t, err)
+			var restored Config
+			require.NoError(t, json.Unmarshal(data, &restored))
+			require.Equal(t, config.HiddenRequestTypes, restored.HiddenRequestTypes)
+			require.NoError(t, json.Unmarshal([]byte(`{"enabled":false}`), &restored))
+			require.Empty(t, restored.HiddenRequestTypes)
+		})
+	}
+	var config Config
+	require.Error(t, json.Unmarshal([]byte(`{"hidden_request_types":"embedding"}`), &config))
+	require.Error(t, json.Unmarshal([]byte(`{"hidden_request_types":[123]}`), &config))
+}
+
+func TestHiddenRequestTypesReads(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	base := context.Background()
+	t.Cleanup(func() { require.NoError(t, s.Close(base)) })
+	ctx := context.WithValue(base, HiddenRequestTypesContextKey, []string{"count_tokens", "embedding"})
+	now := time.Now().UTC().Truncate(time.Minute)
+	session := "session"
+	for i, object := range []string{"count_tokens", "chat_completion", "embedding", "responses", "chat_completion_stream"} {
+		cost := 1.0
+		// Even a context carrying visibility must not suppress writes.
+		require.NoError(t, s.Create(ctx, &Log{
+			ID: object, Object: object, Timestamp: now.Add(time.Duration(i) * time.Second),
+			Provider: "openai", Model: object, Status: "success", Cost: &cost,
+			TotalTokens: 10, ParentRequestID: &session,
+		}))
+	}
+	page := PaginationOptions{Limit: 2, SortBy: "timestamp", Order: "asc"}
+	first, err := s.SearchLogs(ctx, SearchFilters{}, page)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), first.Pagination.TotalCount)
+	require.Len(t, first.Logs, 2)
+	require.Equal(t, "chat_completion", first.Logs[0].ID)
+	require.Equal(t, "responses", first.Logs[1].ID)
+	page.Offset = 2
+	second, err := s.SearchLogs(ctx, SearchFilters{}, page)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), second.Pagination.TotalCount)
+	require.Len(t, second.Logs, 1)
+	require.Equal(t, "chat_completion_stream", second.Logs[0].ID)
+
+	stats, err := s.GetStats(ctx, SearchFilters{})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), stats.TotalRequests)
+	require.Equal(t, int64(30), stats.TotalTokens)
+	require.Equal(t, 3.0, stats.TotalCost)
+	hist, err := s.GetHistogram(ctx, SearchFilters{}, 60)
+	require.NoError(t, err)
+	require.Len(t, hist.Buckets, 1)
+	require.Equal(t, int64(3), hist.Buckets[0].Count)
+
+	detail, err := s.GetSessionLogs(ctx, session, PaginationOptions{Limit: 2, Offset: 2})
+	require.NoError(t, err)
+	require.Equal(t, int64(3), detail.Count)
+	require.Len(t, detail.Logs, 1)
+	require.False(t, detail.HasMore)
+	summary, err := s.GetSessionSummary(ctx, session)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), summary.Count)
+	require.Equal(t, int64(30), summary.TotalTokens)
+
+	models, err := s.GetDistinctModels(ctx, 100, "")
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"chat_completion", "responses", "chat_completion_stream"}, models)
+	_, err = s.FindByID(ctx, "embedding")
+	require.ErrorIs(t, err, ErrNotFound)
+	_, err = s.FindByID(base, "embedding")
+	require.NoError(t, err, "hidden logs remain stored")
+	all, err := s.SearchLogs(base, SearchFilters{}, PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, int64(5), all.Pagination.TotalCount)
+
+	// An explicit request-type filter cannot re-include a hidden type.
+	onlyHidden, err := s.SearchLogs(ctx, SearchFilters{Objects: []string{"embedding"}}, page)
+	require.NoError(t, err)
+	require.Zero(t, onlyHidden.Pagination.TotalCount)
+	require.Empty(t, onlyHidden.Logs)
+
+	// Visibility intersects with access control instead of replacing it.
+	scoped := queryscope.WithQueryScope(ctx, func(db *gorm.DB) *gorm.DB {
+		return db.Where("model = ?", "responses")
+	})
+	stats, err = s.GetStats(scoped, SearchFilters{})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.TotalRequests)
+
+	// The consolidated dashboard also reads MCP tables, which lack object_type.
+	_, err = s.SearchMCPToolLogs(ctx, MCPToolLogSearchFilters{}, PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	_, err = s.GetMCPHistogram(ctx, MCPToolLogSearchFilters{}, 60)
+	require.NoError(t, err)
+
+	allHidden := context.WithValue(base, HiddenRequestTypesContextKey, []string{"count_tokens", "embedding", "chat_completion", "responses", "chat_completion_stream"})
+	hasLogs, err := s.HasLogs(allHidden)
+	require.NoError(t, err)
+	require.False(t, hasLogs)
+}
+
+func TestHiddenRequestTypesHourlyViewScope(t *testing.T) {
+	s := newScopedDBTestLogStore(t)
+	ctx := context.WithValue(context.Background(), HiddenRequestTypesContextKey, []string{"embedding"})
+	stmt := s.scopedLogsDB(ctx).Session(&gorm.Session{DryRun: true}).Table("mv_logs_hourly").Select("SUM(total_requests)").Find(&struct{}{}).Statement
+	require.Contains(t, stmt.SQL.String(), "object_type NOT IN (?)")
+	require.Contains(t, stmt.Vars, "embedding")
+}
+
+func TestHiddenRequestTypesSessionsAndFallbacks(t *testing.T) {
+	s := newTestSQLiteStore(t)
+	base := context.Background()
+	t.Cleanup(func() { require.NoError(t, s.Close(base)) })
+	ctx := context.WithValue(base, HiddenRequestTypesContextKey, []string{"embedding"})
+	now := time.Now().UTC()
+	rootID := "root"
+	for _, row := range []*Log{
+		{ID: rootID, Object: "responses", Status: "error", Timestamp: now},
+		{ID: "child", Object: "embedding", Status: "success", Timestamp: now, ParentRequestID: &rootID, FallbackIndex: 1},
+	} {
+		require.NoError(t, s.Create(base, row))
+	}
+	stats, err := s.GetStats(ctx, SearchFilters{})
+	require.NoError(t, err)
+	require.Zero(t, stats.UserFacingSuccessRate, "hidden fallback successes must not affect visible statistics")
+	root, err := s.FindByID(ctx, rootID)
+	require.NoError(t, err)
+	require.Zero(t, root.ChildCount, "hidden children must not enter session rollups")
+
+	// A visible child of a hidden root is still discoverable in the root list.
+	ctx = context.WithValue(base, HiddenRequestTypesContextKey, []string{"responses"})
+	page, err := s.SearchLogs(ctx, SearchFilters{RootsOnly: true}, PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), page.Pagination.TotalCount)
+	require.Len(t, page.Logs, 1)
+	require.Equal(t, "child", page.Logs[0].ID)
+}
+
+func TestHiddenRequestTypesPostgres(t *testing.T) {
+	s, db := setupPerfTestDB(t)
+	s.logger = testLogger{}
+	base := context.Background()
+	ctx := context.WithValue(base, HiddenRequestTypesContextKey, []string{"embedding"})
+	for _, object := range []string{"embedding", "responses"} {
+		require.NoError(t, s.Create(base, &Log{
+			ID: object, Object: object, Status: "success", Model: object,
+			Timestamp: time.Now().UTC().Add(-2 * time.Hour),
+		}))
+	}
+	refreshTestMatViews(t, db)
+	s.matViewsReady.Store(true)
+	require.True(t, s.canUseMatViewForFreshAggregate(SearchFilters{}))
+	require.False(t, s.canUseFilterMatView(ctx))
+	page, err := s.SearchLogs(ctx, SearchFilters{}, PaginationOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), page.Pagination.TotalCount)
+	require.Len(t, page.Logs, 1)
+	stats, err := s.GetStats(ctx, SearchFilters{})
+	require.NoError(t, err)
+	require.Equal(t, int64(1), stats.TotalRequests)
+	models, err := s.GetDistinctModels(ctx, 100, "")
+	require.NoError(t, err)
+	require.Equal(t, []string{"responses"}, models)
+}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1909,6 +1909,12 @@
           "enum": ["sqlite", "postgres", "clickhouse"],
           "description": "Logs store type"
         },
+        "hidden_request_types": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Request types excluded from dashboard and log API reads. Logs are still stored; an empty array shows all request types."
+        },
         "config": {
           "type": "object",
           "oneOf": [


### PR DESCRIPTION
## Summary

Add `logs_store.hidden_request_types` and database read filtering for selected request types. For example, hiding `embedding` removes those rows from scoped reads while retaining them in storage. This is the storage foundation; the next PR applies the configuration to dashboard requests.

## Changes

- Parse and serialize an optional string array; omission or an empty array preserves existing behavior.
- Apply exclusions before pagination, totals, session rollups, rankings, and histograms, composing with access-control scopes.
- Keep PostgreSQL hourly aggregates filtered; use raw-table filter queries when their materialized views lack request types.
- Preserve writes, internal lookups, and MCP reads.

## Type of change

- [x] Feature

## Affected areas

Framework log store and configuration schema.

## How to test

Passed: `go test ./framework/logstore -count=1`.

Tests cover configuration round trips, stored hidden rows, pagination, counts, sessions, fallbacks, access control, and PostgreSQL materialized-view queries against the test database.

## Breaking changes

- [x] No

## Security considerations

Visibility filtering composes with existing access controls and uses bound SQL parameters.
