### PR TITLE
feat: add `onSelect` callback support to breadcrumb for non-URL parent views

### DIFF
--- a/ui/components/topbar.tsx
+++ b/ui/components/topbar.tsx
@@ -94,17 +94,17 @@ function TopbarHeading({ title }: { title: TopbarTitleValue }) {
 				return (
 					<Fragment key={`${crumb.label}-${index}`}>
 						{index > 0 && <span className="text-muted-foreground/50 shrink-0 font-normal">/</span>}
-						{crumb.to && !isLast ? (
+						{(crumb.to || crumb.onSelect) && !isLast ? (
 							<button
 								type="button"
-								onClick={() => navigate({ to: crumb.to })}
+								onClick={() => (crumb.onSelect ? crumb.onSelect() : navigate({ to: crumb.to! }))}
 								className="text-muted-foreground hover:text-foreground shrink-0 cursor-pointer transition-colors"
 								data-testid={`topbar-breadcrumb-${index}`}
 							>
 								{crumb.label}
 							</button>
 						) : (
-							// The current page is never a link, even if a `to` was supplied.
+							// The current page is never a link, even if a `to`/`onSelect` was supplied.
 							<span className={cn("truncate", !isLast && "text-muted-foreground")}>{crumb.label}</span>
 						)}
 					</Fragment>

--- a/ui/lib/contexts/topbarContext.tsx
+++ b/ui/lib/contexts/topbarContext.tsx
@@ -1,5 +1,13 @@
 import { createContext, useContext, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from "react";
-import { EMPTY_TITLE_ENTRY, claimTitle, releaseTitle, type TopbarTitleEntry, type TopbarTitleValue } from "./topbarContext.utils";
+import {
+	EMPTY_TITLE_ENTRY,
+	claimTitle,
+	releaseTitle,
+	titleKey,
+	type Breadcrumb,
+	type TopbarTitleEntry,
+	type TopbarTitleValue,
+} from "./topbarContext.utils";
 
 interface TopbarContextValue {
 	/** Page-supplied title override; null means "fall back to the route-derived title". */
@@ -82,9 +90,36 @@ export function useSetTopbarTitle(title: TopbarTitleValue | null | undefined) {
 	// A breadcrumb trail is a fresh array literal each render, so the effect
 	// keys off its content rather than its identity — otherwise it would refire
 	// on every parent render.
-	const titleKey = Array.isArray(resolved) ? JSON.stringify(resolved) : resolved;
+	const key = titleKey(resolved);
 	const resolvedRef = useRef(resolved);
 	resolvedRef.current = resolved;
+
+	// What actually gets parked in context. A crumb's onSelect is a fresh closure
+	// every render and the equality guard ignores its identity, so parking the
+	// caller's own closure would leave the topbar invoking the one from whichever
+	// render happened to claim the title — captured state and all. Each handler
+	// is replaced by a forwarder that re-reads the caller's newest closure out of
+	// resolvedRef when the crumb is actually clicked, which keeps the guard cheap
+	// and the callback current at the same time.
+	const forwarding = useMemo(() => {
+		if (!Array.isArray(resolved)) return resolved;
+		return resolved.map(
+			(crumb, index): Breadcrumb =>
+				crumb.onSelect
+					? {
+							...crumb,
+							onSelect: () => {
+								const latest = resolvedRef.current;
+								if (Array.isArray(latest)) latest[index]?.onSelect?.();
+							},
+						}
+					: crumb,
+		);
+		// Rebuilt only when the trail itself changes; see titleKey.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [key]);
+	const forwardingRef = useRef(forwarding);
+	forwardingRef.current = forwarding;
 	// One token per hook instance, stable for its whole lifetime.
 	const ownerRef = useRef<symbol | null>(null);
 	if (ownerRef.current === null) ownerRef.current = Symbol("topbar-title");
@@ -92,8 +127,8 @@ export function useSetTopbarTitle(title: TopbarTitleValue | null | undefined) {
 
 	useEffect(() => {
 		if (!setTitleEntry) return;
-		setTitleEntry((current) => claimTitle(current, owner, resolvedRef.current));
-	}, [setTitleEntry, owner, titleKey]);
+		setTitleEntry((current) => claimTitle(current, owner, forwardingRef.current));
+	}, [setTitleEntry, owner, key]);
 
 	useEffect(() => {
 		if (!setTitleEntry) return;

--- a/ui/lib/contexts/topbarContext.utils.ts
+++ b/ui/lib/contexts/topbarContext.utils.ts
@@ -11,11 +11,15 @@
  * comparison cannot tell "the page I replaced" from "the page that replaced
  * me".
  */
-/** One hop in a breadcrumb trail. `to` makes it a link; the last crumb (the
- * current page) normally has none. */
+/**
+ * One hop in a breadcrumb trail. `to` makes it a route link; `onSelect` makes
+ * it a callback for a parent view that lives in page state rather than at its
+ * own URL. The last crumb (the current page) normally has neither.
+ */
 export interface Breadcrumb {
 	label: string;
 	to?: string;
+	onSelect?: () => void;
 }
 
 /**
@@ -40,7 +44,28 @@ export interface TopbarTitleEntry {
 export function sameTitle(a: TopbarTitleValue | null, b: TopbarTitleValue | null): boolean {
 	if (a === b) return true;
 	if (!Array.isArray(a) || !Array.isArray(b)) return false;
-	return a.length === b.length && a.every((crumb, i) => crumb.label === b[i].label && crumb.to === b[i].to);
+	// A handler is compared by presence, never by identity: it is almost always a
+	// fresh closure per render, so comparing identity would defeat the guard,
+	// while ignoring it entirely would hide a crumb turning clickable. Keeping
+	// the *newest* closure reachable is useSetTopbarTitle's job, not this one's.
+	return (
+		a.length === b.length &&
+		a.every((crumb, i) => crumb.label === b[i].label && crumb.to === b[i].to && !!crumb.onSelect === !!b[i].onSelect)
+	);
+}
+
+/**
+ * Stable key for the effect that claims the title: two values with the same key
+ * are the same title as far as the topbar is concerned.
+ *
+ * A trail cannot simply be JSON.stringify'd — that drops handlers silently, so
+ * a crumb gaining or losing its onSelect would produce an unchanged key and the
+ * claim would never refire. Handlers are folded in as presence, matching
+ * sameTitle.
+ */
+export function titleKey(value: TopbarTitleValue | null): string | null {
+	if (!Array.isArray(value)) return value;
+	return JSON.stringify(value.map((crumb) => [crumb.label, crumb.to ?? null, crumb.onSelect ? 1 : 0]));
 }
 
 export const EMPTY_TITLE_ENTRY: TopbarTitleEntry = { value: null, owner: null };


### PR DESCRIPTION
## Summary

Adds an `onSelect` callback option to breadcrumbs, enabling parent views that live in page state (rather than at their own URL) to be navigable from the topbar breadcrumb trail without requiring a dedicated route.

## Changes

- Added an optional `onSelect?: () => void` field to the `Breadcrumb` interface as an alternative to `to` for breadcrumbs that should trigger a callback instead of a route navigation.
- Updated the topbar rendering logic to treat a breadcrumb with `onSelect` the same as one with `to` — rendering it as a clickable button when it is not the last crumb, invoking the callback on click.
- Excluded `onSelect` from the `sameTitle` equality check, since it is almost always a fresh closure per render and comparing it would cause the guard to fire on every render unnecessarily.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to a view that uses breadcrumbs with an `onSelect` handler. Confirm that:
1. The breadcrumb renders as a clickable button when it is not the last crumb.
2. Clicking it invokes the callback rather than navigating to a route.
3. When it is the last crumb, it renders as a plain non-interactive span.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable