### PR TITLE
feat(ui): display hidden request types in logging config view

### DIFF
--- a/transports/bifrost-http/handlers/config.go
+++ b/transports/bifrost-http/handlers/config.go
@@ -217,6 +217,10 @@ func (h *ConfigHandler) getConfig(ctx *fasthttp.RequestCtx) {
 	mapConfig["is_cache_connected"] = h.store.VectorStore != nil
 	mapConfig["is_logs_connected"] = h.store.LogsStore != nil
 	mapConfig["is_object_storage_connected"] = h.store.LogsStoreConfig != nil && h.store.LogsStoreConfig.ObjectStorage != nil
+	mapConfig["hidden_request_types"] = []string{}
+	if h.store.LogsStoreConfig != nil && len(h.store.LogsStoreConfig.HiddenRequestTypes) > 0 {
+		mapConfig["hidden_request_types"] = h.store.LogsStoreConfig.HiddenRequestTypes
+	}
 	// Fetching proxy config
 	if h.store.ConfigStore != nil {
 		proxyConfig, err := h.store.ConfigStore.GetProxyConfig(ctx)

--- a/ui/app/workspace/config/views/loggingView.tsx
+++ b/ui/app/workspace/config/views/loggingView.tsx
@@ -1,10 +1,12 @@
 import PageTitle from "@/components/pageTitle";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { getErrorMessage, useGetCoreConfigQuery, useUpdateCoreConfigMutation } from "@/lib/store";
+import { RequestTypeLabels } from "@/lib/constants/logs";
 import { CoreConfig, DefaultCoreConfig } from "@/lib/types/config";
 import { parseArrayFromText } from "@/lib/utils/array";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
@@ -13,7 +15,7 @@ import { toast } from "sonner";
 
 export default function LoggingView() {
 	const hasSettingsUpdateAccess = useRbac(RbacResource.Settings, RbacOperation.Update);
-	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true });
+	const { data: bifrostConfig, isLoading: isConfigLoading, isError: isConfigError } = useGetCoreConfigQuery({ fromDB: true });
 	const config = bifrostConfig?.client_config;
 	const [updateCoreConfig, { isLoading }] = useUpdateCoreConfigMutation();
 	const [localConfig, setLocalConfig] = useState<CoreConfig>(DefaultCoreConfig);
@@ -107,6 +109,38 @@ export default function LoggingView() {
 						/>
 					</div>
 					{needsRestart && <RestartWarning />}
+				</div>
+
+				<div className="min-w-0 space-y-3 rounded-sm border p-4" data-testid="workspace-hidden-request-types">
+					<div className="space-y-0.5">
+						<p className="text-sm font-medium">Hidden Request Types</p>
+						<p className="text-muted-foreground text-sm">
+							These request types are stored normally but excluded from Logs and Dashboard views. Configure them with{" "}
+							<code className="text-xs">logs_store.hidden_request_types</code> or{" "}
+							<code className="text-xs">storage.logsStore.hiddenRequestTypes</code> in Helm.
+						</p>
+					</div>
+					{bifrostConfig?.hidden_request_types.length ? (
+						<div className="flex flex-wrap gap-2">
+							{bifrostConfig.hidden_request_types.map((requestType) => (
+								<Badge key={requestType} variant="secondary" title={requestType} className="max-w-full truncate">
+									{Object.hasOwn(RequestTypeLabels, requestType)
+										? RequestTypeLabels[requestType as keyof typeof RequestTypeLabels]
+										: requestType}
+								</Badge>
+							))}
+						</div>
+					) : bifrostConfig ? (
+						<p className="text-muted-foreground text-sm">All request types are visible.</p>
+					) : isConfigError ? (
+						<p className="text-destructive text-sm" role="alert">
+							Unable to load hidden request types.
+						</p>
+					) : (
+						<p className="text-muted-foreground text-sm" aria-live="polite">
+							{isConfigLoading ? "Loading configuration…" : "Configuration unavailable."}
+						</p>
+					)}
 				</div>
 
 				{/* Disable Content Logging - Only show when logging is enabled */}

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -651,6 +651,7 @@ export interface BifrostConfig {
 	is_cache_connected: boolean;
 	is_logs_connected: boolean;
 	is_object_storage_connected?: boolean;
+	hidden_request_types: string[];
 	is_git_available: boolean;
 	auth_token?: string;
 	metadata?: Record<string, unknown>;

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -976,6 +976,7 @@ export const bifrostConfigSchema = z.object({
 	is_db_connected: z.boolean(),
 	is_cache_connected: z.boolean(),
 	is_logs_connected: z.boolean(),
+	hidden_request_types: z.array(z.string()).default([]),
 	is_git_available: z.boolean().optional().default(false),
 });
 


### PR DESCRIPTION
## Summary

Exposes `hidden_request_types` from the logs store configuration through the API and displays them in the UI's Logging settings view. This allows users to see which request types are being filtered out of Logs and Dashboard views without needing to inspect raw configuration files.

## Changes

- The config handler now includes `hidden_request_types` in the `/config` response, returning an empty array when none are configured.
- The `BifrostConfig` TypeScript interface and Zod schema were updated to include `hidden_request_types` as a string array.
- A new read-only section was added to the Logging settings view that displays the active hidden request types as labeled badges, or a message indicating all types are visible. The section also documents the relevant config keys (`logs_store.hidden_request_types` and `storage.logsStore.hiddenRequestTypes`) for reference.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Configure `logs_store.hidden_request_types` in your config (e.g., set it to one or more request type values).
2. Start the server and navigate to **Workspace → Config → Logging**.
3. Verify the "Hidden Request Types" section appears and displays the configured types as badges with their human-readable labels.
4. Remove or leave `hidden_request_types` empty and confirm the section shows "All request types are visible."

```sh
# Core/Transports
go test ./transports/bifrost-http/...

# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the Logging settings view showing the new Hidden Request Types section._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Link related issues and discussions.

## Security considerations

No sensitive data is exposed. Hidden request types are configuration-level labels and do not reveal log content or credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable