### PR TITLE
feat(helm): expose hidden request types and document configuration

### DIFF
--- a/docs/architecture/framework/log-store.mdx
+++ b/docs/architecture/framework/log-store.mdx
@@ -9,7 +9,7 @@ The LogStore is a core component of the Bifrost framework responsible for captur
 ## Core Features
 
 - **Persistent Logging**: Automatically saves detailed information about each API request, including input, output, status, latency, and cost.
-- **Multiple Backend Support**: Comes with built-in support for SQLite and PostgreSQL, allowing you to choose the best storage solution for your deployment needs.
+- **Multiple Backend Support**: Comes with built-in support for SQLite, PostgreSQL, and ClickHouse, allowing you to choose the best storage solution for your deployment needs.
 - **Rich Querying and Filtering**: A powerful search API allows you to filter and sort logs based on a wide range of criteria such as provider, model, status, latency, cost, and content.
 - **Performance Analytics**: The search functionality also provides aggregated statistics, including total requests, success rate, average latency, total tokens, and total cost for the queried data.
 - **Structured Data Model**: Logs are stored in a structured format, with complex objects like message history and tool calls serialized as JSON for efficient storage and retrieval.
@@ -23,8 +23,46 @@ The LogStore is built around the `LogStore` interface, which defines the standar
 
 - **SQLite**: The default, file-based database, ideal for local development and smaller, single-node deployments.
 - **PostgreSQL**: A production-ready database for scalable and high-availability deployments.
+- **ClickHouse**: A column-oriented database for high-volume log storage and analytics.
 
 The backend is configured in Bifrost's main configuration file.
+
+### Hiding request types from the dashboard
+
+Set `logs_store.hidden_request_types` to an array of request type strings in `config.json`:
+
+```json
+{
+  "logs_store": {
+    "enabled": true,
+    "type": "sqlite",
+    "config": { "path": "./logs.db" },
+    "hidden_request_types": ["count_tokens", "embedding"]
+  }
+}
+```
+
+For Helm deployments, use `storage.logsStore.hiddenRequestTypes`:
+
+```yaml
+storage:
+  logsStore:
+    hiddenRequestTypes:
+      - count_tokens
+      - embedding
+```
+
+This setting hides matching log rows from the dashboard and log read APIs, including
+pagination counts, statistics, charts, rankings, session details, and filter options.
+A direct lookup of a hidden log returns not found. All requests continue to be logged
+in the database; logging, retention, deletion, and cost recalculation are unchanged.
+MCP tool logs are unaffected.
+
+Use exact request type values, such as `count_tokens`, `embedding`, `chat_completion`,
+`chat_completion_stream`, `responses`, or `responses_stream`. Streaming and
+non-streaming types are separate. An omitted or empty array shows all request types.
+The setting works with SQLite, PostgreSQL, and ClickHouse, including object storage
+for log payloads. Apply the configuration and restart Bifrost to use the new setting.
 
 ### Initialization
 

--- a/docs/deployment-guides/config-json/storage.mdx
+++ b/docs/deployment-guides/config-json/storage.mdx
@@ -9,7 +9,7 @@ Bifrost persists two types of data - **config** (providers, virtual keys, govern
 | Store | Purpose | Backends |
 |-------|---------|---------|
 | `config_store` | Provider configs, virtual keys, governance rules | SQLite, PostgreSQL |
-| `logs_store` | Request/response logs shown in UI | SQLite, PostgreSQL + optional S3/GCS offload |
+| `logs_store` | Request/response logs shown in UI | SQLite, PostgreSQL, ClickHouse + optional S3/GCS offload |
 | `vector_store` | Semantic response caching | Weaviate, Redis, Valkey, Qdrant, Pinecone |
 
 <Note>
@@ -148,6 +148,8 @@ This is the recommended setup for [multinode OSS deployments](/deployment-guides
 ---
 
 ## logs_store
+
+Use `logs_store.hidden_request_types` to hide selected request types from dashboard and log API reads while continuing to store their logs. See [Hiding request types from the dashboard](/architecture/framework/log-store#hiding-request-types-from-the-dashboard) for configuration examples and behavior.
 
 <Tabs>
 

--- a/docs/deployment-guides/helm/storage.mdx
+++ b/docs/deployment-guides/helm/storage.mdx
@@ -11,6 +11,7 @@ Bifrost persists two types of data - **config** (providers, virtual keys, govern
 | `storage.mode` | Default backend for both stores (`sqlite` or `postgres`) | `sqlite` |
 | `storage.configStore.type` | Override backend for the config store | `""` (inherits `storage.mode`) |
 | `storage.logsStore.type` | Override backend for the logs store | `""` (inherits `storage.mode`) |
+| `storage.logsStore.hiddenRequestTypes` | Request types hidden from dashboard and log API reads; logs are still stored. See [Hiding request types from the dashboard](/architecture/framework/log-store#hiding-request-types-from-the-dashboard). | `[]` |
 
 <Note>
 When any store uses SQLite the chart deploys a **StatefulSet** with a PVC. With PostgreSQL only (no SQLite) it deploys a **Deployment**. Mixing backends (e.g. config=postgres, logs=sqlite) still requires a StatefulSet.

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1053,6 +1053,9 @@ false
 {{- end }}
 {{- $_ := set $config "logs_store" $sqliteLogsStore }}
 {{- end }}
+{{- if .Values.storage.logsStore.hiddenRequestTypes }}
+{{- $_ := set (index $config "logs_store") "hidden_request_types" .Values.storage.logsStore.hiddenRequestTypes }}
+{{- end }}
 {{- /* Object Storage for log payloads */ -}}
 {{- if and .Values.storage.logsStore.objectStorage .Values.storage.logsStore.objectStorage.enabled }}
 {{- $os := .Values.storage.logsStore.objectStorage }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -4617,6 +4617,12 @@
             "enabled": {
               "type": "boolean"
             },
+            "hiddenRequestTypes": {
+              "type": "array",
+              "items": { "type": "string" },
+              "default": [],
+              "description": "Request types hidden from dashboard/API reads. Logs are still stored."
+            },
             "type": {
               "type": "string",
               "enum": ["", "sqlite", "postgres", "clickhouse"]

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -1479,6 +1479,9 @@ storage:
   # Logs store settings
   logsStore:
     enabled: true
+    # Hide these request types from dashboard/API reads. Logs are still stored.
+    # Example: [count_tokens, embedding, chat_completion_stream]
+    hiddenRequestTypes: []
     # Backend type for logs store. Empty string uses storage.mode as default
     type: "" # Options: sqlite, postgres, clickhouse, or "" (uses storage.mode)
     # PostgreSQL connection pool tuning (only applies when type is postgres)


### PR DESCRIPTION
## Summary

Expose request-type visibility in Helm as `storage.logsStore.hiddenRequestTypes`. The chart renders this string array into `logs_store.hidden_request_types` for SQLite, PostgreSQL, and ClickHouse.

## Changes

- Add an empty-array default, values-schema validation, and shared configuration rendering.
- Document JSON and Helm examples, exact request-type names, restart behavior, and the effect on log reads.

## Type of change

- [x] Feature
- [x] Documentation

## Affected areas

Helm chart.
- [x] Docs

## How to test

Passed Helm lint with `image.tag=v1.5.12`. Rendered each of SQLite, PostgreSQL, and ClickHouse with populated and empty arrays and verified the generated JSON. Confirmed the values schema rejects a string instead of an array.

Example:

```yaml
storage:
  logsStore:
    hiddenRequestTypes: [count_tokens, embedding]
```

## Breaking changes

- [x] No

An omitted or empty array preserves all existing log visibility.
