### PR TITLE
feat(ui): hide unreleased `github-copilot` provider from the UI while preserving config.json rendering

### DIFF
--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -7,7 +7,7 @@ import { TruncatedLabel } from "@/components/ui/truncatedLabel";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { DefaultNetworkConfig, DefaultPerformanceConfig } from "@/lib/constants/config";
 import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
-import { ProviderLabels, ProviderNames } from "@/lib/constants/logs";
+import { HiddenProviders, ProviderLabels, ProviderNames, VisibleProviderNames } from "@/lib/constants/logs";
 import { useDismissedProviderCollisions } from "@/lib/hooks/useDismissedProviderCollisions";
 import {
 	getErrorMessage,
@@ -77,15 +77,21 @@ export default function Providers() {
 	const configuredProviderNamesKey = JSON.stringify(configuredProviderNamesArr);
 	const existingInSidebarNames = new Set(configuredProviders.map((p) => p.name));
 
-	const knownProviders = ProviderNames.map((name) => ({ name }));
+	const knownProviders = VisibleProviderNames.map((name) => ({ name }));
 
 	// Custom providers whose name matches a provider that is now supported natively.
 	// Databricks is excluded: it gets the guided migration dialog below instead of the advisory one.
+	// Hidden (unreleased) providers are excluded too, since the user cannot add them yet.
 	const activeCollision = collisionsHydrated
 		? findCustomProviderCollisions(configuredProviders).find((c) => {
-			const key = normalizeProviderName(c.customName);
-			return c.knownProvider !== DATABRICKS_PROVIDER && !dismissedCollisions.has(key) && !handledCollisions.has(key);
-		})
+				const key = normalizeProviderName(c.customName);
+				return (
+					c.knownProvider !== DATABRICKS_PROVIDER &&
+					!HiddenProviders.has(c.knownProvider) &&
+					!dismissedCollisions.has(key) &&
+					!handledCollisions.has(key)
+				);
+			})
 		: undefined;
 
 	// Open the migration dialog when the selected provider is a custom provider named exactly

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -39,6 +39,16 @@ export type ProviderName = (typeof KnownProvidersNames)[number];
 
 export const ProviderNames: readonly ProviderName[] = KnownProvidersNames;
 
+// Providers that exist in code but are not yet released. They are kept out of the
+// "Add Provider" picker and the first-party-integration nudge so users cannot configure
+// them from the UI. Everything else (types, schemas, icons, labels) still resolves, so a
+// provider configured via config.json continues to render correctly.
+// TODO: remove "github-copilot" once the integration has been tested and released.
+export const HiddenProviders: ReadonlySet<ProviderName> = new Set<ProviderName>(["github-copilot"]);
+
+// Known providers that users can add from the UI.
+export const VisibleProviderNames: readonly ProviderName[] = KnownProvidersNames.filter((name) => !HiddenProviders.has(name));
+
 // Built-in providers whose Bifrost implementation supports embedding requests.
 // Custom providers must instead be checked via custom_provider_config.allowed_requests.embedding.
 export const EmbeddingSupportedProviders: readonly ProviderName[] = [


### PR DESCRIPTION
## Summary

Introduces a mechanism to hide unreleased providers from the UI while keeping their underlying code (types, schemas, icons, labels) fully functional. This allows providers to be configured via `config.json` and rendered correctly without being exposed in the "Add Provider" picker or triggering first-party integration nudges.

The `github-copilot` provider is the first entry in this hidden set, pending testing and an official release.

## Changes

- Added `HiddenProviders`, a `ReadonlySet` of provider names that are implemented but not yet released, currently containing `"github-copilot"`.
- Added `VisibleProviderNames`, which filters `KnownProvidersNames` to exclude hidden providers, and replaced the use of `ProviderNames` with `VisibleProviderNames` when populating the "Add Provider" picker.
- Updated the custom provider collision detection logic to skip hidden providers, so users are not nudged to migrate to a first-party integration that isn't yet available in the UI.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Confirm `github-copilot` does not appear in the "Add Provider" picker in the UI.
2. Configure `github-copilot` manually via `config.json` and verify it renders correctly (icon, label, schema) without errors.
3. Confirm no migration/collision dialog appears for a custom provider named `github-copilot`.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Breaking changes

- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable