### PR TITLE
docs: add Projects enterprise feature with full configuration, access rules, accounting modes, and observability attribution

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -305,7 +305,12 @@
               "enterprise/access-profiles",
               "enterprise/rbac",
               "enterprise/data-access-control",
+<<<<<<< HEAD
               "enterprise/virtual-mcps",
+=======
+              "enterprise/mcp-tool-groups",
+              "enterprise/projects",
+>>>>>>> 15c99a742 (docs: add enterprise Projects page)
               {
                 "group": "Guardrails",
                 "icon": "road-barrier",

--- a/docs/enterprise/data-access-control.mdx
+++ b/docs/enterprise/data-access-control.mdx
@@ -39,7 +39,7 @@ Every role in Bifrost Enterprise has a data access scope with one of three value
 
 DAC tracks ownership on every row created through the dashboard or API. When a user makes a request, Bifrost determines who is asking, looks up the membership context (team, business unit, customer), and filters every query so the result set matches the role's scope.
 
-Resources that participate in scoping include virtual keys, prompts, teams, customers, routing rules, access profiles, guardrail configurations, business units, MCP clients, Virtual MCPs, and API keys. Resources without an ownership concept (system-wide configuration, supported provider list) are not scoped.
+Resources that participate in scoping include virtual keys, prompts, teams, customers, routing rules, access profiles, guardrail configurations, business units, MCP clients, Virtual MCPs, projects, and API keys. Resources without an ownership concept (system-wide configuration, supported provider list) are not scoped.
 
 ### Identity resolution
 
@@ -84,15 +84,16 @@ For programmatic configuration (create role, update scope, assign role to user, 
 
 The table below summarizes which rows a member sees under each scope. Resources not listed here are not row-scoped.
 
-| Resource                                                             | `own-data`                                                | `team-data`                                                             | `all-data`      |
-| -------------------------------------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------- | --------------- |
-| Virtual keys                                                         | Keys the user personally owns                             | Own keys + keys created by team members + keys attached to user's teams | All keys        |
-| Prompts                                                              | Prompts authored by the user (+ legacy unowned prompts)   | Own prompts + prompts belonging to user's teams                         | All prompts     |
-| Teams                                                                | Teams the user belongs to or created                      | Same as own + teams created by team members                             | All teams       |
-| Customers                                                            | Customers derived from user's team or virtual key linkage | Same + customers created by team members                                | All customers   |
-| Routing rules                                                        | Rules user created                                        | Rules created by user or any team member                                | All rules       |
-| Access profile attachments                                           | Attachments matching user's role                          | Attachments held by user + team members                                 | All attachments |
-| Guardrails / Audit logs / Business units / MCP clients / Virtual MCPs | Rows the user created                                     | Rows created by user + team members                                     | All rows        |
+| Resource                                                             | `own-data`                                                                            | `team-data`                                                                                 | `all-data`      |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | --------------- |
+| Virtual keys                                                         | Keys the user personally owns                                                         | Own keys + keys created by team members + keys attached to user's teams                     | All keys        |
+| Prompts                                                              | Prompts authored by the user (+ legacy unowned prompts)                               | Own prompts + prompts belonging to user's teams                                             | All prompts     |
+| Teams                                                                | Teams the user belongs to or created                                                  | Same as own + teams created by team members                                                 | All teams       |
+| Customers                                                            | Customers derived from user's team or virtual key linkage                             | Same + customers created by team members                                                    | All customers   |
+| Routing rules                                                        | Rules user created                                                                    | Rules created by user or any team member                                                    | All rules       |
+| Access profile attachments                                           | Attachments matching user's role                                                      | Attachments held by user + team members                                                     | All attachments |
+| Projects                                                             | Projects the user created or belongs to, showing only their own membership and shares | Same + projects created by or holding team members, with the roster limited to team members | All projects    |
+| Guardrails / Audit logs / Business units / MCP clients / Virtual MCPs | Rows the user created                                                                 | Rows created by user + team members                                                         | All rows        |
 
 <Note>
   Rows created before DAC was adopted remain visible under every scope. New rows always carry

--- a/docs/enterprise/overview.mdx
+++ b/docs/enterprise/overview.mdx
@@ -105,6 +105,9 @@ Decide what each user is allowed to do with the gateway: which providers, which 
   <Card title="Virtual MCPs" icon="layer-group" href="/enterprise/virtual-mcps">
     Curated bundles of MCP tools served at /mcp/&lt;slug&gt; and attachable to virtual keys and access profiles.
   </Card>
+  <Card title="Projects" icon="diagram-project" href="/enterprise/projects">
+    Per-request scopes with their own access, budget, and reporting line, chosen by the caller with a header.
+  </Card>
 </CardGroup>
 
 ---

--- a/docs/enterprise/projects.mdx
+++ b/docs/enterprise/projects.mdx
@@ -1,0 +1,658 @@
+---
+title: "Projects"
+description: "Scope a request to a piece of work with its own access, its own budget, and its own line in every report, chosen per request by the caller."
+icon: "square-kanban"
+---
+
+## Overview
+
+Bifrost Enterprise already answers **who is calling**. Virtual keys, teams, customers, business units and access profiles are all attributes of the caller: they are fixed the moment a request authenticates, and spend flows up one ownership tree.
+
+A **project** answers a different question: **what is this call for?**
+
+A project is a per-request access gate and accounting scope, activated by a header. It sits deliberately outside the ownership hierarchy. A caller keeps their own identity and their own access; naming a project re-shapes what that one request may reach and where its spend lands.
+
+A project never authenticates anything. It is not a credential, and it does not replace the caller. It composes with an already-authenticated principal, which is what keeps it orthogonal to everything else on this page.
+
+**Key benefits:**
+
+- **Chosen per request.** The same person, with the same key, can bill one call to an evaluation and the next to production support.
+- **One shared pot, with per-member slices.** A project holds a single budget that everyone draws from, and can cap each member's share of it at the same time.
+- **Can widen access, not only narrow it.** A project can add providers, models and MCP tools on top of what the caller already holds, for the duration of that request only.
+- **Can pay instead of the caller.** Spend can be taken off the caller's key, profile, team and customer limits entirely.
+- **A first-class reporting dimension.** Every log row, span, metric and warehouse export carries the project, so "what did this initiative cost" is a query rather than an inference.
+
+A project carries three parts, and nothing obliges it to use all three: an optional **access** rule composed into the request, an optional **ledger** of budgets and rate limits, and an **attribution** dimension that is always on. Switching different parts on gives the three shapes this page returns to throughout:
+
+| Shape | Access rule | What it does |
+|---|---|---|
+| **Restrict** | `intersect` | Narrows a broadly-privileged caller while they work inside the project |
+| **Extend** | `union` | Adds access the caller does not personally hold, paid for by the project |
+| **Cost center** | either, with no provider or MCP config | Leaves access untouched and only attributes and caps spend |
+
+<Info>
+To create your first project, skip to [Configuration](#configuration). The sections in between explain the fields that walkthrough asks you to fill in.
+</Info>
+
+---
+
+## When to use a project
+
+Every other governance entity describes a person or a credential. A project describes work. That gives a single decision rule:
+
+> Ask whether the access should apply to **every request this person makes, for as long as they hold it**. If yes, it is an access profile. If it should apply **only while they are doing a particular piece of work, and that work has its own budget**, it is a project.
+
+So "contractors get `gpt-4o-mini` only, with \$50 a month" is an access profile and should stay one. "This evaluation has \$5,000 and these six people can draw on it" is a project.
+
+### A worked example
+
+An organisation has a `platform` team and a `data-science` team, both under an `acme-internal` customer. Engineers sign in with SSO and hold an "Engineer" access profile: OpenAI `gpt-4o-mini` only, \$200 per month. That is the right policy for their day-to-day work and none of it should change.
+
+Leadership now wants to evaluate moving to Claude. Six named people, four from platform, two from data-science, plus one contractor, get \$5,000 for the quarter to run comparisons on Anthropic models. The spend must not touch their personal budgets, must report as one line item, must stop dead at \$5,000, and nobody else gets Anthropic.
+
+As a project that is one entity: access rule **Extend** with an Anthropic provider config, accounting **Project only**, a \$5,000 quarterly budget, split policy **Equal**, and six explicit members. The engineers keep their own identity and their own profile for everything else, and add `x-bf-project-id` to eval calls only. Those calls, and only those calls, reach Anthropic; the spend lands on the project's \$5,000 and is taken off their personal, team and customer limits; every log row carries `project=claude-eval`; and the equal split caps each member near \$833 so one person cannot drain the pot.
+
+### Why not an access profile?
+
+An access profile is the closest alternative, and it gets part of the way. It handles "these six users only" perfectly well, and if the eval profile allows Anthropic while the Engineer profile allows only OpenAI, the spend does land on the right ledger. Five things still break:
+
+- **Assignments create one ledger per person, not a shared pot.** A profile is a template; assigning it clones its budgets for each user. A \$5,000 profile given to six people is six \$5,000 budgets, so the initiative's real ceiling is \$30,000. Hand-setting \$833 each recreates the cap but not the pot: it applies only at the top tier, and every roster change means rewriting every ledger by hand.
+- **The payer becomes unpredictable as soon as the two profiles overlap.** A caller holding several profiles has one of them picked to pay, at random among those that permit the requested provider and model. An evaluation benchmarks Claude *against* the incumbent, so the moment both profiles permit `gpt-4o` the comparison calls charge the engineer's personal budget on roughly half of requests, with nothing in the request to say which.
+- **It is always on.** Access is the union of everything the caller holds, so they reach Anthropic on every request from assignment until detachment, including work unrelated to the eval. There is no per-request opt-in.
+- **Nothing marks a request as eval work.** Access profiles are not a reporting dimension. "What did the eval cost" becomes "spend where provider is Anthropic", which is wrong the moment the eval touches GPT for its baseline, or anyone uses Anthropic for anything else.
+- **The spend still rolls up the organisation.** When a profile pays, the teams and business units above the user pay too, so eval spend consumes the platform team's and the customer's budgets. Only a project's accounting mode can take a request off the caller's tree.
+
+Every one of those is the same root cause in a different costume: a profile is instantiated per person and evaluated on every request that person makes.
+
+### Why not a team or a customer?
+
+Teams and customers model reporting lines. A user's team drives which data they can see and which budgets their ordinary spend rolls up through, so inventing a `claude-eval` team to hold an initiative distorts both. Initiatives are also concurrent and short-lived where org position is singular and durable: a person belongs to one team for years while participating in several projects at once, each ending on its own schedule. And a team cannot be chosen per request, so it can never separate two kinds of work done by the same person.
+
+### Why not a shared virtual key?
+
+A shared key gets the money right, since it is one pot with one cap, and loses the person. Every log row records the same key, so there is no per-person attribution and no way to cap an individual's slice. Membership is unenforced: anyone holding the secret has the access. Most importantly a key *replaces* the caller's identity rather than composing with it, so audit, RBAC and data access control all lose track of who actually ran the request.
+
+---
+
+## How a request resolves
+
+```mermaid
+flowchart TD
+  A[Request names a project<br/>x-bf-project-id or -name] --> B{Project exists?}
+  B -- no --> R["403 access_blocked<br/>project not found"]
+  B -- yes --> C{Caller admitted?<br/>member, or open membership}
+  C -- no --> R
+  C -- yes --> D{Enabled and not expired?}
+  D -- no --> E["403 access_blocked<br/>project has expired"]
+  D -- yes --> F[Combine access<br/>per the access rule]
+  F --> G[Select which caps apply<br/>per the accounting mode]
+  G --> H[Check caps, serve, then charge]
+```
+
+### Activating a project on a request
+
+A request names a project with one of two headers:
+
+| Header | Value |
+|---|---|
+| `x-bf-project-id` | The project's id |
+| `x-bf-project-name` | The project's name, which is globally unique |
+
+The **Use project** button on a project's page shows both, with a copy-ready request that sends one of them.
+
+<Note>
+Send one or the other. If `x-bf-project-id` is present at all it decides the outcome and the name header is ignored, **including when its value is empty**. An empty or unrecognised id resolves to no project, which is refused rather than quietly falling back to the caller's own access.
+</Note>
+
+A request may name **one** project. There is no list form, and no request is placed in a project implicitly: activation is always the explicit header.
+
+When a named project cannot scope the request, the answer is `403` with `error.type` of `access_blocked` and the message `project "<name>" not found. It does not exist or does not admit this request.` That single answer deliberately covers both "no such project" and "you are not one of its members": a caller who may not use a project has no business learning whether it exists.
+
+A request that names no project is served exactly as it is today, against the caller's own access and ledgers.
+
+Resolution happens once, before the request is served, and every consumer downstream reads the **resolved** project rather than the caller's header. The same funnel governs the LLM, streaming, realtime and MCP paths, so the behaviour is identical on all of them.
+
+### Membership
+
+`membership_mode` decides who may use the project:
+
+- **`explicit`** (default) admits only the users on its roster.
+- **`open`** admits every authenticated caller. There are no member rows, so an open project cannot divide its budgets between members.
+
+Members are **users**, never keys or teams. A key authenticates a request; the user behind it is who belongs to a project.
+
+<Warning>
+A request authenticating with a plain virtual key never resolves to a user, so it can only use projects with `open` membership. Against an explicit roster it is refused exactly as though the project did not exist. If your callers present virtual keys directly rather than signing in, either open the project's membership or scope it through a user identity.
+</Warning>
+
+An `explicit` project with an empty roster is usable by nobody. This is a legitimate intermediate state while you set one up, and the dashboard says so rather than treating it as an error.
+
+### Access rules
+
+`access_rule` decides how the project's own access composes with what the caller already holds. It is **required**, it applies uniformly to providers, models, key ids and MCP tools, and there is no per-resource variant.
+
+- **`intersect`** (Restrict) permits only what the caller **and** the project both allow.
+- **`union`** (Extend) permits everything the caller already had **plus** what the project adds.
+
+<Warning>
+Under `intersect`, a project with no provider configs permits nothing at all: the intersection of "everything the caller holds" and "nothing" is empty, and every request naming it is refused. If you want a project that only attributes and caps spend, either use `union`, or give it the provider configs you intend to allow. The dashboard flags this state as **Permits Nothing** on the project list.
+</Warning>
+
+Under `union`, a project with no provider or MCP configs leaves access untouched. That is the cost-center shape: the ledger and the attribution apply, the access rule changes nothing.
+
+Two details worth knowing. Provider **weights** do not compose, because two preferences have no meaningful intersection; where the project states a weight it wins as the more specific context, and otherwise the caller's stands. And an unrecognised access rule permits nothing, since `union` is the mode that can widen a request and an unknown value must never be read as that.
+
+### Accounting modes
+
+`accounting_mode` decides whose ledgers a request draws from. The deployment's own global caps always apply: no accounting mode buys a request past them.
+
+| Mode | Project's budgets and rate limits | Member shares | Caller's own key, profile, team, customer | Deployment globals |
+|---|---|---|---|---|
+| `both` (default) | Charged | Charged | Charged | Charged |
+| `project_only` | Charged | Charged | Not consulted | Charged |
+| `principal_only` | Not consulted | Not consulted | Charged | Charged |
+
+**`both`** enforces everything. A request has to fit inside the project's caps *and* the caller's own.
+
+**`project_only`** takes the request off everything the caller funds, including their per-model budgets and the teams and business units above them. Use it when an initiative's spend genuinely should not count against the people doing the work, as in the evaluation example.
+
+**`principal_only`** is pure attribution: the project keeps its caps on record but checks and charges none of them, so the request is capped only by the caller and by the deployment. The project's own Overview tab says so explicitly while this mode is set, because a funded project that charges nothing is otherwise a confusing thing to look at.
+
+A scoped request whose caller holds no permit at all is refused under `both` and `principal_only`: those modes say the caller's money moves, and there is nothing to take it from.
+
+---
+
+## What a project allows
+
+### Provider and model access
+
+A project holds at most one configuration per provider. Each one carries:
+
+| Field | Meaning |
+|---|---|
+| `provider_name` | The provider this configuration allows |
+| `all_models_allowed` | Allows every model the provider offers |
+| `allowed_models` | An allowlist; `["*"]` means all models |
+| `blacklisted_models` | A denylist, which wins over the allowlist |
+| `key_ids` | Which provider keys may serve it; `["*"]` means all, and an empty list means none |
+| `weight` | Load-balancing preference for this provider inside the project |
+| `budgets`, `rate_limit` | Money for this provider specifically |
+| `model_budgets` | Money for individual models under this provider |
+
+A list may not mix a wildcard with named entries: `["*", "gpt-4o"]` is refused rather than interpreted. Key ids are validated when you save, and a key that does not exist or belongs to a different provider is rejected. A provider may carry up to 100 per-model budgets, each naming a concrete model; the `*` tier belongs on the provider configuration itself.
+
+### MCP servers and virtual MCPs
+
+A project opens up MCP access two ways, and both only ever add: where they overlap, they union rather than cap.
+
+**Per-client tool allowlists** name an MCP server and the tools a project may execute on it. `["*"]` allows every tool the server exposes, including ones added later; an empty list allows nothing and, importantly, still counts as the project having named that server, so a server the project deliberately closed off cannot be reopened by a default-allowed rule.
+
+**Virtual MCPs** are assigned by reference. Assigning one also makes it addressable at its slug endpoint for that request, exactly as a direct assignment to a virtual key would.
+
+Tool allowlists union within the project, and then compose with the caller's own MCP access through the project's access rule: `intersect` caps what the caller may execute while inside the project, `union` extends it.
+
+---
+
+## Budgets, limits and splits
+
+A project's budgets and rate limits are ordinary governance rows. They share every mechanic described in [Budgets and Limits](/features/governance/budget-and-limits): reset durations, quarterly and fiscal windows, cluster-wide accounting and refusal behaviour. This section covers only what is specific to projects.
+
+### Budget tiers
+
+A project can hold money at three tiers, and a request is checked against all of the ones that apply to it:
+
+- **The project's own budgets and rate limit.** Provider-agnostic: the same cap whichever provider serves the request.
+- **Per-provider budgets and rate limits**, on a provider configuration.
+- **Per-model budgets and rate limits**, on a model under a provider configuration.
+
+Whichever cap binds first refuses the request, and the refusal names the tier that ran out rather than the project as a whole. A budget refusal is `402` with `error.type` of `budget_exceeded`; a rate-limit refusal is `429` as `rate_limited`, `token_limited` or `request_limited`. Rate limits are checked before budgets, so a caller who is both throttled and out of money gets the cheaper answer consistently.
+
+### Splitting caps between members
+
+`split_policy` decides whether the project's caps are shared as one pot or sliced per member.
+
+- **`none`** (default) holds everyone together in the project's caps. Individual members can still be given their own caps by hand, from the Members tab.
+- **`equal`** gives every member an equal slice of **every budget and rate limit the project holds, at every tier**, as a cap within it. The project's own money, each provider's, and each model's all divide by head count.
+
+A member's slice is a **second cap, not a replacement**. The budget it slices still caps the whole, both are checked, and whichever binds first refuses. So six members sharing \$5,000 under an equal split are capped individually near \$833 and collectively at \$5,000.
+
+Budgets divide exactly. Rate-limit token and request counts divide with whole numbers, so a small remainder can be left unallocated rather than handed to an arbitrary member. A rate limit too small to give every member a whole unit is refused rather than stored, so an equal split can never leave a member with a slice of zero: if a project's token limit will not divide by its roster, raise the limit or shrink the roster before the edit is accepted.
+
+Adding or removing a member redivides every slice automatically. Under `equal` that work is queued and runs in the background, with progress reported in the dashboard; under `none` only the affected member's own caps change, and that happens immediately.
+
+<Note>
+Redivision moves caps, never spend. Adding a seventh member to a \$5,000 project drops everyone's slice from about \$833 to about \$714, so a member who has already spent \$900 is refused until the window resets. Removing a member widens everyone else's slice the same way.
+</Note>
+
+Per-member caps stated by hand are only available under `split_policy: none`. Under `equal` the split owns those rows, so the dashboard hides the editor and the API refuses the request. Switching a project to `equal` replaces any hand-written member caps with the equal division, and the dashboard asks before doing it.
+
+### Calendar alignment
+
+`calendar_aligned` moves a project's windows onto the calendar rather than running them from the moment each budget was created. It applies uniformly to the project's own money, every provider's and model's, and every member's derived share, so a member who joins mid-month still resets with everyone else.
+
+Windows shorter than a day cannot be aligned and stay rolling even on an aligned project. The dashboard hides the toggle when no window on the project is a day or longer.
+
+<Note>
+Turning alignment **on** re-anchors existing windows and keeps the spend already recorded against them. Turning it **off** returns those budgets to windows measured from their creation, which can land the next boundary in the past and clear the current window's spend on the next sweep. Prefer creating a project with the alignment you want.
+</Note>
+
+Quarterly budgets can name the first month of their fiscal year. Only that month's position within a quarter matters, so January, April, July and October all produce plain calendar quarters; the setting shifts anything only for the other eight starts. Rate limits carry no fiscal-quarter setting and always use calendar quarters.
+
+---
+
+## Configuration
+
+<Tabs>
+<Tab title="Web UI">
+
+Navigate to **Governance** -> **Projects** in the Bifrost dashboard.
+
+The list shows every project you can see, with its providers, the budget closest to its cap, its access rule, its accounting mode, its member count, expiry and whether it is enabled. The **Budget** column shows the tightest cap across every tier, so a project whose per-model budget is nearly spent reads as nearly spent even when its overall budget is untouched.
+
+<Frame>
+  <img
+    src="/media/projects/projects-home.png"
+    alt="Projects list page with provider chips, budget meters, access rule and member count columns"
+  />
+</Frame>
+
+### Creating a project
+
+Click **Create Project**.
+
+1. **Name and description.** The name is globally unique and is what `x-bf-project-name` refers to, so pick something callers can type.
+2. **Enabled.** On by default. A disabled project refuses every request that names it.
+3. **Expires.** Optional, with **7 days**, **30 days**, **90 days** and **1 year** presets or an explicit date. An expired project refuses every request that names it.
+4. **Access.** Who may use the project: `Explicit` to admit only a roster you manage, `Open` to admit every authenticated caller.
+
+<Frame>
+  <img
+    src="/media/projects/new-project.png"
+    alt="Create Project sheet showing name, description, enabled toggle, expiry presets and membership mode"
+  />
+</Frame>
+
+5. **Access rule.** Choose **Restrict** or **Extend**. The card explains the consequence of each, including that a Restrict project with no providers permits nothing.
+6. **Providers.** Add a provider, then choose all models or an explicit allowlist, optionally a denylist, which keys may serve it, a weight, and any per-provider or per-model money.
+
+<Frame>
+  <img
+    src="/media/projects/project-provider-config.png"
+    alt="Providers section with model allowlist, blocked models, key selection, weight and nested model budgets"
+  />
+</Frame>
+
+7. **MCP configurations.** Choose which tools the project may execute under **MCP servers**, and assign any **Virtual MCPs** it should reach.
+
+<Frame>
+  <img
+    src="/media/projects/project-mcp-config.png"
+    alt="MCP configuration section with per-server tool allowlists and virtual MCP assignment list"
+  />
+</Frame>
+
+8. **Project budget** and **Rate limit.** Add one or more budget lines, each with an amount and a reset window, then optionally a **Maximum tokens** and **Maximum requests** limit. **Align to calendar cycle** moves every window on the project onto the calendar.
+9. **Accounting.** Choose **Both budgets**, **Project only** or **User only**, and a split of **No split** or **Equal**.
+
+<Frame>
+  <img
+    src="/media/projects/project-accounting.png"
+    alt="Accounting mode and split policy selectors with explanatory copy beneath each"
+  />
+</Frame>
+
+Save with **Create Project**, or **Create & Add Members** when membership is explicit, which lands you on the new project's Members tab ready to add its roster.
+
+### The project detail view
+
+A project's page has five tabs, in this order: **Overview**, **Budgets & limits**, **Members**, **Providers** and **MCPs**. Each of the last three carries a count, and the **Use project** button beside them shows the headers a caller sends to reach the project.
+
+**Overview** opens with a **Finish Setting Up** checklist while anything essential is missing, then tiles for spend, tokens, requests, members, providers, MCP servers, the access rule, the accounting mode and when the project was created. A **Needs attention** card lists caps near or past their limit, and flags members left holding no slice of a cap under an equal split.
+
+<Frame>
+  <img
+    src="/media/projects/project-overview-tab.png"
+    alt="Project Overview tab with Finish Setting Up checklist, usage tiles and Needs attention card"
+  />
+</Frame>
+
+<Frame>
+  <img
+    src="/media/projects/project-use-project.png"
+    alt="Use project sheet showing the project headers and a copy-ready curl request"
+  />
+</Frame>
+
+**Budgets & limits** is the full ladder: the project's own caps, then each provider, with models nested beneath. Every row shows what has been used, what is left and when it resets. Deployment-wide caps appear when they are close to refusing, tagged **Global**. Rows that are not charged under the current accounting mode are dimmed with a footnote saying so.
+
+<Frame>
+  <img
+    src="/media/projects/project-limits-tab.png"
+    alt="Budgets and limits tab showing project, provider and model cap rungs with usage meters"
+  />
+</Frame>
+
+**Providers** and **MCPs** are read-only views of what the project allows: allowed and blocked models per provider with weights, and tools per server plus assigned virtual MCPs with their slug endpoints.
+
+<Frame>
+  <img
+    src="/media/projects/project-providers-tab.png"
+    alt="Providers tab listing each provider with allowed models, blocked models and weight"
+  />
+</Frame>
+
+<Frame>
+  <img
+    src="/media/projects/project-mcp-tab.png"
+    alt="MCPs tab listing servers with their allowed tools and assigned virtual MCPs"
+  />
+</Frame>
+
+### Managing members
+
+**Members** lists the roster with each member's tightest cap for spend, tokens and requests. Open membership shows an explanation instead of a roster, since there is none.
+
+<Frame>
+  <img
+    src="/media/projects/project-members-tab.png"
+    alt="Members tab with per-member spend, token and request cap meters"
+  />
+</Frame>
+
+**Add Members** takes users one at a time, or snapshots a team's current roster as a convenience. Under an equal split the sheet previews what every member's share becomes before and after, at every tier, so a roster change is never a surprise.
+
+<Frame>
+  <img
+    src="/media/projects/add-project-members.png"
+    alt="Add members sheet with user picker, team snapshot option and equal-share before-and-after preview"
+  />
+</Frame>
+
+Clicking a member opens their usage, grouped project then provider then model. From there, **Edit Caps** gives that member their own cap on any budget or rate limit the project holds, as an amount or a percentage, with a live preview translating between the two. This is available only under `No split`.
+
+<Frame>
+  <img
+    src="/media/projects/member-usage-sheet.png"
+    alt="Member usage sheet showing every cap that applies to one member, grouped by tier"
+  />
+</Frame>
+
+<Frame>
+  <img
+    src="/media/projects/edit-member-caps.png"
+    alt="Edit member caps sheet with amount or percentage unit selectors and live preview"
+  />
+</Frame>
+
+Removing a member takes their caps with them and, under an equal split, redivides the rest.
+
+### Enabling, expiring and deleting
+
+The **Enabled** switch is on the list row and in the edit sheet; disabling asks for confirmation, since every request naming the project will be refused. Expiry is a field on the edit sheet.
+
+Deleting a project removes its providers, budgets and the spend recorded against them, and removes its members' access through it. Log rows keep the attribution they already carry.
+
+<Frame>
+  <img
+    src="/media/projects/project-delete.png"
+    alt="Delete project confirmation dialog naming what is removed"
+  />
+</Frame>
+
+</Tab>
+<Tab title="config.json">
+
+Projects can be declared in `governance.projects`, which is useful for seeding the same set of projects across environments.
+
+```json
+{
+  "governance": {
+    "projects": [
+      {
+        "name": "claude-eval",
+        "description": "Q3 evaluation of Anthropic models",
+        "access_rule": "union",
+        "membership_mode": "explicit",
+        "accounting_mode": "project_only",
+        "split_policy": "equal",
+        "calendar_aligned": true,
+        "budgets": [
+          { "max_limit": 5000, "reset_duration": "1Q" }
+        ],
+        "provider_configs": [
+          {
+            "provider_name": "anthropic",
+            "all_models_allowed": true
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+<Note>
+Membership cannot be declared in the file. A project declared here starts with no members, and the schema rejects a `members` key. Add the roster from the dashboard or the API. Virtual MCP assignments are likewise dashboard and API only.
+</Note>
+
+Projects are reconciled by **name**: a name the database does not have is created, and a name it does have is updated only when the declaration has actually changed, so dashboard edits survive until the file changes. Edits keep spend, and a child the file stops declaring is removed. With `source_of_truth` set to `config.json`, declarations always overwrite the database and projects the file does not declare are deleted, members included.
+
+For the full field reference and the reconciliation rules, see [config.json governance](/deployment-guides/config-json/governance#projects).
+
+</Tab>
+<Tab title="API">
+
+All routes require the `Projects` resource, with the operation implied by the method.
+
+| Method | Path | Permission |
+|---|---|---|
+| `GET` | `/api/governance/projects` | `Projects:View` |
+| `POST` | `/api/governance/projects` | `Projects:Create` |
+| `GET` | `/api/governance/projects/{project_id}` | `Projects:View` |
+| `PUT` | `/api/governance/projects/{project_id}` | `Projects:Update` |
+| `DELETE` | `/api/governance/projects/{project_id}` | `Projects:Delete` |
+| `GET` | `/api/governance/projects/{project_id}/members` | `Projects:View` |
+| `POST` | `/api/governance/projects/{project_id}/members` | `Projects:Create` |
+| `PUT` | `/api/governance/projects/{project_id}/members/{member_id}` | `Projects:Update` |
+| `DELETE` | `/api/governance/projects/{project_id}/members/{member_id}` | `Projects:Delete` |
+| `GET` | `/api/governance/users/{user_id}/projects` | `Projects:View` |
+
+### Create a project
+
+`access_rule` is required. `membership_mode`, `accounting_mode` and `split_policy` default to `explicit`, `both` and `none`. Members are not accepted here; they are their own endpoint.
+
+```bash
+curl -X POST "$BIFROST_URL/api/governance/projects" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "claude-eval",
+    "description": "Q3 evaluation of Anthropic models",
+    "access_rule": "union",
+    "accounting_mode": "project_only",
+    "split_policy": "equal",
+    "calendar_aligned": true,
+    "budgets": [{ "max_limit": 5000, "reset_duration": "1Q" }],
+    "provider_configs": [
+      { "provider_name": "anthropic", "all_models_allowed": true }
+    ]
+  }'
+```
+
+### List projects
+
+```bash
+curl "$BIFROST_URL/api/governance/projects?search=eval&is_active=true&limit=25&offset=0" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+**Query parameters:**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `limit` | integer | Page size, clamped to 100 |
+| `offset` | integer | Page offset; `page` is accepted as an alternative |
+| `search` | string | Matches name or description, case-insensitive |
+| `is_active` | boolean | Return only enabled or only disabled projects |
+
+### Add members
+
+```bash
+curl -X POST "$BIFROST_URL/api/governance/projects/$PROJECT_ID/members" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "members": [{ "user_id": "usr_abc" }, { "user_id": "usr_def" }] }'
+```
+
+Under an equal split the response carries a `redivision_job_id`, because every member's slice of every cap is recalculated in the background.
+
+### Cap one member
+
+Only under `split_policy: none`. The body is the member's **complete** statement of caps: a source it does not name loses its cap, and an empty body clears all of them.
+
+```bash
+curl -X PUT "$BIFROST_URL/api/governance/projects/$PROJECT_ID/members/$MEMBER_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "budget_shares": [
+      { "source_budget_id": "bdg_top", "share_value": 30, "share_type": "percent" }
+    ],
+    "rate_limit_shares": [
+      { "source_rate_limit_id": "rl_top", "token_share": 50, "token_share_type": "percent" }
+    ]
+  }'
+```
+
+### Update a project
+
+Every field is optional and read-then-patch: a field you omit is left alone, while an explicit `null` clears it. Child lists are matched by id, so restate the ids you read to update them and leave out the ones you want removed. Adding `"reset_budget_usage": true` clears recorded spend on the budgets the edit restates, along with each member's slice of them.
+
+```bash
+curl -X PUT "$BIFROST_URL/api/governance/projects/$PROJECT_ID" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{ "accounting_mode": "both", "is_active": false }'
+```
+
+### Delete a project
+
+```bash
+curl -X DELETE "$BIFROST_URL/api/governance/projects/$PROJECT_ID" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Members are removed with the project.
+
+</Tab>
+</Tabs>
+
+---
+
+## Attribution and reporting
+
+Every request scoped to a project carries it through the whole observability stack, using the resolved project rather than the header the caller sent.
+
+**Logs.** Both request logs and MCP tool logs record the project's id and name. The logs list filters on projects from the sidebar and has a **Project** column, hidden by default and enabled from the column picker. A log's detail view links back to a filtered list for that project. The project filter section hides itself entirely until at least one project has appeared in your logs.
+
+**Analytics.** `project` is a ranking dimension and the dashboard has a **Project Rankings** tab, alongside cost, token and latency histograms by project. Requests carrying no project are reported under an **Unassigned** bucket rather than dropped, so the totals reconcile with real traffic and you can see how much of your spend is attributed.
+
+**Traces and metrics.** Spans carry `bifrost.project.id` and `bifrost.project.name`. Prometheus and OpenTelemetry metrics carry `project_id` and `project_name` labels on both request and MCP metrics. Because a request is scoped to at most one project, these are always scalar; there is no plural form as there is for teams and customers.
+
+**Warehouse exports.** BigQuery carries `project_id` and `project_name` columns, and the Datadog and Splunk exporters carry them as tags and attributes.
+
+---
+
+## Visibility and permissions
+
+Two independent controls apply, as they do everywhere in Bifrost Enterprise: RBAC decides **what operations** a role may perform, and data access control scopes **the result set**.
+
+The `Projects` resource carries `View`, `Create`, `Update` and `Delete`. The dashboard hides what a role cannot do: without `Update` the enabled switch and edit action are disabled, and without `Create` the add-members action is unavailable.
+
+Project visibility then follows the caller's data access scope, and projects are unusual in two ways. Membership is a visibility path in its own right, so a user sees projects they created **or belong to**, where most resources are creator-only. And the roster inside a project is scoped as well as the project row, so two administrators can open the same project and see different member lists and different per-member caps.
+
+| Scope | What the caller sees |
+|---|---|
+| `own-data` | Projects they created or belong to, showing only their own membership and caps |
+| `team-data` | The same, plus projects created by or holding team members, with the roster limited to team members |
+| `all-data` | Every project, with every member |
+
+See [Data Access Control](/enterprise/data-access-control) for how scopes are assigned.
+
+---
+
+## Examples
+
+### An evaluation with its own funding
+
+Six people from two teams get \$5,000 for the quarter to evaluate a provider nobody personally has access to, without their own budgets being touched.
+
+```json
+{
+  "name": "claude-eval",
+  "access_rule": "union",
+  "membership_mode": "explicit",
+  "accounting_mode": "project_only",
+  "split_policy": "equal",
+  "calendar_aligned": true,
+  "budgets": [{ "max_limit": 5000, "reset_duration": "1Q" }],
+  "provider_configs": [
+    { "provider_name": "anthropic", "all_models_allowed": true }
+  ]
+}
+```
+
+**Extend** adds Anthropic to what each member already holds. **Project only** keeps the spend off their personal, team and customer limits. **Equal** caps each member near \$833 while the project stops at \$5,000. Add the six members from the Members tab; each one's slice is recalculated as the roster changes.
+
+### A batch job confined to one provider
+
+A CI principal with broad access should only reach OpenAI while running the nightly batch, with that spend reported separately.
+
+```json
+{
+  "name": "nightly-batch",
+  "access_rule": "intersect",
+  "membership_mode": "open",
+  "accounting_mode": "both",
+  "split_policy": "none",
+  "budgets": [{ "max_limit": 300, "reset_duration": "1d" }],
+  "provider_configs": [
+    {
+      "provider_name": "openai",
+      "allowed_models": ["gpt-4o-mini"]
+    }
+  ]
+}
+```
+
+**Restrict** narrows the caller to the intersection, so the job reaches `gpt-4o-mini` on OpenAI and nothing else however broad its own access is. **Both** keeps the caller's own caps in force as well. Open membership means the job needs no roster, which also lets it authenticate with a plain virtual key.
+
+### A cost center for one tool
+
+An organisation wants everything done through a particular client capped and reported as one line item, without changing anyone's access.
+
+```json
+{
+  "name": "claude-code",
+  "access_rule": "union",
+  "membership_mode": "open",
+  "accounting_mode": "both",
+  "split_policy": "none",
+  "calendar_aligned": true,
+  "budgets": [{ "max_limit": 5000, "reset_duration": "1M" }]
+}
+```
+
+No provider or MCP configs, so **Extend** leaves access exactly as it was and only the ledger and the attribution apply. Open membership means anyone can opt in by sending the header. Configure the client to send `x-bf-project-name: claude-code` and its spend is capped at \$5,000 a month and reportable on its own.
+
+---
+
+## Next steps
+
+- **[Access Profiles](/enterprise/access-profiles)** - the policy container for access that belongs to a person rather than to a piece of work
+- **[Data Access Control](/enterprise/data-access-control)** - how project and roster visibility is scoped per role
+- **[RBAC](/enterprise/rbac)** - assigning the `Projects` permissions
+- **[Budgets and Limits](/features/governance/budget-and-limits)** - reset windows, fiscal quarters and how cluster-wide accounting works
+- **[Model Limits](/features/governance/model-limits)** - per-model caps and the scope system
+- **[Virtual Keys](/features/governance/virtual-keys)** - the credential a project composes with
+- **[config.json governance](/deployment-guides/config-json/governance#projects)** - the full declarative field reference

--- a/docs/features/observability/bigquery.mdx
+++ b/docs/features/observability/bigquery.mdx
@@ -235,7 +235,7 @@ Each row corresponds to one trace — one full LLM request lifecycle. The column
 
 </Accordion>
 
-<Accordion title="Governance attribution (14 columns)">
+<Accordion title="Governance attribution (16 columns)">
 
 | Column | Type | Description |
 |--------|------|-------------|
@@ -246,6 +246,7 @@ Each row corresponds to one trace — one full LLM request lifecycle. The column
 | `customer_id` / `customer_name` | `STRING` | Customer. |
 | `business_unit_id` / `business_unit_name` | `STRING` | Business unit. |
 | `user_id` / `user_name` | `STRING` | User. |
+| `project_id` / `project_name` | `STRING` | Project the request was scoped to. Not to be confused with the `project_id` in this plugin's own config, which is the GCP project holding the dataset. |
 
 </Accordion>
 

--- a/docs/features/observability/datadog.mdx
+++ b/docs/features/observability/datadog.mdx
@@ -423,7 +423,7 @@ The plugin emits the following metrics to Datadog:
 | `bifrost.cache.hits` | Counter | Cache hits | provider, model, cache_type |
 | `bifrost.stream.first_token_latency` | Histogram | Time to first token (streaming) | provider, model |
 | `bifrost.stream.inter_token_latency` | Histogram | Inter-token latency (streaming) | provider, model |
-| `bifrost.mcp.client.operation.duration` | Histogram | Duration of an MCP tool call (mirrors the OTel semconv `mcp.client.operation.duration`) | mcp_method, mcp_tool_name, network_transport, error_type, virtual_key_id, virtual_key_name, team_id, team_name, customer_id, customer_name, business_unit_id, business_unit_name |
+| `bifrost.mcp.client.operation.duration` | Histogram | Duration of an MCP tool call (mirrors the OTel semconv `mcp.client.operation.duration`) | mcp_method, mcp_tool_name, network_transport, error_type, virtual_key_id, virtual_key_name, team_id, team_name, customer_id, customer_name, business_unit_id, business_unit_name, project_id, project_name |
 
 ### Migrating from `bifrost.cost.usd`
 
@@ -502,7 +502,7 @@ Set `disable_content_logging: true` to stop message content from reaching Datado
 <Warning>
 This flag is **independent** of the global `client.disable_content_logging`, which governs the Bifrost log store only. Setting the client flag does not stop content from reaching Datadog. Set `disable_content_logging` on the Datadog connector as well.
 
-It also does **not** cover attribution identifiers. Metric tags continue to include `user_id`, `user_name`, `team_ids`, `team_names`, `customer_ids`, `customer_names`, `business_unit_ids`, and `business_unit_names`. If end-user identifiers are sensitive in your deployment, treat that as a separate concern from content logging.
+It also does **not** cover attribution identifiers. Metric tags continue to include `user_id`, `user_name`, `team_ids`, `team_names`, `customer_ids`, `customer_names`, `business_unit_ids`, `business_unit_names`, `project_id`, and `project_name`. If end-user identifiers are sensitive in your deployment, treat that as a separate concern from content logging.
 
 Values captured via `request_headers` are attached to spans regardless of this flag. Only enable header capture for headers you intend to export.
 </Warning>

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -897,7 +897,7 @@ Default port: **4317**
 
 The OTel plugin supports **push-based metrics export** via OTLP, which is essential for multi-node cluster deployments. Instead of relying on Prometheus scraping each node's `/metrics` endpoint (which can miss nodes behind a load balancer), all nodes actively push metrics to a central OTEL Collector.
 
-MCP client operations are exported as `mcp.client.operation.duration` (histogram, seconds) following the OTel MCP semantic conventions, dimensioned by `mcp.method.name`, `gen_ai.tool.name`, `network.transport`, `error.type`, and the governance dimensions `virtual_key_id`, `virtual_key_name`, `team_id`, `team_name`, `customer_id`, `customer_name`, `business_unit_id`, `business_unit_name`. This histogram covers all MCP client methods (`tools/call`, `tools/list`, `ping`, `initialize`) — to measure tool calls only, filter for `mcp.method.name="tools/call"`.
+MCP client operations are exported as `mcp.client.operation.duration` (histogram, seconds) following the OTel MCP semantic conventions, dimensioned by `mcp.method.name`, `gen_ai.tool.name`, `network.transport`, `error.type`, and the governance dimensions `virtual_key_id`, `virtual_key_name`, `team_id`, `team_name`, `customer_id`, `customer_name`, `business_unit_id`, `business_unit_name`, `project_id`, `project_name`. This histogram covers all MCP client methods (`tools/call`, `tools/list`, `ping`, `initialize`) — to measure tool calls only, filter for `mcp.method.name="tools/call"`.
 
 ### Configuration
 

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -225,7 +225,7 @@ Emitted for MCP (Model Context Protocol) tool calls executed through Bifrost:
 |--------|------|-------------|
 | `bifrost_mcp_client_operation_duration_seconds` | Histogram | Duration of an MCP tool call, observed by Bifrost (the MCP client). `_count` is call volume; a non-empty `error_type` marks failures. |
 
-Labels: `mcp_client` (server label), `mcp_tool_name`, `mcp_method` (`tools/call`), `error_type` (`auth_required` / `_OTHER` on failure, empty on success), plus the governance labels `virtual_key_id`/`virtual_key_name`, `team_id`/`team_name`, `customer_id`/`customer_name`, `business_unit_id`/`business_unit_name`, and any custom labels. Only tool executions are recorded (lifecycle `ping`/`list_tools` and codemode tools are skipped); provider/model and `network_transport` are not labels here.
+Labels: `mcp_client` (server label), `mcp_tool_name`, `mcp_method` (`tools/call`), `error_type` (`auth_required` / `_OTHER` on failure, empty on success), plus the governance labels `virtual_key_id`/`virtual_key_name`, `team_id`/`team_name`, `customer_id`/`customer_name`, `business_unit_id`/`business_unit_name`, `project_id`/`project_name`, and any custom labels. Only tool executions are recorded (lifecycle `ping`/`list_tools` and codemode tools are skipped); provider/model and `network_transport` are not labels here.
 
 ### Default Labels
 
@@ -244,6 +244,7 @@ Most request-level Bifrost LLM metrics include these labels (the `bifrost_key_ro
 - `fallback_index` - Fallback position
 - `team_id` / `team_name` - Team identifiers (empty when governance is not used)
 - `customer_id` / `customer_name` - Customer identifiers (empty when governance is not used)
+- `project_id` / `project_name` - Project the request was scoped to (empty when the request named no project). A request is scoped to at most one project, so these stay singular where team and customer identifiers can fan out
 
 <Note>
   **v1.5.0-prerelease4+**: `selected_key_id` / `selected_key_name` are only populated when the request succeeds. On final errors both are empty — use the `attempt_trail` log field to see which keys were tried.

--- a/docs/features/observability/splunk.mdx
+++ b/docs/features/observability/splunk.mdx
@@ -254,9 +254,9 @@ Acknowledgement trades a little overhead (per-channel poll traffic, plus unackno
 
 ## Attribution fields
 
-Bifrost attributes each request to a virtual key, user, team, customer, and business unit. Because a request can be attributed to a *set* (multi-tenant), the connector shapes attribution differently for events and metrics:
+Bifrost attributes each request to a virtual key, user, team, customer, business unit, and project. Because a request can be attributed to a *set* (multi-tenant), the connector shapes attribution differently for events and metrics:
 
-- **Events** carry one **multi-value** field per dimension (`team_ids`, `team_names`, `customer_ids`, `customer_names`, `business_unit_ids`, `business_unit_names`) as native JSON arrays, so `customer_ids=acme` matches a member of the set. Virtual-key and user attribution stay scalar (`virtual_key_id`, `virtual_key_name`, `user_id`, `user_name`).
+- **Events** carry one **multi-value** field per dimension (`team_ids`, `team_names`, `customer_ids`, `customer_names`, `business_unit_ids`, `business_unit_names`) as native JSON arrays, so `customer_ids=acme` matches a member of the set. Virtual-key, user, and project attribution stay scalar (`virtual_key_id`, `virtual_key_name`, `user_id`, `user_name`, `project_id`, `project_name`), since a request is scoped to at most one project.
 - **Metrics** dimensions must be scalar (a comma-joined value would break `mstats ... BY`), so metric dimensions keep the **singular** form (`customer_id`, `team_id`, ...). Multi-tenant metric attribution reflects the primary tenant only.
 
 <Note>

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -204,7 +204,9 @@
         "operationId": "listModels",
         "summary": "List available models",
         "description": "Lists available models. If provider is not specified, lists all models from all configured providers.\n\nIf a virtual key is provided, Bifrost only lists (and only queries) providers allowed by that virtual key.\n",
-        "tags": ["Models"],
+        "tags": [
+          "Models"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -285,7 +287,9 @@
         "operationId": "createChatCompletion",
         "summary": "Create a chat completion",
         "description": "Creates a completion for the provided messages. Supports streaming via SSE.\n",
-        "tags": ["Chat Completions"],
+        "tags": [
+          "Chat Completions"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -494,7 +498,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -587,7 +593,9 @@
         "operationId": "createTextCompletion",
         "summary": "Create a text completion",
         "description": "Creates a completion for the provided prompt. Supports streaming via SSE.\n",
-        "tags": ["Text Completions"],
+        "tags": [
+          "Text Completions"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -796,7 +804,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -886,7 +896,9 @@
         "operationId": "createResponse",
         "summary": "Create a response",
         "description": "Creates a response using the OpenAI Responses API format. Supports streaming via SSE.\n",
-        "tags": ["Responses"],
+        "tags": [
+          "Responses"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1024,7 +1036,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -1035,7 +1052,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -1078,11 +1097,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -1203,7 +1228,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -1246,11 +1273,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -1356,7 +1389,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -1390,11 +1425,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -1415,7 +1455,9 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -1458,11 +1500,17 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": ["format", "data"],
+                          "required": [
+                            "format",
+                            "data"
+                          ],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": ["mp3", "wav"]
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
                             },
                             "data": {
                               "type": "string"
@@ -1723,7 +1771,9 @@
         "operationId": "createResponseWebSocket",
         "summary": "Responses API over WebSocket",
         "description": "Upgrades the connection to a WebSocket and runs the OpenAI Responses API\nin WebSocket Mode. Clients send `response.create` events on the socket and\nreceive streamed events through the standard inference pipeline (PreLLMHook,\nkey selection, provider call, PostLLMHook).\n\nAuth is identical to the HTTP POST variant — Bearer/Basic/Virtual Key/API Key\nmay be supplied as request headers on the upgrade request. The OpenAI SDK can\nalso pass an API key via the `openai-insecure-api-key.<key>` WebSocket\nsubprotocol.\n\nThis GET endpoint shares its path with the POST inference endpoint; route\nselection is based on the `Upgrade: websocket` request header.\n",
-        "tags": ["Responses"],
+        "tags": [
+          "Responses"
+        ],
         "parameters": [
           {
             "name": "Upgrade",
@@ -1732,7 +1782,9 @@
             "description": "Must be `websocket`",
             "schema": {
               "type": "string",
-              "enum": ["websocket"]
+              "enum": [
+                "websocket"
+              ]
             }
           },
           {
@@ -1777,7 +1829,9 @@
         "operationId": "performOCR",
         "summary": "Perform OCR",
         "description": "Extracts text and content from documents or images using optical character recognition.\nSupports PDF URLs, base64-encoded documents, and image URLs.\n",
-        "tags": ["OCR"],
+        "tags": [
+          "OCR"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1841,7 +1895,9 @@
         "operationId": "rerankDocuments",
         "summary": "Rerank documents",
         "description": "Reorders input documents by relevance to a query.\n",
-        "tags": ["Rerank"],
+        "tags": [
+          "Rerank"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1905,7 +1961,9 @@
         "operationId": "createEmbedding",
         "summary": "Create embeddings",
         "description": "Creates an embedding vector representing the input text.\n",
-        "tags": ["Embeddings"],
+        "tags": [
+          "Embeddings"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1969,7 +2027,9 @@
         "operationId": "createSpeech",
         "summary": "Create speech",
         "description": "Generates audio from the input text. Returns audio data or streams via SSE.\n",
-        "tags": ["Audio"],
+        "tags": [
+          "Audio"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2001,7 +2061,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["speech.audio.delta", "speech.audio.done"]
+                      "enum": [
+                        "speech.audio.delta",
+                        "speech.audio.done"
+                      ]
                     },
                     "audio": {
                       "type": "string",
@@ -2071,7 +2134,9 @@
         "operationId": "createTranscription",
         "summary": "Create transcription",
         "description": "Transcribes audio into text in the input language.\n",
-        "tags": ["Audio"],
+        "tags": [
+          "Audio"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2097,7 +2162,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["transcript.text.delta", "transcript.text.done"]
+                      "enum": [
+                        "transcript.text.delta",
+                        "transcript.text.done"
+                      ]
                     },
                     "delta": {
                       "type": "string"
@@ -2130,7 +2198,10 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["tokens", "duration"]
+                          "enum": [
+                            "tokens",
+                            "duration"
+                          ]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -2207,7 +2278,9 @@
         "operationId": "imageGeneration",
         "summary": "Generate an image",
         "description": "Generates images from text prompts using the specified model.\n",
-        "tags": ["Images"],
+        "tags": [
+          "Images"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2216,7 +2289,10 @@
                 "allOf": [
                   {
                     "type": "object",
-                    "required": ["model", "prompt"],
+                    "required": [
+                      "model",
+                      "prompt"
+                    ],
                     "properties": {
                       "model": {
                         "type": "string",
@@ -2248,17 +2324,31 @@
                       },
                       "quality": {
                         "type": "string",
-                        "enum": ["auto", "high", "medium", "low", "hd", "standard"],
+                        "enum": [
+                          "auto",
+                          "high",
+                          "medium",
+                          "low",
+                          "hd",
+                          "standard"
+                        ],
                         "description": "Quality of the generated image"
                       },
                       "style": {
                         "type": "string",
-                        "enum": ["natural", "vivid"],
+                        "enum": [
+                          "natural",
+                          "vivid"
+                        ],
                         "description": "Style of the generated image"
                       },
                       "response_format": {
                         "type": "string",
-                        "enum": ["url", "b64_json", "data_uri"],
+                        "enum": [
+                          "url",
+                          "b64_json",
+                          "data_uri"
+                        ],
                         "default": "url",
                         "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                       },
@@ -2279,12 +2369,19 @@
                       },
                       "background": {
                         "type": "string",
-                        "enum": ["transparent", "opaque", "auto"],
+                        "enum": [
+                          "transparent",
+                          "opaque",
+                          "auto"
+                        ],
                         "description": "Background type for the image"
                       },
                       "moderation": {
                         "type": "string",
-                        "enum": ["low", "auto"],
+                        "enum": [
+                          "low",
+                          "auto"
+                        ],
                         "description": "Content moderation level"
                       },
                       "partial_images": {
@@ -2301,7 +2398,13 @@
                       },
                       "output_format": {
                         "type": "string",
-                        "enum": ["png", "webp", "jpeg", "tiff", "svg"],
+                        "enum": [
+                          "png",
+                          "webp",
+                          "jpeg",
+                          "tiff",
+                          "svg"
+                        ],
                         "description": "Output image format. `svg` applies to vectorize operations"
                       },
                       "user": {
@@ -2418,7 +2521,11 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": ["png", "webp", "jpeg"],
+                      "enum": [
+                        "png",
+                        "webp",
+                        "jpeg"
+                      ],
                       "description": "Output image format"
                     },
                     "quality": {
@@ -2552,7 +2659,11 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": ["png", "webp", "jpeg"],
+                      "enum": [
+                        "png",
+                        "webp",
+                        "jpeg"
+                      ],
                       "description": "Output format used"
                     },
                     "revised_prompt": {
@@ -2657,7 +2768,9 @@
         "operationId": "imageEdit",
         "summary": "Edit an image",
         "description": "Edits an image using a text prompt and optional mask. Accepts either `application/json` (sources\nas URLs or base64 under `images`) or `multipart/form-data` (to upload the image as `image` or\n`image[]`). Requires at least `model`, one image, and `prompt` - the latter except for the\noperation types driven purely by the input image, e.g. `background_removal`. Only the JSON body\npreserves the types of provider-native extra params; multipart carries every value as a string.\n",
-        "tags": ["Images"],
+        "tags": [
+          "Images"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2665,7 +2778,10 @@
               "schema": {
                 "type": "object",
                 "description": "JSON encoding of an image edit. Sources are supplied as an `images` array, the same nested form\n/v1/videos/edits uses for its source video. Unrecognised top-level fields are forwarded to the\nprovider as extra params with their JSON types intact, which is what a model's nested tuning\nobject needs (e.g. Runware's `settings` and `providerSettings`). To upload the image as a file,\npost `multipart/form-data` instead - see `ImageEditMultipartRequest`.\n",
-                "required": ["model", "images"],
+                "required": [
+                  "model",
+                  "images"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -2752,12 +2868,23 @@
                   },
                   "size": {
                     "type": "string",
-                    "enum": ["256x256", "512x512", "1024x1024", "1536x1024", "1024x1536", "auto"],
+                    "enum": [
+                      "256x256",
+                      "512x512",
+                      "1024x1024",
+                      "1536x1024",
+                      "1024x1536",
+                      "auto"
+                    ],
                     "description": "Size of the output image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": ["url", "b64_json", "data_uri"],
+                    "enum": [
+                      "url",
+                      "b64_json",
+                      "data_uri"
+                    ],
                     "default": "url",
                     "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                   },
@@ -2768,12 +2895,19 @@
                   },
                   "background": {
                     "type": "string",
-                    "enum": ["transparent", "opaque", "auto"],
+                    "enum": [
+                      "transparent",
+                      "opaque",
+                      "auto"
+                    ],
                     "description": "Background type for the image"
                   },
                   "input_fidelity": {
                     "type": "string",
-                    "enum": ["low", "high"],
+                    "enum": [
+                      "low",
+                      "high"
+                    ],
                     "description": "How closely to follow the original image"
                   },
                   "partial_images": {
@@ -2784,12 +2918,24 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": ["auto", "high", "medium", "low", "standard"],
+                    "enum": [
+                      "auto",
+                      "high",
+                      "medium",
+                      "low",
+                      "standard"
+                    ],
                     "description": "Quality of the output image"
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": ["png", "webp", "jpeg", "tiff", "svg"],
+                    "enum": [
+                      "png",
+                      "webp",
+                      "jpeg",
+                      "tiff",
+                      "svg"
+                    ],
                     "description": "Output image format. `svg` applies to vectorize operations"
                   },
                   "num_inference_steps": {
@@ -2828,7 +2974,9 @@
               "schema": {
                 "type": "object",
                 "description": "Multipart encoding of an image edit, and the only encoding that can upload the image as a file.\nThis is what the official OpenAI SDKs send unconditionally. Every value crosses the wire as a\nstring, so provider-native extra params arrive as strings; post `application/json` instead when\na provider expects them as numbers, booleans or nested objects - see `ImageEditRequest`.\n",
-                "required": ["model"],
+                "required": [
+                  "model"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -2896,12 +3044,23 @@
                   },
                   "size": {
                     "type": "string",
-                    "enum": ["256x256", "512x512", "1024x1024", "1536x1024", "1024x1536", "auto"],
+                    "enum": [
+                      "256x256",
+                      "512x512",
+                      "1024x1024",
+                      "1536x1024",
+                      "1024x1536",
+                      "auto"
+                    ],
                     "description": "Size of the output image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": ["url", "b64_json", "data_uri"],
+                    "enum": [
+                      "url",
+                      "b64_json",
+                      "data_uri"
+                    ],
                     "default": "url",
                     "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                   },
@@ -2912,12 +3071,19 @@
                   },
                   "background": {
                     "type": "string",
-                    "enum": ["transparent", "opaque", "auto"],
+                    "enum": [
+                      "transparent",
+                      "opaque",
+                      "auto"
+                    ],
                     "description": "Background type for the image"
                   },
                   "input_fidelity": {
                     "type": "string",
-                    "enum": ["low", "high"],
+                    "enum": [
+                      "low",
+                      "high"
+                    ],
                     "description": "How closely to follow the original image"
                   },
                   "partial_images": {
@@ -2928,12 +3094,24 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": ["auto", "high", "medium", "low", "standard"],
+                    "enum": [
+                      "auto",
+                      "high",
+                      "medium",
+                      "low",
+                      "standard"
+                    ],
                     "description": "Quality of the output image"
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": ["png", "webp", "jpeg", "tiff", "svg"],
+                    "enum": [
+                      "png",
+                      "webp",
+                      "jpeg",
+                      "tiff",
+                      "svg"
+                    ],
                     "description": "Output image format. `svg` applies to vectorize operations"
                   },
                   "num_inference_steps": {
@@ -3049,7 +3227,11 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": ["png", "webp", "jpeg"],
+                      "enum": [
+                        "png",
+                        "webp",
+                        "jpeg"
+                      ],
                       "description": "Output image format"
                     },
                     "quality": {
@@ -3130,7 +3312,11 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": ["image_edit.partial_image", "image_edit.completed", "error"],
+                      "enum": [
+                        "image_edit.partial_image",
+                        "image_edit.completed",
+                        "error"
+                      ],
                       "description": "Type of stream event"
                     },
                     "partial_image_index": {
@@ -3169,7 +3355,11 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": ["png", "webp", "jpeg"],
+                      "enum": [
+                        "png",
+                        "webp",
+                        "jpeg"
+                      ],
                       "description": "Output format used"
                     },
                     "revised_prompt": {
@@ -3274,14 +3464,19 @@
         "operationId": "imageVariation",
         "summary": "Create Variation",
         "description": "Creates variations of an image. Request must be sent as multipart/form-data with `model` and `image` (or `image[]`).\nDoes not support streaming.\n",
-        "tags": ["Images"],
+        "tags": [
+          "Images"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["model", "image"],
+                "required": [
+                  "model",
+                  "image"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -3314,7 +3509,10 @@
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": ["url", "b64_json"],
+                    "enum": [
+                      "url",
+                      "b64_json"
+                    ],
                     "default": "url",
                     "description": "Format of the response"
                   },
@@ -3413,7 +3611,11 @@
                     },
                     "output_format": {
                       "type": "string",
-                      "enum": ["png", "webp", "jpeg"],
+                      "enum": [
+                        "png",
+                        "webp",
+                        "jpeg"
+                      ],
                       "description": "Output image format"
                     },
                     "quality": {
@@ -3527,14 +3729,18 @@
         "operationId": "videoGeneration",
         "summary": "Generate a video",
         "description": "Creates a video generation job from a text prompt. This is an asynchronous operation\nthat returns immediately with a job ID. Use the retrieve endpoint to check the status\nand get the video URL when generation is complete.\n",
-        "tags": ["Videos"],
+        "tags": [
+          "Videos"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["model"],
+                "required": [
+                  "model"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -3557,7 +3763,11 @@
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": ["mp4", "webm", "mov"],
+                    "enum": [
+                      "mp4",
+                      "webm",
+                      "mov"
+                    ],
                     "description": "Output container format"
                   },
                   "input_reference": {
@@ -3614,7 +3824,9 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": ["video"],
+                      "enum": [
+                        "video"
+                      ],
                       "description": "Object type, always \"video\""
                     },
                     "model": {
@@ -3623,7 +3835,12 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["queued", "in_progress", "completed", "failed"],
+                      "enum": [
+                        "queued",
+                        "in_progress",
+                        "completed",
+                        "failed"
+                      ],
                       "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                     },
                     "progress": {
@@ -3672,7 +3889,10 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["url", "base64"],
+                            "enum": [
+                              "url",
+                              "base64"
+                            ],
                             "description": "Output format of this video"
                           },
                           "url": {
@@ -3769,7 +3989,9 @@
         "operationId": "videoList",
         "summary": "List video generation jobs",
         "description": "Lists video generation jobs for a specific provider. Results are paginated\nand can be filtered using query parameters.\n",
-        "tags": ["Videos"],
+        "tags": [
+          "Videos"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -3807,7 +4029,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "desc"
             },
             "description": "Sort order by creation time"
@@ -3823,7 +4048,9 @@
                   "properties": {
                     "object": {
                       "type": "string",
-                      "enum": ["list"],
+                      "enum": [
+                        "list"
+                      ],
                       "description": "Object type, always \"list\""
                     },
                     "data": {
@@ -3837,7 +4064,9 @@
                           },
                           "object": {
                             "type": "string",
-                            "enum": ["video"],
+                            "enum": [
+                              "video"
+                            ],
                             "description": "Object type, always \"video\""
                           },
                           "model": {
@@ -3846,7 +4075,12 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["queued", "in_progress", "completed", "failed"],
+                            "enum": [
+                              "queued",
+                              "in_progress",
+                              "completed",
+                              "failed"
+                            ],
                             "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                           },
                           "progress": {
@@ -3966,7 +4200,9 @@
         "operationId": "videoRetrieve",
         "summary": "Retrieve a video generation job",
         "description": "Retrieves the status and metadata for a video generation job.\nUse this endpoint to poll for completion status after creating a video generation job.\nWhen the status is \"completed\", the response will include a URL to download the video.\n",
-        "tags": ["Videos"],
+        "tags": [
+          "Videos"
+        ],
         "parameters": [
           {
             "name": "video_id",
@@ -3992,7 +4228,9 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": ["video"],
+                      "enum": [
+                        "video"
+                      ],
                       "description": "Object type, always \"video\""
                     },
                     "model": {
@@ -4001,7 +4239,12 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["queued", "in_progress", "completed", "failed"],
+                      "enum": [
+                        "queued",
+                        "in_progress",
+                        "completed",
+                        "failed"
+                      ],
                       "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                     },
                     "progress": {
@@ -4050,7 +4293,10 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["url", "base64"],
+                            "enum": [
+                              "url",
+                              "base64"
+                            ],
                             "description": "Output format of this video"
                           },
                           "url": {
@@ -4157,7 +4403,9 @@
         "operationId": "videoDelete",
         "summary": "Delete a video generation job",
         "description": "Deletes a video generation job and its associated assets.\nThis operation cannot be undone.\n",
-        "tags": ["Videos"],
+        "tags": [
+          "Videos"
+        ],
         "parameters": [
           {
             "name": "video_id",
@@ -4183,7 +4431,9 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": ["video.deleted"],
+                      "enum": [
+                        "video.deleted"
+                      ],
                       "description": "Object type, always \"video.deleted\""
                     },
                     "deleted": {
@@ -4250,7 +4500,9 @@
         "operationId": "videoDownload",
         "summary": "Download video content",
         "description": "Downloads the binary content of a generated video.\nThe video must have a status of \"completed\" to be downloadable.\nReturns the raw video file (typically MP4 format).\n",
-        "tags": ["Videos"],
+        "tags": [
+          "Videos"
+        ],
         "parameters": [
           {
             "name": "video_id",
@@ -4267,7 +4519,11 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["video", "thumbnail", "spritesheet"]
+              "enum": [
+                "video",
+                "thumbnail",
+                "spritesheet"
+              ]
             },
             "description": "Variant of the video content to download (provider-specific)"
           }
@@ -4342,7 +4598,9 @@
         "operationId": "videoRemix",
         "summary": "Remix a video",
         "description": "Creates a new video generation job by remixing an existing video with a new prompt.\nThe source video must have a status of \"completed\" to be remixed.\nReturns a new video generation job that can be polled for completion.\n",
-        "tags": ["Videos"],
+        "tags": [
+          "Videos"
+        ],
         "parameters": [
           {
             "name": "video_id",
@@ -4360,7 +4618,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["prompt"],
+                "required": [
+                  "prompt"
+                ],
                 "properties": {
                   "prompt": {
                     "type": "string",
@@ -4385,7 +4645,9 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": ["video"],
+                      "enum": [
+                        "video"
+                      ],
                       "description": "Object type, always \"video\""
                     },
                     "model": {
@@ -4394,7 +4656,12 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["queued", "in_progress", "completed", "failed"],
+                      "enum": [
+                        "queued",
+                        "in_progress",
+                        "completed",
+                        "failed"
+                      ],
                       "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                     },
                     "progress": {
@@ -4443,7 +4710,10 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["url", "base64"],
+                            "enum": [
+                              "url",
+                              "base64"
+                            ],
                             "description": "Output format of this video"
                           },
                           "url": {
@@ -4552,7 +4822,9 @@
         "operationId": "videoEdit",
         "summary": "Edit a video",
         "description": "Edits an existing video - prompt-driven editing, upscaling, or background removal, selected\nwith `type`. Accepts either `application/json` (with the source as a provider-side ID or a\nURL) or `multipart/form-data` (to upload the source as `video`). Like generation this is an\nasynchronous operation that returns a job ID; poll the retrieve endpoint for completion.\n",
-        "tags": ["Videos"],
+        "tags": [
+          "Videos"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -4560,7 +4832,10 @@
               "schema": {
                 "type": "object",
                 "description": "JSON encoding of a video edit. The source is supplied as a nested `video` object holding either\nan `id` or a `url`. To upload the source as a file, post `multipart/form-data` instead - see\n`VideoEditMultipartRequest`.\n",
-                "required": ["model", "video"],
+                "required": [
+                  "model",
+                  "video"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -4586,7 +4861,12 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["upscale", "background_removal", "remove_background", "remove_bg"],
+                    "enum": [
+                      "upscale",
+                      "background_removal",
+                      "remove_background",
+                      "remove_bg"
+                    ],
                     "description": "Operation selector. Omit for prompt-driven editing. Support varies by provider; unsupported\nvalues fall back to a standard edit.\n"
                   },
                   "seed": {
@@ -4595,7 +4875,11 @@
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": ["mp4", "webm", "mov"],
+                    "enum": [
+                      "mp4",
+                      "webm",
+                      "mov"
+                    ],
                     "description": "Output container format"
                   },
                   "upscale_factor": {
@@ -4620,7 +4904,9 @@
               "schema": {
                 "type": "object",
                 "description": "Multipart encoding of a video edit, and the only encoding that can upload a source file. This\nis what the official OpenAI SDKs send unconditionally, flattening the reference form to a\n`video[id]` field. Supply exactly one of `video`, `video[id]` or `video[url]`.\n",
-                "required": ["model"],
+                "required": [
+                  "model"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -4645,7 +4931,12 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["upscale", "background_removal", "remove_background", "remove_bg"],
+                    "enum": [
+                      "upscale",
+                      "background_removal",
+                      "remove_background",
+                      "remove_bg"
+                    ],
                     "description": "Operation selector. Omit for prompt-driven editing"
                   },
                   "seed": {
@@ -4654,7 +4945,11 @@
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": ["mp4", "webm", "mov"],
+                    "enum": [
+                      "mp4",
+                      "webm",
+                      "mov"
+                    ],
                     "description": "Output container format"
                   },
                   "upscale_factor": {
@@ -4684,7 +4979,9 @@
                     },
                     "object": {
                       "type": "string",
-                      "enum": ["video"],
+                      "enum": [
+                        "video"
+                      ],
                       "description": "Object type, always \"video\""
                     },
                     "model": {
@@ -4693,7 +4990,12 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["queued", "in_progress", "completed", "failed"],
+                      "enum": [
+                        "queued",
+                        "in_progress",
+                        "completed",
+                        "failed"
+                      ],
                       "description": "Current lifecycle status of the video generation job:\n- `queued`: Job is waiting to be processed\n- `in_progress`: Video is currently being generated\n- `completed`: Video generation completed successfully\n- `failed`: Video generation failed\n"
                     },
                     "progress": {
@@ -4742,7 +5044,10 @@
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["url", "base64"],
+                            "enum": [
+                              "url",
+                              "base64"
+                            ],
                             "description": "Output format of this video"
                           },
                           "url": {
@@ -4841,7 +5146,9 @@
         "operationId": "countTokens",
         "summary": "Count tokens",
         "description": "Counts the number of tokens in the provided messages.\n",
-        "tags": ["Count Tokens"],
+        "tags": [
+          "Count Tokens"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -4905,14 +5212,18 @@
         "operationId": "createCompaction",
         "summary": "Compact context",
         "description": "Compresses a conversation into an opaque encrypted compaction item using the\nOpenAI-compatible context compaction API.\n\nThe response `output` array contains the original user messages plus a final item\nwith `type: \"response.compaction\"` and an `encrypted_content` field. Pass the\nfull `output` array as `input` to future Responses API requests to continue the\nconversation without retransmitting the full history.\n\n**Supported providers:** OpenAI, Azure OpenAI, xAI. Requests to unsupported\nproviders return a 400 error.\n",
-        "tags": ["Compaction"],
+        "tags": [
+          "Compaction"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["model"],
+                "required": [
+                  "model"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -4969,7 +5280,12 @@
                             },
                             "role": {
                               "type": "string",
-                              "enum": ["assistant", "user", "system", "developer"]
+                              "enum": [
+                                "assistant",
+                                "user",
+                                "system",
+                                "developer"
+                              ]
                             },
                             "content": {
                               "oneOf": [
@@ -4980,7 +5296,9 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
@@ -5023,11 +5341,17 @@
                                       },
                                       "input_audio": {
                                         "type": "object",
-                                        "required": ["format", "data"],
+                                        "required": [
+                                          "format",
+                                          "data"
+                                        ],
                                         "properties": {
                                           "format": {
                                             "type": "string",
-                                            "enum": ["mp3", "wav"]
+                                            "enum": [
+                                              "mp3",
+                                              "wav"
+                                            ]
                                           },
                                           "data": {
                                             "type": "string"
@@ -5148,7 +5472,9 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
@@ -5191,11 +5517,17 @@
                                       },
                                       "input_audio": {
                                         "type": "object",
-                                        "required": ["format", "data"],
+                                        "required": [
+                                          "format",
+                                          "data"
+                                        ],
                                         "properties": {
                                           "format": {
                                             "type": "string",
-                                            "enum": ["mp3", "wav"]
+                                            "enum": [
+                                              "mp3",
+                                              "wav"
+                                            ]
                                           },
                                           "data": {
                                             "type": "string"
@@ -5301,7 +5633,9 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": ["computer_screenshot"]
+                                      "enum": [
+                                        "computer_screenshot"
+                                      ]
                                     },
                                     "file_id": {
                                       "type": "string"
@@ -5335,11 +5669,16 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type", "text"],
+                                "required": [
+                                  "type",
+                                  "text"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["summary_text"]
+                                    "enum": [
+                                      "summary_text"
+                                    ]
                                   },
                                   "text": {
                                     "type": "string"
@@ -5453,7 +5792,12 @@
                           },
                           "role": {
                             "type": "string",
-                            "enum": ["assistant", "user", "system", "developer"]
+                            "enum": [
+                              "assistant",
+                              "user",
+                              "system",
+                              "developer"
+                            ]
                           },
                           "content": {
                             "oneOf": [
@@ -5464,7 +5808,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "properties": {
                                     "type": {
                                       "type": "string",
@@ -5507,11 +5853,17 @@
                                     },
                                     "input_audio": {
                                       "type": "object",
-                                      "required": ["format", "data"],
+                                      "required": [
+                                        "format",
+                                        "data"
+                                      ],
                                       "properties": {
                                         "format": {
                                           "type": "string",
-                                          "enum": ["mp3", "wav"]
+                                          "enum": [
+                                            "mp3",
+                                            "wav"
+                                          ]
                                         },
                                         "data": {
                                           "type": "string"
@@ -5632,7 +5984,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "properties": {
                                     "type": {
                                       "type": "string",
@@ -5675,11 +6029,17 @@
                                     },
                                     "input_audio": {
                                       "type": "object",
-                                      "required": ["format", "data"],
+                                      "required": [
+                                        "format",
+                                        "data"
+                                      ],
                                       "properties": {
                                         "format": {
                                           "type": "string",
-                                          "enum": ["mp3", "wav"]
+                                          "enum": [
+                                            "mp3",
+                                            "wav"
+                                          ]
                                         },
                                         "data": {
                                           "type": "string"
@@ -5785,7 +6145,9 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["computer_screenshot"]
+                                    "enum": [
+                                      "computer_screenshot"
+                                    ]
                                   },
                                   "file_id": {
                                     "type": "string"
@@ -5819,11 +6181,16 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["type", "text"],
+                              "required": [
+                                "type",
+                                "text"
+                              ],
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["summary_text"]
+                                  "enum": [
+                                    "summary_text"
+                                  ]
                                 },
                                 "text": {
                                   "type": "string"
@@ -5953,7 +6320,9 @@
         "operationId": "retrieveResponse",
         "summary": "Retrieve a response",
         "description": "Retrieves a stored response by ID.\n",
-        "tags": ["Responses"],
+        "tags": [
+          "Responses"
+        ],
         "parameters": [
           {
             "name": "response_id",
@@ -6135,7 +6504,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -6146,7 +6520,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -6189,11 +6565,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -6314,7 +6696,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -6357,11 +6741,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -6467,7 +6857,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -6501,11 +6893,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -6526,7 +6923,9 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -6569,11 +6968,17 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": ["format", "data"],
+                          "required": [
+                            "format",
+                            "data"
+                          ],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": ["mp3", "wav"]
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
                             },
                             "data": {
                               "type": "string"
@@ -6844,7 +7249,9 @@
         "operationId": "deleteResponse",
         "summary": "Delete a response",
         "description": "Deletes a stored response.\n",
-        "tags": ["Responses"],
+        "tags": [
+          "Responses"
+        ],
         "parameters": [
           {
             "name": "response_id",
@@ -6927,7 +7334,9 @@
         "operationId": "cancelResponse",
         "summary": "Cancel a response",
         "description": "Cancels an in-flight response. Only responses created with `background: true`\ncan be cancelled.\n",
-        "tags": ["Responses"],
+        "tags": [
+          "Responses"
+        ],
         "parameters": [
           {
             "name": "response_id",
@@ -7010,7 +7419,9 @@
         "operationId": "listResponseInputItems",
         "summary": "List response input items",
         "description": "Lists the input items of a stored response.\n",
-        "tags": ["Responses"],
+        "tags": [
+          "Responses"
+        ],
         "parameters": [
           {
             "name": "response_id",
@@ -7063,7 +7474,10 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           }
         ],
@@ -7130,7 +7544,9 @@
         "operationId": "createBatch",
         "summary": "Create a batch job",
         "description": "Creates a batch job for asynchronous processing.\n",
-        "tags": ["Batch"],
+        "tags": [
+          "Batch"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -7192,7 +7608,9 @@
         "operationId": "listBatches",
         "summary": "List batch jobs",
         "description": "Lists batch jobs for a provider.\n",
-        "tags": ["Batch"],
+        "tags": [
+          "Batch"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -7282,7 +7700,9 @@
         "operationId": "retrieveBatch",
         "summary": "Retrieve a batch job",
         "description": "Retrieves a specific batch job by ID.\n",
-        "tags": ["Batch"],
+        "tags": [
+          "Batch"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -7356,7 +7776,9 @@
         "operationId": "cancelBatch",
         "summary": "Cancel a batch job",
         "description": "Cancels a batch job.\n",
-        "tags": ["Batch"],
+        "tags": [
+          "Batch"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -7489,7 +7911,9 @@
         "operationId": "getBatchResults",
         "summary": "Get batch results",
         "description": "Retrieves results from a completed batch job.\n",
-        "tags": ["Batch"],
+        "tags": [
+          "Batch"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -7624,7 +8048,9 @@
         "operationId": "uploadFile",
         "summary": "Upload a file",
         "description": "Uploads a file to be used with batch operations or other features.\n",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -7696,7 +8122,9 @@
         "operationId": "listFiles",
         "summary": "List files",
         "description": "Lists files for a provider.\n",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -7748,7 +8176,10 @@
             "description": "Sort order (asc/desc)",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           }
         ],
@@ -7805,7 +8236,9 @@
         "operationId": "retrieveFile",
         "summary": "Retrieve file metadata",
         "description": "Retrieves metadata for a specific file.\n",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -7866,7 +8299,13 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["uploaded", "processed", "processing", "error", "deleted"]
+                      "enum": [
+                        "uploaded",
+                        "processed",
+                        "processing",
+                        "error",
+                        "deleted"
+                      ]
                     },
                     "status_details": {
                       "type": "string"
@@ -7929,7 +8368,9 @@
         "operationId": "deleteFile",
         "summary": "Delete a file",
         "description": "Deletes a file.\n",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -8017,7 +8458,9 @@
         "operationId": "getFileContent",
         "summary": "Download file content",
         "description": "Downloads the content of a file.\n",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -8092,14 +8535,19 @@
         "operationId": "createContainer",
         "summary": "Create a container",
         "description": "Creates a new container for storing files and data.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["provider", "name"],
+                "required": [
+                  "provider",
+                  "name"
+                ],
                 "properties": {
                   "provider": {
                     "$ref": "#/components/schemas/ModelProvider"
@@ -8172,7 +8620,9 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["running"],
+                      "enum": [
+                        "running"
+                      ],
                       "description": "The status of a container"
                     },
                     "expires_after": {
@@ -8253,7 +8703,9 @@
         "operationId": "listContainers",
         "summary": "List containers",
         "description": "Lists containers for a provider.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -8289,7 +8741,10 @@
             "description": "Sort order (asc/desc)",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           }
         ],
@@ -8330,7 +8785,9 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["running"],
+                            "enum": [
+                              "running"
+                            ],
                             "description": "The status of a container"
                           },
                           "expires_after": {
@@ -8429,7 +8886,9 @@
         "operationId": "retrieveContainer",
         "summary": "Retrieve a container",
         "description": "Retrieves a specific container by ID.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -8477,7 +8936,9 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["running"],
+                      "enum": [
+                        "running"
+                      ],
                       "description": "The status of a container"
                     },
                     "expires_after": {
@@ -8558,7 +9019,9 @@
         "operationId": "deleteContainer",
         "summary": "Delete a container",
         "description": "Deletes a container.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -8649,7 +9112,9 @@
         "operationId": "createContainerFile",
         "summary": "Create a file in a container",
         "description": "Creates a new file in a container. You can either upload file content directly\nvia multipart/form-data or reference an existing file by its ID.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -8694,7 +9159,9 @@
               "schema": {
                 "type": "object",
                 "description": "Request to create a file in a container by referencing an existing file",
-                "required": ["file_id"],
+                "required": [
+                  "file_id"
+                ],
                 "properties": {
                   "file_id": {
                     "type": "string",
@@ -8796,7 +9263,9 @@
         "operationId": "listContainerFiles",
         "summary": "List files in a container",
         "description": "Lists all files in a container.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -8840,7 +9309,10 @@
             "description": "Sort order (asc/desc)",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           }
         ],
@@ -8959,7 +9431,9 @@
         "operationId": "retrieveContainerFile",
         "summary": "Retrieve a file from a container",
         "description": "Retrieves metadata for a specific file in a container.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -9076,7 +9550,9 @@
         "operationId": "deleteContainerFile",
         "summary": "Delete a file from a container",
         "description": "Deletes a file from a container.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -9177,7 +9653,9 @@
         "operationId": "getContainerFileContent",
         "summary": "Download file content from a container",
         "description": "Downloads the content of a file from a container.\n",
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -9261,7 +9739,9 @@
         "operationId": "createAsyncChatCompletion",
         "summary": "Create async chat completion",
         "description": "Submits a chat completion request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9333,7 +9813,9 @@
         "operationId": "createAsyncTextCompletion",
         "summary": "Create async text completion",
         "description": "Submits a text completion request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9405,7 +9887,9 @@
         "operationId": "createAsyncResponse",
         "summary": "Create async response",
         "description": "Submits a response request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9477,7 +9961,9 @@
         "operationId": "createAsyncEmbedding",
         "summary": "Create async embedding",
         "description": "Submits an embedding request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9549,7 +10035,9 @@
         "operationId": "createAsyncSpeech",
         "summary": "Create async speech",
         "description": "Submits a speech synthesis request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nSSE streaming is not supported for async requests.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9621,7 +10109,9 @@
         "operationId": "createAsyncTranscription",
         "summary": "Create async transcription",
         "description": "Submits a transcription request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9693,7 +10183,9 @@
         "operationId": "createAsyncImageGeneration",
         "summary": "Create async image generation",
         "description": "Submits an image generation request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9710,7 +10202,10 @@
                 "allOf": [
                   {
                     "type": "object",
-                    "required": ["model", "prompt"],
+                    "required": [
+                      "model",
+                      "prompt"
+                    ],
                     "properties": {
                       "model": {
                         "type": "string",
@@ -9742,17 +10237,31 @@
                       },
                       "quality": {
                         "type": "string",
-                        "enum": ["auto", "high", "medium", "low", "hd", "standard"],
+                        "enum": [
+                          "auto",
+                          "high",
+                          "medium",
+                          "low",
+                          "hd",
+                          "standard"
+                        ],
                         "description": "Quality of the generated image"
                       },
                       "style": {
                         "type": "string",
-                        "enum": ["natural", "vivid"],
+                        "enum": [
+                          "natural",
+                          "vivid"
+                        ],
                         "description": "Style of the generated image"
                       },
                       "response_format": {
                         "type": "string",
-                        "enum": ["url", "b64_json", "data_uri"],
+                        "enum": [
+                          "url",
+                          "b64_json",
+                          "data_uri"
+                        ],
                         "default": "url",
                         "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                       },
@@ -9773,12 +10282,19 @@
                       },
                       "background": {
                         "type": "string",
-                        "enum": ["transparent", "opaque", "auto"],
+                        "enum": [
+                          "transparent",
+                          "opaque",
+                          "auto"
+                        ],
                         "description": "Background type for the image"
                       },
                       "moderation": {
                         "type": "string",
-                        "enum": ["low", "auto"],
+                        "enum": [
+                          "low",
+                          "auto"
+                        ],
                         "description": "Content moderation level"
                       },
                       "partial_images": {
@@ -9795,7 +10311,13 @@
                       },
                       "output_format": {
                         "type": "string",
-                        "enum": ["png", "webp", "jpeg", "tiff", "svg"],
+                        "enum": [
+                          "png",
+                          "webp",
+                          "jpeg",
+                          "tiff",
+                          "svg"
+                        ],
                         "description": "Output image format. `svg` applies to vectorize operations"
                       },
                       "user": {
@@ -9886,7 +10408,9 @@
         "operationId": "createAsyncImageEdit",
         "summary": "Create async image edit",
         "description": "Submits an image edit request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\nStreaming is not supported for async requests.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -9902,7 +10426,10 @@
               "schema": {
                 "type": "object",
                 "description": "JSON encoding of an image edit. Sources are supplied as an `images` array, the same nested form\n/v1/videos/edits uses for its source video. Unrecognised top-level fields are forwarded to the\nprovider as extra params with their JSON types intact, which is what a model's nested tuning\nobject needs (e.g. Runware's `settings` and `providerSettings`). To upload the image as a file,\npost `multipart/form-data` instead - see `ImageEditMultipartRequest`.\n",
-                "required": ["model", "images"],
+                "required": [
+                  "model",
+                  "images"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -9989,12 +10516,23 @@
                   },
                   "size": {
                     "type": "string",
-                    "enum": ["256x256", "512x512", "1024x1024", "1536x1024", "1024x1536", "auto"],
+                    "enum": [
+                      "256x256",
+                      "512x512",
+                      "1024x1024",
+                      "1536x1024",
+                      "1024x1536",
+                      "auto"
+                    ],
                     "description": "Size of the output image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": ["url", "b64_json", "data_uri"],
+                    "enum": [
+                      "url",
+                      "b64_json",
+                      "data_uri"
+                    ],
                     "default": "url",
                     "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                   },
@@ -10005,12 +10543,19 @@
                   },
                   "background": {
                     "type": "string",
-                    "enum": ["transparent", "opaque", "auto"],
+                    "enum": [
+                      "transparent",
+                      "opaque",
+                      "auto"
+                    ],
                     "description": "Background type for the image"
                   },
                   "input_fidelity": {
                     "type": "string",
-                    "enum": ["low", "high"],
+                    "enum": [
+                      "low",
+                      "high"
+                    ],
                     "description": "How closely to follow the original image"
                   },
                   "partial_images": {
@@ -10021,12 +10566,24 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": ["auto", "high", "medium", "low", "standard"],
+                    "enum": [
+                      "auto",
+                      "high",
+                      "medium",
+                      "low",
+                      "standard"
+                    ],
                     "description": "Quality of the output image"
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": ["png", "webp", "jpeg", "tiff", "svg"],
+                    "enum": [
+                      "png",
+                      "webp",
+                      "jpeg",
+                      "tiff",
+                      "svg"
+                    ],
                     "description": "Output image format. `svg` applies to vectorize operations"
                   },
                   "num_inference_steps": {
@@ -10065,7 +10622,9 @@
               "schema": {
                 "type": "object",
                 "description": "Multipart encoding of an image edit, and the only encoding that can upload the image as a file.\nThis is what the official OpenAI SDKs send unconditionally. Every value crosses the wire as a\nstring, so provider-native extra params arrive as strings; post `application/json` instead when\na provider expects them as numbers, booleans or nested objects - see `ImageEditRequest`.\n",
-                "required": ["model"],
+                "required": [
+                  "model"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -10133,12 +10692,23 @@
                   },
                   "size": {
                     "type": "string",
-                    "enum": ["256x256", "512x512", "1024x1024", "1536x1024", "1024x1536", "auto"],
+                    "enum": [
+                      "256x256",
+                      "512x512",
+                      "1024x1024",
+                      "1536x1024",
+                      "1024x1536",
+                      "auto"
+                    ],
                     "description": "Size of the output image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": ["url", "b64_json", "data_uri"],
+                    "enum": [
+                      "url",
+                      "b64_json",
+                      "data_uri"
+                    ],
                     "default": "url",
                     "description": "Format of the response. `data_uri` is supported by providers that return an inline\ndata URI (e.g. Runware).\n"
                   },
@@ -10149,12 +10719,19 @@
                   },
                   "background": {
                     "type": "string",
-                    "enum": ["transparent", "opaque", "auto"],
+                    "enum": [
+                      "transparent",
+                      "opaque",
+                      "auto"
+                    ],
                     "description": "Background type for the image"
                   },
                   "input_fidelity": {
                     "type": "string",
-                    "enum": ["low", "high"],
+                    "enum": [
+                      "low",
+                      "high"
+                    ],
                     "description": "How closely to follow the original image"
                   },
                   "partial_images": {
@@ -10165,12 +10742,24 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": ["auto", "high", "medium", "low", "standard"],
+                    "enum": [
+                      "auto",
+                      "high",
+                      "medium",
+                      "low",
+                      "standard"
+                    ],
                     "description": "Quality of the output image"
                   },
                   "output_format": {
                     "type": "string",
-                    "enum": ["png", "webp", "jpeg", "tiff", "svg"],
+                    "enum": [
+                      "png",
+                      "webp",
+                      "jpeg",
+                      "tiff",
+                      "svg"
+                    ],
                     "description": "Output image format. `svg` applies to vectorize operations"
                   },
                   "num_inference_steps": {
@@ -10260,7 +10849,9 @@
         "operationId": "createAsyncImageVariation",
         "summary": "Create async image variation",
         "description": "Submits an image variation request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -10275,7 +10866,10 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["model", "image"],
+                "required": [
+                  "model",
+                  "image"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -10308,7 +10902,10 @@
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": ["url", "b64_json"],
+                    "enum": [
+                      "url",
+                      "b64_json"
+                    ],
                     "default": "url",
                     "description": "Format of the response"
                   },
@@ -10381,7 +10978,9 @@
         "operationId": "getAsyncChatCompletionJob",
         "summary": "Get async chat completion job",
         "description": "Retrieves the status and result of an async chat completion job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10440,7 +11039,9 @@
         "operationId": "getAsyncTextCompletionJob",
         "summary": "Get async text completion job",
         "description": "Retrieves the status and result of an async text completion job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10499,7 +11100,9 @@
         "operationId": "getAsyncResponseJob",
         "summary": "Get async response job",
         "description": "Retrieves the status and result of an async response job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10558,7 +11161,9 @@
         "operationId": "getAsyncEmbeddingJob",
         "summary": "Get async embedding job",
         "description": "Retrieves the status and result of an async embedding job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10617,7 +11222,9 @@
         "operationId": "getAsyncSpeechJob",
         "summary": "Get async speech job",
         "description": "Retrieves the status and result of an async speech job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10676,7 +11283,9 @@
         "operationId": "getAsyncTranscriptionJob",
         "summary": "Get async transcription job",
         "description": "Retrieves the status and result of an async transcription job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10735,7 +11344,9 @@
         "operationId": "getAsyncImageGenerationJob",
         "summary": "Get async image generation job",
         "description": "Retrieves the status and result of an async image generation job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10794,7 +11405,9 @@
         "operationId": "getAsyncImageEditJob",
         "summary": "Get async image edit job",
         "description": "Retrieves the status and result of an async image edit job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10853,7 +11466,9 @@
         "operationId": "getAsyncImageVariationJob",
         "summary": "Get async image variation job",
         "description": "Retrieves the status and result of an async image variation job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -10912,7 +11527,9 @@
         "operationId": "createAsyncRerank",
         "summary": "Create async rerank",
         "description": "Submits a rerank request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -10984,7 +11601,9 @@
         "operationId": "getAsyncRerankJob",
         "summary": "Get async rerank job",
         "description": "Retrieves the status and result of an async rerank job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11043,7 +11662,9 @@
         "operationId": "createAsyncOCR",
         "summary": "Create async OCR job",
         "description": "Submits an OCR request for asynchronous execution. Returns a job ID immediately\nwith HTTP 202. Poll the corresponding GET endpoint with the job ID to retrieve the result.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncResultTTL"
@@ -11112,7 +11733,9 @@
         "operationId": "getAsyncOCRJob",
         "summary": "Get async OCR job",
         "description": "Retrieves the status and result of an async OCR job.\nReturns HTTP 202 if the job is still pending or processing, HTTP 200 if completed or failed.\n",
-        "tags": ["Async Jobs"],
+        "tags": [
+          "Async Jobs"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/AsyncJobId"
@@ -11171,7 +11794,9 @@
         "operationId": "connectRealtime",
         "summary": "Realtime API WebSocket",
         "description": "Opens a bidirectional WebSocket session to a realtime-capable provider\n(e.g. OpenAI Realtime, Azure Realtime preview). Bifrost proxies the upstream\nsocket and applies governance, observability, and key selection on connect.\n\nThe target model is provided via the `model` query parameter (or `deployment`\nfor Azure-style routes). The OpenAI SDK sends the API key over the\n`openai-insecure-api-key.<key>` WebSocket subprotocol; Bifrost extracts it and\ntreats it the same as a Bearer header.\n\nInference auth applies — Bearer/Basic/Virtual Key/API Key headers are all\naccepted, plus the subprotocol form above.\n",
-        "tags": ["Realtime"],
+        "tags": [
+          "Realtime"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -11198,7 +11823,9 @@
             "description": "Must be `websocket`",
             "schema": {
               "type": "string",
-              "enum": ["websocket"]
+              "enum": [
+                "websocket"
+              ]
             }
           },
           {
@@ -11243,14 +11870,19 @@
         "operationId": "createRealtimeCall",
         "summary": "Realtime WebRTC SDP exchange",
         "description": "Negotiates a WebRTC peer connection with the realtime provider on behalf of\nthe client. Implements the OpenAI GA `/realtime/calls` contract: the request\nbody is `multipart/form-data` with `sdp` (client SDP offer) and `session`\n(JSON session description containing `model`).\n\nBifrost forwards the offer to the upstream provider, returns the upstream\nSDP answer to the client, and pipes RTP media between the two peers for the\nlifetime of the session.\n\nInference auth applies (Bearer/Basic/Virtual Key/API Key).\n",
-        "tags": ["Realtime"],
+        "tags": [
+          "Realtime"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["sdp", "session"],
+                "required": [
+                  "sdp",
+                  "session"
+                ],
                 "properties": {
                   "sdp": {
                     "type": "string",
@@ -11320,7 +11952,9 @@
         "operationId": "createRealtimeClientSecret",
         "summary": "Mint a realtime ephemeral client secret",
         "description": "Calls the upstream realtime provider's `client_secrets` endpoint to mint a\nshort-lived ephemeral token (e.g. for browser-based WebRTC clients).\nBifrost selects a provider key, evaluates governance, and proxies the\nresponse. The returned token is cached and mapped to the originating\nvirtual key for downstream attribution.\n\nRequest body must be JSON. `session.model` (or top-level `model`) must use\n`provider/model` form.\n",
-        "tags": ["Realtime"],
+        "tags": [
+          "Realtime"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -11389,7 +12023,9 @@
         "operationId": "createRealtimeSession",
         "summary": "Mint a realtime session (legacy alias)",
         "description": "Legacy alias for the realtime client-secret minting endpoint. Behaves\nidentically to `createRealtimeClientSecret` but uses the `sessions` route\nshape; provided for compatibility with older OpenAI Realtime client\nlibraries.\n",
-        "tags": ["Realtime"],
+        "tags": [
+          "Realtime"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -11458,7 +12094,9 @@
         "operationId": "openaiCreateChatCompletion",
         "summary": "Create chat completion (OpenAI format)",
         "description": "Creates a chat completion using OpenAI-compatible format.\nSupports streaming via SSE.\n\n**Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response will have an empty `choices` array. When completed, `choices` will contain the full result. See [Async Inference](/features/async-inference) for details.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/chat/completions`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "x-bf-async",
@@ -11466,7 +12104,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["true"]
+              "enum": [
+                "true"
+              ]
             },
             "description": "Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming."
           },
@@ -11698,7 +12338,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -11791,7 +12433,10 @@
         "operationId": "azureCreateChatCompletion",
         "summary": "Create chat completion (Azure OpenAI)",
         "description": "Creates a chat completion using Azure OpenAI deployment.\n",
-        "tags": ["OpenAI Integration", "Azure Integration"],
+        "tags": [
+          "OpenAI Integration",
+          "Azure Integration"
+        ],
         "parameters": [
           {
             "name": "deployment-id",
@@ -12019,7 +12664,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -12112,7 +12759,9 @@
         "operationId": "openaiCreateTextCompletion",
         "summary": "Create text completion (OpenAI format)",
         "description": "Creates a text completion using OpenAI-compatible format.\nThis is the legacy completions API.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/completions`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -12321,7 +12970,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -12410,7 +13061,10 @@
       "post": {
         "operationId": "azureCreateTextCompletion",
         "summary": "Create text completion (Azure OpenAI)",
-        "tags": ["OpenAI Integration", "Azure Integration"],
+        "tags": [
+          "OpenAI Integration",
+          "Azure Integration"
+        ],
         "parameters": [
           {
             "name": "deployment-id",
@@ -12637,7 +13291,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -12727,7 +13383,9 @@
         "operationId": "openaiCreateResponse",
         "summary": "Create response (OpenAI Responses API)",
         "description": "Creates a response using OpenAI Responses API format.\nSupports streaming via SSE.\n\n**Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response `status` will not be `completed`. When completed, the full response with `output_text` will be returned. See [Async Inference](/features/async-inference) for details.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "x-bf-async",
@@ -12735,7 +13393,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["true"]
+              "enum": [
+                "true"
+              ]
             },
             "description": "Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming."
           },
@@ -12896,7 +13556,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -12907,7 +13572,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -12950,11 +13617,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -13075,7 +13748,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -13118,11 +13793,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -13228,7 +13909,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -13262,11 +13945,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -13287,7 +13975,9 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -13330,11 +14020,17 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": ["format", "data"],
+                          "required": [
+                            "format",
+                            "data"
+                          ],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": ["mp3", "wav"]
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
                             },
                             "data": {
                               "type": "string"
@@ -13595,7 +14291,9 @@
         "operationId": "openaiResponsesWebSocket",
         "summary": "WebSocket Responses (OpenAI alias)",
         "description": "WebSocket upgrade endpoint for the Responses API. Mirrors the canonical\n`GET /v1/responses` WS endpoint; the OpenAI-prefixed path is selected\nwhen the request includes an `Upgrade: websocket` header.\nAuthentication accepts the same headers as the inference HTTP surface\nplus the `openai-insecure-api-key.<key>` subprotocol fallback.\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "Upgrade",
@@ -13603,7 +14301,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["websocket"]
+              "enum": [
+                "websocket"
+              ]
             }
           },
           {
@@ -13647,7 +14347,10 @@
       "post": {
         "operationId": "azureCreateResponse",
         "summary": "Create response (Azure OpenAI)",
-        "tags": ["OpenAI Integration", "Azure Integration"],
+        "tags": [
+          "OpenAI Integration",
+          "Azure Integration"
+        ],
         "parameters": [
           {
             "name": "deployment-id",
@@ -13803,7 +14506,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -13814,7 +14522,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -13857,11 +14567,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -13982,7 +14698,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -14025,11 +14743,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -14135,7 +14859,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -14169,11 +14895,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -14194,7 +14925,9 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -14237,11 +14970,17 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": ["format", "data"],
+                          "required": [
+                            "format",
+                            "data"
+                          ],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": ["mp3", "wav"]
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
                             },
                             "data": {
                               "type": "string"
@@ -14504,7 +15243,9 @@
         "operationId": "openaiCountInputTokens",
         "summary": "Count input tokens",
         "description": "Counts the number of tokens in a Responses API request.\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -14568,7 +15309,9 @@
         "operationId": "openaiRetrieveResponse",
         "summary": "Retrieve a response (OpenAI format)",
         "description": "Retrieves a stored response by ID.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "response_id",
@@ -14750,7 +15493,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -14761,7 +15509,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -14804,11 +15554,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -14929,7 +15685,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -14972,11 +15730,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -15082,7 +15846,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -15116,11 +15882,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -15141,7 +15912,9 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -15184,11 +15957,17 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": ["format", "data"],
+                          "required": [
+                            "format",
+                            "data"
+                          ],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": ["mp3", "wav"]
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
                             },
                             "data": {
                               "type": "string"
@@ -15459,7 +16238,9 @@
         "operationId": "openaiDeleteResponse",
         "summary": "Delete a response (OpenAI format)",
         "description": "Deletes a stored response.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "response_id",
@@ -15542,7 +16323,9 @@
         "operationId": "openaiCancelResponse",
         "summary": "Cancel a response (OpenAI format)",
         "description": "Cancels an in-flight response. Only responses created with `background: true`\ncan be cancelled.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}/cancel`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "response_id",
@@ -15625,7 +16408,9 @@
         "operationId": "openaiListResponseInputItems",
         "summary": "List response input items (OpenAI format)",
         "description": "Lists the input items of a stored response.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/{response_id}/input_items`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "response_id",
@@ -15678,7 +16463,10 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           }
         ],
@@ -15745,14 +16533,18 @@
         "operationId": "openaiCreateCompaction",
         "summary": "Compact context (OpenAI)",
         "description": "Compresses a conversation into an opaque compaction item using the OpenAI-compatible\n`/v1/responses/compact` endpoint. Drop-in compatible with the OpenAI SDK.\n\nThe response `output` contains the user messages plus a final item with\n`type: \"response.compaction\"` and `encrypted_content`. Pass this output as `input`\nto future Responses API calls to continue the conversation using the compacted context.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/responses/compact`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["model"],
+                "required": [
+                  "model"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -15809,7 +16601,12 @@
                             },
                             "role": {
                               "type": "string",
-                              "enum": ["assistant", "user", "system", "developer"]
+                              "enum": [
+                                "assistant",
+                                "user",
+                                "system",
+                                "developer"
+                              ]
                             },
                             "content": {
                               "oneOf": [
@@ -15820,7 +16617,9 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
@@ -15863,11 +16662,17 @@
                                       },
                                       "input_audio": {
                                         "type": "object",
-                                        "required": ["format", "data"],
+                                        "required": [
+                                          "format",
+                                          "data"
+                                        ],
                                         "properties": {
                                           "format": {
                                             "type": "string",
-                                            "enum": ["mp3", "wav"]
+                                            "enum": [
+                                              "mp3",
+                                              "wav"
+                                            ]
                                           },
                                           "data": {
                                             "type": "string"
@@ -15988,7 +16793,9 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": ["type"],
+                                    "required": [
+                                      "type"
+                                    ],
                                     "properties": {
                                       "type": {
                                         "type": "string",
@@ -16031,11 +16838,17 @@
                                       },
                                       "input_audio": {
                                         "type": "object",
-                                        "required": ["format", "data"],
+                                        "required": [
+                                          "format",
+                                          "data"
+                                        ],
                                         "properties": {
                                           "format": {
                                             "type": "string",
-                                            "enum": ["mp3", "wav"]
+                                            "enum": [
+                                              "mp3",
+                                              "wav"
+                                            ]
                                           },
                                           "data": {
                                             "type": "string"
@@ -16141,7 +16954,9 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": ["computer_screenshot"]
+                                      "enum": [
+                                        "computer_screenshot"
+                                      ]
                                     },
                                     "file_id": {
                                       "type": "string"
@@ -16175,11 +16990,16 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type", "text"],
+                                "required": [
+                                  "type",
+                                  "text"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["summary_text"]
+                                    "enum": [
+                                      "summary_text"
+                                    ]
                                   },
                                   "text": {
                                     "type": "string"
@@ -16293,7 +17113,12 @@
                           },
                           "role": {
                             "type": "string",
-                            "enum": ["assistant", "user", "system", "developer"]
+                            "enum": [
+                              "assistant",
+                              "user",
+                              "system",
+                              "developer"
+                            ]
                           },
                           "content": {
                             "oneOf": [
@@ -16304,7 +17129,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "properties": {
                                     "type": {
                                       "type": "string",
@@ -16347,11 +17174,17 @@
                                     },
                                     "input_audio": {
                                       "type": "object",
-                                      "required": ["format", "data"],
+                                      "required": [
+                                        "format",
+                                        "data"
+                                      ],
                                       "properties": {
                                         "format": {
                                           "type": "string",
-                                          "enum": ["mp3", "wav"]
+                                          "enum": [
+                                            "mp3",
+                                            "wav"
+                                          ]
                                         },
                                         "data": {
                                           "type": "string"
@@ -16472,7 +17305,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["type"],
+                                  "required": [
+                                    "type"
+                                  ],
                                   "properties": {
                                     "type": {
                                       "type": "string",
@@ -16515,11 +17350,17 @@
                                     },
                                     "input_audio": {
                                       "type": "object",
-                                      "required": ["format", "data"],
+                                      "required": [
+                                        "format",
+                                        "data"
+                                      ],
                                       "properties": {
                                         "format": {
                                           "type": "string",
-                                          "enum": ["mp3", "wav"]
+                                          "enum": [
+                                            "mp3",
+                                            "wav"
+                                          ]
                                         },
                                         "data": {
                                           "type": "string"
@@ -16625,7 +17466,9 @@
                                 "properties": {
                                   "type": {
                                     "type": "string",
-                                    "enum": ["computer_screenshot"]
+                                    "enum": [
+                                      "computer_screenshot"
+                                    ]
                                   },
                                   "file_id": {
                                     "type": "string"
@@ -16659,11 +17502,16 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["type", "text"],
+                              "required": [
+                                "type",
+                                "text"
+                              ],
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["summary_text"]
+                                  "enum": [
+                                    "summary_text"
+                                  ]
                                 },
                                 "text": {
                                   "type": "string"
@@ -16793,7 +17641,9 @@
         "operationId": "openaiCreateEmbedding",
         "summary": "Create embeddings (OpenAI format)",
         "description": "Creates embedding vectors for the input text.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/embeddings`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -16856,7 +17706,10 @@
       "post": {
         "operationId": "azureCreateEmbedding",
         "summary": "Create embeddings (Azure OpenAI)",
-        "tags": ["OpenAI Integration", "Azure Integration"],
+        "tags": [
+          "OpenAI Integration",
+          "Azure Integration"
+        ],
         "parameters": [
           {
             "name": "deployment-id",
@@ -16938,7 +17791,9 @@
         "operationId": "openaiCreateSpeech",
         "summary": "Create speech (OpenAI TTS)",
         "description": "Generates audio from text using OpenAI TTS.\nSupports streaming via SSE when stream_format is set to 'sse'.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/audio/speech`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -16983,7 +17838,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["speech.audio.delta", "speech.audio.done"]
+                      "enum": [
+                        "speech.audio.delta",
+                        "speech.audio.done"
+                      ]
                     },
                     "audio": {
                       "type": "string",
@@ -17052,7 +17910,10 @@
       "post": {
         "operationId": "azureCreateSpeech",
         "summary": "Create speech (Azure OpenAI TTS)",
-        "tags": ["OpenAI Integration", "Azure Integration"],
+        "tags": [
+          "OpenAI Integration",
+          "Azure Integration"
+        ],
         "parameters": [
           {
             "name": "deployment-id",
@@ -17115,7 +17976,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["speech.audio.delta", "speech.audio.done"]
+                      "enum": [
+                        "speech.audio.delta",
+                        "speech.audio.done"
+                      ]
                     },
                     "audio": {
                       "type": "string",
@@ -17185,7 +18049,9 @@
         "operationId": "openaiCreateTranscription",
         "summary": "Create transcription (OpenAI Whisper)",
         "description": "Transcribes audio into text using OpenAI Whisper.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/audio/transcriptions`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -17211,7 +18077,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["transcript.text.delta", "transcript.text.done"]
+                      "enum": [
+                        "transcript.text.delta",
+                        "transcript.text.done"
+                      ]
                     },
                     "delta": {
                       "type": "string"
@@ -17244,7 +18113,10 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["tokens", "duration"]
+                          "enum": [
+                            "tokens",
+                            "duration"
+                          ]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -17320,7 +18192,10 @@
       "post": {
         "operationId": "azureCreateTranscription",
         "summary": "Create transcription (Azure OpenAI)",
-        "tags": ["OpenAI Integration", "Azure Integration"],
+        "tags": [
+          "OpenAI Integration",
+          "Azure Integration"
+        ],
         "parameters": [
           {
             "name": "deployment-id",
@@ -17364,7 +18239,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["transcript.text.delta", "transcript.text.done"]
+                      "enum": [
+                        "transcript.text.delta",
+                        "transcript.text.done"
+                      ]
                     },
                     "delta": {
                       "type": "string"
@@ -17397,7 +18275,10 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["tokens", "duration"]
+                          "enum": [
+                            "tokens",
+                            "duration"
+                          ]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -17474,7 +18355,9 @@
         "operationId": "openaiListModels",
         "summary": "List models (OpenAI format)",
         "description": "Lists available models in OpenAI format.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/models`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -17527,7 +18410,10 @@
       "get": {
         "operationId": "azureListModels",
         "summary": "List models (Azure OpenAI)",
-        "tags": ["OpenAI Integration", "Azure Integration"],
+        "tags": [
+          "OpenAI Integration",
+          "Azure Integration"
+        ],
         "parameters": [
           {
             "name": "deployment-id",
@@ -17599,7 +18485,9 @@
         "operationId": "openaiCreateBatch",
         "summary": "Create batch job (OpenAI format)",
         "description": "Creates a batch processing job.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/batches`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -17661,7 +18549,9 @@
         "operationId": "openaiListBatches",
         "summary": "List batch jobs (OpenAI format)",
         "description": "Lists batch processing jobs.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/batches`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -17742,7 +18632,9 @@
         "operationId": "openaiRetrieveBatch",
         "summary": "Retrieve batch job (OpenAI format)",
         "description": "Retrieves details of a batch processing job.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/batches/{batch_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -17815,7 +18707,9 @@
         "operationId": "openaiCancelBatch",
         "summary": "Cancel batch job (OpenAI format)",
         "description": "Cancels a batch processing job.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/batches/{batch_id}/cancel`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -17947,14 +18841,19 @@
         "operationId": "openaiCreateImage",
         "summary": "Create image",
         "description": "Generates images from text prompts using OpenAI-compatible format.\n\n**Note:** Azure OpenAI deployments are also supported via the Azure integration endpoint.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/images/generations`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["model", "prompt"],
+                "required": [
+                  "model",
+                  "prompt"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -17987,17 +18886,26 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": ["standard", "hd"],
+                    "enum": [
+                      "standard",
+                      "hd"
+                    ],
                     "description": "Quality of the generated image"
                   },
                   "style": {
                     "type": "string",
-                    "enum": ["natural", "vivid"],
+                    "enum": [
+                      "natural",
+                      "vivid"
+                    ],
                     "description": "Style of the generated image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": ["url", "b64_json"],
+                    "enum": [
+                      "url",
+                      "b64_json"
+                    ],
                     "default": "url",
                     "description": "Format of the response. This parameter is not supported for streaming requests."
                   },
@@ -18287,7 +19195,10 @@
         "operationId": "azureCreateImage",
         "summary": "Create image (Azure OpenAI)",
         "description": "Generates images from text prompts using Azure OpenAI deployment.\n",
-        "tags": ["OpenAI Integration", "Azure Integration"],
+        "tags": [
+          "OpenAI Integration",
+          "Azure Integration"
+        ],
         "parameters": [
           {
             "name": "deployment-id",
@@ -18313,7 +19224,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["model", "prompt"],
+                "required": [
+                  "model",
+                  "prompt"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -18346,17 +19260,26 @@
                   },
                   "quality": {
                     "type": "string",
-                    "enum": ["standard", "hd"],
+                    "enum": [
+                      "standard",
+                      "hd"
+                    ],
                     "description": "Quality of the generated image"
                   },
                   "style": {
                     "type": "string",
-                    "enum": ["natural", "vivid"],
+                    "enum": [
+                      "natural",
+                      "vivid"
+                    ],
                     "description": "Style of the generated image"
                   },
                   "response_format": {
                     "type": "string",
-                    "enum": ["url", "b64_json"],
+                    "enum": [
+                      "url",
+                      "b64_json"
+                    ],
                     "default": "url",
                     "description": "Format of the response. This parameter is not supported for streaming requests."
                   },
@@ -18646,14 +19569,19 @@
         "operationId": "openaiUploadFile",
         "summary": "Upload file (OpenAI format)",
         "description": "Uploads a file for use with batch processing or other features.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file", "purpose"],
+                "required": [
+                  "file",
+                  "purpose"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -18777,7 +19705,9 @@
         "operationId": "openaiListFiles",
         "summary": "List files (OpenAI format)",
         "description": "Lists uploaded files.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "purpose",
@@ -18808,7 +19738,10 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           },
           {
@@ -18873,7 +19806,9 @@
         "operationId": "openaiRetrieveFile",
         "summary": "Retrieve file metadata (OpenAI format)",
         "description": "Retrieves metadata for an uploaded file.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files/{file_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -18933,7 +19868,13 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["uploaded", "processed", "processing", "error", "deleted"]
+                      "enum": [
+                        "uploaded",
+                        "processed",
+                        "processing",
+                        "error",
+                        "deleted"
+                      ]
                     },
                     "status_details": {
                       "type": "string"
@@ -18996,7 +19937,9 @@
         "operationId": "openaiDeleteFile",
         "summary": "Delete file (OpenAI format)",
         "description": "Deletes an uploaded file.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files/{file_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -19083,7 +20026,9 @@
         "operationId": "openaiGetFileContent",
         "summary": "Get file content (OpenAI format)",
         "description": "Retrieves the content of an uploaded file.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/files/{file_id}/content`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -19157,14 +20102,19 @@
         "operationId": "openaiCreateContainer",
         "summary": "Create container (OpenAI format)",
         "description": "Creates a new container for storing files and data.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["provider", "name"],
+                "required": [
+                  "provider",
+                  "name"
+                ],
                 "properties": {
                   "provider": {
                     "$ref": "#/components/schemas/ModelProvider"
@@ -19237,7 +20187,9 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["running"],
+                      "enum": [
+                        "running"
+                      ],
                       "description": "The status of a container"
                     },
                     "expires_after": {
@@ -19318,7 +20270,9 @@
         "operationId": "openaiListContainers",
         "summary": "List containers (OpenAI format)",
         "description": "Lists containers for a provider.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -19349,7 +20303,10 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             },
             "description": "Sort order"
           }
@@ -19391,7 +20348,9 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["running"],
+                            "enum": [
+                              "running"
+                            ],
                             "description": "The status of a container"
                           },
                           "expires_after": {
@@ -19490,7 +20449,9 @@
         "operationId": "openaiRetrieveContainer",
         "summary": "Retrieve container (OpenAI format)",
         "description": "Retrieves a specific container by ID.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -19537,7 +20498,9 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["running"],
+                      "enum": [
+                        "running"
+                      ],
                       "description": "The status of a container"
                     },
                     "expires_after": {
@@ -19618,7 +20581,9 @@
         "operationId": "openaiDeleteContainer",
         "summary": "Delete container (OpenAI format)",
         "description": "Deletes a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -19708,7 +20673,9 @@
         "operationId": "openaiCreateContainerFile",
         "summary": "Create file in container (OpenAI format)",
         "description": "Creates a new file in a container. You can either upload file content directly\nvia multipart/form-data or reference an existing file by its ID.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -19752,7 +20719,9 @@
               "schema": {
                 "type": "object",
                 "description": "Request to create a file in a container by referencing an existing file",
-                "required": ["file_id"],
+                "required": [
+                  "file_id"
+                ],
                 "properties": {
                   "file_id": {
                     "type": "string",
@@ -19854,7 +20823,9 @@
         "operationId": "openaiListContainerFiles",
         "summary": "List files in container (OpenAI format)",
         "description": "Lists all files in a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -19894,7 +20865,10 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             },
             "description": "Sort order"
           }
@@ -20014,7 +20988,9 @@
         "operationId": "openaiRetrieveContainerFile",
         "summary": "Retrieve file from container (OpenAI format)",
         "description": "Retrieves metadata for a specific file in a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files/{file_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -20130,7 +21106,9 @@
         "operationId": "openaiDeleteContainerFile",
         "summary": "Delete file from container (OpenAI format)",
         "description": "Deletes a file from a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files/{file_id}`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -20230,7 +21208,9 @@
         "operationId": "openaiGetContainerFileContent",
         "summary": "Get file content from container (OpenAI format)",
         "description": "Downloads the content of a file from a container.\n\n**Note:** This endpoint also works without the `/v1` prefix (e.g., `/openai/containers/{container_id}/files/{file_id}/content`).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "container_id",
@@ -20313,14 +21293,19 @@
         "operationId": "openaiCreateVideo",
         "summary": "Create a video generation",
         "description": "Submits a video generation job using OpenAI's Videos API.\nThe request is multipart/form-data and may include reference images.\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["prompt", "model"],
+                "required": [
+                  "prompt",
+                  "model"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -20402,7 +21387,9 @@
         "operationId": "openaiListVideos",
         "summary": "List video generations",
         "description": "Lists previously submitted video generation jobs.",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -20426,7 +21413,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           }
         ],
@@ -20485,7 +21475,9 @@
         "operationId": "openaiRetrieveVideo",
         "summary": "Retrieve a video generation",
         "description": "Returns metadata for a previously submitted video generation job.",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "video_id",
@@ -20551,7 +21543,9 @@
         "operationId": "openaiDeleteVideo",
         "summary": "Delete a video generation",
         "description": "Deletes a previously generated video.",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "video_id",
@@ -20619,7 +21613,9 @@
         "operationId": "openaiDownloadVideo",
         "summary": "Download generated video content",
         "description": "Streams the binary video bytes for a completed generation job.",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "video_id",
@@ -20683,7 +21679,9 @@
         "operationId": "openaiRemixVideo",
         "summary": "Remix an existing video",
         "description": "Creates a new generation by remixing a prior video with new prompt parameters.",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "video_id",
@@ -20760,7 +21758,9 @@
         "operationId": "openaiRealtimeWebSocket",
         "summary": "WebSocket Realtime (OpenAI alias)",
         "description": "OpenAI-prefixed alias of `GET /v1/realtime`. WebSocket upgrade endpoint\nfor OpenAI Realtime; selects the model via the `model` query parameter\n(Azure GA) or `deployment` (preview).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -20784,7 +21784,9 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["websocket"]
+              "enum": [
+                "websocket"
+              ]
             }
           },
           {
@@ -20835,7 +21837,9 @@
         "operationId": "openaiRealtimeCall",
         "summary": "WebRTC Realtime SDP exchange (OpenAI alias)",
         "description": "OpenAI-prefixed alias of `POST /v1/realtime/calls`. Performs the WebRTC\nSDP exchange for OpenAI Realtime calls. Accepts either multipart form\ndata with `sdp` + `session` parts (GA) or a raw SDP body (legacy).\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -20915,7 +21919,9 @@
         "operationId": "openaiRealtimeClientSecret",
         "summary": "Create realtime client secret (OpenAI alias)",
         "description": "OpenAI-prefixed alias of `POST /v1/realtime/client_secrets`. Mints an\nephemeral client secret used to authorize a downstream Realtime client.\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -20982,7 +21988,9 @@
         "operationId": "openaiRealtimeSession",
         "summary": "Create realtime session (OpenAI alias)",
         "description": "OpenAI-prefixed alias of `POST /v1/realtime/sessions`. Creates a\npre-configured realtime session that can be joined by clients.\n",
-        "tags": ["OpenAI Integration"],
+        "tags": [
+          "OpenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -21049,7 +22057,9 @@
         "operationId": "anthropicCreateMessage",
         "summary": "Create message (Anthropic format)",
         "description": "Creates a message using Anthropic Messages API format.\nSupports streaming via SSE.\n\n**Async inference:** Send `x-bf-async: true` to submit the request as a background job and receive a job ID immediately. Poll with `x-bf-async-id: <job-id>` to retrieve the result. When the job is still processing, the response will have an empty `content` array. When completed, `content` will contain the full result. See [Async Inference](/features/async-inference) for details.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "x-bf-async",
@@ -21057,7 +22067,9 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["true"]
+              "enum": [
+                "true"
+              ]
             },
             "description": "Set to `true` to submit this request as an async job. Returns immediately with a job ID. Not compatible with streaming."
           },
@@ -21285,7 +22297,9 @@
         "operationId": "anthropicCreateMessageWildcard",
         "summary": "Create message (Anthropic format) - wildcard",
         "description": "Handles extended messages API paths.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "path",
@@ -21501,7 +22515,9 @@
         "operationId": "anthropicCreateComplete",
         "summary": "Create completion (Anthropic legacy format)",
         "description": "Creates a text completion using Anthropic's legacy Complete API.\nSupports streaming via SSE.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -21532,7 +22548,11 @@
                     },
                     "stop_reason": {
                       "type": "string",
-                      "enum": ["stop_sequence", "max_tokens", null]
+                      "enum": [
+                        "stop_sequence",
+                        "max_tokens",
+                        null
+                      ]
                     },
                     "model": {
                       "type": "string"
@@ -21569,7 +22589,11 @@
                     },
                     "stop_reason": {
                       "type": "string",
-                      "enum": ["stop_sequence", "max_tokens", null]
+                      "enum": [
+                        "stop_sequence",
+                        "max_tokens",
+                        null
+                      ]
                     },
                     "model": {
                       "type": "string"
@@ -21672,7 +22696,9 @@
         "operationId": "anthropicListModels",
         "summary": "List models (Anthropic format)",
         "description": "Lists available models in Anthropic format.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -21790,7 +22816,9 @@
         "operationId": "anthropicCountTokens",
         "summary": "Count tokens (Anthropic format)",
         "description": "Counts the number of tokens in a message request.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -21902,7 +22930,9 @@
         "operationId": "anthropicCreateBatch",
         "summary": "Create batch job (Anthropic format)",
         "description": "Creates a batch processing job using Anthropic format.\nUse x-model-provider header to specify the provider.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -21919,13 +22949,18 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["requests"],
+                "required": [
+                  "requests"
+                ],
                 "properties": {
                   "requests": {
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["custom_id", "params"],
+                      "required": [
+                        "custom_id",
+                        "params"
+                      ],
                       "properties": {
                         "custom_id": {
                           "type": "string",
@@ -21961,7 +22996,11 @@
                     },
                     "processing_status": {
                       "type": "string",
-                      "enum": ["in_progress", "ended", "canceling"]
+                      "enum": [
+                        "in_progress",
+                        "ended",
+                        "canceling"
+                      ]
                     },
                     "request_counts": {
                       "type": "object",
@@ -22093,7 +23132,9 @@
         "operationId": "anthropicListBatches",
         "summary": "List batch jobs (Anthropic format)",
         "description": "Lists batch processing jobs.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -22143,7 +23184,11 @@
                           },
                           "processing_status": {
                             "type": "string",
-                            "enum": ["in_progress", "ended", "canceling"]
+                            "enum": [
+                              "in_progress",
+                              "ended",
+                              "canceling"
+                            ]
                           },
                           "request_counts": {
                             "type": "object",
@@ -22289,7 +23334,9 @@
         "operationId": "anthropicRetrieveBatch",
         "summary": "Retrieve batch job (Anthropic format)",
         "description": "Retrieves details of a batch processing job.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -22326,7 +23373,11 @@
                     },
                     "processing_status": {
                       "type": "string",
-                      "enum": ["in_progress", "ended", "canceling"]
+                      "enum": [
+                        "in_progress",
+                        "ended",
+                        "canceling"
+                      ]
                     },
                     "request_counts": {
                       "type": "object",
@@ -22460,7 +23511,9 @@
         "operationId": "anthropicCancelBatch",
         "summary": "Cancel batch job (Anthropic format)",
         "description": "Cancels a batch processing job.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -22497,7 +23550,11 @@
                     },
                     "processing_status": {
                       "type": "string",
-                      "enum": ["in_progress", "ended", "canceling"]
+                      "enum": [
+                        "in_progress",
+                        "ended",
+                        "canceling"
+                      ]
                     },
                     "request_counts": {
                       "type": "object",
@@ -22631,7 +23688,9 @@
         "operationId": "anthropicGetBatchResults",
         "summary": "Get batch results (Anthropic format)",
         "description": "Retrieves results of a completed batch job.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -22742,7 +23801,9 @@
         "operationId": "anthropicUploadFile",
         "summary": "Upload file (Anthropic format)",
         "description": "Uploads a file. Use x-model-provider header to specify the provider.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -22759,7 +23820,9 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "file": {
                     "type": "string",
@@ -22895,7 +23958,9 @@
         "operationId": "anthropicListFiles",
         "summary": "List files (Anthropic format)",
         "description": "Lists uploaded files.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -23058,7 +24123,9 @@
         "operationId": "anthropicGetFileContent",
         "summary": "Get file content (Anthropic format)",
         "description": "Retrieves file content. Returns raw binary file data when Accept header is set to application/octet-stream,\nor file metadata as JSON when Accept header is set to application/json.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -23082,7 +24149,10 @@
             "in": "header",
             "schema": {
               "type": "string",
-              "enum": ["application/json", "application/octet-stream"],
+              "enum": [
+                "application/json",
+                "application/octet-stream"
+              ],
               "default": "application/json"
             },
             "description": "Response content type - use application/octet-stream for binary download"
@@ -23227,7 +24297,9 @@
         "operationId": "anthropicDeleteFile",
         "summary": "Delete file (Anthropic format)",
         "description": "Deletes an uploaded file.\n",
-        "tags": ["Anthropic Integration"],
+        "tags": [
+          "Anthropic Integration"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -23347,7 +24419,9 @@
         "operationId": "geminiGenerateContent",
         "summary": "Generate content (Gemini format)",
         "description": "Generates content using Google Gemini API format.\nThe model is specified in the URL path.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -23422,7 +24496,9 @@
         "operationId": "geminiStreamGenerateContent",
         "summary": "Stream generate content (Gemini format)",
         "description": "Streams content generation using Google Gemini API format.\nThe model is specified in the URL path.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -23497,7 +24573,9 @@
         "operationId": "geminiEmbedContent",
         "summary": "Embed content (Gemini format)",
         "description": "Creates embeddings using Google Gemini API format.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -23572,7 +24650,9 @@
         "operationId": "geminiCountTokens",
         "summary": "Count tokens (Gemini format)",
         "description": "Counts tokens using Google Gemini API format.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -23700,7 +24780,9 @@
         "operationId": "geminiGenerateImage",
         "summary": "Generate image (Gemini format)",
         "description": "For Imagen models, use the `:predict` suffix (e.g., `imagen-3.0-generate-001:predict`).\nFor Gemini models, use `:generateContent` with `generationConfig.responseModalities: [\"IMAGE\"]` in the request body.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -23780,7 +24862,9 @@
         "operationId": "geminiListModels",
         "summary": "List models (Gemini format)",
         "description": "Lists available models in Google Gemini API format.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "pageSize",
@@ -23852,7 +24936,9 @@
         "operationId": "geminiUploadFile",
         "summary": "Upload file (Gemini format)",
         "description": "Uploads a file using Google Gemini API format.\n\nThis is a multipart upload with two parts:\n- \"metadata\": JSON object containing file metadata\n- \"file\": Binary file content\n\nNote: Direct file content download is not supported by Gemini Files API.\nUse the file.uri field from the response to access uploaded files.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -23860,7 +24946,9 @@
               "schema": {
                 "type": "object",
                 "description": "Multipart upload for Gemini Files API. Send two parts: - \"metadata\": JSON object {\"file\": {\"displayName\": \"<optional label>\"}} - \"file\": binary content Note: Direct file content download is not supported by Gemini Files API. Use the file.uri field from the response to access the file.\n",
-                "required": ["file"],
+                "required": [
+                  "file"
+                ],
                 "properties": {
                   "metadata": {
                     "type": "object",
@@ -23939,7 +25027,12 @@
                         },
                         "state": {
                           "type": "string",
-                          "enum": ["STATE_UNSPECIFIED", "PROCESSING", "ACTIVE", "FAILED"]
+                          "enum": [
+                            "STATE_UNSPECIFIED",
+                            "PROCESSING",
+                            "ACTIVE",
+                            "FAILED"
+                          ]
                         },
                         "error": {
                           "type": "object",
@@ -24009,7 +25102,9 @@
         "operationId": "geminiListFiles",
         "summary": "List files (Gemini format)",
         "description": "Lists uploaded files in Google Gemini API format.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "pageSize",
@@ -24076,7 +25171,12 @@
                           },
                           "state": {
                             "type": "string",
-                            "enum": ["STATE_UNSPECIFIED", "PROCESSING", "ACTIVE", "FAILED"]
+                            "enum": [
+                              "STATE_UNSPECIFIED",
+                              "PROCESSING",
+                              "ACTIVE",
+                              "FAILED"
+                            ]
                           },
                           "error": {
                             "type": "object",
@@ -24150,7 +25250,9 @@
         "operationId": "geminiRetrieveFile",
         "summary": "Retrieve file (Gemini format)",
         "description": "Retrieves file metadata in Google Gemini API format.\n\nNote: This endpoint returns file metadata only. Direct file content\ndownload is not supported by Gemini Files API. Use the file.uri\nfield from the response to access the file content.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -24205,7 +25307,12 @@
                     },
                     "state": {
                       "type": "string",
-                      "enum": ["STATE_UNSPECIFIED", "PROCESSING", "ACTIVE", "FAILED"]
+                      "enum": [
+                        "STATE_UNSPECIFIED",
+                        "PROCESSING",
+                        "ACTIVE",
+                        "FAILED"
+                      ]
                     },
                     "error": {
                       "type": "object",
@@ -24271,7 +25378,9 @@
         "operationId": "geminiDeleteFile",
         "summary": "Delete file (Gemini format)",
         "description": "Deletes a file in Google Gemini API format.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "file_id",
@@ -24337,7 +25446,9 @@
         "operationId": "geminiListBatches",
         "summary": "List batch jobs (Gemini format)",
         "description": "Lists batch jobs in Gemini format. Supports `pageSize` / `pageToken` pagination.",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "pageSize",
@@ -24409,7 +25520,9 @@
       "get": {
         "operationId": "geminiRetrieveBatch",
         "summary": "Retrieve a batch job (Gemini format)",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -24472,7 +25585,9 @@
         "operationId": "geminiCancelBatch",
         "summary": "Cancel a batch job (Gemini format)",
         "description": "Cancels a batch job. Gemini conventionally sends the request as\n`/v1beta/batches/{batch_id}:cancel`; the router matches the `:cancel`\nsuffix into the `batch_id` path parameter.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -24535,7 +25650,9 @@
       "delete": {
         "operationId": "geminiDeleteBatch",
         "summary": "Delete a batch job (Gemini format)",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "batch_id",
@@ -24600,7 +25717,9 @@
         "operationId": "geminiCreateCachedContent",
         "summary": "Create cached content (Gemini format)",
         "description": "Creates a cached content entry that can be re-used across subsequent\ngenerate-content calls to reduce repeated prefix tokens.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -24618,7 +25737,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["model"],
+                "required": [
+                  "model"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -24706,7 +25827,9 @@
       "get": {
         "operationId": "geminiListCachedContents",
         "summary": "List cached content entries (Gemini format)",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "pageSize",
@@ -24776,7 +25899,9 @@
       "get": {
         "operationId": "geminiRetrieveCachedContent",
         "summary": "Retrieve cached content (Gemini format)",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "cached_id",
@@ -24837,7 +25962,9 @@
         "operationId": "geminiUpdateCachedContent",
         "summary": "Update cached content (Gemini format)",
         "description": "Updates the TTL or expiration time of a cached content entry. Only\n`ttl` or `expireTime` may be modified.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "cached_id",
@@ -24917,7 +26044,9 @@
       "delete": {
         "operationId": "geminiDeleteCachedContent",
         "summary": "Delete cached content (Gemini format)",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "cached_id",
@@ -24980,7 +26109,9 @@
         "operationId": "vertexRank",
         "summary": "Rerank documents (Vertex Rank)",
         "description": "Reranks records using Google Vertex AI's Ranking API. The request body\nfollows the Vertex `rankRecords` schema.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -25079,7 +26210,9 @@
         "operationId": "geminiRetrieveVideoOperation",
         "summary": "Retrieve video generation operation (Gemini format)",
         "description": "Polls the status of a long-running video generation operation produced\nby `models/{model}:generateVideos`. The Gemini SDK appends the\noperation name as a wildcard path segment. If the operation name\ncontains `/`, it must be percent-encoded in the request path (for\nexample, `%2F`) to remain conformant with OpenAPI 3.x path-parameter\nsemantics.\n",
-        "tags": ["GenAI Integration"],
+        "tags": [
+          "GenAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -25154,7 +26287,9 @@
         "operationId": "bedrockConverse",
         "summary": "Converse with model (Bedrock format)",
         "description": "Sends messages to a model using AWS Bedrock Converse API format.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -25229,7 +26364,9 @@
         "operationId": "bedrockConverseStream",
         "summary": "Stream converse with model (Bedrock format)",
         "description": "Streams messages from a model using AWS Bedrock Converse API format.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -25401,7 +26538,9 @@
         "operationId": "bedrockInvokeModel",
         "summary": "Invoke model (Bedrock format)",
         "description": "Invokes a model using AWS Bedrock InvokeModel API format.\nAccepts raw model-specific request body.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -25476,7 +26615,9 @@
         "operationId": "bedrockInvokeModelStream",
         "summary": "Invoke model with streaming (Bedrock format)",
         "description": "Invokes a model with streaming using AWS Bedrock InvokeModelWithResponseStream API format.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -25552,7 +26693,9 @@
         "operationId": "bedrockCountTokens",
         "summary": "Count tokens (Bedrock format)",
         "description": "Counts tokens for a Converse-style request using AWS Bedrock format.\nThe request body must include `input.converse` with a complete Converse\npayload; only Converse-shaped input is supported.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -25570,11 +26713,15 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["input"],
+                "required": [
+                  "input"
+                ],
                 "properties": {
                   "input": {
                     "type": "object",
-                    "required": ["converse"],
+                    "required": [
+                      "converse"
+                    ],
                     "properties": {
                       "converse": {
                         "description": "Converse-shaped request used to compute the token count.",
@@ -25647,7 +26794,9 @@
         "operationId": "bedrockCreateBatchJob",
         "summary": "Create batch inference job (Bedrock format)",
         "description": "Creates a batch inference job using AWS Bedrock format.\nRoutes to native Bedrock by default; set `x-model-provider` to route the\njob to another provider (`openai`, `gemini`, etc.).\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "x-model-provider",
@@ -25722,7 +26871,9 @@
         "operationId": "bedrockListBatchJobs",
         "summary": "List batch inference jobs (Bedrock format)",
         "description": "Lists batch inference jobs using AWS Bedrock format.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "maxResults",
@@ -25871,7 +27022,9 @@
         "operationId": "bedrockRetrieveBatchJob",
         "summary": "Retrieve batch inference job (Bedrock format)",
         "description": "Retrieves a batch inference job using AWS Bedrock format.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "job_arn",
@@ -25945,7 +27098,9 @@
         "operationId": "bedrockCancelBatchJob",
         "summary": "Cancel batch inference job (Bedrock format)",
         "description": "Stops a batch inference job using AWS Bedrock format.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "job_arn",
@@ -26027,7 +27182,9 @@
         "operationId": "bedrockS3ListObjects",
         "summary": "S3-compatible ListObjectsV2",
         "description": "Lists objects in a bucket using S3 ListObjectsV2 semantics. Supports\nthe `prefix` and `max-keys` query parameters used by boto3.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "bucket",
@@ -26115,7 +27272,9 @@
         "operationId": "bedrockS3PutObject",
         "summary": "S3-compatible PutObject",
         "description": "Uploads an object to the Bifrost file store using S3 PutObject semantics.\nThe response is empty with an `ETag` header, mirroring native S3.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "bucket",
@@ -26191,7 +27350,9 @@
         "operationId": "bedrockS3GetObject",
         "summary": "S3-compatible GetObject",
         "description": "Retrieves raw object bytes from the Bifrost file store.",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "bucket",
@@ -26263,7 +27424,9 @@
         "operationId": "bedrockS3HeadObject",
         "summary": "S3-compatible HeadObject",
         "description": "Returns S3 metadata headers (ETag, Content-Length, etc.) without a body.\n",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "bucket",
@@ -26320,7 +27483,9 @@
         "operationId": "bedrockS3DeleteObject",
         "summary": "S3-compatible DeleteObject",
         "description": "Deletes an object from the Bifrost file store.",
-        "tags": ["Bedrock Integration"],
+        "tags": [
+          "Bedrock Integration"
+        ],
         "parameters": [
           {
             "name": "bucket",
@@ -26386,7 +27551,9 @@
         "operationId": "cohereChatV2",
         "summary": "Chat with model (Cohere v2 format)",
         "description": "Sends a chat request using Cohere v2 API format.\n",
-        "tags": ["Cohere Integration"],
+        "tags": [
+          "Cohere Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -26453,7 +27620,12 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": ["text", "image_url", "thinking", "document"]
+                                      "enum": [
+                                        "text",
+                                        "image_url",
+                                        "thinking",
+                                        "document"
+                                      ]
                                     },
                                     "text": {
                                       "type": "string"
@@ -26470,7 +27642,12 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "image_url", "thinking", "document"]
+                                        "enum": [
+                                          "text",
+                                          "image_url",
+                                          "thinking",
+                                          "document"
+                                        ]
                                       },
                                       "text": {
                                         "type": "string"
@@ -26498,7 +27675,9 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["function"]
+                                      "enum": [
+                                        "function"
+                                      ]
                                     },
                                     "function": {
                                       "type": "object",
@@ -26523,7 +27702,9 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["function"]
+                                        "enum": [
+                                          "function"
+                                        ]
                                       },
                                       "function": {
                                         "type": "object",
@@ -26566,7 +27747,10 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["tool", "document"],
+                                            "enum": [
+                                              "tool",
+                                              "document"
+                                            ],
                                             "description": "Source type"
                                           },
                                           "id": {
@@ -26590,7 +27774,11 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
+                                      "enum": [
+                                        "TEXT_CONTENT",
+                                        "THINKING_CONTENT",
+                                        "PLAN"
+                                      ],
                                       "description": "Type of citation"
                                     }
                                   }
@@ -26619,7 +27807,10 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": ["tool", "document"],
+                                              "enum": [
+                                                "tool",
+                                                "document"
+                                              ],
                                               "description": "Source type"
                                             },
                                             "id": {
@@ -26643,7 +27834,11 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
+                                        "enum": [
+                                          "TEXT_CONTENT",
+                                          "THINKING_CONTENT",
+                                          "PLAN"
+                                        ],
                                         "description": "Type of citation"
                                       }
                                     }
@@ -26757,7 +27952,9 @@
         "operationId": "cohereEmbedV2",
         "summary": "Create embeddings (Cohere v2 format)",
         "description": "Creates embeddings using Cohere v2 API format.\n",
-        "tags": ["Cohere Integration"],
+        "tags": [
+          "Cohere Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -26821,14 +28018,20 @@
         "operationId": "cohereRerank",
         "summary": "Rerank documents (Cohere format)",
         "description": "Reranks a list of documents against a query using Cohere's v2 Rerank\nAPI. The request body matches Cohere's native format.\n",
-        "tags": ["Cohere Integration"],
+        "tags": [
+          "Cohere Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["model", "query", "documents"],
+                "required": [
+                  "model",
+                  "query",
+                  "documents"
+                ],
                 "properties": {
                   "model": {
                     "type": "string",
@@ -26848,7 +28051,9 @@
                         },
                         {
                           "type": "object",
-                          "required": ["text"],
+                          "required": [
+                            "text"
+                          ],
                           "properties": {
                             "text": {
                               "type": "string"
@@ -26958,7 +28163,9 @@
         "operationId": "cohereTokenize",
         "summary": "Tokenize text (Cohere format)",
         "description": "Tokenizes text using Cohere v1 API format.\n",
-        "tags": ["Cohere Integration"],
+        "tags": [
+          "Cohere Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -27022,7 +28229,9 @@
         "operationId": "cursorChatCompletions",
         "summary": "Cursor hybrid chat completions",
         "description": "Accepts Cursor's hybrid chat-completions payload (which is structurally\na Responses API request with `input` blocks) and returns a chat-\ncompletions-shaped response (`choices` + `delta` chunks for streams).\nRoutes the request through the Responses pipeline internally.\n",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -27231,7 +28440,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -27324,7 +28535,9 @@
         "operationId": "cursorListModels",
         "summary": "List models (Cursor)",
         "description": "Lists available models, returning the OpenAI `/v1/models` shape.",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -27369,7 +28582,9 @@
         "operationId": "cursorAnthropicComplete",
         "summary": "Anthropic complete (Cursor mount)",
         "description": "Cursor mount of the legacy Anthropic `POST /v1/complete` endpoint.",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -27400,7 +28615,11 @@
                     },
                     "stop_reason": {
                       "type": "string",
-                      "enum": ["stop_sequence", "max_tokens", null]
+                      "enum": [
+                        "stop_sequence",
+                        "max_tokens",
+                        null
+                      ]
                     },
                     "model": {
                       "type": "string"
@@ -27445,7 +28664,9 @@
         "operationId": "cursorAnthropicMessages",
         "summary": "Anthropic messages (Cursor mount)",
         "description": "Cursor mount of `POST /anthropic/v1/messages`. Same request/response shape and streaming behaviour.",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -27650,7 +28871,9 @@
         "operationId": "cursorAnthropicMessagesWildcard",
         "summary": "Anthropic messages — wildcard (Cursor mount)",
         "description": "Cursor mount of the Anthropic messages wildcard (`POST /anthropic/v1/messages/{path}`).\nRoutes extended Anthropic messages endpoints (e.g. batches, count tokens)\nthrough Cursor.\n",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "parameters": [
           {
             "name": "path",
@@ -27762,7 +28985,9 @@
         "operationId": "cursorAnthropicCountTokens",
         "summary": "Anthropic count tokens (Cursor mount)",
         "description": "Cursor mount of `POST /anthropic/v1/messages/count_tokens`.",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -27807,7 +29032,9 @@
         "operationId": "cursorGeminiListModels",
         "summary": "Gemini list models (Cursor mount)",
         "description": "Cursor mount of `GET /genai/v1beta/models`.",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -27842,7 +29069,9 @@
         "operationId": "cursorGeminiModelAction",
         "summary": "Gemini model action (Cursor mount)",
         "description": "Cursor mount of Gemini's wildcard generate-content/embed/count-tokens/\npredict endpoints. The `model` path parameter includes the action\nsuffix (e.g. `gemini-pro:generateContent`).\n",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -27896,7 +29125,9 @@
       "get": {
         "operationId": "cursorGeminiRetrieveVideoOperation",
         "summary": "Gemini video operation polling (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -27949,7 +29180,9 @@
         "operationId": "cursorVertexRank",
         "summary": "Vertex rank (Cursor mount)",
         "description": "Cursor mount of `POST /genai/v1/rank` — Vertex AI ranking.",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -27994,7 +29227,9 @@
       "post": {
         "operationId": "cursorBedrockConverse",
         "summary": "Bedrock converse (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -28047,7 +29282,9 @@
       "post": {
         "operationId": "cursorBedrockConverseStream",
         "summary": "Bedrock converse stream (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -28101,7 +29338,9 @@
       "post": {
         "operationId": "cursorBedrockInvoke",
         "summary": "Bedrock invoke (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -28156,7 +29395,9 @@
       "post": {
         "operationId": "cursorBedrockInvokeStream",
         "summary": "Bedrock invoke-with-response-stream (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -28211,7 +29452,9 @@
       "post": {
         "operationId": "cursorBedrockRerank",
         "summary": "Bedrock rerank (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -28256,7 +29499,9 @@
       "post": {
         "operationId": "cursorBedrockCountTokens",
         "summary": "Bedrock count tokens (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -28325,7 +29570,9 @@
       "post": {
         "operationId": "cursorCohereChat",
         "summary": "Cohere chat (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -28370,7 +29617,9 @@
       "post": {
         "operationId": "cursorCohereEmbed",
         "summary": "Cohere embed (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -28415,7 +29664,9 @@
       "post": {
         "operationId": "cursorCohereRerank",
         "summary": "Cohere rerank (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -28460,7 +29711,9 @@
       "post": {
         "operationId": "cursorCohereTokenize",
         "summary": "Cohere tokenize (Cursor mount)",
-        "tags": ["Cursor Integration"],
+        "tags": [
+          "Cursor Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -28506,7 +29759,9 @@
         "operationId": "litellmOpenAITextCompletions",
         "summary": "Text completions (LiteLLM - OpenAI format)",
         "description": "Creates a text completion using OpenAI-compatible format via LiteLLM.\nThis is the legacy completions API.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -28715,7 +29970,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -28805,7 +30062,9 @@
         "operationId": "litellmOpenAIChatCompletions",
         "summary": "Chat completions (LiteLLM - OpenAI format)",
         "description": "Creates a chat completion using OpenAI-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -29014,7 +30273,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -29107,7 +30368,9 @@
         "operationId": "litellmOpenAIEmbeddings",
         "summary": "Create embeddings (LiteLLM - OpenAI format)",
         "description": "Creates embeddings using OpenAI-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -29171,7 +30434,9 @@
         "operationId": "litellmOpenAIListModels",
         "summary": "List models (LiteLLM - OpenAI format)",
         "description": "Lists available models using OpenAI-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -29225,7 +30490,9 @@
         "operationId": "litellmOpenAIResponses",
         "summary": "Create response (LiteLLM - OpenAI Responses API)",
         "description": "Creates a response using OpenAI Responses API format via LiteLLM.\nSupports streaming via SSE.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -29363,7 +30630,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -29374,7 +30646,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -29417,11 +30691,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -29542,7 +30822,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -29585,11 +30867,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -29695,7 +30983,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -29729,11 +31019,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -29754,7 +31049,9 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -29797,11 +31094,17 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": ["format", "data"],
+                          "required": [
+                            "format",
+                            "data"
+                          ],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": ["mp3", "wav"]
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
                             },
                             "data": {
                               "type": "string"
@@ -30064,7 +31367,9 @@
         "operationId": "litellmOpenAICountInputTokens",
         "summary": "Count input tokens (LiteLLM - OpenAI format)",
         "description": "Counts the number of tokens in a Responses API request via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -30128,7 +31433,9 @@
         "operationId": "litellmOpenAISpeech",
         "summary": "Create speech (LiteLLM - OpenAI TTS)",
         "description": "Generates audio from text using OpenAI TTS via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -30155,7 +31462,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["speech.audio.delta", "speech.audio.done"]
+                      "enum": [
+                        "speech.audio.delta",
+                        "speech.audio.done"
+                      ]
                     },
                     "audio": {
                       "type": "string",
@@ -30225,7 +31535,9 @@
         "operationId": "litellmOpenAITranscriptions",
         "summary": "Create transcription (LiteLLM - OpenAI Whisper)",
         "description": "Transcribes audio into text using OpenAI Whisper via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -30251,7 +31563,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["transcript.text.delta", "transcript.text.done"]
+                      "enum": [
+                        "transcript.text.delta",
+                        "transcript.text.done"
+                      ]
                     },
                     "delta": {
                       "type": "string"
@@ -30284,7 +31599,10 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["tokens", "duration"]
+                          "enum": [
+                            "tokens",
+                            "duration"
+                          ]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -30361,7 +31679,9 @@
         "operationId": "litellmAnthropicMessages",
         "summary": "Create message (LiteLLM - Anthropic format)",
         "description": "Creates a message using Anthropic-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -30566,7 +31886,9 @@
         "operationId": "litellmGeminiListModels",
         "summary": "List models (LiteLLM - Gemini format)",
         "description": "Lists available models in Google Gemini API format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "parameters": [
           {
             "name": "pageSize",
@@ -30638,7 +31960,9 @@
         "operationId": "litellmGeminiGenerateContent",
         "summary": "Generate content (LiteLLM - Gemini format)",
         "description": "Generates content using Google Gemini-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -30713,7 +32037,9 @@
         "operationId": "litellmGeminiStreamGenerateContent",
         "summary": "Stream generate content (LiteLLM - Gemini format)",
         "description": "Streams content generation using Google Gemini-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -30788,7 +32114,9 @@
         "operationId": "litellmBedrockConverse",
         "summary": "Converse with model (LiteLLM - Bedrock format)",
         "description": "Sends messages using AWS Bedrock Converse-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -30863,7 +32191,9 @@
         "operationId": "litellmBedrockConverseStream",
         "summary": "Stream converse with model (LiteLLM - Bedrock format)",
         "description": "Streams messages using AWS Bedrock Converse-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -31035,7 +32365,9 @@
         "operationId": "litellmCohereChat",
         "summary": "Chat with model (LiteLLM - Cohere format)",
         "description": "Sends a chat request using Cohere-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -31102,7 +32434,12 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": ["text", "image_url", "thinking", "document"]
+                                      "enum": [
+                                        "text",
+                                        "image_url",
+                                        "thinking",
+                                        "document"
+                                      ]
                                     },
                                     "text": {
                                       "type": "string"
@@ -31119,7 +32456,12 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "image_url", "thinking", "document"]
+                                        "enum": [
+                                          "text",
+                                          "image_url",
+                                          "thinking",
+                                          "document"
+                                        ]
                                       },
                                       "text": {
                                         "type": "string"
@@ -31147,7 +32489,9 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["function"]
+                                      "enum": [
+                                        "function"
+                                      ]
                                     },
                                     "function": {
                                       "type": "object",
@@ -31172,7 +32516,9 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["function"]
+                                        "enum": [
+                                          "function"
+                                        ]
                                       },
                                       "function": {
                                         "type": "object",
@@ -31215,7 +32561,10 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["tool", "document"],
+                                            "enum": [
+                                              "tool",
+                                              "document"
+                                            ],
                                             "description": "Source type"
                                           },
                                           "id": {
@@ -31239,7 +32588,11 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
+                                      "enum": [
+                                        "TEXT_CONTENT",
+                                        "THINKING_CONTENT",
+                                        "PLAN"
+                                      ],
                                       "description": "Type of citation"
                                     }
                                   }
@@ -31268,7 +32621,10 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": ["tool", "document"],
+                                              "enum": [
+                                                "tool",
+                                                "document"
+                                              ],
                                               "description": "Source type"
                                             },
                                             "id": {
@@ -31292,7 +32648,11 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
+                                        "enum": [
+                                          "TEXT_CONTENT",
+                                          "THINKING_CONTENT",
+                                          "PLAN"
+                                        ],
                                         "description": "Type of citation"
                                       }
                                     }
@@ -31406,7 +32766,9 @@
         "operationId": "litellmCohereEmbed",
         "summary": "Create embeddings (LiteLLM - Cohere format)",
         "description": "Creates embeddings using Cohere-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -31470,7 +32832,9 @@
         "operationId": "litellmCohereTokenize",
         "summary": "Tokenize text (LiteLLM - Cohere format)",
         "description": "Tokenizes text using Cohere-compatible format via LiteLLM.\n",
-        "tags": ["LiteLLM Integration"],
+        "tags": [
+          "LiteLLM Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -31534,7 +32898,9 @@
         "operationId": "langchainOpenAITextCompletions",
         "summary": "Text completions (LangChain - OpenAI format)",
         "description": "Creates a text completion using OpenAI-compatible format via LangChain.\nThis is the legacy completions API.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -31743,7 +33109,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -31833,7 +33201,9 @@
         "operationId": "langchainOpenAIChatCompletions",
         "summary": "Chat completions (LangChain - OpenAI format)",
         "description": "Creates a chat completion using OpenAI-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -32042,7 +33412,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -32135,7 +33507,9 @@
         "operationId": "langchainOpenAIEmbeddings",
         "summary": "Create embeddings (LangChain - OpenAI format)",
         "description": "Creates embeddings using OpenAI-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -32199,7 +33573,9 @@
         "operationId": "langchainOpenAIListModels",
         "summary": "List models (LangChain - OpenAI format)",
         "description": "Lists available models using OpenAI-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -32253,7 +33629,9 @@
         "operationId": "langchainOpenAIResponses",
         "summary": "Create response (LangChain - OpenAI Responses API)",
         "description": "Creates a response using OpenAI Responses API format via LangChain.\nSupports streaming via SSE.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -32391,7 +33769,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -32402,7 +33785,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -32445,11 +33830,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -32570,7 +33961,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -32613,11 +34006,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -32723,7 +34122,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -32757,11 +34158,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -32782,7 +34188,9 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -32825,11 +34233,17 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": ["format", "data"],
+                          "required": [
+                            "format",
+                            "data"
+                          ],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": ["mp3", "wav"]
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
                             },
                             "data": {
                               "type": "string"
@@ -33092,7 +34506,9 @@
         "operationId": "langchainOpenAICountInputTokens",
         "summary": "Count input tokens (LangChain - OpenAI format)",
         "description": "Counts the number of tokens in a Responses API request via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -33156,7 +34572,9 @@
         "operationId": "langchainOpenAISpeech",
         "summary": "Create speech (LangChain - OpenAI TTS)",
         "description": "Generates audio from text using OpenAI TTS via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -33183,7 +34601,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["speech.audio.delta", "speech.audio.done"]
+                      "enum": [
+                        "speech.audio.delta",
+                        "speech.audio.done"
+                      ]
                     },
                     "audio": {
                       "type": "string",
@@ -33253,7 +34674,9 @@
         "operationId": "langchainOpenAITranscriptions",
         "summary": "Create transcription (LangChain - OpenAI Whisper)",
         "description": "Transcribes audio into text using OpenAI Whisper via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -33279,7 +34702,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["transcript.text.delta", "transcript.text.done"]
+                      "enum": [
+                        "transcript.text.delta",
+                        "transcript.text.done"
+                      ]
                     },
                     "delta": {
                       "type": "string"
@@ -33312,7 +34738,10 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["tokens", "duration"]
+                          "enum": [
+                            "tokens",
+                            "duration"
+                          ]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -33389,7 +34818,9 @@
         "operationId": "langchainAnthropicMessages",
         "summary": "Create message (LangChain - Anthropic format)",
         "description": "Creates a message using Anthropic-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -33594,7 +35025,9 @@
         "operationId": "langchainAnthropicCountTokens",
         "summary": "Count tokens (LangChain - Anthropic format)",
         "description": "Counts tokens using Anthropic-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -33706,7 +35139,9 @@
         "operationId": "langchainGeminiListModels",
         "summary": "List models (LangChain - Gemini format)",
         "description": "Lists available models in Google Gemini API format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "parameters": [
           {
             "name": "pageSize",
@@ -33778,7 +35213,9 @@
         "operationId": "langchainGeminiGenerateContent",
         "summary": "Generate content (LangChain - Gemini format)",
         "description": "Generates content using Google Gemini-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -33853,7 +35290,9 @@
         "operationId": "langchainGeminiStreamGenerateContent",
         "summary": "Stream generate content (LangChain - Gemini format)",
         "description": "Streams content generation using Google Gemini-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -33928,7 +35367,9 @@
         "operationId": "langchainBedrockConverse",
         "summary": "Converse with model (LangChain - Bedrock format)",
         "description": "Sends messages using AWS Bedrock Converse-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -34003,7 +35444,9 @@
         "operationId": "langchainBedrockConverseStream",
         "summary": "Stream converse with model (LangChain - Bedrock format)",
         "description": "Streams messages using AWS Bedrock Converse-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -34175,7 +35618,9 @@
         "operationId": "langchainCohereChat",
         "summary": "Chat with model (LangChain - Cohere format)",
         "description": "Sends a chat request using Cohere-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -34242,7 +35687,12 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": ["text", "image_url", "thinking", "document"]
+                                      "enum": [
+                                        "text",
+                                        "image_url",
+                                        "thinking",
+                                        "document"
+                                      ]
                                     },
                                     "text": {
                                       "type": "string"
@@ -34259,7 +35709,12 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "image_url", "thinking", "document"]
+                                        "enum": [
+                                          "text",
+                                          "image_url",
+                                          "thinking",
+                                          "document"
+                                        ]
                                       },
                                       "text": {
                                         "type": "string"
@@ -34287,7 +35742,9 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["function"]
+                                      "enum": [
+                                        "function"
+                                      ]
                                     },
                                     "function": {
                                       "type": "object",
@@ -34312,7 +35769,9 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["function"]
+                                        "enum": [
+                                          "function"
+                                        ]
                                       },
                                       "function": {
                                         "type": "object",
@@ -34355,7 +35814,10 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["tool", "document"],
+                                            "enum": [
+                                              "tool",
+                                              "document"
+                                            ],
                                             "description": "Source type"
                                           },
                                           "id": {
@@ -34379,7 +35841,11 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
+                                      "enum": [
+                                        "TEXT_CONTENT",
+                                        "THINKING_CONTENT",
+                                        "PLAN"
+                                      ],
                                       "description": "Type of citation"
                                     }
                                   }
@@ -34408,7 +35874,10 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": ["tool", "document"],
+                                              "enum": [
+                                                "tool",
+                                                "document"
+                                              ],
                                               "description": "Source type"
                                             },
                                             "id": {
@@ -34432,7 +35901,11 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
+                                        "enum": [
+                                          "TEXT_CONTENT",
+                                          "THINKING_CONTENT",
+                                          "PLAN"
+                                        ],
                                         "description": "Type of citation"
                                       }
                                     }
@@ -34546,7 +36019,9 @@
         "operationId": "langchainCohereEmbed",
         "summary": "Create embeddings (LangChain - Cohere format)",
         "description": "Creates embeddings using Cohere-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -34610,7 +36085,9 @@
         "operationId": "langchainCohereTokenize",
         "summary": "Tokenize text (LangChain - Cohere format)",
         "description": "Tokenizes text using Cohere-compatible format via LangChain.\n",
-        "tags": ["LangChain Integration"],
+        "tags": [
+          "LangChain Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -34674,7 +36151,9 @@
         "operationId": "pydanticaiOpenAITextCompletions",
         "summary": "Text completions (PydanticAI - OpenAI format)",
         "description": "Creates a text completion using OpenAI-compatible format via PydanticAI.\nThis is the legacy completions API.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -34883,7 +36362,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -34973,7 +36454,9 @@
         "operationId": "pydanticaiOpenAIChatCompletions",
         "summary": "Chat completions (PydanticAI - OpenAI format)",
         "description": "Creates a chat completion using OpenAI-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -35182,7 +36665,9 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["function"],
+                                  "required": [
+                                    "function"
+                                  ],
                                   "properties": {
                                     "index": {
                                       "type": "integer"
@@ -35275,7 +36760,9 @@
         "operationId": "pydanticaiOpenAIEmbeddings",
         "summary": "Create embeddings (PydanticAI - OpenAI format)",
         "description": "Creates embeddings using OpenAI-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -35339,7 +36826,9 @@
         "operationId": "pydanticaiOpenAIListModels",
         "summary": "List models (PydanticAI - OpenAI format)",
         "description": "Lists available models using OpenAI-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -35393,7 +36882,9 @@
         "operationId": "pydanticaiOpenAIResponses",
         "summary": "Create response (PydanticAI - OpenAI Responses API)",
         "description": "Creates a response using OpenAI Responses API format via PydanticAI.\nSupports streaming via SSE.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -35531,7 +37022,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -35542,7 +37038,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -35585,11 +37083,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -35710,7 +37214,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -35753,11 +37259,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -35863,7 +37375,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -35897,11 +37411,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -35922,7 +37441,9 @@
                     },
                     "part": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
@@ -35965,11 +37486,17 @@
                         },
                         "input_audio": {
                           "type": "object",
-                          "required": ["format", "data"],
+                          "required": [
+                            "format",
+                            "data"
+                          ],
                           "properties": {
                             "format": {
                               "type": "string",
-                              "enum": ["mp3", "wav"]
+                              "enum": [
+                                "mp3",
+                                "wav"
+                              ]
                             },
                             "data": {
                               "type": "string"
@@ -36232,7 +37759,9 @@
         "operationId": "pydanticaiOpenAICountInputTokens",
         "summary": "Count input tokens (PydanticAI - OpenAI format)",
         "description": "Counts the number of tokens in a Responses API request via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -36296,7 +37825,9 @@
         "operationId": "pydanticaiOpenAISpeech",
         "summary": "Create speech (PydanticAI - OpenAI TTS)",
         "description": "Generates audio from text using OpenAI TTS via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -36323,7 +37854,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["speech.audio.delta", "speech.audio.done"]
+                      "enum": [
+                        "speech.audio.delta",
+                        "speech.audio.done"
+                      ]
                     },
                     "audio": {
                       "type": "string",
@@ -36393,7 +37927,9 @@
         "operationId": "pydanticaiOpenAITranscriptions",
         "summary": "Create transcription (PydanticAI - OpenAI Whisper)",
         "description": "Transcribes audio into text using OpenAI Whisper via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -36419,7 +37955,10 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["transcript.text.delta", "transcript.text.done"]
+                      "enum": [
+                        "transcript.text.delta",
+                        "transcript.text.done"
+                      ]
                     },
                     "delta": {
                       "type": "string"
@@ -36452,7 +37991,10 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["tokens", "duration"]
+                          "enum": [
+                            "tokens",
+                            "duration"
+                          ]
                         },
                         "input_tokens": {
                           "type": "integer"
@@ -36529,7 +38071,9 @@
         "operationId": "pydanticaiAnthropicMessages",
         "summary": "Create message (PydanticAI - Anthropic format)",
         "description": "Creates a message using Anthropic-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -36734,7 +38278,9 @@
         "operationId": "pydanticaiGeminiListModels",
         "summary": "List models (PydanticAI - Gemini format)",
         "description": "Lists available models in Google Gemini API format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "parameters": [
           {
             "name": "pageSize",
@@ -36806,7 +38352,9 @@
         "operationId": "pydanticaiGeminiGenerateContent",
         "summary": "Generate content (PydanticAI - Gemini format)",
         "description": "Generates content using Google Gemini-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -36881,7 +38429,9 @@
         "operationId": "pydanticaiGeminiStreamGenerateContent",
         "summary": "Stream generate content (PydanticAI - Gemini format)",
         "description": "Streams content generation using Google Gemini-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "parameters": [
           {
             "name": "model",
@@ -36956,7 +38506,9 @@
         "operationId": "pydanticaiBedrockConverse",
         "summary": "Converse with model (PydanticAI - Bedrock format)",
         "description": "Sends messages using AWS Bedrock Converse-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -37031,7 +38583,9 @@
         "operationId": "pydanticaiBedrockConverseStream",
         "summary": "Stream converse with model (PydanticAI - Bedrock format)",
         "description": "Streams messages using AWS Bedrock Converse-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "parameters": [
           {
             "name": "modelId",
@@ -37203,7 +38757,9 @@
         "operationId": "pydanticaiCohereChat",
         "summary": "Chat with model (PydanticAI - Cohere format)",
         "description": "Sends a chat request using Cohere-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -37270,7 +38826,12 @@
                                   "properties": {
                                     "type": {
                                       "type": "string",
-                                      "enum": ["text", "image_url", "thinking", "document"]
+                                      "enum": [
+                                        "text",
+                                        "image_url",
+                                        "thinking",
+                                        "document"
+                                      ]
                                     },
                                     "text": {
                                       "type": "string"
@@ -37287,7 +38848,12 @@
                                     "properties": {
                                       "type": {
                                         "type": "string",
-                                        "enum": ["text", "image_url", "thinking", "document"]
+                                        "enum": [
+                                          "text",
+                                          "image_url",
+                                          "thinking",
+                                          "document"
+                                        ]
                                       },
                                       "text": {
                                         "type": "string"
@@ -37315,7 +38881,9 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["function"]
+                                      "enum": [
+                                        "function"
+                                      ]
                                     },
                                     "function": {
                                       "type": "object",
@@ -37340,7 +38908,9 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["function"]
+                                        "enum": [
+                                          "function"
+                                        ]
                                       },
                                       "function": {
                                         "type": "object",
@@ -37383,7 +38953,10 @@
                                         "properties": {
                                           "type": {
                                             "type": "string",
-                                            "enum": ["tool", "document"],
+                                            "enum": [
+                                              "tool",
+                                              "document"
+                                            ],
                                             "description": "Source type"
                                           },
                                           "id": {
@@ -37407,7 +38980,11 @@
                                     },
                                     "type": {
                                       "type": "string",
-                                      "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
+                                      "enum": [
+                                        "TEXT_CONTENT",
+                                        "THINKING_CONTENT",
+                                        "PLAN"
+                                      ],
                                       "description": "Type of citation"
                                     }
                                   }
@@ -37436,7 +39013,10 @@
                                           "properties": {
                                             "type": {
                                               "type": "string",
-                                              "enum": ["tool", "document"],
+                                              "enum": [
+                                                "tool",
+                                                "document"
+                                              ],
                                               "description": "Source type"
                                             },
                                             "id": {
@@ -37460,7 +39040,11 @@
                                       },
                                       "type": {
                                         "type": "string",
-                                        "enum": ["TEXT_CONTENT", "THINKING_CONTENT", "PLAN"],
+                                        "enum": [
+                                          "TEXT_CONTENT",
+                                          "THINKING_CONTENT",
+                                          "PLAN"
+                                        ],
                                         "description": "Type of citation"
                                       }
                                     }
@@ -37574,7 +39158,9 @@
         "operationId": "pydanticaiCohereEmbed",
         "summary": "Create embeddings (PydanticAI - Cohere format)",
         "description": "Creates embeddings using Cohere-compatible format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -37638,7 +39224,9 @@
         "operationId": "pydanticaiCohereTokenize",
         "summary": "Tokenize text (PydanticAI - Cohere format)",
         "description": "Tokenizes text using Cohere v1 API format via PydanticAI.\n",
-        "tags": ["PydanticAI Integration"],
+        "tags": [
+          "PydanticAI Integration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -37702,7 +39290,9 @@
         "operationId": "getHealth",
         "summary": "Health check",
         "description": "Returns the health status of the Bifrost server. Checks connectivity to config store,\nlog store, and vector store if configured.\n",
-        "tags": ["Health"],
+        "tags": [
+          "Health"
+        ],
         "responses": {
           "200": {
             "description": "Server is healthy",
@@ -37732,7 +39322,9 @@
         "operationId": "getConfig",
         "summary": "Get configuration",
         "description": "Retrieves the current Bifrost configuration including client config, framework config,\nauth config, and connection status for various stores.\n",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "parameters": [
           {
             "name": "from_db",
@@ -37740,7 +39332,10 @@
             "description": "If true, fetch configuration directly from the database",
             "schema": {
               "type": "string",
-              "enum": ["true", "false"]
+              "enum": [
+                "true",
+                "false"
+              ]
             }
           }
         ],
@@ -37776,7 +39371,9 @@
         "operationId": "updateConfig",
         "summary": "Update configuration",
         "description": "Updates the Bifrost configuration. Supports hot-reloading of certain settings\nlike drop_excess_requests. Some settings may require a restart to take effect.\n",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -37831,7 +39428,9 @@
         "operationId": "getVersion",
         "summary": "Get version",
         "description": "Returns the current Bifrost version information.",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -37856,7 +39455,9 @@
         "operationId": "getProxyConfig",
         "summary": "Get proxy configuration",
         "description": "Retrieves the current global proxy configuration.",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -37876,7 +39477,11 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": ["http", "socks5", "tcp"]
+                      "enum": [
+                        "http",
+                        "socks5",
+                        "tcp"
+                      ]
                     },
                     "url": {
                       "type": "string"
@@ -37937,7 +39542,9 @@
         "operationId": "updateProxyConfig",
         "summary": "Update proxy configuration",
         "description": "Updates the global proxy configuration.",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -37951,7 +39558,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["http", "socks5", "tcp"]
+                    "enum": [
+                      "http",
+                      "socks5",
+                      "tcp"
+                    ]
                   },
                   "url": {
                     "type": "string"
@@ -38030,7 +39641,9 @@
         "operationId": "forceSyncPricing",
         "summary": "Force pricing sync",
         "description": "Triggers an immediate pricing sync and resets the pricing sync timer.",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -38081,7 +39694,9 @@
         },
         "summary": "List users",
         "description": "Returns a paginated list of users with optional search.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "offset",
@@ -38125,7 +39740,13 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["users", "count", "total_count", "limit", "offset"],
+                  "required": [
+                    "users",
+                    "count",
+                    "total_count",
+                    "limit",
+                    "offset"
+                  ],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -38286,14 +39907,19 @@
         },
         "summary": "Create user",
         "description": "Manually creates a new user in the organization.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name", "email"],
+                "required": [
+                  "name",
+                  "email"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -38489,7 +40115,9 @@
         },
         "summary": "Get user",
         "description": "Returns a single Enterprise user.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -38659,7 +40287,9 @@
         },
         "summary": "Delete user",
         "description": "Permanently removes a user from the organization. This cascades to delete the user's governance settings (budget/rate limits), team memberships, access profiles, and OIDC sessions. Cannot delete yourself.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -38731,7 +40361,9 @@
         },
         "summary": "Get current user permissions",
         "description": "Returns the RBAC permissions for the authenticated user. When SCIM is not enabled, returns full permissions for all resources. Otherwise returns the permissions associated with the user's assigned role.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -38804,7 +40436,9 @@
         },
         "summary": "Assign role to user",
         "description": "Assigns an RBAC role to a user. This also auto-assigns the default access profile for the new role and reloads the RBAC permission cache.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -38822,7 +40456,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["role_id"],
+                "required": [
+                  "role_id"
+                ],
                 "properties": {
                   "role_id": {
                     "type": "integer",
@@ -38893,7 +40529,9 @@
         },
         "summary": "Get user's teams",
         "description": "Returns the list of teams a user belongs to, including the membership source.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -38985,7 +40623,9 @@
         },
         "summary": "Update user's team assignments",
         "description": "Replaces the user's manual team assignments. Synced team memberships (from SCIM providers) are preserved and cannot be removed via this endpoint.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -39003,7 +40643,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["team_ids"],
+                "required": [
+                  "team_ids"
+                ],
                 "properties": {
                   "team_ids": {
                     "type": "array",
@@ -39076,7 +40718,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Create user governance",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -39306,7 +40950,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Update user governance",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -39526,7 +41172,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Delete user governance",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -39586,7 +41234,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List virtual keys available to a user",
-        "tags": ["Users", "Virtual Keys"],
+        "tags": [
+          "Users",
+          "Virtual Keys"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -39636,7 +41287,9 @@
         },
         "summary": "Get user's virtual keys by email",
         "description": "**Enterprise only.**\nReturns all virtual keys associated with a user, looked up by email address. Returns an empty `virtual_keys` array when the user exists but has no virtual keys assigned. Intended for MDM and credential-helper integrations that need to resolve a user's keys without knowing their internal ID.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "email",
@@ -39746,7 +41399,9 @@
         },
         "summary": "Get user by email",
         "description": "Returns a single Enterprise user resolved by URL-encoded email address.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "email",
@@ -39918,7 +41573,9 @@
         },
         "summary": "List team members",
         "description": "Returns all members of a team with their user details and membership source.",
-        "tags": ["Teams"],
+        "tags": [
+          "Teams"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -40011,7 +41668,9 @@
         },
         "summary": "Add team member",
         "description": "Adds a user to a team. Both the team and user must exist.",
-        "tags": ["Teams"],
+        "tags": [
+          "Teams"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -40029,7 +41688,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user_id"],
+                "required": [
+                  "user_id"
+                ],
                 "properties": {
                   "user_id": {
                     "type": "string",
@@ -40100,7 +41761,9 @@
         },
         "summary": "Remove team member",
         "description": "Removes a user from a team.",
-        "tags": ["Teams"],
+        "tags": [
+          "Teams"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -40165,7 +41828,9 @@
         "operationId": "login",
         "summary": "Login",
         "description": "Authenticates a user and returns a session token.\nSets a cookie with the session token for subsequent requests.\n",
-        "tags": ["Session"],
+        "tags": [
+          "Session"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -40236,7 +41901,9 @@
         "operationId": "logout",
         "summary": "Logout",
         "description": "Logs out the current user and invalidates the session token.",
-        "tags": ["Session"],
+        "tags": [
+          "Session"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -40281,7 +41948,9 @@
         "operationId": "isAuthEnabled",
         "summary": "Check if authentication is enabled",
         "description": "Returns whether authentication is enabled and if the current token is valid.",
-        "tags": ["Session"],
+        "tags": [
+          "Session"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -40312,7 +41981,9 @@
         "operationId": "issueWSTicket",
         "summary": "Issue WebSocket ticket",
         "description": "Issues a short-lived ticket for authenticating WebSocket connections.\nThe ticket can be used as a query parameter when upgrading to WebSocket.\n",
-        "tags": ["Session"],
+        "tags": [
+          "Session"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -40366,7 +42037,9 @@
         "operationId": "listProviders",
         "summary": "List all providers",
         "description": "Returns a list of all configured providers with their configurations and status.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -40399,7 +42072,9 @@
         "operationId": "addProvider",
         "summary": "Add a new provider",
         "description": "Adds a new provider with the specified configuration.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -40464,7 +42139,9 @@
         "operationId": "getProvider",
         "summary": "Get a specific provider",
         "description": "Returns the configuration for a specific provider.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -40528,7 +42205,9 @@
         "operationId": "updateProvider",
         "summary": "Update a provider",
         "description": "Updates a provider's configuration. Expects ALL fields to be provided,\nincluding both edited and non-edited fields. Partial updates are not supported.\n",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -40592,7 +42271,9 @@
         "operationId": "deleteProvider",
         "summary": "Delete a provider",
         "description": "Removes a provider from the configuration.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -40658,7 +42339,9 @@
         "operationId": "listProviderKeys",
         "summary": "List keys for a provider",
         "description": "Returns all keys configured for a specific provider.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -40722,7 +42405,9 @@
         "operationId": "createProviderKey",
         "summary": "Create a key for a provider",
         "description": "Creates a new API key for the specified provider. The key `id` is auto-generated\nif omitted. `enabled` defaults to `true` if omitted. `value` is required and must\nnot be empty. Keys cannot be created on keyless providers.\n",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -40808,7 +42493,9 @@
         "operationId": "getProviderKey",
         "summary": "Get a specific key for a provider",
         "description": "Returns a single key for the specified provider.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -40881,7 +42568,9 @@
         "operationId": "updateProviderKey",
         "summary": "Update a key for a provider",
         "description": "Updates an existing key. Send the full key object. Redacted values sent back\nunchanged are automatically preserved (the server merges them with the stored\nraw values).\n",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -40964,7 +42653,9 @@
         "operationId": "deleteProviderKey",
         "summary": "Delete a key from a provider",
         "description": "Deletes a key from the specified provider. Returns the deleted key.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "provider",
@@ -41039,7 +42730,9 @@
         "operationId": "listKeys",
         "summary": "List all keys",
         "description": "Returns a list of all configured API keys across all providers.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -41077,7 +42770,9 @@
         "operationId": "listModelsManagement",
         "summary": "List models",
         "description": "Lists available models with optional filtering by query, provider, or keys.\n",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "query",
@@ -41188,7 +42883,9 @@
         "operationId": "listModelDetailsManagement",
         "summary": "List model details",
         "description": "Lists available models with capability metadata, when available from the model catalog, with optional filtering by query, provider, or keys.\n",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "query",
@@ -41356,7 +43053,9 @@
         "operationId": "getModelParameters",
         "summary": "Get model parameters",
         "description": "Returns the available parameter definitions for a model. The model ID is resolved against the model-parameters catalog with fallbacks, so provider-qualified IDs returned by /v1/models (e.g. \"openai/gpt-4o\", \"openrouter/openai/gpt-4o\") and bare aliases of provider-qualified catalog entries resolve to the same record as the stored key.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -41413,7 +43112,9 @@
         "operationId": "listBaseModels",
         "summary": "List base models",
         "description": "Returns a list of base models from the model catalog.",
-        "tags": ["Providers"],
+        "tags": [
+          "Providers"
+        ],
         "parameters": [
           {
             "name": "query",
@@ -41475,7 +43176,9 @@
         "operationId": "listPlugins",
         "summary": "List all plugins",
         "description": "Returns a list of all plugins with their configurations and status.\nThe `actualName` field contains the plugin name from `GetName()` (used as the map key),\nwhile `name` contains the display name from the configuration.\nThe `types` array in the status shows which interfaces the plugin implements (llm, mcp, http).\n",
-        "tags": ["Plugins"],
+        "tags": [
+          "Plugins"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -41508,7 +43211,9 @@
         "operationId": "createPlugin",
         "summary": "Create a new plugin",
         "description": "Creates a new plugin with the specified configuration.\nSetting `path` on a non-builtin plugin loads native code (a .so, via dlopen) into the\ngateway process and requires genuine admin authentication - it is refused with 403 if\ndashboard authentication is disabled or unconfigured, even though other management\nendpoints remain reachable in that state. Only `http`/`https` URLs are fetched for\nremote paths, and by default only ones resolving to a public address; private,\nloopback, link-local, and CGNAT addresses are additionally allowed if explicitly\nlisted in the deploy-time `server.plugin_download_private_allowlist` config. Local\nfilesystem paths are unaffected.\n",
-        "tags": ["Plugins"],
+        "tags": [
+          "Plugins"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -41585,7 +43290,9 @@
         "operationId": "listBuiltinPlugins",
         "summary": "List built-in plugin names",
         "description": "Returns the canonical list of built-in plugin names available in this Bifrost build.\nUse this to discover which plugins can be enabled without supplying a custom binary.\n",
-        "tags": ["Plugins"],
+        "tags": [
+          "Plugins"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -41629,7 +43336,9 @@
         "operationId": "getPlugin",
         "summary": "Get a specific plugin",
         "description": "Returns the configuration for a specific plugin.\nThe response includes the plugin status with types array showing which interfaces\nthe plugin implements (llm, mcp, http). The `actualName` field shows the plugin name\nfrom GetName() (used as the map key), which may differ from the display name (`name`).\n",
-        "tags": ["Plugins"],
+        "tags": [
+          "Plugins"
+        ],
         "parameters": [
           {
             "name": "name",
@@ -41693,7 +43402,9 @@
         "operationId": "updatePlugin",
         "summary": "Update a plugin",
         "description": "Updates a plugin's configuration. Will reload or stop the plugin based on enabled status.\nThe response `actualName` field shows the plugin name from GetName() (used as the map key),\nwhich may differ from the display name (`name`).\nSetting `path` on a non-builtin plugin loads native code (a .so, via dlopen) into the\ngateway process and requires genuine admin authentication - it is refused with 403 if\ndashboard authentication is disabled or unconfigured, even though other management\nendpoints remain reachable in that state. Only `http`/`https` URLs are fetched for\nremote paths, and by default only ones resolving to a public address; private,\nloopback, link-local, and CGNAT addresses are additionally allowed if explicitly\nlisted in the deploy-time `server.plugin_download_private_allowlist` config. Local\nfilesystem paths are unaffected.\n",
-        "tags": ["Plugins"],
+        "tags": [
+          "Plugins"
+        ],
         "parameters": [
           {
             "name": "name",
@@ -41779,7 +43490,9 @@
         "operationId": "deletePlugin",
         "summary": "Delete a plugin",
         "description": "Removes a plugin from the configuration and stops it if running.",
-        "tags": ["Plugins"],
+        "tags": [
+          "Plugins"
+        ],
         "parameters": [
           {
             "name": "name",
@@ -41845,7 +43558,9 @@
         "operationId": "executeMCPTool",
         "summary": "Execute MCP tool",
         "description": "Executes an MCP tool and returns the result.",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "format",
@@ -41854,7 +43569,10 @@
             "description": "Format of the tool execution request/response.\n",
             "schema": {
               "type": "string",
-              "enum": ["chat", "responses"],
+              "enum": [
+                "chat",
+                "responses"
+              ],
               "default": "chat"
             }
           }
@@ -41946,7 +43664,12 @@
                         },
                         "role": {
                           "type": "string",
-                          "enum": ["assistant", "user", "system", "developer"]
+                          "enum": [
+                            "assistant",
+                            "user",
+                            "system",
+                            "developer"
+                          ]
                         },
                         "content": {
                           "oneOf": [
@@ -41957,7 +43680,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -42000,11 +43725,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -42125,7 +43856,9 @@
                               "type": "array",
                               "items": {
                                 "type": "object",
-                                "required": ["type"],
+                                "required": [
+                                  "type"
+                                ],
                                 "properties": {
                                   "type": {
                                     "type": "string",
@@ -42168,11 +43901,17 @@
                                   },
                                   "input_audio": {
                                     "type": "object",
-                                    "required": ["format", "data"],
+                                    "required": [
+                                      "format",
+                                      "data"
+                                    ],
                                     "properties": {
                                       "format": {
                                         "type": "string",
-                                        "enum": ["mp3", "wav"]
+                                        "enum": [
+                                          "mp3",
+                                          "wav"
+                                        ]
                                       },
                                       "data": {
                                         "type": "string"
@@ -42278,7 +44017,9 @@
                               "properties": {
                                 "type": {
                                   "type": "string",
-                                  "enum": ["computer_screenshot"]
+                                  "enum": [
+                                    "computer_screenshot"
+                                  ]
                                 },
                                 "file_id": {
                                   "type": "string"
@@ -42312,11 +44053,16 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type", "text"],
+                            "required": [
+                              "type",
+                              "text"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
-                                "enum": ["summary_text"]
+                                "enum": [
+                                  "summary_text"
+                                ]
                               },
                               "text": {
                                 "type": "string"
@@ -42403,7 +44149,9 @@
         "operationId": "getMCPClients",
         "summary": "List MCP clients",
         "description": "Returns a paginated list of configured MCP clients with their tools and connection state.\nSupports case-insensitive name search and exact-match filtering by connection type, auth type,\ncode-mode, and enabled/disabled status. Multi-value filters accept a comma-separated list and\nuse OR semantics within a field.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -42514,7 +44262,13 @@
                 "schema": {
                   "type": "object",
                   "description": "Paginated list of MCP clients.",
-                  "required": ["clients", "count", "total_count", "limit", "offset"],
+                  "required": [
+                    "clients",
+                    "count",
+                    "total_count",
+                    "limit",
+                    "offset"
+                  ],
                   "properties": {
                     "clients": {
                       "type": "array",
@@ -42572,7 +44326,9 @@
         "operationId": "addMCPClient",
         "summary": "Add MCP client",
         "description": "Adds a new MCP client with the specified configuration.\nNote: tool_pricing is not available when creating a new client; tool\npricing can only be set once the tool list is known. For shared-connection\nclients tools are fetched after client creation; for per-user auth types\nthey are discovered during the create/verify flow itself.\n\nTwo cases require a genuinely authenticated admin session and are refused\nwith 403 when dashboard authentication is disabled or unconfigured, even\nthough other management endpoints stay reachable in that state:\nconnection_type \"stdio\" (which runs the supplied command as a gateway\nsubprocess), and connection_type \"http\"/\"sse\" whose connection_string\nresolves to a loopback, private-network, link-local, or CGNAT address.\nPublic http/sse targets are unaffected.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -42583,11 +44339,16 @@
                     "allOf": [
                       {
                         "type": "object",
-                        "required": ["name", "connection_type"],
+                        "required": [
+                          "name",
+                          "connection_type"
+                        ],
                         "allOf": [
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "const": "per_user_headers"
@@ -42595,7 +44356,9 @@
                               }
                             },
                             "then": {
-                              "required": ["per_user_header_keys"],
+                              "required": [
+                                "per_user_header_keys"
+                              ],
                               "properties": {
                                 "per_user_header_keys": {
                                   "type": "array",
@@ -42611,7 +44374,9 @@
                           },
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "const": "token_exchange"
@@ -42619,13 +44384,17 @@
                               }
                             },
                             "then": {
-                              "required": ["token_exchange"],
+                              "required": [
+                                "token_exchange"
+                              ],
                               "description": "When `auth_type` is `token_exchange`, `token_exchange` must declare\nat least `audience`, plus either `client_id` or\n`use_idp_credentials: true` — there is nothing to scope the\nexchange to, or exchange with, otherwise.\n"
                             }
                           },
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "not": {
@@ -42636,7 +44405,9 @@
                             },
                             "then": {
                               "not": {
-                                "required": ["token_exchange"]
+                                "required": [
+                                  "token_exchange"
+                                ]
                               },
                               "description": "A `token_exchange` block only applies to auth_type \"token_exchange\";\nreject it for every other auth_type instead of silently ignoring it.\n"
                             }
@@ -42683,7 +44454,12 @@
                           },
                           "connection_type": {
                             "type": "string",
-                            "enum": ["http", "stdio", "sse", "inprocess"],
+                            "enum": [
+                              "http",
+                              "stdio",
+                              "sse",
+                              "inprocess"
+                            ],
                             "description": "Connection type for MCP client"
                           },
                           "auth_type": {
@@ -42755,7 +44531,9 @@
                           },
                           "token_exchange": {
                             "type": "object",
-                            "required": ["audience"],
+                            "required": [
+                              "audience"
+                            ],
                             "properties": {
                               "audience": {
                                 "type": "string",
@@ -42796,11 +44574,15 @@
                                         "const": true
                                       }
                                     },
-                                    "required": ["use_idp_credentials"]
+                                    "required": [
+                                      "use_idp_credentials"
+                                    ]
                                   }
                                 },
                                 "then": {
-                                  "required": ["client_id"],
+                                  "required": [
+                                    "client_id"
+                                  ],
                                   "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                                 }
                               }
@@ -42819,11 +44601,15 @@
                       },
                       {
                         "type": "object",
-                        "required": ["connection_string"],
+                        "required": [
+                          "connection_string"
+                        ],
                         "properties": {
                           "connection_type": {
                             "type": "string",
-                            "enum": ["http"]
+                            "enum": [
+                              "http"
+                            ]
                           },
                           "connection_string": {
                             "type": "string",
@@ -42837,11 +44623,16 @@
                     "allOf": [
                       {
                         "type": "object",
-                        "required": ["name", "connection_type"],
+                        "required": [
+                          "name",
+                          "connection_type"
+                        ],
                         "allOf": [
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "const": "per_user_headers"
@@ -42849,7 +44640,9 @@
                               }
                             },
                             "then": {
-                              "required": ["per_user_header_keys"],
+                              "required": [
+                                "per_user_header_keys"
+                              ],
                               "properties": {
                                 "per_user_header_keys": {
                                   "type": "array",
@@ -42865,7 +44658,9 @@
                           },
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "const": "token_exchange"
@@ -42873,13 +44668,17 @@
                               }
                             },
                             "then": {
-                              "required": ["token_exchange"],
+                              "required": [
+                                "token_exchange"
+                              ],
                               "description": "When `auth_type` is `token_exchange`, `token_exchange` must declare\nat least `audience`, plus either `client_id` or\n`use_idp_credentials: true` — there is nothing to scope the\nexchange to, or exchange with, otherwise.\n"
                             }
                           },
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "not": {
@@ -42890,7 +44689,9 @@
                             },
                             "then": {
                               "not": {
-                                "required": ["token_exchange"]
+                                "required": [
+                                  "token_exchange"
+                                ]
                               },
                               "description": "A `token_exchange` block only applies to auth_type \"token_exchange\";\nreject it for every other auth_type instead of silently ignoring it.\n"
                             }
@@ -42937,7 +44738,12 @@
                           },
                           "connection_type": {
                             "type": "string",
-                            "enum": ["http", "stdio", "sse", "inprocess"],
+                            "enum": [
+                              "http",
+                              "stdio",
+                              "sse",
+                              "inprocess"
+                            ],
                             "description": "Connection type for MCP client"
                           },
                           "auth_type": {
@@ -43009,7 +44815,9 @@
                           },
                           "token_exchange": {
                             "type": "object",
-                            "required": ["audience"],
+                            "required": [
+                              "audience"
+                            ],
                             "properties": {
                               "audience": {
                                 "type": "string",
@@ -43050,11 +44858,15 @@
                                         "const": true
                                       }
                                     },
-                                    "required": ["use_idp_credentials"]
+                                    "required": [
+                                      "use_idp_credentials"
+                                    ]
                                   }
                                 },
                                 "then": {
-                                  "required": ["client_id"],
+                                  "required": [
+                                    "client_id"
+                                  ],
                                   "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                                 }
                               }
@@ -43073,11 +44885,15 @@
                       },
                       {
                         "type": "object",
-                        "required": ["connection_string"],
+                        "required": [
+                          "connection_string"
+                        ],
                         "properties": {
                           "connection_type": {
                             "type": "string",
-                            "enum": ["sse"]
+                            "enum": [
+                              "sse"
+                            ]
                           },
                           "connection_string": {
                             "type": "string",
@@ -43091,11 +44907,16 @@
                     "allOf": [
                       {
                         "type": "object",
-                        "required": ["name", "connection_type"],
+                        "required": [
+                          "name",
+                          "connection_type"
+                        ],
                         "allOf": [
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "const": "per_user_headers"
@@ -43103,7 +44924,9 @@
                               }
                             },
                             "then": {
-                              "required": ["per_user_header_keys"],
+                              "required": [
+                                "per_user_header_keys"
+                              ],
                               "properties": {
                                 "per_user_header_keys": {
                                   "type": "array",
@@ -43119,7 +44942,9 @@
                           },
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "const": "token_exchange"
@@ -43127,13 +44952,17 @@
                               }
                             },
                             "then": {
-                              "required": ["token_exchange"],
+                              "required": [
+                                "token_exchange"
+                              ],
                               "description": "When `auth_type` is `token_exchange`, `token_exchange` must declare\nat least `audience`, plus either `client_id` or\n`use_idp_credentials: true` — there is nothing to scope the\nexchange to, or exchange with, otherwise.\n"
                             }
                           },
                           {
                             "if": {
-                              "required": ["auth_type"],
+                              "required": [
+                                "auth_type"
+                              ],
                               "properties": {
                                 "auth_type": {
                                   "not": {
@@ -43144,7 +44973,9 @@
                             },
                             "then": {
                               "not": {
-                                "required": ["token_exchange"]
+                                "required": [
+                                  "token_exchange"
+                                ]
                               },
                               "description": "A `token_exchange` block only applies to auth_type \"token_exchange\";\nreject it for every other auth_type instead of silently ignoring it.\n"
                             }
@@ -43191,7 +45022,12 @@
                           },
                           "connection_type": {
                             "type": "string",
-                            "enum": ["http", "stdio", "sse", "inprocess"],
+                            "enum": [
+                              "http",
+                              "stdio",
+                              "sse",
+                              "inprocess"
+                            ],
                             "description": "Connection type for MCP client"
                           },
                           "auth_type": {
@@ -43263,7 +45099,9 @@
                           },
                           "token_exchange": {
                             "type": "object",
-                            "required": ["audience"],
+                            "required": [
+                              "audience"
+                            ],
                             "properties": {
                               "audience": {
                                 "type": "string",
@@ -43304,11 +45142,15 @@
                                         "const": true
                                       }
                                     },
-                                    "required": ["use_idp_credentials"]
+                                    "required": [
+                                      "use_idp_credentials"
+                                    ]
                                   }
                                 },
                                 "then": {
-                                  "required": ["client_id"],
+                                  "required": [
+                                    "client_id"
+                                  ],
                                   "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                                 }
                               }
@@ -43327,11 +45169,15 @@
                       },
                       {
                         "type": "object",
-                        "required": ["stdio_config"],
+                        "required": [
+                          "stdio_config"
+                        ],
                         "properties": {
                           "connection_type": {
                             "type": "string",
-                            "enum": ["stdio"]
+                            "enum": [
+                              "stdio"
+                            ]
                           },
                           "stdio_config": {
                             "type": "object",
@@ -43429,7 +45275,9 @@
         "operationId": "editMCPClient",
         "summary": "Edit MCP client",
         "description": "Updates an existing MCP client's configuration. All fields are optional\n(PATCH semantics); connection_type, auth_type, connection_string,\nstdio_config, and oauth_config_id are immutable after creation.\nUnlike client creation, tool_pricing can be included to set per-tool execution costs since tools are already fetched.\nFor OAuth-based clients, providing oauth_config rotates the stored OAuth\nconfiguration in place and flips every bound token to needs_reauth when\na field actually changes (see MCPClientUpdateRequest.oauth_config).\nOptionally provide vk_configs to manage which virtual keys have access to this MCP server and with which tools. When provided, this fully replaces all existing VK assignments in a single atomic transaction.\nSet disabled: true to shut down the client's connection and workers without removing it. Set disabled: false to reconnect a previously disabled client.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -43529,7 +45377,9 @@
                   },
                   "token_exchange": {
                     "type": "object",
-                    "required": ["audience"],
+                    "required": [
+                      "audience"
+                    ],
                     "properties": {
                       "audience": {
                         "type": "string",
@@ -43570,11 +45420,15 @@
                                 "const": true
                               }
                             },
-                            "required": ["use_idp_credentials"]
+                            "required": [
+                              "use_idp_credentials"
+                            ]
                           }
                         },
                         "then": {
-                          "required": ["client_id"],
+                          "required": [
+                            "client_id"
+                          ],
                           "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                         }
                       }
@@ -43606,7 +45460,10 @@
                     "items": {
                       "type": "object",
                       "description": "Per-virtual-key tool access configuration for an MCP client",
-                      "required": ["virtual_key_id", "tools_to_execute"],
+                      "required": [
+                        "virtual_key_id",
+                        "tools_to_execute"
+                      ],
                       "properties": {
                         "virtual_key_id": {
                           "type": "string",
@@ -43670,7 +45527,9 @@
         "operationId": "removeMCPClient",
         "summary": "Remove MCP client",
         "description": "Removes an MCP client from the configuration.",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -43726,7 +45585,9 @@
         "operationId": "reconnectMCPClient",
         "summary": "Reconnect MCP client",
         "description": "Reconnects an MCP client that is in an error or unstable state.\nNot applicable (400) to any per-call client — a shared client running\nper-call (needs_session_stickiness false/omitted) as well as any\nper-user auth type — since none of them hold a shared upstream\nconnection to re-establish. Also not applicable to clients in\npending_verification state — complete the admin verification instead.\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -43782,7 +45643,10 @@
         "operationId": "completeMCPClientOAuth",
         "summary": "Complete MCP client OAuth flow",
         "description": "Completes an OAuth flow for an MCP client after the admin has authorized\nthe request upstream. Call it once the flow's status_url reports\n\"authorized\". It serves every admin-side OAuth completion with one\nendpoint:\n\n- Create-time and config.json-bootstrap flows: retrieves the pending MCP\n  client configuration and establishes the connection with the\n  OAuth-provided credentials (per_user_oauth clients instead verify with\n  the admin token, discover tools, and retain the token as the admin\n  discovery credential).\n- Reauthorize flows (started via POST /api/mcp/client/{id}/reauthorize):\n  for shared \"oauth\" clients, reconnects the client with the fresh\n  credential; for per_user_oauth clients, verifies the fresh admin token\n  upstream, re-discovers tools, and promotes it to the retained admin\n  discovery credential.\n\nReplays are rejected with 409: hitting the endpoint again after the flow\nalready completed (no pending configuration and no freshly-written\ntoken) returns \"OAuth flow has already been completed\". A shared\n\"oauth\" reauthorize is also rejected with 409 if its flow never\nactually resolved via a real callback — e.g. the upstream authorization\nserver rejected the request outright before ever redirecting back —\nreturning \"Authorization has not completed yet\". This is detected via\nthe flow's own row rather than the client's overall OAuth status,\nwhich never regresses once a client has been authorized once and so\ncan't distinguish a stale prior authorization from a fresh one.\n",
-        "tags": ["MCP", "OAuth"],
+        "tags": [
+          "MCP",
+          "OAuth"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -43858,7 +45722,10 @@
         "operationId": "initiateMCPClientVerification",
         "summary": "Initiate verification for a pending MCP client",
         "description": "Starts the one-time admin OAuth authorization for an MCP client sitting\nin pending_verification state (declared via config.json with auth_type\n\"oauth\" or \"per_user_oauth\"). Runs OAuth metadata discovery (RFC 8414)\nand dynamic client registration (RFC 7591) against the client's\nconnection_string when the declared oauth_config omits those fields,\ncreates a fresh OAuth flow, and returns the authorization URL.\n\nComplete the flow like a create-time OAuth flow: open authorize_url in a\nbrowser, poll status_url until \"authorized\", then POST complete_url.\nSafe to call again if a previous attempt expired or was abandoned — each\ncall starts a fresh flow.\n",
-        "tags": ["MCP", "OAuth"],
+        "tags": [
+          "MCP",
+          "OAuth"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -43924,7 +45791,10 @@
         "operationId": "reauthorizeMCPClient",
         "summary": "Reauthorize an MCP client",
         "description": "Redoes the OAuth consent flow for an already-authorized OAuth-based MCP\nclient, without delete-and-recreate. The flow always runs against the\ncredentials currently stored on the client's OAuth config.\n\n- auth_type \"oauth\": serves both a standalone admin-triggered reauth\n  (e.g. the upstream provider revoked the credential and the client sits\n  in needs_reauth) and the follow-up to rotating oauth_config via\n  PUT /api/mcp/client/{id} (which cascades every bound token to\n  needs_reauth).\n- auth_type \"per_user_oauth\": repairs the retained admin discovery\n  credential used for periodic tool-list refresh. Only allowed while\n  that credential actually sits in needs_reauth (409 otherwise);\n  end-user credentials are untouched either way.\n\nComplete the returned flow like any other admin OAuth flow: open\nauthorize_url in a browser, poll status_url until \"authorized\", then\nPOST complete_url.\n",
-        "tags": ["MCP", "OAuth"],
+        "tags": [
+          "MCP",
+          "OAuth"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44010,7 +45880,9 @@
         "operationId": "verifyMCPClientHeaders",
         "summary": "Verify a pending per-user-headers MCP client",
         "description": "Completes the admin verification for an MCP client with auth_type\n\"per_user_headers\". The admin supplies sample values for every declared\nper_user_header_keys entry; Bifrost opens an upstream connection with\nthem, discovers the tool list, persists it, and transitions the client\nto connected. The sample values are retained as the admin discovery\ncredential the periodic tool syncer uses to refresh the tool list; each\nend-user still submits their own values at runtime. Synchronous; no\nbrowser flow.\n\nServes two situations: the one-time bootstrap verification for a client\nsitting in pending_verification (declared via config.json), and a\nvoluntary refresh of an already-verified client's retained admin\ndiscovery credential — resubmitting sample values always re-runs\nverification and upserts the credential back to active, whether or not\nit currently needs repair (mirrors POST /reauthorize for OAuth-based\nclients).\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44028,7 +45900,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user_headers"],
+                "required": [
+                  "user_headers"
+                ],
                 "properties": {
                   "user_headers": {
                     "type": "object",
@@ -44057,7 +45931,9 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": ["success"]
+                      "enum": [
+                        "success"
+                      ]
                     },
                     "message": {
                       "type": "string"
@@ -44119,7 +45995,9 @@
         "operationId": "verifyMCPClientExchange",
         "summary": "Verify a pending or repair a needs_reauth token_exchange MCP client",
         "description": "Completes admin verification for an MCP client with auth_type\n\"token_exchange\". No request body: the subject of the exchange is\nalways the signed-in admin's own identity-provider token (from an SSO\nsession or an identity-authenticated bearer request) — there is no\nmanual token input. Bifrost exchanges it exactly like a real caller's\ntoken would be exchanged, opens an upstream connection with the result,\ndiscovers the tool list, persists it, and transitions the client to\nconnected. The exchanged token (and any refresh token the identity\nprovider issued alongside it) is retained as the admin discovery\ncredential the periodic tool syncer uses to refresh the tool list;\nend-user tool calls always exchange the caller's own token instead.\nSynchronous; no browser flow.\n\nServes two situations: the one-time bootstrap verification for a client\nsitting in pending_verification, and a voluntary refresh of an\nalready-verified client's retained admin discovery credential —\nresubmitting always re-runs verification and retains a fresh\ncredential, whether or not it currently needs repair (mirrors POST\n/reauthorize for OAuth-based clients).\n",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44146,7 +46024,9 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": ["success"]
+                      "enum": [
+                        "success"
+                      ]
                     },
                     "message": {
                       "type": "string"
@@ -44208,7 +46088,9 @@
         "summary": "List MCP sessions",
         "description": "Returns every per-user MCP authentication artifact visible to the caller:\nOAuth tokens, header credentials, and pending submission / consent flows.\n\nRow visibility is scoped to the caller's identity (Virtual Key, signed-in\nuser, or asserted session ID). Server-level `headers` / `oauth` clients\nare not surfaced here; their credentials live on the MCP client config.\nAdmin discovery credentials (the retained bootstrap credential Bifrost\nuses for periodic tool-list refresh on per-user clients) never appear\nhere either; only user-, vk-, and session-keyed rows are listed.\n\nWhen both a credential and a pending flow exist for the same\n`(identity, mcp_client)` binding, the credential is returned and the\nflow is suppressed to avoid duplicate entries.\n",
         "operationId": "listMcpSessions",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -44253,7 +46135,9 @@
         "summary": "Revoke an MCP session",
         "description": "Revokes a session by primary key. Accepts these row kinds:\n- OAuth token rows → hard-deletes the token plus any pending OAuth flow\n  for the same binding (so an in-flight callback can't undo the revoke)\n- Header credential rows → hard-deletes the credential plus any pending\n  header submission flow for the same binding\n- Pending per-user-headers flow rows → hard-deletes just the flow\n\nNote: pending per-user OAuth flow rows are **not** revocable by this\nendpoint — they expire naturally or are cleared when the bound token\nrow is revoked. To cancel a pending OAuth flow, revoke its parent token\n(if one exists) or wait for expiry.\n\nBifrost does **not** call the upstream provider's revoke endpoint —\nrevocation is local. Per-user-headers credentials never call upstream.\n",
         "operationId": "revokeMcpSession",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44312,7 +46196,9 @@
         "summary": "Re-authenticate or edit an MCP session",
         "description": "Mints a fresh authentication flow against the same MCP client and identity\nas the existing row. Two branches based on row type:\n\n- **OAuth token** (any non-`orphaned` row, typically `needs_reauth` —\n  but `active` is also accepted) — opens a fresh upstream OAuth consent\n  flow. Caller is expected to follow `authorize_url` to the provider;\n  on callback the credential is replaced in place.\n- **Header credential** (`active` or `needs_update`) — opens a fresh\n  per-user-headers submission flow. Caller follows the same URL field\n  to the Bifrost submission form; on submit the credential is replaced\n  in place. `kind: \"headers\"` is set on the response.\n\nRefused with 403 if the row is `orphaned` — a fresh credential wouldn't\nhelp; the issue is the identity has lost access to the MCP, which the\nadmin must fix.\n",
         "operationId": "reauthMcpSession",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44381,7 +46267,9 @@
         "summary": "Get per-user-headers submission flow",
         "description": "Returns the pending submission flow row plus the live MCP client's schema\n(required header names + optional admin header names). Used by the\n`/workspace/mcp-sessions/auth?flow=<id>&kind=headers` landing page to\nrender the values form.\n\nRequires management API authentication via `Authorization: Bearer <API key>`.\n",
         "operationId": "getPerUserHeadersFlow",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44445,7 +46333,9 @@
         "summary": "Submit per-user-headers values",
         "description": "Consumes a pending submission flow row: verifies the caller's values\nagainst the upstream MCP server, upserts the credential keyed by the flow\nrow's (mode, identity), then deletes the flow row and the bound temp\ntoken. Mirrors the OAuth callback's \"complete the flow\" semantics.\n\nValues for any key not in the live `per_user_header_keys` schema are\ndropped server-side so a stale UI can't persist deprecated keys.\n",
         "operationId": "submitPerUserHeadersFlow",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44537,7 +46427,9 @@
         "summary": "Revoke a per-user-headers credential",
         "description": "Hard-deletes a per-user-headers credential row by primary key. Authorization\nscoping is enforced server-side — callers may only delete credentials\nvisible to their identity.\n\nThe unified DELETE /api/mcp/sessions/{id} is the more convenient entry\npoint; this typed endpoint exists for callers that already know they're\nacting on a header credential row.\n",
         "operationId": "revokePerUserHeadersCredential",
-        "tags": ["MCP"],
+        "tags": [
+          "MCP"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44596,7 +46488,9 @@
         "operationId": "getPerUserOauthFlow",
         "summary": "Get per-user OAuth flow detail",
         "description": "Returns the pending OAuth flow row metadata: which MCP client is being\nauthorized, which identity (user / VK / session) the resulting token\nwill be bound to, and whether an active token already exists for that\nbinding (`has_active_token`).\n\nRequires management API authentication via `Authorization: Bearer <API key>`.\n",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44662,7 +46556,9 @@
         "operationId": "startPerUserOauthFlow",
         "summary": "Start the upstream OAuth authorization for a pending flow",
         "description": "Reconstructs the upstream provider's authorize URL for a pending OAuth\nflow. The auth-landing page redirects the browser to that URL; the user\ncompletes upstream auth; the upstream provider redirects back to\n`/api/oauth/callback`, which exchanges the code for tokens server-side\nand stores them against the flow's identity.\n\nReturns 410 if the flow is no longer pending (expired / completed /\nfailed). The caller should restart the original action to get a fresh\nflow.\n",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44686,7 +46582,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["authorize_url"],
+                  "required": [
+                    "authorize_url"
+                  ],
                   "properties": {
                     "authorize_url": {
                       "type": "string",
@@ -44755,7 +46653,9 @@
         "operationId": "handleOAuthCallback",
         "summary": "OAuth callback endpoint",
         "description": "Handles the OAuth provider callback after user authorization.\nThis endpoint processes the authorization code and exchanges it for an access token.\nOn success, displays an HTML page that closes the authorization window.\n",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "parameters": [
           {
             "name": "state",
@@ -44824,7 +46724,9 @@
         "operationId": "getOAuthConfigStatus",
         "summary": "Get OAuth config status",
         "description": "Retrieves the current status of an OAuth configuration.\nShows whether the OAuth flow is pending, authorized, or failed,\nand includes token expiration and scopes if authorized.\n",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44880,7 +46782,9 @@
         "operationId": "revokeOAuthConfig",
         "summary": "Revoke OAuth config",
         "description": "Revokes a server-level OAuth configuration and its associated access token.\nAfter revocation, the MCP client will no longer be able to use this OAuth token.\nRevocation is not terminal for the client: an admin can restore access by\nredoing consent via POST /api/mcp/client/{id}/reauthorize, which runs\nagainst the credentials currently stored on the client's OAuth config.\n",
-        "tags": ["OAuth"],
+        "tags": [
+          "OAuth"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44936,7 +46840,9 @@
         "operationId": "listVirtualKeys",
         "summary": "List virtual keys",
         "description": "Returns a list of all virtual keys with their configurations.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "from_memory",
@@ -45003,7 +46909,12 @@
             "description": "Field to sort by",
             "schema": {
               "type": "string",
-              "enum": ["name", "budget_spent", "created_at", "status"]
+              "enum": [
+                "name",
+                "budget_spent",
+                "created_at",
+                "status"
+              ]
             }
           },
           {
@@ -45012,7 +46923,10 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"]
+              "enum": [
+                "asc",
+                "desc"
+              ]
             }
           },
           {
@@ -45076,7 +46990,9 @@
         "operationId": "createVirtualKey",
         "summary": "Create virtual key",
         "description": "Creates a new virtual key with the specified configuration.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -45131,7 +47047,9 @@
         "operationId": "getVirtualKeyQuota",
         "summary": "Get virtual key quota",
         "description": "Returns the overall budget and rate limit quota for the authenticated virtual key,\nas well as per-provider and per-model budgets and rate limits (with current usage).\nEach budget also carries the actual per-model usage for its current cycle.\nThis is a self-service endpoint - no admin authentication required.\nThe virtual key value itself (provided via header) is the credential.\nDuring an active rotation grace window (client vk_rotation_cooldown), the\nprevious key value also authenticates until previous_value_expires_at.\nAn expired virtual key is rejected with 403; an inactive one still returns\nits quota with is_active false.\n",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "security": [
           {
             "VirtualKeyAuth": []
@@ -45202,7 +47120,9 @@
         "operationId": "getVirtualKey",
         "summary": "Get virtual key",
         "description": "Returns a specific virtual key by ID.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45235,7 +47155,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["virtual_key"],
+                  "required": [
+                    "virtual_key"
+                  ],
                   "properties": {
                     "virtual_key": {
                       "$ref": "#/components/schemas/VirtualKey"
@@ -45271,7 +47193,9 @@
         "operationId": "updateVirtualKey",
         "summary": "Update virtual key",
         "description": "Updates an existing virtual key's configuration.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45345,7 +47269,9 @@
         "operationId": "deleteVirtualKey",
         "summary": "Delete virtual key",
         "description": "Deletes a virtual key.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45401,7 +47327,9 @@
         "operationId": "updateVirtualKeyBudgetOverride",
         "summary": "Set virtual key budget override",
         "description": "Sets or replaces the spending override on one of a virtual key's budgets. The override is additive —\nwhile it is active the budget is enforced against `max_limit + override_amount` — and it leaves the\nbudget's base limit, current usage, and reset schedule untouched.\n\nUse `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows\n(the current window counts as the first), or `mode: forever` to keep the override until it is deleted.\nA finite grant is anchored to the budget's current reset window, so every node in a cluster derives the\nsame number of remaining cycles and a config reload cannot resurrect a spent one.\n",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45484,7 +47412,9 @@
         "operationId": "deleteVirtualKeyBudgetOverride",
         "summary": "Remove virtual key budget override",
         "description": "Removes any active override from the budget, so it is enforced against its base `max_limit` again.\nThe budget's current usage and reset schedule are unchanged, and the removal is permanent — a cleared\ngrant cannot be re-derived. Safe to call on a budget that has no override.\n",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45554,7 +47484,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List users attached to a virtual key",
-        "tags": ["Virtual Keys", "Users"],
+        "tags": [
+          "Virtual Keys",
+          "Users"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45577,7 +47510,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["users", "count"],
+                  "required": [
+                    "users",
+                    "count"
+                  ],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -45714,7 +47650,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach users to a virtual key",
-        "tags": ["Virtual Keys", "Users"],
+        "tags": [
+          "Virtual Keys",
+          "Users"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45731,7 +47670,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user_ids"],
+                "required": [
+                  "user_ids"
+                ],
                 "properties": {
                   "user_ids": {
                     "type": "array",
@@ -45777,7 +47718,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a user from a virtual key",
-        "tags": ["Virtual Keys", "Users"],
+        "tags": [
+          "Virtual Keys",
+          "Users"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45820,7 +47764,9 @@
         "operationId": "bulkRotateVirtualKeys",
         "summary": "Rotate multiple virtual keys",
         "description": "Generates a new value for each listed virtual key. When the client vk_rotation_cooldown setting is non-zero, each retired value keeps authenticating until previous_value_expires_at; otherwise it stops working immediately.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -45832,7 +47778,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["ids"],
+                "required": [
+                  "ids"
+                ],
                 "properties": {
                   "ids": {
                     "type": "array",
@@ -45854,7 +47802,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["message", "virtual_keys"],
+                  "required": [
+                    "message",
+                    "virtual_keys"
+                  ],
                   "properties": {
                     "message": {
                       "type": "string"
@@ -45893,7 +47844,11 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["message", "virtual_keys", "errors"],
+                  "required": [
+                    "message",
+                    "virtual_keys",
+                    "errors"
+                  ],
                   "properties": {
                     "message": {
                       "type": "string"
@@ -45925,7 +47880,9 @@
         "operationId": "rotateVirtualKey",
         "summary": "Rotate virtual key",
         "description": "Generates a new value for the virtual key. When the client vk_rotation_cooldown setting is non-zero, the retired value keeps authenticating until previous_value_expires_at; otherwise it stops working immediately.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -45949,7 +47906,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["message", "virtual_key"],
+                  "required": [
+                    "message",
+                    "virtual_key"
+                  ],
                   "properties": {
                     "message": {
                       "type": "string"
@@ -45990,7 +47950,9 @@
         "operationId": "listTeams",
         "summary": "List teams",
         "description": "Returns a list of all teams.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "customer_id",
@@ -46042,7 +48004,9 @@
         "operationId": "createTeam",
         "summary": "Create team",
         "description": "Creates a new team.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -46097,7 +48061,9 @@
         "operationId": "getTeam",
         "summary": "Get team",
         "description": "Returns a specific team by ID.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -46165,7 +48131,9 @@
         "operationId": "updateTeam",
         "summary": "Update team",
         "description": "Updates an existing team.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -46239,7 +48207,9 @@
         "operationId": "deleteTeam",
         "summary": "Delete team",
         "description": "Deletes a team.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -46300,7 +48270,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List customers attached to a team",
-        "tags": ["Teams", "Customers"],
+        "tags": [
+          "Teams",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -46354,7 +48327,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach a customer to a team",
-        "tags": ["Teams", "Customers"],
+        "tags": [
+          "Teams",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -46371,7 +48347,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["customer_id"],
+                "required": [
+                  "customer_id"
+                ],
                 "properties": {
                   "customer_id": {
                     "type": "string"
@@ -46410,7 +48388,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a customer from a team",
-        "tags": ["Teams", "Customers"],
+        "tags": [
+          "Teams",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -46453,7 +48434,9 @@
         "operationId": "listCustomers",
         "summary": "List customers",
         "description": "Returns a list of all customers.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "from_memory",
@@ -46497,7 +48480,9 @@
         "operationId": "createCustomer",
         "summary": "Create customer",
         "description": "Creates a new customer.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -46552,7 +48537,9 @@
         "operationId": "getCustomer",
         "summary": "Get customer",
         "description": "Returns a specific customer by ID.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "customer_id",
@@ -46620,7 +48607,9 @@
         "operationId": "updateCustomer",
         "summary": "Update customer",
         "description": "Updates an existing customer.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "customer_id",
@@ -46694,7 +48683,9 @@
         "operationId": "deleteCustomer",
         "summary": "Delete customer",
         "description": "Deletes a customer.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "customer_id",
@@ -46755,7 +48746,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List teams attached to a customer",
-        "tags": ["Customers", "Teams"],
+        "tags": [
+          "Customers",
+          "Teams"
+        ],
         "parameters": [
           {
             "name": "customer_id",
@@ -46811,7 +48805,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List business units attached to a customer",
-        "tags": ["Customers", "Business Units"],
+        "tags": [
+          "Customers",
+          "Business Units"
+        ],
         "parameters": [
           {
             "name": "customer_id",
@@ -46868,7 +48865,9 @@
         },
         "summary": "List business units",
         "description": "Returns a paginated list of business units, each with its team count.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "offset",
@@ -46913,7 +48912,13 @@
                 "schema": {
                   "type": "object",
                   "description": "Paginated list of business units",
-                  "required": ["business_units", "count", "total_count", "limit", "offset"],
+                  "required": [
+                    "business_units",
+                    "count",
+                    "total_count",
+                    "limit",
+                    "offset"
+                  ],
                   "properties": {
                     "business_units": {
                       "type": "array",
@@ -46983,7 +48988,9 @@
         },
         "summary": "Create business unit",
         "description": "Creates a new business unit. Names must be unique.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -46991,7 +48998,9 @@
               "schema": {
                 "type": "object",
                 "description": "Create business unit request",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -47070,7 +49079,9 @@
         },
         "summary": "Get business unit",
         "description": "Returns a specific business unit by ID, including governance and team count.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -47156,7 +49167,9 @@
         },
         "summary": "Update business unit",
         "description": "Updates the business unit name.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -47175,7 +49188,9 @@
               "schema": {
                 "type": "object",
                 "description": "Create business unit request",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -47262,7 +49277,9 @@
         },
         "summary": "Delete business unit",
         "description": "Deletes a business unit. Any teams assigned to it are atomically unassigned\nas part of the deletion.\n",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -47324,7 +49341,9 @@
         },
         "summary": "List business unit teams",
         "description": "Returns a paginated list of teams assigned to the business unit.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -47378,7 +49397,13 @@
                 "schema": {
                   "type": "object",
                   "description": "Paginated list of teams assigned to a business unit",
-                  "required": ["teams", "count", "total_count", "limit", "offset"],
+                  "required": [
+                    "teams",
+                    "count",
+                    "total_count",
+                    "limit",
+                    "offset"
+                  ],
                   "properties": {
                     "teams": {
                       "type": "array",
@@ -47443,7 +49468,9 @@
         },
         "summary": "Assign team to business unit",
         "description": "Assigns an existing team to the business unit. Returns 409 if the team is\nalready assigned to a different business unit.\n",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -47462,7 +49489,9 @@
               "schema": {
                 "type": "object",
                 "description": "Request to assign a team to a business unit",
-                "required": ["team_id"],
+                "required": [
+                  "team_id"
+                ],
                 "properties": {
                   "team_id": {
                     "type": "string"
@@ -47542,7 +49571,9 @@
         },
         "summary": "Remove team from business unit",
         "description": "Unassigns a team from the business unit.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -47623,7 +49654,9 @@
         },
         "summary": "Create business unit governance",
         "description": "Configures budget and/or rate limit governance for a business unit. At least\none of `budget` or `rate_limit` is required. Returns 409 if the business unit\nalready has governance configured (use PUT to update).\n",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -47644,10 +49677,14 @@
                 "description": "Create business unit governance request. The business unit is identified by\nthe {id} path parameter. At least one of budget or rate_limit is required.\n",
                 "anyOf": [
                   {
-                    "required": ["budget"]
+                    "required": [
+                      "budget"
+                    ]
                   },
                   {
-                    "required": ["rate_limit"]
+                    "required": [
+                      "rate_limit"
+                    ]
                   }
                 ],
                 "properties": {
@@ -47793,7 +49830,9 @@
         },
         "summary": "Update business unit governance",
         "description": "Updates budget and/or rate limit governance for a business unit. Passing an\nempty `budget` or `rate_limit` object removes that governance component.\n",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -47945,7 +49984,9 @@
         },
         "summary": "Delete business unit governance",
         "description": "Removes all budget and rate limit governance from a business unit.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -48006,7 +50047,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List customers attached to a business unit",
-        "tags": ["Business Units", "Customers"],
+        "tags": [
+          "Business Units",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -48090,7 +50134,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach customers to a business unit",
-        "tags": ["Business Units", "Customers"],
+        "tags": [
+          "Business Units",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -48151,7 +50198,10 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a customer from a business unit",
-        "tags": ["Business Units", "Customers"],
+        "tags": [
+          "Business Units",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "business_unit_id",
@@ -48194,7 +50244,9 @@
         "operationId": "listBudgets",
         "summary": "List budgets",
         "description": "Returns a list of all budgets. Use the `from_memory` query parameter to get data from in-memory cache.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "from_memory",
@@ -48240,7 +50292,9 @@
         "operationId": "listRateLimits",
         "summary": "List rate limits",
         "description": "Returns a list of all rate limits. Use the `from_memory` query parameter to get data from in-memory cache.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "from_memory",
@@ -48286,7 +50340,9 @@
         "operationId": "listModelConfigs",
         "summary": "List model limits",
         "description": "Returns a paginated list of model limits with their budget and rate limit settings.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -48325,7 +50381,11 @@
             "description": "Filter by scope (`global`, `virtual_key`, or `user`; `user` is Enterprise only)",
             "schema": {
               "type": "string",
-              "enum": ["global", "virtual_key", "user"]
+              "enum": [
+                "global",
+                "virtual_key",
+                "user"
+              ]
             }
           },
           {
@@ -48373,7 +50433,9 @@
         "operationId": "createModelConfig",
         "summary": "Create model config",
         "description": "Creates a new model configuration with budget and rate limit settings.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -48428,7 +50490,9 @@
         "operationId": "getModelConfig",
         "summary": "Get model config",
         "description": "Returns a specific model configuration by ID.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "mc_id",
@@ -48487,7 +50551,9 @@
         "operationId": "updateModelConfig",
         "summary": "Update model config",
         "description": "Updates an existing model configuration's budget and rate limit settings.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "mc_id",
@@ -48561,7 +50627,9 @@
         "operationId": "deleteModelConfig",
         "summary": "Delete model config",
         "description": "Deletes a model configuration.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "mc_id",
@@ -48617,7 +50685,9 @@
         "operationId": "listProviderGovernance",
         "summary": "List provider governance",
         "description": "Returns a list of all providers with their governance settings (budget and rate limits).",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -48652,7 +50722,9 @@
         "operationId": "updateProviderGovernance",
         "summary": "Update provider governance",
         "description": "Updates governance settings (budget and rate limits) for a specific provider.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "provider_name",
@@ -48726,7 +50798,9 @@
         "operationId": "deleteProviderGovernance",
         "summary": "Delete provider governance",
         "description": "Removes governance settings (budget and rate limits) for a specific provider.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "provider_name",
@@ -48782,7 +50856,9 @@
         "operationId": "listPricingOverrides",
         "summary": "List pricing overrides",
         "description": "Returns all pricing overrides, optionally filtered by scope.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "scope_kind",
@@ -48883,7 +50959,9 @@
         "operationId": "createPricingOverride",
         "summary": "Create pricing override",
         "description": "Creates a new pricing override. The most specific matching scope always wins during cost resolution.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -48938,7 +51016,9 @@
         "operationId": "updatePricingOverride",
         "summary": "Update pricing override",
         "description": "Updates an existing pricing override. Omitted fields are merged from the existing record. The `patch` field is always replaced in full when provided.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -49012,7 +51092,9 @@
         "operationId": "deletePricingOverride",
         "summary": "Delete pricing override",
         "description": "Deletes a pricing override by ID.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -49064,7 +51146,9 @@
         },
         "summary": "List roles",
         "description": "Returns all roles visible to the caller, scoped by data access control.",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -49101,7 +51185,11 @@
                           },
                           "dac": {
                             "type": "string",
-                            "enum": ["own-data", "team-data", "all-data"],
+                            "enum": [
+                              "own-data",
+                              "team-data",
+                              "all-data"
+                            ],
                             "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                           },
                           "created_by_user_id": {
@@ -49146,14 +51234,18 @@
         },
         "summary": "Create role",
         "description": "Creates a custom role with the specified data access control scope.\nIf `dac` is omitted, defaults to `all-data`.\n",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -49165,7 +51257,11 @@
                   },
                   "dac": {
                     "type": "string",
-                    "enum": ["own-data", "team-data", "all-data"],
+                    "enum": [
+                      "own-data",
+                      "team-data",
+                      "all-data"
+                    ],
                     "description": "Defaults to `all-data` when omitted."
                   }
                 }
@@ -49207,7 +51303,11 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": ["own-data", "team-data", "all-data"],
+                          "enum": [
+                            "own-data",
+                            "team-data",
+                            "all-data"
+                          ],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -49262,7 +51362,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get role by ID",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -49307,7 +51409,11 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": ["own-data", "team-data", "all-data"],
+                          "enum": [
+                            "own-data",
+                            "team-data",
+                            "all-data"
+                          ],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -49354,7 +51460,9 @@
         },
         "summary": "Update role",
         "description": "Partial update. Omitted fields preserve the current value.\nNotable: omitting `dac` preserves the current scope (does not default to `all-data`).\n",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -49384,7 +51492,11 @@
                   },
                   "dac": {
                     "type": "string",
-                    "enum": ["own-data", "team-data", "all-data"],
+                    "enum": [
+                      "own-data",
+                      "team-data",
+                      "all-data"
+                    ],
                     "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                   }
                 }
@@ -49426,7 +51538,11 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": ["own-data", "team-data", "all-data"],
+                          "enum": [
+                            "own-data",
+                            "team-data",
+                            "all-data"
+                          ],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -49483,7 +51599,9 @@
         },
         "summary": "Delete role",
         "description": "Deletes a custom role. Built-in system roles cannot be deleted and return 403.\n",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -49557,7 +51675,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List permissions assigned to a role",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -49629,7 +51749,9 @@
         },
         "summary": "Replace the permission set on a role",
         "description": "Replaces the permission set assigned to the role.\nSend the complete list of permission IDs that should be active for the role.\n",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -49646,7 +51768,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["permission_ids"],
+                "required": [
+                  "permission_ids"
+                ],
                 "properties": {
                   "permission_ids": {
                     "type": "array",
@@ -49718,7 +51842,9 @@
         },
         "summary": "List RBAC resources",
         "description": "Returns the set of resource names that permissions can target.",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -49776,7 +51902,9 @@
         },
         "summary": "List RBAC operations",
         "description": "Returns the set of operation names that permissions can grant.",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -49834,7 +51962,9 @@
         },
         "summary": "List all RBAC permissions",
         "description": "Returns every (resource, operation) pair that can be granted to a role.",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -49895,7 +52025,9 @@
         },
         "summary": "List access profiles",
         "description": "Returns access profiles visible to the caller.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -49979,7 +52111,9 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["provider_name"],
+                              "required": [
+                                "provider_name"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -50005,7 +52139,10 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": ["max_limit", "reset_duration"],
+                                    "required": [
+                                      "max_limit",
+                                      "reset_duration"
+                                    ],
                                     "properties": {
                                       "id": {
                                         "type": "string",
@@ -50017,7 +52154,14 @@
                                       },
                                       "reset_duration": {
                                         "type": "string",
-                                        "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                        "enum": [
+                                          "1h",
+                                          "1d",
+                                          "1w",
+                                          "1M",
+                                          "1Q",
+                                          "1Y"
+                                        ],
                                         "description": "Reset duration for a budget."
                                       },
                                       "reset_config": {
@@ -50062,7 +52206,13 @@
                                     },
                                     "token_reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a rate limit."
                                     },
                                     "request_max_limit": {
@@ -50071,7 +52221,13 @@
                                     },
                                     "request_reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a rate limit."
                                     },
                                     "token_current_usage": {
@@ -50091,7 +52247,10 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["max_limit", "reset_duration"],
+                              "required": [
+                                "max_limit",
+                                "reset_duration"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "string",
@@ -50103,7 +52262,14 @@
                                 },
                                 "reset_duration": {
                                   "type": "string",
-                                  "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                  "enum": [
+                                    "1h",
+                                    "1d",
+                                    "1w",
+                                    "1M",
+                                    "1Q",
+                                    "1Y"
+                                  ],
                                   "description": "Reset duration for a budget."
                                 },
                                 "reset_config": {
@@ -50148,7 +52314,13 @@
                               },
                               "token_reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a rate limit."
                               },
                               "request_max_limit": {
@@ -50157,7 +52329,13 @@
                               },
                               "request_reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a rate limit."
                               },
                               "token_current_usage": {
@@ -50177,7 +52355,9 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["tool_group_id"],
+                              "required": [
+                                "tool_group_id"
+                              ],
                               "properties": {
                                 "tool_group_id": {
                                   "type": "integer",
@@ -50190,7 +52370,9 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["mcp_server_id"],
+                              "required": [
+                                "mcp_server_id"
+                              ],
                               "properties": {
                                 "mcp_server_id": {
                                   "type": "string"
@@ -50202,7 +52384,11 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["mcp_client_id", "tool_name", "action"],
+                              "required": [
+                                "mcp_client_id",
+                                "tool_name",
+                                "action"
+                              ],
                               "properties": {
                                 "mcp_client_id": {
                                   "type": "string"
@@ -50212,7 +52398,10 @@
                                 },
                                 "action": {
                                   "type": "string",
-                                  "enum": ["include", "exclude"]
+                                  "enum": [
+                                    "include",
+                                    "exclude"
+                                  ]
                                 }
                               }
                             }
@@ -50267,14 +52456,18 @@
         },
         "summary": "Create access profile",
         "description": "Creates a new access profile template. The profile is inactive until attached to a role.\nNo size limits are enforced on create; the limits apply on update.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -50293,7 +52486,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["provider_name"],
+                      "required": [
+                        "provider_name"
+                      ],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -50319,7 +52514,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -50331,7 +52529,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -50376,7 +52581,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -50385,7 +52596,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -50405,7 +52622,10 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["max_limit", "reset_duration"],
+                      "required": [
+                        "max_limit",
+                        "reset_duration"
+                      ],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -50417,7 +52637,14 @@
                         },
                         "reset_duration": {
                           "type": "string",
-                          "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                          "enum": [
+                            "1h",
+                            "1d",
+                            "1w",
+                            "1M",
+                            "1Q",
+                            "1Y"
+                          ],
                           "description": "Reset duration for a budget."
                         },
                         "reset_config": {
@@ -50462,7 +52689,13 @@
                       },
                       "token_reset_duration": {
                         "type": "string",
-                        "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                        "enum": [
+                          "1h",
+                          "1d",
+                          "1w",
+                          "1M",
+                          "1Y"
+                        ],
                         "description": "Reset duration for a rate limit."
                       },
                       "request_max_limit": {
@@ -50471,7 +52704,13 @@
                       },
                       "request_reset_duration": {
                         "type": "string",
-                        "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                        "enum": [
+                          "1h",
+                          "1d",
+                          "1w",
+                          "1M",
+                          "1Y"
+                        ],
                         "description": "Reset duration for a rate limit."
                       },
                       "token_current_usage": {
@@ -50491,7 +52730,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["tool_group_id"],
+                      "required": [
+                        "tool_group_id"
+                      ],
                       "properties": {
                         "tool_group_id": {
                           "type": "integer",
@@ -50504,7 +52745,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_server_id"],
+                      "required": [
+                        "mcp_server_id"
+                      ],
                       "properties": {
                         "mcp_server_id": {
                           "type": "string"
@@ -50516,7 +52759,11 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_client_id", "tool_name", "action"],
+                      "required": [
+                        "mcp_client_id",
+                        "tool_name",
+                        "action"
+                      ],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string"
@@ -50526,7 +52773,10 @@
                         },
                         "action": {
                           "type": "string",
-                          "enum": ["include", "exclude"]
+                          "enum": [
+                            "include",
+                            "exclude"
+                          ]
                         }
                       }
                     }
@@ -50579,7 +52829,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -50605,7 +52857,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -50617,7 +52872,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -50662,7 +52924,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -50671,7 +52939,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -50691,7 +52965,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -50703,7 +52980,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -50748,7 +53032,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -50757,7 +53047,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -50777,7 +53073,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -50790,7 +53088,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -50802,7 +53102,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -50812,7 +53116,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -50869,7 +53176,9 @@
         },
         "summary": "Get access profile by ID",
         "description": "Returns the profile plus its role attachments and the count of users holding a copy.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -50924,7 +53233,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -50950,7 +53261,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -50962,7 +53276,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -51007,7 +53328,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -51016,7 +53343,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -51036,7 +53369,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -51048,7 +53384,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -51093,7 +53436,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -51102,7 +53451,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -51122,7 +53477,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -51135,7 +53492,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -51147,7 +53506,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -51157,7 +53520,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -51231,7 +53597,9 @@
         },
         "summary": "Update access profile",
         "description": "Partial update. Omitted fields preserve the current value.\n`rate_limit: null` explicitly clears the existing rate limit.\nSize limits enforced: max 100 provider_configs, max 100 budgets, max 50 tags.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -51268,7 +53636,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["provider_name"],
+                      "required": [
+                        "provider_name"
+                      ],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -51294,7 +53664,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -51306,7 +53679,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -51351,7 +53731,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -51360,7 +53746,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -51380,7 +53772,10 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["max_limit", "reset_duration"],
+                      "required": [
+                        "max_limit",
+                        "reset_duration"
+                      ],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -51392,7 +53787,14 @@
                         },
                         "reset_duration": {
                           "type": "string",
-                          "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                          "enum": [
+                            "1h",
+                            "1d",
+                            "1w",
+                            "1M",
+                            "1Q",
+                            "1Y"
+                          ],
                           "description": "Reset duration for a budget."
                         },
                         "reset_config": {
@@ -51441,7 +53843,13 @@
                           },
                           "token_reset_duration": {
                             "type": "string",
-                            "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                            "enum": [
+                              "1h",
+                              "1d",
+                              "1w",
+                              "1M",
+                              "1Y"
+                            ],
                             "description": "Reset duration for a rate limit."
                           },
                           "request_max_limit": {
@@ -51450,7 +53858,13 @@
                           },
                           "request_reset_duration": {
                             "type": "string",
-                            "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                            "enum": [
+                              "1h",
+                              "1d",
+                              "1w",
+                              "1M",
+                              "1Y"
+                            ],
                             "description": "Reset duration for a rate limit."
                           },
                           "token_current_usage": {
@@ -51473,7 +53887,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["tool_group_id"],
+                      "required": [
+                        "tool_group_id"
+                      ],
                       "properties": {
                         "tool_group_id": {
                           "type": "integer",
@@ -51486,7 +53902,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_server_id"],
+                      "required": [
+                        "mcp_server_id"
+                      ],
                       "properties": {
                         "mcp_server_id": {
                           "type": "string"
@@ -51498,7 +53916,11 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_client_id", "tool_name", "action"],
+                      "required": [
+                        "mcp_client_id",
+                        "tool_name",
+                        "action"
+                      ],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string"
@@ -51508,7 +53930,10 @@
                         },
                         "action": {
                           "type": "string",
-                          "enum": ["include", "exclude"]
+                          "enum": [
+                            "include",
+                            "exclude"
+                          ]
                         }
                       }
                     }
@@ -51561,7 +53986,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -51587,7 +54014,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -51599,7 +54029,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -51644,7 +54081,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -51653,7 +54096,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -51673,7 +54122,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -51685,7 +54137,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -51730,7 +54189,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -51739,7 +54204,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -51759,7 +54230,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -51772,7 +54245,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -51784,7 +54259,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -51794,7 +54273,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -51852,7 +54334,9 @@
         },
         "summary": "Delete access profile",
         "description": "Blocked with 409 if any users still hold copies. Detach role attachments or remove user assignments first.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -51914,7 +54398,9 @@
         },
         "summary": "Activate access profile",
         "description": "Sets the profile active. Idempotent.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -51968,7 +54454,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -51994,7 +54482,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -52006,7 +54497,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -52051,7 +54549,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -52060,7 +54564,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -52080,7 +54590,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -52092,7 +54605,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -52137,7 +54657,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -52146,7 +54672,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -52166,7 +54698,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -52179,7 +54713,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -52191,7 +54727,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -52201,7 +54741,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -52248,7 +54791,9 @@
         },
         "summary": "Deactivate access profile",
         "description": "Sets the profile inactive. Idempotent. User copies are preserved; the profile is hidden from selection menus.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -52302,7 +54847,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -52328,7 +54875,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -52340,7 +54890,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -52385,7 +54942,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -52394,7 +54957,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -52414,7 +54983,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -52426,7 +54998,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -52471,7 +55050,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -52480,7 +55065,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -52500,7 +55091,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -52513,7 +55106,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -52525,7 +55120,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -52535,7 +55134,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -52582,7 +55184,9 @@
         },
         "summary": "Clone an access profile",
         "description": "Creates a fresh copy of the profile under a new name. The clone has no role attachments or user copies.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -52599,7 +55203,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -52655,7 +55261,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -52681,7 +55289,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -52693,7 +55304,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -52738,7 +55356,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -52747,7 +55371,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -52767,7 +55397,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -52779,7 +55412,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -52824,7 +55464,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -52833,7 +55479,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -52853,7 +55505,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -52866,7 +55520,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -52878,7 +55534,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -52888,7 +55548,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -52948,7 +55611,9 @@
         },
         "summary": "Propagate template changes to user copies",
         "description": "Pushes selected fields from the template to every user that holds a copy.\nUse `dry_run: true` to preview the impact. By default, accumulated usage is preserved.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -52965,7 +55630,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["fields"],
+                "required": [
+                  "fields"
+                ],
                 "properties": {
                   "dry_run": {
                     "type": "boolean"
@@ -53094,7 +55761,9 @@
         },
         "summary": "Attach roles to access profile",
         "description": "Attaches one or more roles. Setting `is_default: true` makes the profile the role's default\nfor new users. `apply_to_existing: true` provisions the profile to users already in the role.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -53111,7 +55780,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["role_ids"],
+                "required": [
+                  "role_ids"
+                ],
                 "properties": {
                   "role_ids": {
                     "type": "array",
@@ -53192,7 +55863,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach role from access profile",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -53258,7 +55931,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List version snapshots for an access profile",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -53345,7 +56020,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get a single version snapshot",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -53440,7 +56117,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List audit log entries for a single profile",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -53565,7 +56244,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List workspace-wide audit log entries",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -53681,7 +56362,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List access profiles held by a user",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -53776,7 +56459,9 @@
         },
         "summary": "Detach a user's access profile",
         "description": "Removes the profile from the user and deletes every virtual key it produced. Fails closed if a virtual key cannot be deleted.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -53852,7 +56537,9 @@
         },
         "summary": "Set a user's access-profile budget override",
         "description": "Sets or replaces the spending override on one budget of a single user's copy of an access profile.\nThe override is additive — while it is active the budget is enforced against\n`max_limit + override_amount` — and it leaves the budget's base limit, current usage, and reset\nschedule untouched. Only this user is affected; the access profile template and every other user\nassigned to it keep their original limits.\n\nUse `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows\n(the current window counts as the first), or `mode: forever` to keep the override until it is deleted.\nA finite grant is anchored to the profile's reset window — calendar-aligned profiles anchor at the\ncalendar period start — so every node in a cluster derives the same number of remaining cycles.\nThe change is propagated cluster-wide and survives access-profile cloning and propagation.\n\nRequires the `AccessProfiles.Update` permission. `budget_id` must be a budget on the user's own copy\nof the profile, not on the shared template.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -53943,7 +56630,9 @@
         },
         "summary": "Remove a user's access-profile budget override",
         "description": "Removes any active override from the user's budget, so it is enforced against its base `max_limit`\nagain. The budget's current usage and reset schedule are unchanged, and the removal is permanent — a\ncleared grant cannot be re-derived. Safe to call on a budget that has no override.\n\nRequires the `AccessProfiles.Update` permission.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -54015,7 +56704,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Add an extra virtual key under a user's access profile",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -54111,7 +56802,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Delete a virtual key from a user's access profile",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -54177,7 +56870,10 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/virtual-keys/{vk_id}/users` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List users attached to a virtual key (deprecated path)",
-        "tags": ["Virtual Keys", "Users"],
+        "tags": [
+          "Virtual Keys",
+          "Users"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -54200,7 +56896,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["users", "count"],
+                  "required": [
+                    "users",
+                    "count"
+                  ],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -54340,7 +57039,10 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/virtual-keys/{vk_id}/users` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach users to a virtual key (deprecated path)",
-        "tags": ["Virtual Keys", "Users"],
+        "tags": [
+          "Virtual Keys",
+          "Users"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -54357,7 +57059,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user_ids"],
+                "required": [
+                  "user_ids"
+                ],
                 "properties": {
                   "user_ids": {
                     "type": "array",
@@ -54406,7 +57110,10 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/virtual-keys/{vk_id}/users/{user_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a user from a virtual key (deprecated path)",
-        "tags": ["Virtual Keys", "Users"],
+        "tags": [
+          "Virtual Keys",
+          "Users"
+        ],
         "parameters": [
           {
             "name": "vk_id",
@@ -54457,7 +57164,10 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/teams/{team_id}/customers` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List customers attached to a team (deprecated path)",
-        "tags": ["Teams", "Customers"],
+        "tags": [
+          "Teams",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -54514,7 +57224,10 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/teams/{team_id}/customers` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Attach a customer to a team (deprecated path)",
-        "tags": ["Teams", "Customers"],
+        "tags": [
+          "Teams",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -54531,7 +57244,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["customer_id"],
+                "required": [
+                  "customer_id"
+                ],
                 "properties": {
                   "customer_id": {
                     "type": "string"
@@ -54573,7 +57288,10 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/teams/{team_id}/customers/{customer_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach a customer from a team (deprecated path)",
-        "tags": ["Teams", "Customers"],
+        "tags": [
+          "Teams",
+          "Customers"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -54624,7 +57342,10 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/customers/{customer_id}/teams` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List teams attached to a customer (deprecated path)",
-        "tags": ["Customers", "Teams"],
+        "tags": [
+          "Customers",
+          "Teams"
+        ],
         "parameters": [
           {
             "name": "customer_id",
@@ -54684,7 +57405,9 @@
         },
         "summary": "List roles (deprecated path)",
         "description": "Returns all roles visible to the caller, scoped by data access control.",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -54721,7 +57444,11 @@
                           },
                           "dac": {
                             "type": "string",
-                            "enum": ["own-data", "team-data", "all-data"],
+                            "enum": [
+                              "own-data",
+                              "team-data",
+                              "all-data"
+                            ],
                             "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                           },
                           "created_by_user_id": {
@@ -54769,14 +57496,18 @@
         },
         "summary": "Create role (deprecated path)",
         "description": "Creates a custom role with the specified data access control scope.\nIf `dac` is omitted, defaults to `all-data`.\n",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -54788,7 +57519,11 @@
                   },
                   "dac": {
                     "type": "string",
-                    "enum": ["own-data", "team-data", "all-data"],
+                    "enum": [
+                      "own-data",
+                      "team-data",
+                      "all-data"
+                    ],
                     "description": "Defaults to `all-data` when omitted."
                   }
                 }
@@ -54830,7 +57565,11 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": ["own-data", "team-data", "all-data"],
+                          "enum": [
+                            "own-data",
+                            "team-data",
+                            "all-data"
+                          ],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -54888,7 +57627,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/rbac/roles/{role_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get role by ID (deprecated path)",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -54933,7 +57674,11 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": ["own-data", "team-data", "all-data"],
+                          "enum": [
+                            "own-data",
+                            "team-data",
+                            "all-data"
+                          ],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -54983,7 +57728,9 @@
         },
         "summary": "Update role (deprecated path)",
         "description": "Partial update. Omitted fields preserve the current value.\nNotable: omitting `dac` preserves the current scope (does not default to `all-data`).\n",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -55013,7 +57760,11 @@
                   },
                   "dac": {
                     "type": "string",
-                    "enum": ["own-data", "team-data", "all-data"],
+                    "enum": [
+                      "own-data",
+                      "team-data",
+                      "all-data"
+                    ],
                     "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                   }
                 }
@@ -55055,7 +57806,11 @@
                         },
                         "dac": {
                           "type": "string",
-                          "enum": ["own-data", "team-data", "all-data"],
+                          "enum": [
+                            "own-data",
+                            "team-data",
+                            "all-data"
+                          ],
                           "description": "Data access scope. Determines which rows members of the role can see.\n- `own-data` - Only rows the member personally owns.\n- `team-data` - Own rows plus rows owned by any team they belong to.\n- `all-data` - No row filtering.\n"
                         },
                         "created_by_user_id": {
@@ -55115,7 +57870,9 @@
         },
         "summary": "Delete role (deprecated path)",
         "description": "Deletes a custom role. Built-in system roles cannot be deleted and return 403.\n",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -55192,7 +57949,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/rbac/roles/{role_id}/permissions` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List permissions assigned to a role (deprecated path)",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -55267,7 +58026,9 @@
         },
         "summary": "Replace the permission set on a role (deprecated path)",
         "description": "Replaces the permission set assigned to the role.\nSend the complete list of permission IDs that should be active for the role.\n",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "parameters": [
           {
             "name": "role_id",
@@ -55284,7 +58045,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["permission_ids"],
+                "required": [
+                  "permission_ids"
+                ],
                 "properties": {
                   "permission_ids": {
                     "type": "array",
@@ -55359,7 +58122,9 @@
         },
         "summary": "List RBAC resources (deprecated path)",
         "description": "Returns the set of resource names that permissions can target.",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -55420,7 +58185,9 @@
         },
         "summary": "List RBAC operations (deprecated path)",
         "description": "Returns the set of operation names that permissions can grant.",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -55481,7 +58248,9 @@
         },
         "summary": "List all RBAC permissions (deprecated path)",
         "description": "Returns every (resource, operation) pair that can be granted to a role.",
-        "tags": ["RBAC"],
+        "tags": [
+          "RBAC"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -55545,7 +58314,9 @@
         },
         "summary": "List users (deprecated path)",
         "description": "Returns a paginated list of users with optional search.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -55605,7 +58376,14 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["users", "total", "page", "limit", "total_pages", "has_more"],
+                  "required": [
+                    "users",
+                    "total",
+                    "page",
+                    "limit",
+                    "total_pages",
+                    "has_more"
+                  ],
                   "properties": {
                     "users": {
                       "type": "array",
@@ -55768,14 +58546,19 @@
         },
         "summary": "Create user (deprecated path)",
         "description": "Manually creates a new user in the organization.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name", "email"],
+                "required": [
+                  "name",
+                  "email"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -55974,7 +58757,9 @@
         },
         "summary": "Get user (deprecated path)",
         "description": "Returns a single Enterprise user.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -56147,7 +58932,9 @@
         },
         "summary": "Delete user (deprecated path)",
         "description": "Permanently removes a user from the organization. This cascades to delete the user's governance settings (budget/rate limits), team memberships, access profiles, and OIDC sessions. Cannot delete yourself.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -56222,7 +59009,9 @@
         },
         "summary": "Get current user permissions (deprecated path)",
         "description": "Returns the RBAC permissions for the authenticated user. When SCIM is not enabled, returns full permissions for all resources. Otherwise returns the permissions associated with the user's assigned role.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -56298,7 +59087,9 @@
         },
         "summary": "Assign role to user (deprecated path)",
         "description": "Assigns an RBAC role to a user. This also auto-assigns the default access profile for the new role and reloads the RBAC permission cache.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -56316,7 +59107,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["role_id"],
+                "required": [
+                  "role_id"
+                ],
                 "properties": {
                   "role_id": {
                     "type": "integer",
@@ -56390,7 +59183,9 @@
         },
         "summary": "Get user's teams (deprecated path)",
         "description": "Returns the list of teams a user belongs to, including the membership source.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -56485,7 +59280,9 @@
         },
         "summary": "Update user's team assignments (deprecated path)",
         "description": "Replaces the user's manual team assignments. Synced team memberships (from SCIM providers) are preserved and cannot be removed via this endpoint.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -56503,7 +59300,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["team_ids"],
+                "required": [
+                  "team_ids"
+                ],
                 "properties": {
                   "team_ids": {
                     "type": "array",
@@ -56580,7 +59379,9 @@
         },
         "summary": "Get user's virtual keys by email (deprecated path)",
         "description": "**Enterprise only.**\nReturns all virtual keys associated with a user, looked up by email address. Returns an empty `virtual_keys` array when the user exists but has no virtual keys assigned. Intended for MDM and credential-helper integrations that need to resolve a user's keys without knowing their internal ID.\n",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "email",
@@ -56693,7 +59494,9 @@
         },
         "summary": "Get user by email (deprecated path)",
         "description": "Returns a single Enterprise user resolved by URL-encoded email address.",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "email",
@@ -56862,7 +59665,9 @@
         "operationId": "listTeamsLegacy",
         "summary": "List teams (deprecated path)",
         "description": "Returns a list of all teams.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -56899,7 +59704,9 @@
             "description": "Set to `business_unit` to include business-unit associations",
             "schema": {
               "type": "string",
-              "enum": ["business_unit"]
+              "enum": [
+                "business_unit"
+              ]
             }
           }
         ],
@@ -56915,7 +59722,12 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["teams", "total", "page", "limit"],
+                  "required": [
+                    "teams",
+                    "total",
+                    "page",
+                    "limit"
+                  ],
                   "properties": {
                     "teams": {
                       "type": "array",
@@ -56962,7 +59774,9 @@
         "operationId": "createTeamLegacy",
         "summary": "Create team (deprecated path)",
         "description": "Creates a new team.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -57026,7 +59840,9 @@
         "operationId": "getTeamLegacy",
         "summary": "Get team (deprecated path)",
         "description": "Returns a specific team by ID.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -57103,7 +59919,9 @@
         "operationId": "updateTeamLegacy",
         "summary": "Update team (deprecated path)",
         "description": "Updates an existing team.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -57186,7 +60004,9 @@
         "operationId": "deleteTeamLegacy",
         "summary": "Delete team (deprecated path)",
         "description": "Deletes a team.",
-        "tags": ["Governance"],
+        "tags": [
+          "Governance"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -57257,7 +60077,9 @@
         },
         "summary": "List team members (deprecated path)",
         "description": "Returns all members of a team with their user details and membership source.",
-        "tags": ["Teams"],
+        "tags": [
+          "Teams"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -57353,7 +60175,9 @@
         },
         "summary": "Add team member (deprecated path)",
         "description": "Adds a user to a team. Both the team and user must exist.",
-        "tags": ["Teams"],
+        "tags": [
+          "Teams"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -57371,7 +60195,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user_id"],
+                "required": [
+                  "user_id"
+                ],
                 "properties": {
                   "user_id": {
                     "type": "string",
@@ -57445,7 +60271,9 @@
         },
         "summary": "Remove team member (deprecated path)",
         "description": "Removes a user from a team.",
-        "tags": ["Teams"],
+        "tags": [
+          "Teams"
+        ],
         "parameters": [
           {
             "name": "team_id",
@@ -57519,7 +60347,9 @@
         },
         "summary": "List access profiles (deprecated path)",
         "description": "Returns access profiles visible to the caller.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -57603,7 +60433,9 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["provider_name"],
+                              "required": [
+                                "provider_name"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "integer",
@@ -57629,7 +60461,10 @@
                                   "type": "array",
                                   "items": {
                                     "type": "object",
-                                    "required": ["max_limit", "reset_duration"],
+                                    "required": [
+                                      "max_limit",
+                                      "reset_duration"
+                                    ],
                                     "properties": {
                                       "id": {
                                         "type": "string",
@@ -57641,7 +60476,14 @@
                                       },
                                       "reset_duration": {
                                         "type": "string",
-                                        "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                        "enum": [
+                                          "1h",
+                                          "1d",
+                                          "1w",
+                                          "1M",
+                                          "1Q",
+                                          "1Y"
+                                        ],
                                         "description": "Reset duration for a budget."
                                       },
                                       "reset_config": {
@@ -57686,7 +60528,13 @@
                                     },
                                     "token_reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a rate limit."
                                     },
                                     "request_max_limit": {
@@ -57695,7 +60543,13 @@
                                     },
                                     "request_reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a rate limit."
                                     },
                                     "token_current_usage": {
@@ -57715,7 +60569,10 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["max_limit", "reset_duration"],
+                              "required": [
+                                "max_limit",
+                                "reset_duration"
+                              ],
                               "properties": {
                                 "id": {
                                   "type": "string",
@@ -57727,7 +60584,14 @@
                                 },
                                 "reset_duration": {
                                   "type": "string",
-                                  "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                  "enum": [
+                                    "1h",
+                                    "1d",
+                                    "1w",
+                                    "1M",
+                                    "1Q",
+                                    "1Y"
+                                  ],
                                   "description": "Reset duration for a budget."
                                 },
                                 "reset_config": {
@@ -57772,7 +60636,13 @@
                               },
                               "token_reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a rate limit."
                               },
                               "request_max_limit": {
@@ -57781,7 +60651,13 @@
                               },
                               "request_reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a rate limit."
                               },
                               "token_current_usage": {
@@ -57801,7 +60677,9 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["tool_group_id"],
+                              "required": [
+                                "tool_group_id"
+                              ],
                               "properties": {
                                 "tool_group_id": {
                                   "type": "integer",
@@ -57814,7 +60692,9 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["mcp_server_id"],
+                              "required": [
+                                "mcp_server_id"
+                              ],
                               "properties": {
                                 "mcp_server_id": {
                                   "type": "string"
@@ -57826,7 +60706,11 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["mcp_client_id", "tool_name", "action"],
+                              "required": [
+                                "mcp_client_id",
+                                "tool_name",
+                                "action"
+                              ],
                               "properties": {
                                 "mcp_client_id": {
                                   "type": "string"
@@ -57836,7 +60720,10 @@
                                 },
                                 "action": {
                                   "type": "string",
-                                  "enum": ["include", "exclude"]
+                                  "enum": [
+                                    "include",
+                                    "exclude"
+                                  ]
                                 }
                               }
                             }
@@ -57894,14 +60781,18 @@
         },
         "summary": "Create access profile (deprecated path)",
         "description": "Creates a new access profile template. The profile is inactive until attached to a role.\nNo size limits are enforced on create; the limits apply on update.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -57920,7 +60811,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["provider_name"],
+                      "required": [
+                        "provider_name"
+                      ],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -57946,7 +60839,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -57958,7 +60854,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -58003,7 +60906,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -58012,7 +60921,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -58032,7 +60947,10 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["max_limit", "reset_duration"],
+                      "required": [
+                        "max_limit",
+                        "reset_duration"
+                      ],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -58044,7 +60962,14 @@
                         },
                         "reset_duration": {
                           "type": "string",
-                          "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                          "enum": [
+                            "1h",
+                            "1d",
+                            "1w",
+                            "1M",
+                            "1Q",
+                            "1Y"
+                          ],
                           "description": "Reset duration for a budget."
                         },
                         "reset_config": {
@@ -58089,7 +61014,13 @@
                       },
                       "token_reset_duration": {
                         "type": "string",
-                        "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                        "enum": [
+                          "1h",
+                          "1d",
+                          "1w",
+                          "1M",
+                          "1Y"
+                        ],
                         "description": "Reset duration for a rate limit."
                       },
                       "request_max_limit": {
@@ -58098,7 +61029,13 @@
                       },
                       "request_reset_duration": {
                         "type": "string",
-                        "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                        "enum": [
+                          "1h",
+                          "1d",
+                          "1w",
+                          "1M",
+                          "1Y"
+                        ],
                         "description": "Reset duration for a rate limit."
                       },
                       "token_current_usage": {
@@ -58118,7 +61055,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["tool_group_id"],
+                      "required": [
+                        "tool_group_id"
+                      ],
                       "properties": {
                         "tool_group_id": {
                           "type": "integer",
@@ -58131,7 +61070,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_server_id"],
+                      "required": [
+                        "mcp_server_id"
+                      ],
                       "properties": {
                         "mcp_server_id": {
                           "type": "string"
@@ -58143,7 +61084,11 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_client_id", "tool_name", "action"],
+                      "required": [
+                        "mcp_client_id",
+                        "tool_name",
+                        "action"
+                      ],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string"
@@ -58153,7 +61098,10 @@
                         },
                         "action": {
                           "type": "string",
-                          "enum": ["include", "exclude"]
+                          "enum": [
+                            "include",
+                            "exclude"
+                          ]
                         }
                       }
                     }
@@ -58206,7 +61154,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -58232,7 +61182,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -58244,7 +61197,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -58289,7 +61249,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -58298,7 +61264,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -58318,7 +61290,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -58330,7 +61305,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -58375,7 +61357,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -58384,7 +61372,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -58404,7 +61398,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -58417,7 +61413,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -58429,7 +61427,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -58439,7 +61441,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -58499,7 +61504,9 @@
         },
         "summary": "Get access profile by ID (deprecated path)",
         "description": "Returns the profile plus its role attachments and the count of users holding a copy.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -58554,7 +61561,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -58580,7 +61589,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -58592,7 +61604,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -58637,7 +61656,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -58646,7 +61671,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -58666,7 +61697,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -58678,7 +61712,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -58723,7 +61764,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -58732,7 +61779,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -58752,7 +61805,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -58765,7 +61820,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -58777,7 +61834,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -58787,7 +61848,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -58864,7 +61928,9 @@
         },
         "summary": "Update access profile (deprecated path)",
         "description": "Partial update. Omitted fields preserve the current value.\n`rate_limit: null` explicitly clears the existing rate limit.\nSize limits enforced: max 100 provider_configs, max 100 budgets, max 50 tags.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -58901,7 +61967,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["provider_name"],
+                      "required": [
+                        "provider_name"
+                      ],
                       "properties": {
                         "id": {
                           "type": "integer",
@@ -58927,7 +61995,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -58939,7 +62010,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -58984,7 +62062,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -58993,7 +62077,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -59013,7 +62103,10 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["max_limit", "reset_duration"],
+                      "required": [
+                        "max_limit",
+                        "reset_duration"
+                      ],
                       "properties": {
                         "id": {
                           "type": "string",
@@ -59025,7 +62118,14 @@
                         },
                         "reset_duration": {
                           "type": "string",
-                          "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                          "enum": [
+                            "1h",
+                            "1d",
+                            "1w",
+                            "1M",
+                            "1Q",
+                            "1Y"
+                          ],
                           "description": "Reset duration for a budget."
                         },
                         "reset_config": {
@@ -59074,7 +62174,13 @@
                           },
                           "token_reset_duration": {
                             "type": "string",
-                            "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                            "enum": [
+                              "1h",
+                              "1d",
+                              "1w",
+                              "1M",
+                              "1Y"
+                            ],
                             "description": "Reset duration for a rate limit."
                           },
                           "request_max_limit": {
@@ -59083,7 +62189,13 @@
                           },
                           "request_reset_duration": {
                             "type": "string",
-                            "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                            "enum": [
+                              "1h",
+                              "1d",
+                              "1w",
+                              "1M",
+                              "1Y"
+                            ],
                             "description": "Reset duration for a rate limit."
                           },
                           "token_current_usage": {
@@ -59106,7 +62218,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["tool_group_id"],
+                      "required": [
+                        "tool_group_id"
+                      ],
                       "properties": {
                         "tool_group_id": {
                           "type": "integer",
@@ -59119,7 +62233,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_server_id"],
+                      "required": [
+                        "mcp_server_id"
+                      ],
                       "properties": {
                         "mcp_server_id": {
                           "type": "string"
@@ -59131,7 +62247,11 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_client_id", "tool_name", "action"],
+                      "required": [
+                        "mcp_client_id",
+                        "tool_name",
+                        "action"
+                      ],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string"
@@ -59141,7 +62261,10 @@
                         },
                         "action": {
                           "type": "string",
-                          "enum": ["include", "exclude"]
+                          "enum": [
+                            "include",
+                            "exclude"
+                          ]
                         }
                       }
                     }
@@ -59194,7 +62317,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -59220,7 +62345,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -59232,7 +62360,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -59277,7 +62412,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -59286,7 +62427,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -59306,7 +62453,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -59318,7 +62468,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -59363,7 +62520,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -59372,7 +62535,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -59392,7 +62561,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -59405,7 +62576,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -59417,7 +62590,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -59427,7 +62604,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -59488,7 +62668,9 @@
         },
         "summary": "Delete access profile (deprecated path)",
         "description": "Blocked with 409 if any users still hold copies. Detach role attachments or remove user assignments first.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -59553,7 +62735,9 @@
         },
         "summary": "Activate access profile (deprecated path)",
         "description": "Sets the profile active. Idempotent.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -59607,7 +62791,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -59633,7 +62819,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -59645,7 +62834,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -59690,7 +62886,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -59699,7 +62901,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -59719,7 +62927,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -59731,7 +62942,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -59776,7 +62994,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -59785,7 +63009,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -59805,7 +63035,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -59818,7 +63050,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -59830,7 +63064,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -59840,7 +63078,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -59890,7 +63131,9 @@
         },
         "summary": "Deactivate access profile (deprecated path)",
         "description": "Sets the profile inactive. Idempotent. User copies are preserved; the profile is hidden from selection menus.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -59944,7 +63187,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -59970,7 +63215,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -59982,7 +63230,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -60027,7 +63282,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -60036,7 +63297,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -60056,7 +63323,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -60068,7 +63338,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -60113,7 +63390,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -60122,7 +63405,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -60142,7 +63431,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -60155,7 +63446,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -60167,7 +63460,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -60177,7 +63474,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -60227,7 +63527,9 @@
         },
         "summary": "Clone an access profile (deprecated path)",
         "description": "Creates a fresh copy of the profile under a new name. The clone has no role attachments or user copies.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -60244,7 +63546,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -60300,7 +63604,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["provider_name"],
+                            "required": [
+                              "provider_name"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "integer",
@@ -60326,7 +63632,10 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
-                                  "required": ["max_limit", "reset_duration"],
+                                  "required": [
+                                    "max_limit",
+                                    "reset_duration"
+                                  ],
                                   "properties": {
                                     "id": {
                                       "type": "string",
@@ -60338,7 +63647,14 @@
                                     },
                                     "reset_duration": {
                                       "type": "string",
-                                      "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                      "enum": [
+                                        "1h",
+                                        "1d",
+                                        "1w",
+                                        "1M",
+                                        "1Q",
+                                        "1Y"
+                                      ],
                                       "description": "Reset duration for a budget."
                                     },
                                     "reset_config": {
@@ -60383,7 +63699,13 @@
                                   },
                                   "token_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "request_max_limit": {
@@ -60392,7 +63714,13 @@
                                   },
                                   "request_reset_duration": {
                                     "type": "string",
-                                    "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                                    "enum": [
+                                      "1h",
+                                      "1d",
+                                      "1w",
+                                      "1M",
+                                      "1Y"
+                                    ],
                                     "description": "Reset duration for a rate limit."
                                   },
                                   "token_current_usage": {
@@ -60412,7 +63740,10 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["max_limit", "reset_duration"],
+                            "required": [
+                              "max_limit",
+                              "reset_duration"
+                            ],
                             "properties": {
                               "id": {
                                 "type": "string",
@@ -60424,7 +63755,14 @@
                               },
                               "reset_duration": {
                                 "type": "string",
-                                "enum": ["1h", "1d", "1w", "1M", "1Q", "1Y"],
+                                "enum": [
+                                  "1h",
+                                  "1d",
+                                  "1w",
+                                  "1M",
+                                  "1Q",
+                                  "1Y"
+                                ],
                                 "description": "Reset duration for a budget."
                               },
                               "reset_config": {
@@ -60469,7 +63807,13 @@
                             },
                             "token_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "request_max_limit": {
@@ -60478,7 +63822,13 @@
                             },
                             "request_reset_duration": {
                               "type": "string",
-                              "enum": ["1h", "1d", "1w", "1M", "1Y"],
+                              "enum": [
+                                "1h",
+                                "1d",
+                                "1w",
+                                "1M",
+                                "1Y"
+                              ],
                               "description": "Reset duration for a rate limit."
                             },
                             "token_current_usage": {
@@ -60498,7 +63848,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["tool_group_id"],
+                            "required": [
+                              "tool_group_id"
+                            ],
                             "properties": {
                               "tool_group_id": {
                                 "type": "integer",
@@ -60511,7 +63863,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_server_id"],
+                            "required": [
+                              "mcp_server_id"
+                            ],
                             "properties": {
                               "mcp_server_id": {
                                 "type": "string"
@@ -60523,7 +63877,11 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id", "tool_name", "action"],
+                            "required": [
+                              "mcp_client_id",
+                              "tool_name",
+                              "action"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string"
@@ -60533,7 +63891,10 @@
                               },
                               "action": {
                                 "type": "string",
-                                "enum": ["include", "exclude"]
+                                "enum": [
+                                  "include",
+                                  "exclude"
+                                ]
                               }
                             }
                           }
@@ -60596,7 +63957,9 @@
         },
         "summary": "Propagate template changes to user copies (deprecated path)",
         "description": "Pushes selected fields from the template to every user that holds a copy.\nUse `dry_run: true` to preview the impact. By default, accumulated usage is preserved.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -60613,7 +63976,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["fields"],
+                "required": [
+                  "fields"
+                ],
                 "properties": {
                   "dry_run": {
                     "type": "boolean"
@@ -60745,7 +64110,9 @@
         },
         "summary": "Attach roles to access profile (deprecated path)",
         "description": "Attaches one or more roles. Setting `is_default: true` makes the profile the role's default\nfor new users. `apply_to_existing: true` provisions the profile to users already in the role.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -60762,7 +64129,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["role_ids"],
+                "required": [
+                  "role_ids"
+                ],
                 "properties": {
                   "role_ids": {
                     "type": "array",
@@ -60846,7 +64215,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/{profile_id}/roles/{role_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Detach role from access profile (deprecated path)",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -60915,7 +64286,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/{profile_id}/versions` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List version snapshots for an access profile (deprecated path)",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -61005,7 +64378,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/{profile_id}/versions/{version}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get a single version snapshot (deprecated path)",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -61103,7 +64478,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/{profile_id}/audit-logs` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List audit log entries for a single profile (deprecated path)",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "profile_id",
@@ -61231,7 +64608,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/access-profiles/audit-logs` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List workspace-wide audit log entries (deprecated path)",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -61350,7 +64729,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/users/{user_id}/access-profiles` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List access profiles held by a user (deprecated path)",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -61447,7 +64828,10 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/users/{user_id}/virtual-keys` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "List virtual keys available to a user (deprecated path)",
-        "tags": ["Users", "Virtual Keys"],
+        "tags": [
+          "Users",
+          "Virtual Keys"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -61500,7 +64884,9 @@
         },
         "summary": "Set a user's access-profile budget override (deprecated path)",
         "description": "Sets or replaces the spending override on one budget of a single user's copy of an access profile.\nThe override is additive — while it is active the budget is enforced against\n`max_limit + override_amount` — and it leaves the budget's base limit, current usage, and reset\nschedule untouched. Only this user is affected; the access profile template and every other user\nassigned to it keep their original limits.\n\nUse `mode: cycles` with a `cycles` count to grant extra spend for a finite number of reset windows\n(the current window counts as the first), or `mode: forever` to keep the override until it is deleted.\nA finite grant is anchored to the profile's reset window — calendar-aligned profiles anchor at the\ncalendar period start — so every node in a cluster derives the same number of remaining cycles.\nThe change is propagated cluster-wide and survives access-profile cloning and propagation.\n\nRequires the `AccessProfiles.Update` permission. `budget_id` must be a budget on the user's own copy\nof the profile, not on the shared template.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -61594,7 +64980,9 @@
         },
         "summary": "Remove a user's access-profile budget override (deprecated path)",
         "description": "Removes any active override from the user's budget, so it is enforced against its base `max_limit`\nagain. The budget's current usage and reset schedule are unchanged, and the removal is permanent — a\ncleared grant cannot be re-derived. Safe to call on a budget that has no override.\n\nRequires the `AccessProfiles.Update` permission.\n",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -61670,7 +65058,9 @@
         },
         "summary": "Detach a user's access profile (deprecated path)",
         "description": "Removes the profile from the user and deletes every virtual key it produced. Fails closed if a virtual key cannot be deleted.",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -61748,7 +65138,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/users/{user_id}/access-profiles/{profile_id}/virtual-keys` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Add an extra virtual key under a user's access profile (deprecated path)",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -61847,7 +65239,9 @@
           "content": "<Warning>\n  This path is deprecated and will be removed in the following major release.\n  Use `/api/governance/users/{user_id}/access-profiles/virtual-keys/{vk_id}` instead.\n</Warning>\n<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Delete a virtual key from a user's access profile (deprecated path)",
-        "tags": ["Access Profiles"],
+        "tags": [
+          "Access Profiles"
+        ],
         "parameters": [
           {
             "name": "user_id",
@@ -61917,7 +65311,9 @@
         },
         "summary": "List audit logs",
         "description": "Retrieves CADF-compliant audit log events with filtering, search, and\npagination via query parameters. Most filter dimensions accept either a\nsingle value (singular parameter, e.g. `action`) or a JSON-encoded array\nof values (plural parameter, e.g. `actions`); when both are supplied the\nplural array takes precedence.\n",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -62166,7 +65562,10 @@
             "description": "Sort direction.",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "desc"
             }
           }
@@ -62221,7 +65620,9 @@
         },
         "summary": "Get audit log filter data",
         "description": "Returns the distinct values available for each audit log filter dimension,\nused to populate filter dropdowns in the dashboard.\n",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "dimensions",
@@ -62281,7 +65682,9 @@
         },
         "summary": "Export audit logs",
         "description": "Streams audit log events matching the supplied filters as a downloadable\nfile. Accepts the same filter query parameters as `GET /api/audit-logs`.\nThe response is returned as an attachment with a generated filename.\n",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "format",
@@ -62289,7 +65692,11 @@
             "description": "Export format. Defaults to `json` when omitted or unrecognized.\n- `json`: a JSON array of events\n- `jsonl`: JSON Lines, one event per line\n- `syslog`: RFC 5424 syslog format\n",
             "schema": {
               "type": "string",
-              "enum": ["json", "jsonl", "syslog"],
+              "enum": [
+                "json",
+                "jsonl",
+                "syslog"
+              ],
               "default": "json"
             }
           },
@@ -62410,7 +65817,9 @@
         },
         "summary": "Get audit log by ID",
         "description": "Retrieves a single audit log event by its unique ID.",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -62482,7 +65891,9 @@
         },
         "summary": "Verify audit log signature",
         "description": "Recomputes the HMAC-SHA256 signature for a single audit log event and\ncompares it (in constant time) against the stored signature to detect\ntampering.\n",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -62554,7 +65965,9 @@
         },
         "summary": "List audit logs (deprecated path)",
         "description": "Retrieves CADF-compliant audit log events with filtering, search, and\npagination via query parameters. Most filter dimensions accept either a\nsingle value (singular parameter, e.g. `action`) or a JSON-encoded array\nof values (plural parameter, e.g. `actions`); when both are supplied the\nplural array takes precedence.\n",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -62803,7 +66216,10 @@
             "description": "Sort direction.",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "desc"
             }
           }
@@ -62861,7 +66277,9 @@
         },
         "summary": "Get audit log filter data (deprecated path)",
         "description": "Returns the distinct values available for each audit log filter dimension,\nused to populate filter dropdowns in the dashboard.\n",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "dimensions",
@@ -62924,7 +66342,9 @@
         },
         "summary": "Export audit logs (deprecated path)",
         "description": "Streams audit log events matching the supplied filters as a downloadable\nfile. Accepts the same filter query parameters as `GET /api/audit-logs`.\nThe response is returned as an attachment with a generated filename.\n",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "format",
@@ -62932,7 +66352,11 @@
             "description": "Export format. Defaults to `json` when omitted or unrecognized.\n- `json`: a JSON array of events\n- `jsonl`: JSON Lines, one event per line\n- `syslog`: RFC 5424 syslog format\n",
             "schema": {
               "type": "string",
-              "enum": ["json", "jsonl", "syslog"],
+              "enum": [
+                "json",
+                "jsonl",
+                "syslog"
+              ],
               "default": "json"
             }
           },
@@ -63056,7 +66480,9 @@
         },
         "summary": "Get audit log by ID (deprecated path)",
         "description": "Retrieves a single audit log event by its unique ID.",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -63131,7 +66557,9 @@
         },
         "summary": "Verify audit log signature (deprecated path)",
         "description": "Recomputes the HMAC-SHA256 signature for a single audit log event and\ncompares it (in constant time) against the stored signature to detect\ntampering.\n",
-        "tags": ["Audit Logs"],
+        "tags": [
+          "Audit Logs"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -63206,7 +66634,9 @@
         },
         "summary": "List MCP Tool Groups",
         "description": "Returns tool groups visible to the caller. When all of `limit`, `offset`, and `search` are omitted, every group is returned in one response.\n",
-        "tags": ["MCP Tool Groups"],
+        "tags": [
+          "MCP Tool Groups"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -63268,7 +66698,9 @@
                             "type": "array",
                             "items": {
                               "type": "object",
-                              "required": ["mcp_client_id"],
+                              "required": [
+                                "mcp_client_id"
+                              ],
                               "properties": {
                                 "mcp_client_id": {
                                   "type": "string",
@@ -63371,14 +66803,19 @@
         },
         "summary": "Create MCP Tool Group",
         "description": "Creates a new tool group along with its attachments in a single transaction.\nValidates that every `mcp_client_id` points to a deployed MCP client and that every named\ntool exists on its server.\n",
-        "tags": ["MCP Tool Groups"],
+        "tags": [
+          "MCP Tool Groups"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name", "tools"],
+                "required": [
+                  "name",
+                  "tools"
+                ],
                 "properties": {
                   "name": {
                     "type": "string",
@@ -63395,7 +66832,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_client_id"],
+                      "required": [
+                        "mcp_client_id"
+                      ],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string",
@@ -63488,7 +66927,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id"],
+                            "required": [
+                              "mcp_client_id"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string",
@@ -63582,7 +67023,9 @@
           "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
         },
         "summary": "Get MCP Tool Group by ID",
-        "tags": ["MCP Tool Groups"],
+        "tags": [
+          "MCP Tool Groups"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -63628,7 +67071,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id"],
+                            "required": [
+                              "mcp_client_id"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string",
@@ -63721,7 +67166,9 @@
         },
         "summary": "Update MCP Tool Group",
         "description": "Partial update. Scalar fields preserve the current value when omitted.\nArray fields are replace-on-send: an empty array clears all attachments in that dimension.\n",
-        "tags": ["MCP Tool Groups"],
+        "tags": [
+          "MCP Tool Groups"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -63756,7 +67203,9 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["mcp_client_id"],
+                      "required": [
+                        "mcp_client_id"
+                      ],
                       "properties": {
                         "mcp_client_id": {
                           "type": "string",
@@ -63849,7 +67298,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["mcp_client_id"],
+                            "required": [
+                              "mcp_client_id"
+                            ],
                             "properties": {
                               "mcp_client_id": {
                                 "type": "string",
@@ -63945,7 +67396,9 @@
         },
         "summary": "Delete MCP Tool Group",
         "description": "Deletes the group; attachments are removed automatically.",
-        "tags": ["MCP Tool Groups"],
+        "tags": [
+          "MCP Tool Groups"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -64004,7 +67457,9 @@
         },
         "summary": "List circuit breaker policies",
         "description": "Returns all circuit breaker policies defined in this workspace.",
-        "tags": ["Circuit Breaker"],
+        "tags": [
+          "Circuit Breaker"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -64065,11 +67520,16 @@
                           },
                           "condition": {
                             "type": "object",
-                            "required": ["signals"],
+                            "required": [
+                              "signals"
+                            ],
                             "properties": {
                               "operator": {
                                 "type": "string",
-                                "enum": ["OR", "AND"],
+                                "enum": [
+                                  "OR",
+                                  "AND"
+                                ],
                                 "default": "OR",
                                 "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                               },
@@ -64079,11 +67539,16 @@
                                 "description": "List of response signals to evaluate. At least one required.",
                                 "items": {
                                   "type": "object",
-                                  "required": ["source", "header_name"],
+                                  "required": [
+                                    "source",
+                                    "header_name"
+                                  ],
                                   "properties": {
                                     "source": {
                                       "type": "string",
-                                      "enum": ["response_header"],
+                                      "enum": [
+                                        "response_header"
+                                      ],
                                       "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                                     },
                                     "header_name": {
@@ -64156,7 +67621,9 @@
         },
         "summary": "Create circuit breaker policy",
         "description": "Creates a new circuit breaker policy and immediately activates it in the running gateway.\nReturns 409 if a policy with the same name already exists.\n",
-        "tags": ["Circuit Breaker"],
+        "tags": [
+          "Circuit Breaker"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -64206,11 +67673,16 @@
                   },
                   "condition": {
                     "type": "object",
-                    "required": ["signals"],
+                    "required": [
+                      "signals"
+                    ],
                     "properties": {
                       "operator": {
                         "type": "string",
-                        "enum": ["OR", "AND"],
+                        "enum": [
+                          "OR",
+                          "AND"
+                        ],
                         "default": "OR",
                         "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                       },
@@ -64220,11 +67692,16 @@
                         "description": "List of response signals to evaluate. At least one required.",
                         "items": {
                           "type": "object",
-                          "required": ["source", "header_name"],
+                          "required": [
+                            "source",
+                            "header_name"
+                          ],
                           "properties": {
                             "source": {
                               "type": "string",
-                              "enum": ["response_header"],
+                              "enum": [
+                                "response_header"
+                              ],
                               "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                             },
                             "header_name": {
@@ -64323,11 +67800,16 @@
                     },
                     "condition": {
                       "type": "object",
-                      "required": ["signals"],
+                      "required": [
+                        "signals"
+                      ],
                       "properties": {
                         "operator": {
                           "type": "string",
-                          "enum": ["OR", "AND"],
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ],
                           "default": "OR",
                           "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                         },
@@ -64337,11 +67819,16 @@
                           "description": "List of response signals to evaluate. At least one required.",
                           "items": {
                             "type": "object",
-                            "required": ["source", "header_name"],
+                            "required": [
+                              "source",
+                              "header_name"
+                            ],
                             "properties": {
                               "source": {
                                 "type": "string",
-                                "enum": ["response_header"],
+                                "enum": [
+                                  "response_header"
+                                ],
                                 "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                               },
                               "header_name": {
@@ -64422,7 +67909,9 @@
         },
         "summary": "Update circuit breaker policy",
         "description": "Replaces a circuit breaker policy by name. The `name` field in the request body must match the URL parameter or be omitted.\nChanges take effect immediately in the running gateway.\n",
-        "tags": ["Circuit Breaker"],
+        "tags": [
+          "Circuit Breaker"
+        ],
         "parameters": [
           {
             "name": "name",
@@ -64483,11 +67972,16 @@
                   },
                   "condition": {
                     "type": "object",
-                    "required": ["signals"],
+                    "required": [
+                      "signals"
+                    ],
                     "properties": {
                       "operator": {
                         "type": "string",
-                        "enum": ["OR", "AND"],
+                        "enum": [
+                          "OR",
+                          "AND"
+                        ],
                         "default": "OR",
                         "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                       },
@@ -64497,11 +67991,16 @@
                         "description": "List of response signals to evaluate. At least one required.",
                         "items": {
                           "type": "object",
-                          "required": ["source", "header_name"],
+                          "required": [
+                            "source",
+                            "header_name"
+                          ],
                           "properties": {
                             "source": {
                               "type": "string",
-                              "enum": ["response_header"],
+                              "enum": [
+                                "response_header"
+                              ],
                               "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                             },
                             "header_name": {
@@ -64600,11 +68099,16 @@
                     },
                     "condition": {
                       "type": "object",
-                      "required": ["signals"],
+                      "required": [
+                        "signals"
+                      ],
                       "properties": {
                         "operator": {
                           "type": "string",
-                          "enum": ["OR", "AND"],
+                          "enum": [
+                            "OR",
+                            "AND"
+                          ],
                           "default": "OR",
                           "description": "How multiple signals are combined.\n`OR` (default): circuit opens when any signal matches.\n`AND`: circuit opens only when all signals match simultaneously.\n"
                         },
@@ -64614,11 +68118,16 @@
                           "description": "List of response signals to evaluate. At least one required.",
                           "items": {
                             "type": "object",
-                            "required": ["source", "header_name"],
+                            "required": [
+                              "source",
+                              "header_name"
+                            ],
                             "properties": {
                               "source": {
                                 "type": "string",
-                                "enum": ["response_header"],
+                                "enum": [
+                                  "response_header"
+                                ],
                                 "description": "Part of the HTTP response to inspect. Only `response_header` is currently supported."
                               },
                               "header_name": {
@@ -64697,7 +68206,9 @@
         },
         "summary": "Delete circuit breaker policy",
         "description": "Deletes a circuit breaker policy by name and removes it from the running gateway.\nAny open circuits for this policy are discarded immediately.\n",
-        "tags": ["Circuit Breaker"],
+        "tags": [
+          "Circuit Breaker"
+        ],
         "parameters": [
           {
             "name": "name",
@@ -64757,7 +68268,9 @@
         },
         "summary": "Get circuit breaker state",
         "description": "Returns a snapshot of all currently-open circuits.\nMain circuits are keyed by policy name. Per-key sub-circuits are keyed by `\"<policy_name>\\x00<key_id>\"`.\nCircuits not present in the map are closed.\n",
-        "tags": ["Circuit Breaker"],
+        "tags": [
+          "Circuit Breaker"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -64823,7 +68336,9 @@
         "operationId": "listRoutingRules",
         "summary": "List routing rules",
         "description": "Returns a list of all routing rules configured for intelligent request routing across providers.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "parameters": [
           {
             "name": "scope",
@@ -64874,7 +68389,9 @@
         "operationId": "createRoutingRule",
         "summary": "Create routing rule",
         "description": "Creates a new CEL-based routing rule for intelligent request routing. Provider and model can be left empty to use the incoming request values.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -64929,7 +68446,9 @@
         "operationId": "getRoutingRule",
         "summary": "Get routing rule",
         "description": "Returns a specific routing rule by ID.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "parameters": [
           {
             "name": "rule_id",
@@ -64988,7 +68507,9 @@
         "operationId": "updateRoutingRule",
         "summary": "Update routing rule",
         "description": "Updates an existing routing rule's configuration.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "parameters": [
           {
             "name": "rule_id",
@@ -65062,7 +68583,9 @@
         "operationId": "deleteRoutingRule",
         "summary": "Delete routing rule",
         "description": "Deletes a routing rule.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "parameters": [
           {
             "name": "rule_id",
@@ -65118,7 +68641,9 @@
         "operationId": "getComplexityAnalyzerConfig",
         "summary": "Get complexity analyzer config",
         "description": "Returns the full complexity analyzer runtime config, including the semantic embedding configuration, the llm fallback classifier configuration, and per-tier reference phrase lists. Returns built-in defaults if none have been configured.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -65133,7 +68658,9 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": ["keywords"],
+                  "required": [
+                    "keywords"
+                  ],
                   "allOf": [
                     {
                       "if": {
@@ -65144,13 +68671,19 @@
                                 "const": true
                               }
                             },
-                            "required": ["enabled"]
+                            "required": [
+                              "enabled"
+                            ]
                           }
                         },
-                        "required": ["session"]
+                        "required": [
+                          "session"
+                        ]
                       },
                       "then": {
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       }
                     },
                     {
@@ -65162,13 +68695,19 @@
                                 "const": "llm"
                               }
                             },
-                            "required": ["fallback"]
+                            "required": [
+                              "fallback"
+                            ]
                           }
                         },
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       },
                       "then": {
-                        "required": ["llm"]
+                        "required": [
+                          "llm"
+                        ]
                       }
                     }
                   ],
@@ -65178,7 +68717,10 @@
                       "deprecated": true,
                       "description": "Deprecated score thresholds for the retired lexical complexity classifier.\nThis block is optional and ignored by semantic classification, but remains\naccepted for backward compatibility. When supplied, values must satisfy\n0 < simple_medium < medium_complex < 1.\n",
                       "additionalProperties": false,
-                      "required": ["simple_medium", "medium_complex"],
+                      "required": [
+                        "simple_medium",
+                        "medium_complex"
+                      ],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -65200,7 +68742,11 @@
                       "type": "object",
                       "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
-                      "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                      "required": [
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
+                      ],
                       "properties": {
                         "simple_keywords": {
                           "type": "array",
@@ -65235,7 +68781,10 @@
                       "type": "object",
                       "description": "Embedding configuration for semantic complexity classification. When absent,\nno complexity tier is published and rules referencing complexity_tier fall\nthrough. The provider must have an enabled key.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "embedding_model"],
+                      "required": [
+                        "provider",
+                        "embedding_model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -65278,12 +68827,18 @@
                         },
                         "vector_store": {
                           "type": "string",
-                          "enum": ["embedded", "vector_store"],
+                          "enum": [
+                            "embedded",
+                            "vector_store"
+                          ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
                         },
                         "fallback": {
                           "type": "string",
-                          "enum": ["none", "llm"],
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
                           "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                         }
                       }
@@ -65292,7 +68847,10 @@
                       "type": "object",
                       "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "model"],
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -65338,7 +68896,9 @@
                       "type": "object",
                       "description": "Session-aware complexity routing. When enabled and a request carries a supported session identity, Bifrost retains the highest tier observed across normally sequential turns for 24 hours of inactivity. Overlapping requests for the same session are best-effort and resolve by last writer wins.",
                       "additionalProperties": false,
-                      "required": ["enabled"],
+                      "required": [
+                        "enabled"
+                      ],
                       "properties": {
                         "enabled": {
                           "type": "boolean",
@@ -65377,7 +68937,9 @@
         "operationId": "updateComplexityAnalyzerConfig",
         "summary": "Update complexity analyzer config",
         "description": "Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded. Setting semantic.fallback to llm requires the llm block to be present.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -65386,7 +68948,9 @@
                 "type": "object",
                 "description": "Full runtime configuration for complexity routing analysis.",
                 "additionalProperties": false,
-                "required": ["keywords"],
+                "required": [
+                  "keywords"
+                ],
                 "allOf": [
                   {
                     "if": {
@@ -65397,13 +68961,19 @@
                               "const": true
                             }
                           },
-                          "required": ["enabled"]
+                          "required": [
+                            "enabled"
+                          ]
                         }
                       },
-                      "required": ["session"]
+                      "required": [
+                        "session"
+                      ]
                     },
                     "then": {
-                      "required": ["semantic"]
+                      "required": [
+                        "semantic"
+                      ]
                     }
                   },
                   {
@@ -65415,13 +68985,19 @@
                               "const": "llm"
                             }
                           },
-                          "required": ["fallback"]
+                          "required": [
+                            "fallback"
+                          ]
                         }
                       },
-                      "required": ["semantic"]
+                      "required": [
+                        "semantic"
+                      ]
                     },
                     "then": {
-                      "required": ["llm"]
+                      "required": [
+                        "llm"
+                      ]
                     }
                   }
                 ],
@@ -65431,7 +69007,10 @@
                     "deprecated": true,
                     "description": "Deprecated score thresholds for the retired lexical complexity classifier.\nThis block is optional and ignored by semantic classification, but remains\naccepted for backward compatibility. When supplied, values must satisfy\n0 < simple_medium < medium_complex < 1.\n",
                     "additionalProperties": false,
-                    "required": ["simple_medium", "medium_complex"],
+                    "required": [
+                      "simple_medium",
+                      "medium_complex"
+                    ],
                     "properties": {
                       "simple_medium": {
                         "type": "number",
@@ -65453,7 +69032,11 @@
                     "type": "object",
                     "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                     "additionalProperties": false,
-                    "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                    "required": [
+                      "simple_keywords",
+                      "medium_keywords",
+                      "complex_keywords"
+                    ],
                     "properties": {
                       "simple_keywords": {
                         "type": "array",
@@ -65488,7 +69071,10 @@
                     "type": "object",
                     "description": "Embedding configuration for semantic complexity classification. When absent,\nno complexity tier is published and rules referencing complexity_tier fall\nthrough. The provider must have an enabled key.\n",
                     "additionalProperties": false,
-                    "required": ["provider", "embedding_model"],
+                    "required": [
+                      "provider",
+                      "embedding_model"
+                    ],
                     "properties": {
                       "provider": {
                         "type": "string",
@@ -65531,12 +69117,18 @@
                       },
                       "vector_store": {
                         "type": "string",
-                        "enum": ["embedded", "vector_store"],
+                        "enum": [
+                          "embedded",
+                          "vector_store"
+                        ],
                         "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
                       },
                       "fallback": {
                         "type": "string",
-                        "enum": ["none", "llm"],
+                        "enum": [
+                          "none",
+                          "llm"
+                        ],
                         "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                       }
                     }
@@ -65545,7 +69137,10 @@
                     "type": "object",
                     "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
                     "additionalProperties": false,
-                    "required": ["provider", "model"],
+                    "required": [
+                      "provider",
+                      "model"
+                    ],
                     "properties": {
                       "provider": {
                         "type": "string",
@@ -65591,7 +69186,9 @@
                     "type": "object",
                     "description": "Session-aware complexity routing. When enabled and a request carries a supported session identity, Bifrost retains the highest tier observed across normally sequential turns for 24 hours of inactivity. Overlapping requests for the same session are best-effort and resolve by last writer wins.",
                     "additionalProperties": false,
-                    "required": ["enabled"],
+                    "required": [
+                      "enabled"
+                    ],
                     "properties": {
                       "enabled": {
                         "type": "boolean",
@@ -65618,7 +69215,9 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": ["keywords"],
+                  "required": [
+                    "keywords"
+                  ],
                   "allOf": [
                     {
                       "if": {
@@ -65629,13 +69228,19 @@
                                 "const": true
                               }
                             },
-                            "required": ["enabled"]
+                            "required": [
+                              "enabled"
+                            ]
                           }
                         },
-                        "required": ["session"]
+                        "required": [
+                          "session"
+                        ]
                       },
                       "then": {
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       }
                     },
                     {
@@ -65647,13 +69252,19 @@
                                 "const": "llm"
                               }
                             },
-                            "required": ["fallback"]
+                            "required": [
+                              "fallback"
+                            ]
                           }
                         },
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       },
                       "then": {
-                        "required": ["llm"]
+                        "required": [
+                          "llm"
+                        ]
                       }
                     }
                   ],
@@ -65663,7 +69274,10 @@
                       "deprecated": true,
                       "description": "Deprecated score thresholds for the retired lexical complexity classifier.\nThis block is optional and ignored by semantic classification, but remains\naccepted for backward compatibility. When supplied, values must satisfy\n0 < simple_medium < medium_complex < 1.\n",
                       "additionalProperties": false,
-                      "required": ["simple_medium", "medium_complex"],
+                      "required": [
+                        "simple_medium",
+                        "medium_complex"
+                      ],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -65685,7 +69299,11 @@
                       "type": "object",
                       "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
-                      "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                      "required": [
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
+                      ],
                       "properties": {
                         "simple_keywords": {
                           "type": "array",
@@ -65720,7 +69338,10 @@
                       "type": "object",
                       "description": "Embedding configuration for semantic complexity classification. When absent,\nno complexity tier is published and rules referencing complexity_tier fall\nthrough. The provider must have an enabled key.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "embedding_model"],
+                      "required": [
+                        "provider",
+                        "embedding_model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -65763,12 +69384,18 @@
                         },
                         "vector_store": {
                           "type": "string",
-                          "enum": ["embedded", "vector_store"],
+                          "enum": [
+                            "embedded",
+                            "vector_store"
+                          ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
                         },
                         "fallback": {
                           "type": "string",
-                          "enum": ["none", "llm"],
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
                           "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                         }
                       }
@@ -65777,7 +69404,10 @@
                       "type": "object",
                       "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "model"],
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -65823,7 +69453,9 @@
                       "type": "object",
                       "description": "Session-aware complexity routing. When enabled and a request carries a supported session identity, Bifrost retains the highest tier observed across normally sequential turns for 24 hours of inactivity. Overlapping requests for the same session are best-effort and resolve by last writer wins.",
                       "additionalProperties": false,
-                      "required": ["enabled"],
+                      "required": [
+                        "enabled"
+                      ],
                       "properties": {
                         "enabled": {
                           "type": "boolean",
@@ -65874,7 +69506,9 @@
         "operationId": "resetComplexityAnalyzerConfig",
         "summary": "Reset complexity analyzer config",
         "description": "Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, storage configuration, and llm fallback configuration are preserved.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -65889,7 +69523,9 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": ["keywords"],
+                  "required": [
+                    "keywords"
+                  ],
                   "allOf": [
                     {
                       "if": {
@@ -65900,13 +69536,19 @@
                                 "const": true
                               }
                             },
-                            "required": ["enabled"]
+                            "required": [
+                              "enabled"
+                            ]
                           }
                         },
-                        "required": ["session"]
+                        "required": [
+                          "session"
+                        ]
                       },
                       "then": {
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       }
                     },
                     {
@@ -65918,13 +69560,19 @@
                                 "const": "llm"
                               }
                             },
-                            "required": ["fallback"]
+                            "required": [
+                              "fallback"
+                            ]
                           }
                         },
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       },
                       "then": {
-                        "required": ["llm"]
+                        "required": [
+                          "llm"
+                        ]
                       }
                     }
                   ],
@@ -65934,7 +69582,10 @@
                       "deprecated": true,
                       "description": "Deprecated score thresholds for the retired lexical complexity classifier.\nThis block is optional and ignored by semantic classification, but remains\naccepted for backward compatibility. When supplied, values must satisfy\n0 < simple_medium < medium_complex < 1.\n",
                       "additionalProperties": false,
-                      "required": ["simple_medium", "medium_complex"],
+                      "required": [
+                        "simple_medium",
+                        "medium_complex"
+                      ],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -65956,7 +69607,11 @@
                       "type": "object",
                       "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
-                      "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                      "required": [
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
+                      ],
                       "properties": {
                         "simple_keywords": {
                           "type": "array",
@@ -65991,7 +69646,10 @@
                       "type": "object",
                       "description": "Embedding configuration for semantic complexity classification. When absent,\nno complexity tier is published and rules referencing complexity_tier fall\nthrough. The provider must have an enabled key.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "embedding_model"],
+                      "required": [
+                        "provider",
+                        "embedding_model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -66034,12 +69692,18 @@
                         },
                         "vector_store": {
                           "type": "string",
-                          "enum": ["embedded", "vector_store"],
+                          "enum": [
+                            "embedded",
+                            "vector_store"
+                          ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
                         },
                         "fallback": {
                           "type": "string",
-                          "enum": ["none", "llm"],
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
                           "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                         }
                       }
@@ -66048,7 +69712,10 @@
                       "type": "object",
                       "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "model"],
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -66094,7 +69761,9 @@
                       "type": "object",
                       "description": "Session-aware complexity routing. When enabled and a request carries a supported session identity, Bifrost retains the highest tier observed across normally sequential turns for 24 hours of inactivity. Overlapping requests for the same session are best-effort and resolve by last writer wins.",
                       "additionalProperties": false,
-                      "required": ["enabled"],
+                      "required": [
+                        "enabled"
+                      ],
                       "properties": {
                         "enabled": {
                           "type": "boolean",
@@ -66135,7 +69804,9 @@
         "operationId": "getComplexityAnalyzerStatus",
         "summary": "Get complexity classifier status",
         "description": "Returns the runtime status of the semantic complexity classifier (disabled, warming, ready, or failed), including warmup progress and whether a previous generation is still serving. When the llm fallback block is configured, also returns its readiness and the shipped default classification prompt.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "responses": {
           "200": {
             "description": "Complexity classifier status retrieved successfully",
@@ -66147,7 +69818,12 @@
                   "properties": {
                     "state": {
                       "type": "string",
-                      "enum": ["disabled", "warming", "ready", "failed"],
+                      "enum": [
+                        "disabled",
+                        "warming",
+                        "ready",
+                        "failed"
+                      ],
                       "description": "disabled = no embedding configuration; warming = reference phrases are being embedded; ready = serving the current configuration; failed = the desired configuration failed to warm"
                     },
                     "loaded": {
@@ -66186,7 +69862,10 @@
                     },
                     "storage_mode": {
                       "type": "string",
-                      "enum": ["embedded", "vector_store"],
+                      "enum": [
+                        "embedded",
+                        "vector_store"
+                      ],
                       "description": "Where exemplar vectors are actually kept, which is not always what was configured. semantic.vector_store=vector_store degrades to embedded whenever no top-level vector store is configured, so this reports what is in force rather than what was asked for. Absent until a store has been resolved."
                     },
                     "namespace": {
@@ -66199,7 +69878,10 @@
                       "properties": {
                         "state": {
                           "type": "string",
-                          "enum": ["disabled", "ready"],
+                          "enum": [
+                            "disabled",
+                            "ready"
+                          ],
                           "description": "disabled = no llm configuration; ready = the llm block is configured. The classifier has no warmup, so it is ready as soon as it is saved."
                         }
                       }
@@ -66241,7 +69923,9 @@
         "operationId": "retryComplexityAnalyzerWarmup",
         "summary": "Retry failed complexity classifier warmup",
         "description": "Restarts the saved semantic classifier warmup only when its current state is failed. The retry runs asynchronously and does not change the saved configuration.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "responses": {
           "202": {
             "description": "Semantic warmup retry accepted",
@@ -66253,7 +69937,12 @@
                   "properties": {
                     "state": {
                       "type": "string",
-                      "enum": ["disabled", "warming", "ready", "failed"],
+                      "enum": [
+                        "disabled",
+                        "warming",
+                        "ready",
+                        "failed"
+                      ],
                       "description": "disabled = no embedding configuration; warming = reference phrases are being embedded; ready = serving the current configuration; failed = the desired configuration failed to warm"
                     },
                     "loaded": {
@@ -66292,7 +69981,10 @@
                     },
                     "storage_mode": {
                       "type": "string",
-                      "enum": ["embedded", "vector_store"],
+                      "enum": [
+                        "embedded",
+                        "vector_store"
+                      ],
                       "description": "Where exemplar vectors are actually kept, which is not always what was configured. semantic.vector_store=vector_store degrades to embedded whenever no top-level vector store is configured, so this reports what is in force rather than what was asked for. Absent until a store has been resolved."
                     },
                     "namespace": {
@@ -66305,7 +69997,10 @@
                       "properties": {
                         "state": {
                           "type": "string",
-                          "enum": ["disabled", "ready"],
+                          "enum": [
+                            "disabled",
+                            "ready"
+                          ],
                           "description": "disabled = no llm configuration; ready = the llm block is configured. The classifier has no warmup, so it is ready as soon as it is saved."
                         }
                       }
@@ -66330,7 +70025,14 @@
             }
           },
           "503": {
-            "$ref": "#/components/responses/ConfigStoreUnavailable"
+            "description": "Config store not available",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
           }
         }
       }
@@ -66340,7 +70042,9 @@
         "operationId": "listComplexityGenerations",
         "summary": "List complexity classifier generations",
         "description": "Lists the exemplar generations held in the vector store for semantic complexity routing, flagging the one currently serving. Every configuration change mints a new fingerprinted generation; a node-local store reclaims the previous one automatically, but on a shared external store retired generations are kept because another replica may still be serving them. The store holds no phrase text, so this listing is the only way to identify what has accumulated.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -66396,7 +70100,9 @@
         "operationId": "deleteComplexityGeneration",
         "summary": "Delete a retired complexity generation",
         "description": "Removes one retired exemplar generation and the vectors it holds. The serving generation is refused, as are namespaces outside the classifier's own naming scheme, so this cannot drop an unrelated collection sharing the same backend. Deleting a generation that is already gone succeeds.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -66473,7 +70179,9 @@
         "deprecated": true,
         "summary": "List routing rules (deprecated path)",
         "description": "Returns a list of all routing rules configured for intelligent request routing across providers. Deprecated, use /api/routing/rules instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "parameters": [
           {
             "name": "scope",
@@ -66525,7 +70233,9 @@
         "deprecated": true,
         "summary": "Create routing rule (deprecated path)",
         "description": "Creates a new CEL-based routing rule for intelligent request routing. Provider and model can be left empty to use the incoming request values. Deprecated, use /api/routing/rules instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -66581,7 +70291,9 @@
         "deprecated": true,
         "summary": "Get routing rule (deprecated path)",
         "description": "Returns a specific routing rule by ID. Deprecated, use /api/routing/rules/{rule_id} instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "parameters": [
           {
             "name": "rule_id",
@@ -66641,7 +70353,9 @@
         "deprecated": true,
         "summary": "Update routing rule (deprecated path)",
         "description": "Updates an existing routing rule's configuration. Deprecated, use /api/routing/rules/{rule_id} instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "parameters": [
           {
             "name": "rule_id",
@@ -66716,7 +70430,9 @@
         "deprecated": true,
         "summary": "Delete routing rule (deprecated path)",
         "description": "Deletes a routing rule. Deprecated, use /api/routing/rules/{rule_id} instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "parameters": [
           {
             "name": "rule_id",
@@ -66773,7 +70489,9 @@
         "deprecated": true,
         "summary": "Get complexity analyzer config (deprecated path)",
         "description": "Returns the full complexity analyzer runtime config, including the semantic embedding configuration, the llm fallback classifier configuration, and per-tier reference phrase lists. Returns built-in defaults if none have been configured. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -66788,7 +70506,9 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": ["keywords"],
+                  "required": [
+                    "keywords"
+                  ],
                   "allOf": [
                     {
                       "if": {
@@ -66799,13 +70519,19 @@
                                 "const": true
                               }
                             },
-                            "required": ["enabled"]
+                            "required": [
+                              "enabled"
+                            ]
                           }
                         },
-                        "required": ["session"]
+                        "required": [
+                          "session"
+                        ]
                       },
                       "then": {
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       }
                     },
                     {
@@ -66817,13 +70543,19 @@
                                 "const": "llm"
                               }
                             },
-                            "required": ["fallback"]
+                            "required": [
+                              "fallback"
+                            ]
                           }
                         },
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       },
                       "then": {
-                        "required": ["llm"]
+                        "required": [
+                          "llm"
+                        ]
                       }
                     }
                   ],
@@ -66833,7 +70565,10 @@
                       "deprecated": true,
                       "description": "Deprecated score thresholds for the retired lexical complexity classifier.\nThis block is optional and ignored by semantic classification, but remains\naccepted for backward compatibility. When supplied, values must satisfy\n0 < simple_medium < medium_complex < 1.\n",
                       "additionalProperties": false,
-                      "required": ["simple_medium", "medium_complex"],
+                      "required": [
+                        "simple_medium",
+                        "medium_complex"
+                      ],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -66855,7 +70590,11 @@
                       "type": "object",
                       "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
-                      "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                      "required": [
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
+                      ],
                       "properties": {
                         "simple_keywords": {
                           "type": "array",
@@ -66890,7 +70629,10 @@
                       "type": "object",
                       "description": "Embedding configuration for semantic complexity classification. When absent,\nno complexity tier is published and rules referencing complexity_tier fall\nthrough. The provider must have an enabled key.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "embedding_model"],
+                      "required": [
+                        "provider",
+                        "embedding_model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -66933,12 +70675,18 @@
                         },
                         "vector_store": {
                           "type": "string",
-                          "enum": ["embedded", "vector_store"],
+                          "enum": [
+                            "embedded",
+                            "vector_store"
+                          ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
                         },
                         "fallback": {
                           "type": "string",
-                          "enum": ["none", "llm"],
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
                           "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                         }
                       }
@@ -66947,7 +70695,10 @@
                       "type": "object",
                       "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "model"],
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -66993,7 +70744,9 @@
                       "type": "object",
                       "description": "Session-aware complexity routing. When enabled and a request carries a supported session identity, Bifrost retains the highest tier observed across normally sequential turns for 24 hours of inactivity. Overlapping requests for the same session are best-effort and resolve by last writer wins.",
                       "additionalProperties": false,
-                      "required": ["enabled"],
+                      "required": [
+                        "enabled"
+                      ],
                       "properties": {
                         "enabled": {
                           "type": "boolean",
@@ -67033,7 +70786,9 @@
         "deprecated": true,
         "summary": "Update complexity analyzer config (deprecated path)",
         "description": "Replaces the full complexity analyzer runtime config and hot-reloads the routing plugin. Changing the embedding configuration or reference phrases triggers a background re-warm of the classifier; unchanged phrases are not re-embedded. Setting semantic.fallback to llm requires the llm block to be present. Deprecated, use /api/routing/complexity-analyzer-config instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -67042,7 +70797,9 @@
                 "type": "object",
                 "description": "Full runtime configuration for complexity routing analysis.",
                 "additionalProperties": false,
-                "required": ["keywords"],
+                "required": [
+                  "keywords"
+                ],
                 "allOf": [
                   {
                     "if": {
@@ -67053,13 +70810,19 @@
                               "const": true
                             }
                           },
-                          "required": ["enabled"]
+                          "required": [
+                            "enabled"
+                          ]
                         }
                       },
-                      "required": ["session"]
+                      "required": [
+                        "session"
+                      ]
                     },
                     "then": {
-                      "required": ["semantic"]
+                      "required": [
+                        "semantic"
+                      ]
                     }
                   },
                   {
@@ -67071,13 +70834,19 @@
                               "const": "llm"
                             }
                           },
-                          "required": ["fallback"]
+                          "required": [
+                            "fallback"
+                          ]
                         }
                       },
-                      "required": ["semantic"]
+                      "required": [
+                        "semantic"
+                      ]
                     },
                     "then": {
-                      "required": ["llm"]
+                      "required": [
+                        "llm"
+                      ]
                     }
                   }
                 ],
@@ -67087,7 +70856,10 @@
                     "deprecated": true,
                     "description": "Deprecated score thresholds for the retired lexical complexity classifier.\nThis block is optional and ignored by semantic classification, but remains\naccepted for backward compatibility. When supplied, values must satisfy\n0 < simple_medium < medium_complex < 1.\n",
                     "additionalProperties": false,
-                    "required": ["simple_medium", "medium_complex"],
+                    "required": [
+                      "simple_medium",
+                      "medium_complex"
+                    ],
                     "properties": {
                       "simple_medium": {
                         "type": "number",
@@ -67109,7 +70881,11 @@
                     "type": "object",
                     "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                     "additionalProperties": false,
-                    "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                    "required": [
+                      "simple_keywords",
+                      "medium_keywords",
+                      "complex_keywords"
+                    ],
                     "properties": {
                       "simple_keywords": {
                         "type": "array",
@@ -67144,7 +70920,10 @@
                     "type": "object",
                     "description": "Embedding configuration for semantic complexity classification. When absent,\nno complexity tier is published and rules referencing complexity_tier fall\nthrough. The provider must have an enabled key.\n",
                     "additionalProperties": false,
-                    "required": ["provider", "embedding_model"],
+                    "required": [
+                      "provider",
+                      "embedding_model"
+                    ],
                     "properties": {
                       "provider": {
                         "type": "string",
@@ -67187,12 +70966,18 @@
                       },
                       "vector_store": {
                         "type": "string",
-                        "enum": ["embedded", "vector_store"],
+                        "enum": [
+                          "embedded",
+                          "vector_store"
+                        ],
                         "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
                       },
                       "fallback": {
                         "type": "string",
-                        "enum": ["none", "llm"],
+                        "enum": [
+                          "none",
+                          "llm"
+                        ],
                         "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                       }
                     }
@@ -67201,7 +70986,10 @@
                     "type": "object",
                     "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
                     "additionalProperties": false,
-                    "required": ["provider", "model"],
+                    "required": [
+                      "provider",
+                      "model"
+                    ],
                     "properties": {
                       "provider": {
                         "type": "string",
@@ -67247,7 +71035,9 @@
                     "type": "object",
                     "description": "Session-aware complexity routing. When enabled and a request carries a supported session identity, Bifrost retains the highest tier observed across normally sequential turns for 24 hours of inactivity. Overlapping requests for the same session are best-effort and resolve by last writer wins.",
                     "additionalProperties": false,
-                    "required": ["enabled"],
+                    "required": [
+                      "enabled"
+                    ],
                     "properties": {
                       "enabled": {
                         "type": "boolean",
@@ -67274,7 +71064,9 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": ["keywords"],
+                  "required": [
+                    "keywords"
+                  ],
                   "allOf": [
                     {
                       "if": {
@@ -67285,13 +71077,19 @@
                                 "const": true
                               }
                             },
-                            "required": ["enabled"]
+                            "required": [
+                              "enabled"
+                            ]
                           }
                         },
-                        "required": ["session"]
+                        "required": [
+                          "session"
+                        ]
                       },
                       "then": {
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       }
                     },
                     {
@@ -67303,13 +71101,19 @@
                                 "const": "llm"
                               }
                             },
-                            "required": ["fallback"]
+                            "required": [
+                              "fallback"
+                            ]
                           }
                         },
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       },
                       "then": {
-                        "required": ["llm"]
+                        "required": [
+                          "llm"
+                        ]
                       }
                     }
                   ],
@@ -67319,7 +71123,10 @@
                       "deprecated": true,
                       "description": "Deprecated score thresholds for the retired lexical complexity classifier.\nThis block is optional and ignored by semantic classification, but remains\naccepted for backward compatibility. When supplied, values must satisfy\n0 < simple_medium < medium_complex < 1.\n",
                       "additionalProperties": false,
-                      "required": ["simple_medium", "medium_complex"],
+                      "required": [
+                        "simple_medium",
+                        "medium_complex"
+                      ],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -67341,7 +71148,11 @@
                       "type": "object",
                       "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
-                      "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                      "required": [
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
+                      ],
                       "properties": {
                         "simple_keywords": {
                           "type": "array",
@@ -67376,7 +71187,10 @@
                       "type": "object",
                       "description": "Embedding configuration for semantic complexity classification. When absent,\nno complexity tier is published and rules referencing complexity_tier fall\nthrough. The provider must have an enabled key.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "embedding_model"],
+                      "required": [
+                        "provider",
+                        "embedding_model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -67419,12 +71233,18 @@
                         },
                         "vector_store": {
                           "type": "string",
-                          "enum": ["embedded", "vector_store"],
+                          "enum": [
+                            "embedded",
+                            "vector_store"
+                          ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
                         },
                         "fallback": {
                           "type": "string",
-                          "enum": ["none", "llm"],
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
                           "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                         }
                       }
@@ -67433,7 +71253,10 @@
                       "type": "object",
                       "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "model"],
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -67479,7 +71302,9 @@
                       "type": "object",
                       "description": "Session-aware complexity routing. When enabled and a request carries a supported session identity, Bifrost retains the highest tier observed across normally sequential turns for 24 hours of inactivity. Overlapping requests for the same session are best-effort and resolve by last writer wins.",
                       "additionalProperties": false,
-                      "required": ["enabled"],
+                      "required": [
+                        "enabled"
+                      ],
                       "properties": {
                         "enabled": {
                           "type": "boolean",
@@ -67531,7 +71356,9 @@
         "deprecated": true,
         "summary": "Reset complexity analyzer config (deprecated path)",
         "description": "Restores the built-in reference phrase lists and hot-reloads the routing plugin. The saved embedding provider, model, storage configuration, and llm fallback configuration are preserved. Deprecated, use /api/routing/complexity-analyzer-config/reset instead. This path is kept for backwards compatibility and behaves identically.",
-        "tags": ["Routing"],
+        "tags": [
+          "Routing"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -67546,7 +71373,9 @@
                   "type": "object",
                   "description": "Full runtime configuration for complexity routing analysis.",
                   "additionalProperties": false,
-                  "required": ["keywords"],
+                  "required": [
+                    "keywords"
+                  ],
                   "allOf": [
                     {
                       "if": {
@@ -67557,13 +71386,19 @@
                                 "const": true
                               }
                             },
-                            "required": ["enabled"]
+                            "required": [
+                              "enabled"
+                            ]
                           }
                         },
-                        "required": ["session"]
+                        "required": [
+                          "session"
+                        ]
                       },
                       "then": {
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       }
                     },
                     {
@@ -67575,13 +71410,19 @@
                                 "const": "llm"
                               }
                             },
-                            "required": ["fallback"]
+                            "required": [
+                              "fallback"
+                            ]
                           }
                         },
-                        "required": ["semantic"]
+                        "required": [
+                          "semantic"
+                        ]
                       },
                       "then": {
-                        "required": ["llm"]
+                        "required": [
+                          "llm"
+                        ]
                       }
                     }
                   ],
@@ -67591,7 +71432,10 @@
                       "deprecated": true,
                       "description": "Deprecated score thresholds for the retired lexical complexity classifier.\nThis block is optional and ignored by semantic classification, but remains\naccepted for backward compatibility. When supplied, values must satisfy\n0 < simple_medium < medium_complex < 1.\n",
                       "additionalProperties": false,
-                      "required": ["simple_medium", "medium_complex"],
+                      "required": [
+                        "simple_medium",
+                        "medium_complex"
+                      ],
                       "properties": {
                         "simple_medium": {
                           "type": "number",
@@ -67613,7 +71457,11 @@
                       "type": "object",
                       "description": "Reference phrases for semantic complexity classification, one list per tier.\nEach request is embedded and takes the tier of its nearest phrase. Entries\nshould be whole example prompts rather than individual keywords. Each phrase\nis limited to 2000 characters, the normalized lists may contain at most 750\nphrases combined, and the same phrase cannot appear in two tiers. The field\nnames predate semantic classification and are kept for backward compatibility.\n",
                       "additionalProperties": false,
-                      "required": ["simple_keywords", "medium_keywords", "complex_keywords"],
+                      "required": [
+                        "simple_keywords",
+                        "medium_keywords",
+                        "complex_keywords"
+                      ],
                       "properties": {
                         "simple_keywords": {
                           "type": "array",
@@ -67648,7 +71496,10 @@
                       "type": "object",
                       "description": "Embedding configuration for semantic complexity classification. When absent,\nno complexity tier is published and rules referencing complexity_tier fall\nthrough. The provider must have an enabled key.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "embedding_model"],
+                      "required": [
+                        "provider",
+                        "embedding_model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -67691,12 +71542,18 @@
                         },
                         "vector_store": {
                           "type": "string",
-                          "enum": ["embedded", "vector_store"],
+                          "enum": [
+                            "embedded",
+                            "vector_store"
+                          ],
                           "description": "Where reference-phrase embeddings live. `embedded` (default) uses the\nbuilt-in in-memory store, so phrases are re-embedded on every restart.\n`vector_store` uses the top-level `vector_store` when one is configured\nand falls back to the embedded store otherwise.\n"
                         },
                         "fallback": {
                           "type": "string",
-                          "enum": ["none", "llm"],
+                          "enum": [
+                            "none",
+                            "llm"
+                          ],
                           "description": "What answers when semantic classification produces no tier (a match\nbelow `min_similarity`, a timeout, or an unfinished warmup). `none`\n(the default) records the request as skipped. `llm` asks the chat\nmodel configured in the analyzer's `llm` block, which is required\nwhen this is set.\n"
                         }
                       }
@@ -67705,7 +71562,10 @@
                       "type": "object",
                       "description": "Chat-completion (LLM) fallback classifier settings. The block is inert\nunless `semantic.fallback` selects `llm`; the classifier runs only after\nsemantic classification produces no tier. Tier names (SIMPLE, MEDIUM,\nCOMPLEX) and the response format are fixed: the gateway always appends a\nnon-editable reinforcement stating them.\n",
                       "additionalProperties": false,
-                      "required": ["provider", "model"],
+                      "required": [
+                        "provider",
+                        "model"
+                      ],
                       "properties": {
                         "provider": {
                           "type": "string",
@@ -67751,7 +71611,9 @@
                       "type": "object",
                       "description": "Session-aware complexity routing. When enabled and a request carries a supported session identity, Bifrost retains the highest tier observed across normally sequential turns for 24 hours of inactivity. Overlapping requests for the same session are best-effort and resolve by last writer wins.",
                       "additionalProperties": false,
-                      "required": ["enabled"],
+                      "required": [
+                        "enabled"
+                      ],
                       "properties": {
                         "enabled": {
                           "type": "boolean",
@@ -67792,7 +71654,9 @@
         "operationId": "getLogs",
         "summary": "Get logs",
         "description": "Retrieves logs with filtering, search, and pagination via query parameters.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -67878,6 +71742,14 @@
             "name": "complexity_mechanisms",
             "in": "query",
             "description": "Comma-separated list of complexity decision mechanisms to filter by (semantic, llm, session, or skipped)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "description": "Exact Bifrost session ID used for key stickiness and request correlation",
             "schema": {
               "type": "string"
             }
@@ -67997,7 +71869,12 @@
             "description": "Field to sort by",
             "schema": {
               "type": "string",
-              "enum": ["timestamp", "latency", "tokens", "cost"],
+              "enum": [
+                "timestamp",
+                "latency",
+                "tokens",
+                "cost"
+              ],
               "default": "timestamp"
             }
           },
@@ -68007,7 +71884,10 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "desc"
             }
           }
@@ -68054,7 +71934,9 @@
         "operationId": "deleteLogs",
         "summary": "Delete logs",
         "description": "Deletes logs by their IDs.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -68109,7 +71991,9 @@
         "operationId": "getLogById",
         "summary": "Get a single log entry",
         "description": "Retrieves a single log entry by its ID.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -68165,7 +72049,9 @@
         "operationId": "getLogSessionById",
         "summary": "Get logs for a session",
         "description": "Returns the paginated logs belonging to a single parent-request session\n(grouped by `parent_request_id`). Sorted ascending by timestamp by default.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "session_id",
@@ -68201,7 +72087,10 @@
             "description": "Sort order (default `asc`)",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "asc"
             }
           }
@@ -68241,7 +72130,10 @@
                         },
                         "order": {
                           "type": "string",
-                          "enum": ["asc", "desc"]
+                          "enum": [
+                            "asc",
+                            "desc"
+                          ]
                         },
                         "total_count": {
                           "type": "integer",
@@ -68295,7 +72187,9 @@
         "operationId": "getLogSessionSummaryById",
         "summary": "Get aggregate totals for a session",
         "description": "Returns aggregate request count, token usage, cost, and duration for a single session.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "session_id",
@@ -68380,7 +72274,9 @@
         "operationId": "getLogsStats",
         "summary": "Get log statistics",
         "description": "Returns statistics for logs matching the specified filters.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -68466,6 +72362,14 @@
             "name": "complexity_mechanisms",
             "in": "query",
             "description": "Comma-separated list of complexity decision mechanisms to filter by (semantic, llm, session, or skipped)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "description": "Exact Bifrost session ID used for key stickiness and request correlation",
             "schema": {
               "type": "string"
             }
@@ -68614,7 +72518,9 @@
         "operationId": "getLogsHistogram",
         "summary": "Get request count histogram",
         "description": "Returns time-bucketed request counts. Bucket size is auto-calculated from the time range.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -68935,7 +72841,9 @@
         "operationId": "getLogsTokenHistogram",
         "summary": "Get token usage histogram",
         "description": "Returns time-bucketed token usage (prompt, completion, total).",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -69176,7 +73084,9 @@
         "operationId": "getLogsCostHistogram",
         "summary": "Get cost histogram",
         "description": "Returns time-bucketed cost data with model breakdown.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -69422,7 +73332,9 @@
         "operationId": "getLogsModelHistogram",
         "summary": "Get model usage histogram",
         "description": "Returns time-bucketed model usage with success/error breakdown.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -69679,7 +73591,9 @@
         "operationId": "getLogsLatencyHistogram",
         "summary": "Get latency histogram",
         "description": "Returns time-bucketed latency percentiles (avg, p90, p95, p99).",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -69924,7 +73838,9 @@
         "operationId": "getLogsProviderCostHistogram",
         "summary": "Get cost histogram by provider",
         "description": "Returns time-bucketed cost data with provider breakdown.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -70169,7 +74085,9 @@
         "operationId": "getLogsProviderTokenHistogram",
         "summary": "Get token histogram by provider",
         "description": "Returns time-bucketed token usage with provider breakdown.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -70426,7 +74344,9 @@
         "operationId": "getLogsProviderLatencyHistogram",
         "summary": "Get latency histogram by provider",
         "description": "Returns time-bucketed latency percentiles with provider breakdown.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -70687,7 +74607,9 @@
         "operationId": "getLogsDimensionCostHistogram",
         "summary": "Get cost histogram by dimension",
         "description": "Returns time-bucketed cost data grouped by an arbitrary dimension\n(`provider`, `team_id`, `customer_id`, `user_id`, `business_unit_id`,\n`project_id`, `app`, `user_agent`). The dimension is supplied via the\nrequired `dimension` query parameter.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "dimension",
@@ -70966,7 +74888,9 @@
         "operationId": "getLogsDimensionTokenHistogram",
         "summary": "Get token histogram by dimension",
         "description": "Returns time-bucketed token usage grouped by an arbitrary dimension.\nSee `getLogsDimensionCostHistogram` for the list of supported dimensions.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "dimension",
@@ -71256,7 +75180,9 @@
         "operationId": "getLogsDimensionLatencyHistogram",
         "summary": "Get latency histogram by dimension",
         "description": "Returns time-bucketed latency percentiles (avg, p90, p95, p99) grouped by\nan arbitrary dimension.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "dimension",
@@ -71550,7 +75476,9 @@
         "operationId": "getDroppedRequests",
         "summary": "Get dropped requests count",
         "description": "Returns the number of dropped requests.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -71582,7 +75510,9 @@
         "operationId": "getAvailableFilterData",
         "summary": "Get available filter data",
         "description": "Returns all unique filter data from logs (models, keys, virtual keys).",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -71652,7 +75582,9 @@
         "operationId": "getModelRankings",
         "summary": "Get model usage rankings",
         "description": "Returns models ranked by usage with trend percentages versus the previous\ncomparable period. Accepts the same filter parameters as the histogram\nendpoints.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -71868,6 +75800,14 @@
             "name": "parent_request_id",
             "in": "query",
             "description": "Parent request ID to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "description": "Exact Bifrost session ID used for key stickiness and request correlation",
             "schema": {
               "type": "string"
             }
@@ -72029,7 +75969,9 @@
         "operationId": "getDashboard",
         "summary": "Get consolidated dashboard data",
         "description": "Returns every metric shown on the workspace dashboard in a single\nresponse: overview totals and histograms, provider usage, model rankings,\ndimension rankings (team, user, virtual key, customer, business unit), and\nMCP usage. Intended for external integrations that want the full dashboard\nin one call rather than orchestrating the individual endpoints.\n\nAccepts the same LLM filter parameters as the histogram and rankings\nendpoints, plus the MCP filter parameters (`tool_names`, `server_labels`)\nwhich apply to the `mcp` section. Filters are applied once and every\nsection is computed against the same time window and bucket size. The\nrequest fails as a whole if any section cannot be computed, so the payload\nis always complete.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "providers",
@@ -72245,6 +76187,14 @@
             "name": "parent_request_id",
             "in": "query",
             "description": "Parent request ID to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "session_id",
+            "in": "query",
+            "description": "Exact Bifrost session ID used for key stickiness and request correlation",
             "schema": {
               "type": "string"
             }
@@ -73050,7 +77000,9 @@
         "operationId": "recalculateLogCosts",
         "summary": "Recalculate log costs",
         "description": "Starts an asynchronous background job that recalculates log costs in batches.\nThe returned payload is a job status object that can be polled via the status endpoint.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "requestBody": {
           "required": false,
           "content": {
@@ -73125,7 +77077,9 @@
         "operationId": "getRecalculateCostStatus",
         "summary": "Get log cost recalculation status",
         "description": "Returns the current status of a log cost recalculation job.\nWhen `id` is omitted, the current in-flight job is returned, or `idle` when no job is running.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -73190,7 +77144,9 @@
         "operationId": "getMCPLogs",
         "summary": "Get MCP tool logs",
         "description": "Retrieves MCP tool execution logs with filtering, search, and pagination via query parameters.\n",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "tool_names",
@@ -73214,7 +77170,11 @@
             "description": "Comma-separated list of statuses to filter by (processing, success, error)",
             "schema": {
               "type": "string",
-              "enum": ["processing", "success", "error"]
+              "enum": [
+                "processing",
+                "success",
+                "error"
+              ]
             }
           },
           {
@@ -73300,7 +77260,11 @@
             "description": "Field to sort by",
             "schema": {
               "type": "string",
-              "enum": ["timestamp", "latency", "cost"],
+              "enum": [
+                "timestamp",
+                "latency",
+                "cost"
+              ],
               "default": "timestamp"
             }
           },
@@ -73310,7 +77274,10 @@
             "description": "Sort order",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "desc"
             }
           }
@@ -73387,7 +77354,11 @@
                           },
                           "status": {
                             "type": "string",
-                            "enum": ["processing", "success", "error"],
+                            "enum": [
+                              "processing",
+                              "success",
+                              "error"
+                            ],
                             "description": "Execution status"
                           },
                           "metadata": {
@@ -73432,7 +77403,9 @@
                     },
                     "pagination": {
                       "type": "object",
-                      "required": ["total_count"],
+                      "required": [
+                        "total_count"
+                      ],
                       "properties": {
                         "limit": {
                           "type": "integer"
@@ -73488,7 +77461,9 @@
         "operationId": "deleteMCPLogs",
         "summary": "Delete MCP tool logs",
         "description": "Deletes MCP tool logs by their IDs.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -73496,7 +77471,9 @@
               "schema": {
                 "type": "object",
                 "description": "Delete MCP logs request",
-                "required": ["ids"],
+                "required": [
+                  "ids"
+                ],
                 "properties": {
                   "ids": {
                     "type": "array",
@@ -73554,7 +77531,9 @@
         "operationId": "getMCPLogById",
         "summary": "Get MCP tool log by ID",
         "description": "Retrieves a single MCP tool execution log by ID, including hydrated object-storage payloads when configured.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -73632,7 +77611,11 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["processing", "success", "error"],
+                      "enum": [
+                        "processing",
+                        "success",
+                        "error"
+                      ],
                       "description": "Execution status"
                     },
                     "metadata": {
@@ -73715,7 +77698,9 @@
         "operationId": "getMCPLogsStats",
         "summary": "Get MCP tool log statistics",
         "description": "Returns statistics for MCP tool logs matching the specified filters.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "tool_names",
@@ -73739,7 +77724,11 @@
             "description": "Comma-separated list of statuses to filter by",
             "schema": {
               "type": "string",
-              "enum": ["processing", "success", "error"]
+              "enum": [
+                "processing",
+                "success",
+                "error"
+              ]
             }
           },
           {
@@ -73864,7 +77853,9 @@
         "operationId": "getMCPLogsFilterData",
         "summary": "Get available MCP log filter data",
         "description": "Returns all unique filter data from MCP tool logs (tool names, server labels).",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -73937,7 +77928,9 @@
         "operationId": "getMCPLogsHistogram",
         "summary": "Get MCP tool call volume histogram",
         "description": "Returns time-bucketed MCP tool call volume with success/error breakdown.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "tool_names",
@@ -74098,7 +78091,9 @@
         "operationId": "getMCPLogsCostHistogram",
         "summary": "Get MCP cost histogram",
         "description": "Returns time-bucketed MCP tool call cost data.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "tool_names",
@@ -74250,7 +78245,9 @@
         "operationId": "getMCPLogsTopTools",
         "summary": "Get top MCP tools by call count",
         "description": "Returns the top 10 MCP tools by call count, with cost totals.",
-        "tags": ["Logging"],
+        "tags": [
+          "Logging"
+        ],
         "parameters": [
           {
             "name": "tool_names",
@@ -74401,7 +78398,9 @@
         "operationId": "listFolders",
         "summary": "List folders",
         "description": "Returns all prompt folders.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -74468,14 +78467,18 @@
         "operationId": "createFolder",
         "summary": "Create folder",
         "description": "Creates a new prompt folder.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -74563,7 +78566,9 @@
         "operationId": "getFolder",
         "summary": "Get folder",
         "description": "Returns a folder by ID.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -74647,7 +78652,9 @@
         "operationId": "updateFolder",
         "summary": "Update folder",
         "description": "Updates a folder's name or description.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -74760,7 +78767,9 @@
         "operationId": "deleteFolder",
         "summary": "Delete folder",
         "description": "Deletes a folder and cascades to contained prompts.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -74815,7 +78824,9 @@
         "operationId": "listPrompts",
         "summary": "List prompts",
         "description": "Returns all prompts, optionally filtered by folder.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "folder_id",
@@ -75097,14 +79108,18 @@
         "operationId": "createPrompt",
         "summary": "Create prompt",
         "description": "Creates a new prompt.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -75397,7 +79412,9 @@
         "operationId": "getPrompt",
         "summary": "Get prompt",
         "description": "Returns a prompt by ID with its latest version.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -75686,7 +79703,9 @@
         "operationId": "updatePrompt",
         "summary": "Update prompt",
         "description": "Updates a prompt's name or folder.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -75994,7 +80013,9 @@
         "operationId": "deletePrompt",
         "summary": "Delete prompt",
         "description": "Deletes a prompt and all its versions and sessions.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76049,7 +80070,9 @@
         "operationId": "listPromptVersions",
         "summary": "List prompt versions",
         "description": "Returns all versions for a prompt.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76155,7 +80178,9 @@
         "operationId": "createPromptVersion",
         "summary": "Create prompt version",
         "description": "Creates a new version for a prompt.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76173,7 +80198,13 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["commit_message", "messages", "model_params", "provider", "model"],
+                "required": [
+                  "commit_message",
+                  "messages",
+                  "model_params",
+                  "provider",
+                  "model"
+                ],
                 "properties": {
                   "commit_message": {
                     "type": "string"
@@ -76304,7 +80335,9 @@
         "operationId": "getPromptVersion",
         "summary": "Get prompt version",
         "description": "Returns a specific version by ID.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76417,7 +80450,9 @@
         "operationId": "deletePromptVersion",
         "summary": "Delete prompt version",
         "description": "Deletes a specific version.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76473,7 +80508,9 @@
         "operationId": "listPromptSessions",
         "summary": "List prompt sessions",
         "description": "Returns all sessions for a prompt.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76582,7 +80619,9 @@
         "operationId": "createPromptSession",
         "summary": "Create prompt session",
         "description": "Creates a new playground session for a prompt.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76600,7 +80639,12 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name", "model_params", "provider", "model"],
+                "required": [
+                  "name",
+                  "model_params",
+                  "provider",
+                  "model"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -76737,7 +80781,9 @@
         "operationId": "getPromptSession",
         "summary": "Get prompt session",
         "description": "Returns a specific session by ID.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76853,7 +80899,9 @@
         "operationId": "updatePromptSession",
         "summary": "Update prompt session",
         "description": "Updates a session's messages, model params, etc.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -76871,7 +80919,13 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name", "messages", "model_params", "provider", "model"],
+                "required": [
+                  "name",
+                  "messages",
+                  "model_params",
+                  "provider",
+                  "model"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -77002,7 +81056,9 @@
         "operationId": "deletePromptSession",
         "summary": "Delete prompt session",
         "description": "Deletes a specific session.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -77058,7 +81114,9 @@
         "operationId": "renamePromptSession",
         "summary": "Rename prompt session",
         "description": "Renames a session.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -77076,7 +81134,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -77192,7 +81252,9 @@
         "operationId": "commitPromptSession",
         "summary": "Commit session as version",
         "description": "Commits the current session state as a new prompt version.",
-        "tags": ["Prompt Repository"],
+        "tags": [
+          "Prompt Repository"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -77210,7 +81272,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["commit_message"],
+                "required": [
+                  "commit_message"
+                ],
                 "properties": {
                   "commit_message": {
                     "type": "string"
@@ -77323,7 +81387,9 @@
         "operationId": "uploadSkillFile",
         "summary": "Upload skill file",
         "description": "Uploads one file for later attachment to a skill version. The response contains either an object-storage key or a database blob ID.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -77378,7 +81444,9 @@
         "operationId": "cleanupOrphanSkillFiles",
         "summary": "Clean up orphan skill files",
         "description": "Deletes uploaded files that are not attached to any skill version. This is mostly a maintenance escape hatch: Bifrost also runs orphan cleanup on server startup. Non-forced cleanup preserves uploads newer than 24 hours so files are not deleted while a skill is still being edited.\n",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "parameters": [
           {
             "name": "force",
@@ -77424,7 +81492,9 @@
         "operationId": "getAllSkillsVersion",
         "summary": "Get all-skills version",
         "description": "Returns the current version of the synthetic `bifrost-all-skills` marketplace plugin.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -77457,7 +81527,9 @@
         "operationId": "bumpAllSkillsVersion",
         "summary": "Bump all-skills version",
         "description": "Manually bumps the synthetic `bifrost-all-skills` plugin version as an escape hatch for marketplace refreshes.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -77512,7 +81584,9 @@
         "operationId": "listSkills",
         "summary": "List skills",
         "description": "Returns a paginated list of skills from the Skills Repository.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "parameters": [
           {
             "name": "search",
@@ -77528,7 +81602,11 @@
             "description": "Field to sort by.",
             "schema": {
               "type": "string",
-              "enum": ["name", "updated_at", "created_at"],
+              "enum": [
+                "name",
+                "updated_at",
+                "created_at"
+              ],
               "default": "created_at"
             }
           },
@@ -77538,7 +81616,10 @@
             "description": "Sort order.",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "desc"
             }
           },
@@ -77596,7 +81677,9 @@
         "operationId": "createSkill",
         "summary": "Create skill",
         "description": "Creates a new skill and immediately serves its first immutable version.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -77651,7 +81734,9 @@
         "operationId": "getSkill",
         "summary": "Get skill",
         "description": "Returns a skill by ID. Pass `version` to inspect a historical version snapshot.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -77724,7 +81809,9 @@
         "operationId": "updateSkill",
         "summary": "Update skill",
         "description": "Creates a new immutable skill version. Set `serve` to false to save the version without switching the served version.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -77798,7 +81885,9 @@
         "operationId": "deleteSkill",
         "summary": "Delete skill",
         "description": "Deletes a skill and all of its versions.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -77854,7 +81943,9 @@
         "operationId": "listSkillVersions",
         "summary": "List skill versions",
         "description": "Returns immutable version snapshots for a skill.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -77879,7 +81970,10 @@
             "description": "Field to sort by.",
             "schema": {
               "type": "string",
-              "enum": ["version", "created_at"],
+              "enum": [
+                "version",
+                "created_at"
+              ],
               "default": "created_at"
             }
           },
@@ -77889,7 +81983,10 @@
             "description": "Sort order.",
             "schema": {
               "type": "string",
-              "enum": ["asc", "desc"],
+              "enum": [
+                "asc",
+                "desc"
+              ],
               "default": "desc"
             }
           },
@@ -77959,7 +82056,9 @@
         "operationId": "shiftSkillVersion",
         "summary": "Shift served skill version",
         "description": "Changes the served version for a skill without deleting newer versions.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -78035,7 +82134,9 @@
         "operationId": "getClaudeCodeSkillsMarketplace",
         "summary": "Get Claude Code skills marketplace",
         "description": "Public marketplace JSON consumed by Claude Code. Available only when the Bifrost server can access the `git` binary.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -78076,7 +82177,9 @@
         "operationId": "getCodexSkillsMarketplace",
         "summary": "Get Codex skills marketplace JSON",
         "description": "Public Codex marketplace JSON for inspecting the skills and plugin sources exposed by Bifrost.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -78117,7 +82220,9 @@
         "operationId": "downloadAllSkills",
         "summary": "Download all skills as ZIP",
         "description": "Public ZIP download containing every currently served skill.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "security": [],
         "responses": {
           "200": {
@@ -78149,7 +82254,9 @@
         "operationId": "downloadSkill",
         "summary": "Download skill as ZIP",
         "description": "Public ZIP download containing a single currently served skill.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "security": [],
         "parameters": [
           {
@@ -78202,7 +82309,9 @@
         "operationId": "downloadSkillFile",
         "summary": "Download skill file",
         "description": "Public raw file download from the currently served version of a skill.",
-        "tags": ["Skills"],
+        "tags": [
+          "Skills"
+        ],
         "security": [],
         "parameters": [
           {
@@ -78264,7 +82373,9 @@
         "operationId": "clearCacheByCacheId",
         "summary": "Clear cache entry by cache ID",
         "description": "Deletes a single cache entry by its storage ID. Read the cache ID from\n`extra_fields.cache_debug.cache_id` on a prior response — it is populated\non both cache hits and cache misses.\n",
-        "tags": ["Cache"],
+        "tags": [
+          "Cache"
+        ],
         "parameters": [
           {
             "name": "cacheId",
@@ -78320,7 +82431,9 @@
         "operationId": "clearCacheByCacheKey",
         "summary": "Clear cache by cache key",
         "description": "Clears a cache entry by its direct cache key.",
-        "tags": ["Cache"],
+        "tags": [
+          "Cache"
+        ],
         "parameters": [
           {
             "name": "cacheKey",
@@ -78382,7 +82495,9 @@
         },
         "summary": "Flush vault secret cache",
         "description": "Clears the in-memory vault secret cache so the next resolution of every\n`vault.<path>` reference re-fetches from the configured backend (AWS Secrets\nManager, GCP Secret Manager, or HashiCorp Vault).\n\nUse this after rotating a secret when you cannot wait for the hourly\nbackground refresh. In a clustered deployment the flush is broadcast to all\npeer nodes automatically — you only need to call this on one node.\n\nReturns `400` if vault integration is not enabled.\n",
-        "tags": ["Vault"],
+        "tags": [
+          "Vault"
+        ],
         "security": [
           {
             "ManagementBearerAuth": []
@@ -78439,7 +82554,9 @@
         "operationId": "websocketConnect",
         "summary": "WebSocket connection",
         "description": "Upgrades to a WebSocket connection for real-time updates.\nServer pushes log events, MCP log events, and store update notifications.\nHeartbeat pings are sent every 30 seconds.\n",
-        "tags": ["Infrastructure"],
+        "tags": [
+          "Infrastructure"
+        ],
         "responses": {
           "101": {
             "description": "WebSocket upgrade successful"
@@ -78452,7 +82569,9 @@
         "operationId": "mcpServerMessage",
         "summary": "MCP protocol message",
         "description": "Receives a JSON-RPC 2.0 message for the MCP protocol server.\nReturns a JSON-RPC 2.0 response, or null for notifications.\n",
-        "tags": ["Infrastructure"],
+        "tags": [
+          "Infrastructure"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -78463,7 +82582,9 @@
                 "properties": {
                   "jsonrpc": {
                     "type": "string",
-                    "enum": ["2.0"]
+                    "enum": [
+                      "2.0"
+                    ]
                   },
                   "method": {
                     "type": "string"
@@ -78496,7 +82617,9 @@
                   "properties": {
                     "jsonrpc": {
                       "type": "string",
-                      "enum": ["2.0"]
+                      "enum": [
+                        "2.0"
+                      ]
                     },
                     "result": {
                       "type": "object"
@@ -78547,7 +82670,9 @@
         "operationId": "mcpServerSSE",
         "summary": "MCP protocol SSE stream",
         "description": "Opens a Server-Sent Events stream for the MCP protocol server.\nReturns `Content-Type: text/event-stream`.\n",
-        "tags": ["Infrastructure"],
+        "tags": [
+          "Infrastructure"
+        ],
         "responses": {
           "200": {
             "description": "SSE stream opened",
@@ -78581,7 +82706,9 @@
         "operationId": "getMetrics",
         "summary": "Prometheus metrics",
         "description": "Returns Prometheus-formatted metrics for monitoring.",
-        "tags": ["Infrastructure"],
+        "tags": [
+          "Infrastructure"
+        ],
         "responses": {
           "200": {
             "description": "Prometheus metrics",
@@ -78601,7 +82728,9 @@
         "operationId": "listWebhookEndpoints",
         "summary": "List webhook endpoints",
         "description": "Returns webhook endpoints, optionally filtered by search text, subscribed\nevent, and disabled status. Signing secrets are never included and custom\nheader values are redacted.\n",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "name": "search",
@@ -78679,7 +82808,9 @@
         "operationId": "createWebhookEndpoint",
         "summary": "Create a webhook endpoint",
         "description": "Creates a webhook endpoint. The signing secret is generated by the server\nand returned once in the response — it cannot be supplied and cannot be\nretrieved again afterwards.\n",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -78733,7 +82864,9 @@
       "get": {
         "operationId": "getWebhookEndpoint",
         "summary": "Get a webhook endpoint",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -78781,7 +82914,9 @@
         "operationId": "updateWebhookEndpoint",
         "summary": "Update a webhook endpoint",
         "description": "Updates a webhook endpoint. The signing secret is immutable here — use the\nrotate-secret endpoint to change it.\n",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -78848,7 +82983,9 @@
       "delete": {
         "operationId": "deleteWebhookEndpoint",
         "summary": "Delete a webhook endpoint",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -78898,7 +83035,9 @@
         "operationId": "rotateWebhookEndpointSecret",
         "summary": "Rotate a webhook signing secret",
         "description": "Generates a new signing secret for the endpoint and returns it once. The\nprevious secret stops verifying immediately — there is no grace window, so\nupdate your receiver in the same change.\n",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -78948,7 +83087,9 @@
         "operationId": "testWebhookEndpoint",
         "summary": "Send a test delivery",
         "description": "Sends a sample signed delivery for the chosen event through the production\nsigning path.\n",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -79008,7 +83149,9 @@
         "operationId": "listWebhookDeliveries",
         "summary": "List delivery history",
         "description": "Returns one page of delivery-attempt history for an endpoint, newest first.",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/WebhookEndpointId"
@@ -79074,7 +83217,9 @@
         "operationId": "searchWebhookDeliveries",
         "summary": "Search delivery history",
         "description": "Returns one page of delivery-attempt history across every endpoint the\nfilters select, newest first. Unlike the per-endpoint\n`/api/webhooks/{id}/deliveries` route, every filter is optional, so an\nunfiltered call returns history for all endpoints.\n\nPagination is by delivery group (`webhook_id`), not by individual attempt:\na page holds every attempt of the deliveries it covers, so `deliveries`\ncan hold more entries than `limit`, and `total_count` counts deliveries\nrather than attempts.\n\nFilters select delivery groups, not attempts — a delivery is on the page\nif any of its attempts matches — and the matched delivery is then returned\nwith its full attempt sequence intact.\n",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "name": "endpoint_ids",
@@ -79220,7 +83365,9 @@
         "operationId": "redeliverWebhook",
         "summary": "Re-queue a delivery",
         "description": "Re-queues the delivery a history record belongs to, under its original\nwebhook-id so receivers can deduplicate the replay.\n",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -79286,7 +83433,9 @@
         "operationId": "listNotifications",
         "summary": "List dashboard notifications",
         "description": "Returns notifications the caller is entitled to see, newest first.\nNotifications addressed to `all` are visible to everyone; those addressed\nto `roles` are only returned when the caller holds one of the listed\nroles. A local admin sees every notification.\n\nRead and dismissed state is not stored server-side, so every caller sees\nthe full page regardless of what they have already opened.\n",
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -79362,7 +83511,9 @@
         "operationId": "createNotification",
         "summary": "Publish a dashboard notification",
         "description": "Persists a notification and pushes it over the dashboard WebSocket to\nevery connected client the audience covers.\n\nAdministrators only. Reading is open to any authenticated user because a\ncaller only ever receives rows their role already entitles them to, but a\nsingle publish reaches every dashboard user on the deployment, so it is\nrestricted to the local admin. On a deployment with dashboard auth\ndisabled every request is treated as local admin.\n\nNotifications expire 30 days after creation and are pruned hourly.\n",
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -79605,14 +83756,16 @@
           "fireworks",
           "sarvam",
           "wafer",
-          "databricks",
-          "github-copilot"
+          "databricks"
         ]
       },
       "Fallback": {
         "type": "object",
         "description": "Fallback model configuration",
-        "required": ["provider", "model"],
+        "required": [
+          "provider",
+          "model"
+        ],
         "properties": {
           "provider": {
             "$ref": "#/components/schemas/ModelProvider"
@@ -79763,7 +83916,9 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["ephemeral"]
+            "enum": [
+              "ephemeral"
+            ]
           },
           "ttl": {
             "type": "string",
@@ -79774,12 +83929,21 @@
       "AsyncJobStatus": {
         "type": "string",
         "description": "The status of an async job",
-        "enum": ["pending", "processing", "completed", "failed"]
+        "enum": [
+          "pending",
+          "processing",
+          "completed",
+          "failed"
+        ]
       },
       "AsyncJobResponse": {
         "type": "object",
         "description": "Response returned when creating or polling an async job",
-        "required": ["id", "status", "created_at"],
+        "required": [
+          "id",
+          "status",
+          "created_at"
+        ],
         "properties": {
           "id": {
             "type": "string",
@@ -80112,7 +84276,10 @@
       },
       "ChatCompletionRequest": {
         "type": "object",
-        "required": ["model", "messages"],
+        "required": [
+          "model",
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -80181,7 +84348,14 @@
               "effort": {
                 "type": "string",
                 "description": "Reasoning effort level",
-                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
+                "enum": [
+                  "none",
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ]
               },
               "max_tokens": {
                 "type": "integer"
@@ -80221,19 +84395,34 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["none", "auto", "required"]
+                "enum": [
+                  "none",
+                  "auto",
+                  "required"
+                ]
               },
               {
                 "type": "object",
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["none", "any", "required", "function", "allowed_tools", "custom"]
+                    "enum": [
+                      "none",
+                      "any",
+                      "required",
+                      "function",
+                      "allowed_tools",
+                      "custom"
+                    ]
                   },
                   "function": {
                     "type": "object",
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "properties": {
                       "name": {
                         "type": "string"
@@ -80245,20 +84434,27 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": ["auto", "required"]
+                        "enum": [
+                          "auto",
+                          "required"
+                        ]
                       },
                       "tools": {
                         "type": "array",
                         "items": {
                           "type": "object",
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "properties": {
                             "type": {
                               "type": "string"
                             },
                             "function": {
                               "type": "object",
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "properties": {
                                 "name": {
                                   "type": "string"
@@ -80278,15 +84474,22 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["function", "custom"]
+                  "enum": [
+                    "function",
+                    "custom"
+                  ]
                 },
                 "function": {
                   "type": "object",
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "name": {
                       "type": "string"
@@ -80334,21 +84537,29 @@
                   "properties": {
                     "format": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string"
                         },
                         "grammar": {
                           "type": "object",
-                          "required": ["definition", "syntax"],
+                          "required": [
+                            "definition",
+                            "syntax"
+                          ],
                           "properties": {
                             "definition": {
                               "type": "string"
                             },
                             "syntax": {
                               "type": "string",
-                              "enum": ["lark", "regex"]
+                              "enum": [
+                                "lark",
+                                "regex"
+                              ]
                             }
                           }
                         }
@@ -80419,7 +84630,10 @@
           },
           "prompt_cache_retention": {
             "type": "string",
-            "enum": ["in_memory", "24h"],
+            "enum": [
+              "in_memory",
+              "24h"
+            ],
             "description": "Prompt cache retention policy"
           },
           "web_search_options": {
@@ -80428,7 +84642,11 @@
             "properties": {
               "search_context_size": {
                 "type": "string",
-                "enum": ["low", "medium", "high"],
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
                 "description": "Amount of search context to include"
               },
               "user_location": {
@@ -80470,7 +84688,11 @@
           },
           "verbosity": {
             "type": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
           }
         }
       },
@@ -80636,7 +84858,11 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": ["reasoning.summary", "reasoning.encrypted", "reasoning.text"]
+                            "enum": [
+                              "reasoning.summary",
+                              "reasoning.encrypted",
+                              "reasoning.text"
+                            ]
                           },
                           "summary": {
                             "type": "string"
@@ -80657,7 +84883,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["function"],
+                        "required": [
+                          "function"
+                        ],
                         "properties": {
                           "index": {
                             "type": "integer"
@@ -80731,11 +84959,19 @@
       },
       "ChatMessage": {
         "type": "object",
-        "required": ["role"],
+        "required": [
+          "role"
+        ],
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["assistant", "user", "system", "tool", "developer"]
+            "enum": [
+              "assistant",
+              "user",
+              "system",
+              "tool",
+              "developer"
+            ]
           },
           "name": {
             "type": "string"
@@ -80749,11 +84985,19 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["text", "image_url", "input_audio", "file", "refusal"]
+                      "enum": [
+                        "text",
+                        "image_url",
+                        "input_audio",
+                        "file",
+                        "refusal"
+                      ]
                     },
                     "text": {
                       "type": "string"
@@ -80763,20 +85007,28 @@
                     },
                     "image_url": {
                       "type": "object",
-                      "required": ["url"],
+                      "required": [
+                        "url"
+                      ],
                       "properties": {
                         "url": {
                           "type": "string"
                         },
                         "detail": {
                           "type": "string",
-                          "enum": ["low", "high", "auto"]
+                          "enum": [
+                            "low",
+                            "high",
+                            "auto"
+                          ]
                         }
                       }
                     },
                     "input_audio": {
                       "type": "object",
-                      "required": ["data"],
+                      "required": [
+                        "data"
+                      ],
                       "properties": {
                         "data": {
                           "type": "string"
@@ -80852,7 +85104,11 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": ["reasoning.summary", "reasoning.encrypted", "reasoning.text"]
+                  "enum": [
+                    "reasoning.summary",
+                    "reasoning.encrypted",
+                    "reasoning.text"
+                  ]
                 },
                 "summary": {
                   "type": "string"
@@ -80907,7 +85163,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["function"],
+              "required": [
+                "function"
+              ],
               "properties": {
                 "index": {
                   "type": "integer"
@@ -80980,7 +85238,10 @@
       },
       "TextCompletionRequest": {
         "type": "object",
-        "required": ["model", "prompt"],
+        "required": [
+          "model",
+          "prompt"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -81221,7 +85482,11 @@
                           },
                           "type": {
                             "type": "string",
-                            "enum": ["reasoning.summary", "reasoning.encrypted", "reasoning.text"]
+                            "enum": [
+                              "reasoning.summary",
+                              "reasoning.encrypted",
+                              "reasoning.text"
+                            ]
                           },
                           "summary": {
                             "type": "string"
@@ -81242,7 +85507,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["function"],
+                        "required": [
+                          "function"
+                        ],
                         "properties": {
                           "index": {
                             "type": "integer"
@@ -81329,7 +85596,10 @@
       },
       "ResponsesRequest": {
         "type": "object",
-        "required": ["model", "input"],
+        "required": [
+          "model",
+          "input"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -81376,11 +85646,22 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
+                      "enum": [
+                        "in_progress",
+                        "completed",
+                        "incomplete",
+                        "interpreting",
+                        "failed"
+                      ]
                     },
                     "role": {
                       "type": "string",
-                      "enum": ["assistant", "user", "system", "developer"]
+                      "enum": [
+                        "assistant",
+                        "user",
+                        "system",
+                        "developer"
+                      ]
                     },
                     "content": {
                       "oneOf": [
@@ -81391,7 +85672,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
@@ -81434,11 +85717,17 @@
                               },
                               "input_audio": {
                                 "type": "object",
-                                "required": ["format", "data"],
+                                "required": [
+                                  "format",
+                                  "data"
+                                ],
                                 "properties": {
                                   "format": {
                                     "type": "string",
-                                    "enum": ["mp3", "wav"]
+                                    "enum": [
+                                      "mp3",
+                                      "wav"
+                                    ]
                                   },
                                   "data": {
                                     "type": "string"
@@ -81559,7 +85848,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
@@ -81602,11 +85893,17 @@
                               },
                               "input_audio": {
                                 "type": "object",
-                                "required": ["format", "data"],
+                                "required": [
+                                  "format",
+                                  "data"
+                                ],
                                 "properties": {
                                   "format": {
                                     "type": "string",
-                                    "enum": ["mp3", "wav"]
+                                    "enum": [
+                                      "mp3",
+                                      "wav"
+                                    ]
                                   },
                                   "data": {
                                     "type": "string"
@@ -81712,7 +86009,9 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["computer_screenshot"]
+                              "enum": [
+                                "computer_screenshot"
+                              ]
                             },
                             "file_id": {
                               "type": "string"
@@ -81746,11 +86045,16 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type", "text"],
+                        "required": [
+                          "type",
+                          "text"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["summary_text"]
+                            "enum": [
+                              "summary_text"
+                            ]
                           },
                           "text": {
                             "type": "string"
@@ -81818,7 +86122,14 @@
             "properties": {
               "effort": {
                 "type": "string",
-                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
+                "enum": [
+                  "none",
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ]
               },
               "generate_summary": {
                 "type": "string",
@@ -81826,7 +86137,11 @@
               },
               "summary": {
                 "type": "string",
-                "enum": ["auto", "concise", "detailed"]
+                "enum": [
+                  "auto",
+                  "concise",
+                  "detailed"
+                ]
               },
               "max_tokens": {
                 "type": "integer"
@@ -81858,11 +86173,17 @@
             "properties": {
               "format": {
                 "type": "object",
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["text", "json_schema", "json_object"]
+                    "enum": [
+                      "text",
+                      "json_schema",
+                      "json_object"
+                    ]
                   },
                   "name": {
                     "type": "string"
@@ -81877,7 +86198,11 @@
               },
               "verbosity": {
                 "type": "string",
-                "enum": ["low", "medium", "high"]
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
               }
             }
           },
@@ -81891,11 +86216,17 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["none", "auto", "required"]
+                "enum": [
+                  "none",
+                  "auto",
+                  "required"
+                ]
               },
               {
                 "type": "object",
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
@@ -81928,11 +86259,17 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["function", "mcp", "image_generation"]
+                          "enum": [
+                            "function",
+                            "mcp",
+                            "image_generation"
+                          ]
                         },
                         "name": {
                           "type": "string"
@@ -81951,7 +86288,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -82131,7 +86470,10 @@
           },
           "error": {
             "type": "object",
-            "required": ["code", "message"],
+            "required": [
+              "code",
+              "message"
+            ],
             "properties": {
               "code": {
                 "type": "string"
@@ -82149,7 +86491,9 @@
           },
           "incomplete_details": {
             "type": "object",
-            "required": ["reason"],
+            "required": [
+              "reason"
+            ],
             "properties": {
               "reason": {
                 "type": "string"
@@ -82207,11 +86551,22 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
+                  "enum": [
+                    "in_progress",
+                    "completed",
+                    "incomplete",
+                    "interpreting",
+                    "failed"
+                  ]
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["assistant", "user", "system", "developer"]
+                  "enum": [
+                    "assistant",
+                    "user",
+                    "system",
+                    "developer"
+                  ]
                 },
                 "content": {
                   "oneOf": [
@@ -82222,7 +86577,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -82265,11 +86622,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -82390,7 +86753,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -82433,11 +86798,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -82543,7 +86914,9 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["computer_screenshot"]
+                          "enum": [
+                            "computer_screenshot"
+                          ]
                         },
                         "file_id": {
                           "type": "string"
@@ -82577,11 +86950,16 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": ["type", "text"],
+                    "required": [
+                      "type",
+                      "text"
+                    ],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["summary_text"]
+                        "enum": [
+                          "summary_text"
+                        ]
                       },
                       "text": {
                         "type": "string"
@@ -82612,7 +86990,14 @@
             "properties": {
               "effort": {
                 "type": "string",
-                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
+                "enum": [
+                  "none",
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ]
               },
               "generate_summary": {
                 "type": "string",
@@ -82620,7 +87005,11 @@
               },
               "summary": {
                 "type": "string",
-                "enum": ["auto", "concise", "detailed"]
+                "enum": [
+                  "auto",
+                  "concise",
+                  "detailed"
+                ]
               },
               "max_tokens": {
                 "type": "integer"
@@ -82635,7 +87024,14 @@
           },
           "status": {
             "type": "string",
-            "enum": ["completed", "failed", "in_progress", "canceled", "queued", "incomplete"]
+            "enum": [
+              "completed",
+              "failed",
+              "in_progress",
+              "canceled",
+              "queued",
+              "incomplete"
+            ]
           },
           "stop_reason": {
             "type": "string"
@@ -82651,11 +87047,17 @@
             "properties": {
               "format": {
                 "type": "object",
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["text", "json_schema", "json_object"]
+                    "enum": [
+                      "text",
+                      "json_schema",
+                      "json_object"
+                    ]
                   },
                   "name": {
                     "type": "string"
@@ -82670,7 +87072,11 @@
               },
               "verbosity": {
                 "type": "string",
-                "enum": ["low", "medium", "high"]
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
               }
             }
           },
@@ -82684,11 +87090,17 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["none", "auto", "required"]
+                "enum": [
+                  "none",
+                  "auto",
+                  "required"
+                ]
               },
               {
                 "type": "object",
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
@@ -82721,11 +87133,17 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["function", "mcp", "image_generation"]
+                          "enum": [
+                            "function",
+                            "mcp",
+                            "image_generation"
+                          ]
                         },
                         "name": {
                           "type": "string"
@@ -82744,7 +87162,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -83054,11 +87474,22 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
+                  "enum": [
+                    "in_progress",
+                    "completed",
+                    "incomplete",
+                    "interpreting",
+                    "failed"
+                  ]
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["assistant", "user", "system", "developer"]
+                  "enum": [
+                    "assistant",
+                    "user",
+                    "system",
+                    "developer"
+                  ]
                 },
                 "content": {
                   "oneOf": [
@@ -83069,7 +87500,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -83112,11 +87545,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -83237,7 +87676,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -83280,11 +87721,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -83390,7 +87837,9 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["computer_screenshot"]
+                          "enum": [
+                            "computer_screenshot"
+                          ]
                         },
                         "file_id": {
                           "type": "string"
@@ -83424,11 +87873,16 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": ["type", "text"],
+                    "required": [
+                      "type",
+                      "text"
+                    ],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["summary_text"]
+                        "enum": [
+                          "summary_text"
+                        ]
                       },
                       "text": {
                         "type": "string"
@@ -83458,7 +87912,11 @@
       },
       "RerankRequest": {
         "type": "object",
-        "required": ["model", "query", "documents"],
+        "required": [
+          "model",
+          "query",
+          "documents"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -83507,7 +87965,10 @@
       },
       "RerankResponse": {
         "type": "object",
-        "required": ["results", "model"],
+        "required": [
+          "results",
+          "model"
+        ],
         "properties": {
           "id": {
             "type": "string",
@@ -83534,7 +87995,9 @@
       },
       "RerankDocument": {
         "type": "object",
-        "required": ["text"],
+        "required": [
+          "text"
+        ],
         "properties": {
           "text": {
             "type": "string",
@@ -83555,7 +88018,10 @@
       },
       "RerankResult": {
         "type": "object",
-        "required": ["index", "relevance_score"],
+        "required": [
+          "index",
+          "relevance_score"
+        ],
         "properties": {
           "index": {
             "type": "integer",
@@ -83573,7 +88039,10 @@
       },
       "EmbeddingRequest": {
         "type": "object",
-        "required": ["model", "input"],
+        "required": [
+          "model",
+          "input"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -83616,7 +88085,10 @@
           },
           "encoding_format": {
             "type": "string",
-            "enum": ["float", "base64"]
+            "enum": [
+              "float",
+              "base64"
+            ]
           },
           "dimensions": {
             "type": "integer"
@@ -83678,7 +88150,11 @@
       },
       "SpeechRequest": {
         "type": "object",
-        "required": ["model", "input", "voice"],
+        "required": [
+          "model",
+          "input",
+          "voice"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -83696,7 +88172,9 @@
           },
           "stream_format": {
             "type": "string",
-            "enum": ["sse"],
+            "enum": [
+              "sse"
+            ],
             "description": "Set to \"sse\" to enable streaming"
           },
           "voice": {
@@ -83708,7 +88186,10 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["speaker", "voice"],
+                  "required": [
+                    "speaker",
+                    "voice"
+                  ],
                   "properties": {
                     "speaker": {
                       "type": "string"
@@ -83726,7 +88207,14 @@
           },
           "response_format": {
             "type": "string",
-            "enum": ["mp3", "opus", "aac", "flac", "wav", "pcm"]
+            "enum": [
+              "mp3",
+              "opus",
+              "aac",
+              "flac",
+              "wav",
+              "pcm"
+            ]
           },
           "speed": {
             "type": "number",
@@ -83740,7 +88228,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["pronunciation_dictionary_id"],
+              "required": [
+                "pronunciation_dictionary_id"
+              ],
               "properties": {
                 "pronunciation_dictionary_id": {
                   "type": "string"
@@ -83840,7 +88330,10 @@
       },
       "TranscriptionRequest": {
         "type": "object",
-        "required": ["model", "file"],
+        "required": [
+          "model",
+          "file"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -83868,7 +88361,13 @@
           },
           "response_format": {
             "type": "string",
-            "enum": ["json", "text", "srt", "verbose_json", "vtt"]
+            "enum": [
+              "json",
+              "text",
+              "srt",
+              "verbose_json",
+              "vtt"
+            ]
           },
           "file_format": {
             "type": "string"
@@ -83956,7 +88455,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["tokens", "duration"]
+                "enum": [
+                  "tokens",
+                  "duration"
+                ]
               },
               "input_tokens": {
                 "type": "integer"
@@ -84007,7 +88509,10 @@
       },
       "CountTokensRequest": {
         "type": "object",
-        "required": ["model", "messages"],
+        "required": [
+          "model",
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -84049,11 +88554,22 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
+                  "enum": [
+                    "in_progress",
+                    "completed",
+                    "incomplete",
+                    "interpreting",
+                    "failed"
+                  ]
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["assistant", "user", "system", "developer"]
+                  "enum": [
+                    "assistant",
+                    "user",
+                    "system",
+                    "developer"
+                  ]
                 },
                 "content": {
                   "oneOf": [
@@ -84064,7 +88580,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -84107,11 +88625,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -84232,7 +88756,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -84275,11 +88801,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -84385,7 +88917,9 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["computer_screenshot"]
+                          "enum": [
+                            "computer_screenshot"
+                          ]
                         },
                         "file_id": {
                           "type": "string"
@@ -84419,11 +88953,16 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": ["type", "text"],
+                    "required": [
+                      "type",
+                      "text"
+                    ],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["summary_text"]
+                        "enum": [
+                          "summary_text"
+                        ]
                       },
                       "text": {
                         "type": "string"
@@ -84447,7 +88986,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -84672,7 +89213,9 @@
       },
       "BatchCreateRequest": {
         "type": "object",
-        "required": ["model"],
+        "required": [
+          "model"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -84686,7 +89229,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["custom_id"],
+              "required": [
+                "custom_id"
+              ],
               "properties": {
                 "custom_id": {
                   "type": "string"
@@ -85010,7 +89555,10 @@
       },
       "FileUploadRequest": {
         "type": "object",
-        "required": ["file", "purpose"],
+        "required": [
+          "file",
+          "purpose"
+        ],
         "properties": {
           "file": {
             "type": "string",
@@ -85069,7 +89617,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["uploaded", "processed", "processing", "error", "deleted"]
+            "enum": [
+              "uploaded",
+              "processed",
+              "processing",
+              "error",
+              "deleted"
+            ]
           },
           "status_details": {
             "type": "string"
@@ -85132,7 +89686,13 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["uploaded", "processed", "processing", "error", "deleted"]
+                  "enum": [
+                    "uploaded",
+                    "processed",
+                    "processing",
+                    "error",
+                    "deleted"
+                  ]
                 },
                 "status_details": {
                   "type": "string"
@@ -85157,7 +89717,10 @@
       },
       "OCRRequest": {
         "type": "object",
-        "required": ["model", "document"],
+        "required": [
+          "model",
+          "document"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -85214,17 +89777,28 @@
           },
           "confidence_scores_granularity": {
             "type": "string",
-            "enum": ["page", "block", "word", "document"],
+            "enum": [
+              "page",
+              "block",
+              "word",
+              "document"
+            ],
             "description": "Granularity of confidence scores to include in the response"
           },
           "bbox_annotation_format": {
             "type": "object",
             "description": "Format for bounding box annotations. Supports text, json_object, and json_schema modes.",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["text", "json_object", "json_schema"],
+                "enum": [
+                  "text",
+                  "json_object",
+                  "json_schema"
+                ],
                 "description": "The format type"
               },
               "json_schema": {
@@ -85250,15 +89824,23 @@
               {
                 "properties": {
                   "type": {
-                    "enum": ["text", "json_object"]
+                    "enum": [
+                      "text",
+                      "json_object"
+                    ]
                   }
                 }
               },
               {
-                "required": ["type", "json_schema"],
+                "required": [
+                  "type",
+                  "json_schema"
+                ],
                 "properties": {
                   "type": {
-                    "enum": ["json_schema"]
+                    "enum": [
+                      "json_schema"
+                    ]
                   }
                 }
               }
@@ -85267,11 +89849,17 @@
           "document_annotation_format": {
             "type": "object",
             "description": "Format for document-level annotations. Supports text, json_object, and json_schema modes.",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["text", "json_object", "json_schema"],
+                "enum": [
+                  "text",
+                  "json_object",
+                  "json_schema"
+                ],
                 "description": "The format type"
               },
               "json_schema": {
@@ -85297,15 +89885,23 @@
               {
                 "properties": {
                   "type": {
-                    "enum": ["text", "json_object"]
+                    "enum": [
+                      "text",
+                      "json_object"
+                    ]
                   }
                 }
               },
               {
-                "required": ["type", "json_schema"],
+                "required": [
+                  "type",
+                  "json_schema"
+                ],
                 "properties": {
                   "type": {
-                    "enum": ["json_schema"]
+                    "enum": [
+                      "json_schema"
+                    ]
                   }
                 }
               }
@@ -85322,7 +89918,10 @@
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["document_url", "image_url"],
+            "enum": [
+              "document_url",
+              "image_url"
+            ],
             "description": "Type of document input:\n- `document_url`: A PDF URL or base64 data URL\n- `image_url`: An image URL\n"
           },
           "document_url": {
@@ -85336,18 +89935,28 @@
         },
         "oneOf": [
           {
-            "required": ["type", "document_url"],
+            "required": [
+              "type",
+              "document_url"
+            ],
             "properties": {
               "type": {
-                "enum": ["document_url"]
+                "enum": [
+                  "document_url"
+                ]
               }
             }
           },
           {
-            "required": ["type", "image_url"],
+            "required": [
+              "type",
+              "image_url"
+            ],
             "properties": {
               "type": {
-                "enum": ["image_url"]
+                "enum": [
+                  "image_url"
+                ]
               }
             }
           }
@@ -85355,7 +89964,10 @@
       },
       "OCRResponse": {
         "type": "object",
-        "required": ["model", "pages"],
+        "required": [
+          "model",
+          "pages"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -85382,7 +89994,10 @@
       },
       "OCRPage": {
         "type": "object",
-        "required": ["index", "markdown"],
+        "required": [
+          "index",
+          "markdown"
+        ],
         "properties": {
           "index": {
             "type": "integer",
@@ -85447,7 +90062,13 @@
       },
       "OCRPageImage": {
         "type": "object",
-        "required": ["id", "top_left_x", "top_left_y", "bottom_right_x", "bottom_right_y"],
+        "required": [
+          "id",
+          "top_left_x",
+          "top_left_y",
+          "bottom_right_x",
+          "bottom_right_y"
+        ],
         "properties": {
           "id": {
             "type": "string",
@@ -85477,7 +90098,11 @@
       },
       "OCRPageDimensions": {
         "type": "object",
-        "required": ["dpi", "height", "width"],
+        "required": [
+          "dpi",
+          "height",
+          "width"
+        ],
         "properties": {
           "dpi": {
             "type": "integer",
@@ -85495,7 +90120,10 @@
       },
       "OCRUsageInfo": {
         "type": "object",
-        "required": ["pages_processed", "doc_size_bytes"],
+        "required": [
+          "pages_processed",
+          "doc_size_bytes"
+        ],
         "properties": {
           "pages_processed": {
             "type": "integer",
@@ -85509,7 +90137,10 @@
       },
       "OpenAIChatRequest": {
         "type": "object",
-        "required": ["model", "messages"],
+        "required": [
+          "model",
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -85591,15 +90222,22 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["function", "custom"]
+                  "enum": [
+                    "function",
+                    "custom"
+                  ]
                 },
                 "function": {
                   "type": "object",
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "name": {
                       "type": "string"
@@ -85647,21 +90285,29 @@
                   "properties": {
                     "format": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string"
                         },
                         "grammar": {
                           "type": "object",
-                          "required": ["definition", "syntax"],
+                          "required": [
+                            "definition",
+                            "syntax"
+                          ],
                           "properties": {
                             "definition": {
                               "type": "string"
                             },
                             "syntax": {
                               "type": "string",
-                              "enum": ["lark", "regex"]
+                              "enum": [
+                                "lark",
+                                "regex"
+                              ]
                             }
                           }
                         }
@@ -85679,19 +90325,34 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["none", "auto", "required"]
+                "enum": [
+                  "none",
+                  "auto",
+                  "required"
+                ]
               },
               {
                 "type": "object",
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["none", "any", "required", "function", "allowed_tools", "custom"]
+                    "enum": [
+                      "none",
+                      "any",
+                      "required",
+                      "function",
+                      "allowed_tools",
+                      "custom"
+                    ]
                   },
                   "function": {
                     "type": "object",
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "properties": {
                       "name": {
                         "type": "string"
@@ -85703,20 +90364,27 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": ["auto", "required"]
+                        "enum": [
+                          "auto",
+                          "required"
+                        ]
                       },
                       "tools": {
                         "type": "array",
                         "items": {
                           "type": "object",
-                          "required": ["type"],
+                          "required": [
+                            "type"
+                          ],
                           "properties": {
                             "type": {
                               "type": "string"
                             },
                             "function": {
                               "type": "object",
-                              "required": ["name"],
+                              "required": [
+                                "name"
+                              ],
                               "properties": {
                                 "name": {
                                   "type": "string"
@@ -85741,7 +90409,14 @@
           },
           "reasoning_effort": {
             "type": "string",
-            "enum": ["none", "minimal", "low", "medium", "high", "xhigh"],
+            "enum": [
+              "none",
+              "minimal",
+              "low",
+              "medium",
+              "high",
+              "xhigh"
+            ],
             "description": "OpenAI reasoning effort level"
           },
           "service_tier": {
@@ -85769,11 +90444,19 @@
       },
       "OpenAIMessage": {
         "type": "object",
-        "required": ["role"],
+        "required": [
+          "role"
+        ],
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["system", "user", "assistant", "tool", "developer"]
+            "enum": [
+              "system",
+              "user",
+              "assistant",
+              "tool",
+              "developer"
+            ]
           },
           "name": {
             "type": "string"
@@ -85787,11 +90470,19 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["text", "image_url", "input_audio", "file", "refusal"]
+                      "enum": [
+                        "text",
+                        "image_url",
+                        "input_audio",
+                        "file",
+                        "refusal"
+                      ]
                     },
                     "text": {
                       "type": "string"
@@ -85801,20 +90492,28 @@
                     },
                     "image_url": {
                       "type": "object",
-                      "required": ["url"],
+                      "required": [
+                        "url"
+                      ],
                       "properties": {
                         "url": {
                           "type": "string"
                         },
                         "detail": {
                           "type": "string",
-                          "enum": ["low", "high", "auto"]
+                          "enum": [
+                            "low",
+                            "high",
+                            "auto"
+                          ]
                         }
                       }
                     },
                     "input_audio": {
                       "type": "object",
-                      "required": ["data"],
+                      "required": [
+                        "data"
+                      ],
                       "properties": {
                         "data": {
                           "type": "string"
@@ -85898,7 +90597,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["function"],
+              "required": [
+                "function"
+              ],
               "properties": {
                 "index": {
                   "type": "integer"
@@ -85927,7 +90628,10 @@
       },
       "OpenAITextCompletionRequest": {
         "type": "object",
-        "required": ["model", "prompt"],
+        "required": [
+          "model",
+          "prompt"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -86023,7 +90727,10 @@
       },
       "OpenAIResponsesRequest": {
         "type": "object",
-        "required": ["model", "input"],
+        "required": [
+          "model",
+          "input"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -86071,11 +90778,22 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
+                      "enum": [
+                        "in_progress",
+                        "completed",
+                        "incomplete",
+                        "interpreting",
+                        "failed"
+                      ]
                     },
                     "role": {
                       "type": "string",
-                      "enum": ["assistant", "user", "system", "developer"]
+                      "enum": [
+                        "assistant",
+                        "user",
+                        "system",
+                        "developer"
+                      ]
                     },
                     "content": {
                       "oneOf": [
@@ -86086,7 +90804,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
@@ -86129,11 +90849,17 @@
                               },
                               "input_audio": {
                                 "type": "object",
-                                "required": ["format", "data"],
+                                "required": [
+                                  "format",
+                                  "data"
+                                ],
                                 "properties": {
                                   "format": {
                                     "type": "string",
-                                    "enum": ["mp3", "wav"]
+                                    "enum": [
+                                      "mp3",
+                                      "wav"
+                                    ]
                                   },
                                   "data": {
                                     "type": "string"
@@ -86254,7 +90980,9 @@
                           "type": "array",
                           "items": {
                             "type": "object",
-                            "required": ["type"],
+                            "required": [
+                              "type"
+                            ],
                             "properties": {
                               "type": {
                                 "type": "string",
@@ -86297,11 +91025,17 @@
                               },
                               "input_audio": {
                                 "type": "object",
-                                "required": ["format", "data"],
+                                "required": [
+                                  "format",
+                                  "data"
+                                ],
                                 "properties": {
                                   "format": {
                                     "type": "string",
-                                    "enum": ["mp3", "wav"]
+                                    "enum": [
+                                      "mp3",
+                                      "wav"
+                                    ]
                                   },
                                   "data": {
                                     "type": "string"
@@ -86407,7 +91141,9 @@
                           "properties": {
                             "type": {
                               "type": "string",
-                              "enum": ["computer_screenshot"]
+                              "enum": [
+                                "computer_screenshot"
+                              ]
                             },
                             "file_id": {
                               "type": "string"
@@ -86441,11 +91177,16 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type", "text"],
+                        "required": [
+                          "type",
+                          "text"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
-                            "enum": ["summary_text"]
+                            "enum": [
+                              "summary_text"
+                            ]
                           },
                           "text": {
                             "type": "string"
@@ -86490,15 +91231,30 @@
             "properties": {
               "effort": {
                 "type": "string",
-                "enum": ["none", "minimal", "low", "medium", "high", "xhigh"]
+                "enum": [
+                  "none",
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high",
+                  "xhigh"
+                ]
               },
               "generate_summary": {
                 "type": "string",
-                "enum": ["auto", "concise", "detailed"]
+                "enum": [
+                  "auto",
+                  "concise",
+                  "detailed"
+                ]
               },
               "summary": {
                 "type": "string",
-                "enum": ["auto", "concise", "detailed"]
+                "enum": [
+                  "auto",
+                  "concise",
+                  "detailed"
+                ]
               },
               "max_tokens": {
                 "type": "integer"
@@ -86521,7 +91277,11 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["text", "json_object", "json_schema"]
+                    "enum": [
+                      "text",
+                      "json_object",
+                      "json_schema"
+                    ]
                   },
                   "json_schema": {
                     "type": "object",
@@ -86545,11 +91305,17 @@
             "oneOf": [
               {
                 "type": "string",
-                "enum": ["none", "auto", "required"]
+                "enum": [
+                  "none",
+                  "auto",
+                  "required"
+                ]
               },
               {
                 "type": "object",
-                "required": ["type"],
+                "required": [
+                  "type"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
@@ -86582,11 +91348,17 @@
                     "type": "array",
                     "items": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["function", "mcp", "image_generation"]
+                          "enum": [
+                            "function",
+                            "mcp",
+                            "image_generation"
+                          ]
                         },
                         "name": {
                           "type": "string"
@@ -86605,7 +91377,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
@@ -86768,7 +91542,10 @@
           },
           "truncation": {
             "type": "string",
-            "enum": ["auto", "disabled"]
+            "enum": [
+              "auto",
+              "disabled"
+            ]
           },
           "user": {
             "type": "string"
@@ -86783,7 +91560,10 @@
       },
       "OpenAIEmbeddingRequest": {
         "type": "object",
-        "required": ["model", "input"],
+        "required": [
+          "model",
+          "input"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -86806,7 +91586,10 @@
           },
           "encoding_format": {
             "type": "string",
-            "enum": ["float", "base64"]
+            "enum": [
+              "float",
+              "base64"
+            ]
           },
           "dimensions": {
             "type": "integer",
@@ -86825,7 +91608,10 @@
       },
       "OpenAISpeechRequest": {
         "type": "object",
-        "required": ["model", "input"],
+        "required": [
+          "model",
+          "input"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -86839,11 +91625,25 @@
           "voice": {
             "type": "string",
             "description": "Voice to use",
-            "enum": ["alloy", "echo", "fable", "onyx", "nova", "shimmer"]
+            "enum": [
+              "alloy",
+              "echo",
+              "fable",
+              "onyx",
+              "nova",
+              "shimmer"
+            ]
           },
           "response_format": {
             "type": "string",
-            "enum": ["mp3", "opus", "aac", "flac", "wav", "pcm"]
+            "enum": [
+              "mp3",
+              "opus",
+              "aac",
+              "flac",
+              "wav",
+              "pcm"
+            ]
           },
           "speed": {
             "type": "number",
@@ -86852,7 +91652,9 @@
           },
           "stream_format": {
             "type": "string",
-            "enum": ["sse"],
+            "enum": [
+              "sse"
+            ],
             "description": "Set to 'sse' for streaming"
           },
           "fallbacks": {
@@ -86865,7 +91667,10 @@
       },
       "OpenAITranscriptionRequest": {
         "type": "object",
-        "required": ["model", "file"],
+        "required": [
+          "model",
+          "file"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -86887,7 +91692,13 @@
           },
           "response_format": {
             "type": "string",
-            "enum": ["json", "text", "srt", "verbose_json", "vtt"]
+            "enum": [
+              "json",
+              "text",
+              "srt",
+              "verbose_json",
+              "vtt"
+            ]
           },
           "temperature": {
             "type": "number",
@@ -86898,7 +91709,10 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["word", "segment"]
+              "enum": [
+                "word",
+                "segment"
+              ]
             }
           },
           "stream": {
@@ -86954,7 +91768,11 @@
       },
       "AnthropicMessageRequest": {
         "type": "object",
-        "required": ["model", "max_tokens", "messages"],
+        "required": [
+          "model",
+          "max_tokens",
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -87095,7 +91913,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["approximate"]
+                      "enum": [
+                        "approximate"
+                      ]
                     },
                     "city": {
                       "type": "string"
@@ -87118,7 +91938,12 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["auto", "any", "tool", "none"]
+                    "enum": [
+                      "auto",
+                      "any",
+                      "tool",
+                      "none"
+                    ]
                   },
                   "name": {
                     "type": "string",
@@ -87172,7 +91997,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["enabled", "disabled"]
+                "enum": [
+                  "enabled",
+                  "disabled"
+                ]
               },
               "budget_tokens": {
                 "type": "integer"
@@ -87193,11 +92021,17 @@
       },
       "AnthropicMessage": {
         "type": "object",
-        "required": ["role", "content"],
+        "required": [
+          "role",
+          "content"
+        ],
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["user", "assistant"]
+            "enum": [
+              "user",
+              "assistant"
+            ]
           },
           "content": {
             "oneOf": [
@@ -87217,7 +92051,9 @@
       },
       "AnthropicContentBlock": {
         "type": "object",
-        "required": ["type"],
+        "required": [
+          "type"
+        ],
         "properties": {
           "type": {
             "type": "string",
@@ -87287,11 +92123,18 @@
           },
           "source": {
             "type": "object",
-            "required": ["type"],
+            "required": [
+              "type"
+            ],
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["base64", "url", "text", "content_block"]
+                "enum": [
+                  "base64",
+                  "url",
+                  "text",
+                  "content_block"
+                ]
               },
               "media_type": {
                 "type": "string",
@@ -87402,7 +92245,11 @@
       },
       "AnthropicTextRequest": {
         "type": "object",
-        "required": ["model", "prompt", "max_tokens_to_sample"],
+        "required": [
+          "model",
+          "prompt",
+          "max_tokens_to_sample"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -87662,7 +92509,12 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": ["MODALITY_UNSPECIFIED", "TEXT", "IMAGE", "AUDIO"]
+                  "enum": [
+                    "MODALITY_UNSPECIFIED",
+                    "TEXT",
+                    "IMAGE",
+                    "AUDIO"
+                  ]
                 },
                 "description": "The modalities of the response"
               },
@@ -87733,7 +92585,11 @@
                   },
                   "thinkingLevel": {
                     "type": "string",
-                    "enum": ["THINKING_LEVEL_UNSPECIFIED", "LOW", "HIGH"],
+                    "enum": [
+                      "THINKING_LEVEL_UNSPECIFIED",
+                      "LOW",
+                      "HIGH"
+                    ],
                     "description": "Thinking level preset"
                   }
                 }
@@ -87859,7 +92715,11 @@
                       },
                       "behavior": {
                         "type": "string",
-                        "enum": ["UNSPECIFIED", "BLOCKING", "NON_BLOCKING"],
+                        "enum": [
+                          "UNSPECIFIED",
+                          "BLOCKING",
+                          "NON_BLOCKING"
+                        ],
                         "description": "Function behavior mode. BLOCKING waits for response, NON_BLOCKING continues conversation"
                       }
                     }
@@ -87925,7 +92785,11 @@
                         },
                         "apiSpec": {
                           "type": "string",
-                          "enum": ["API_SPEC_UNSPECIFIED", "SIMPLE_SEARCH", "ELASTIC_SEARCH"]
+                          "enum": [
+                            "API_SPEC_UNSPECIFIED",
+                            "SIMPLE_SEARCH",
+                            "ELASTIC_SEARCH"
+                          ]
                         },
                         "authConfig": {
                           "type": "object",
@@ -88241,7 +93105,10 @@
                   "properties": {
                     "environment": {
                       "type": "string",
-                      "enum": ["ENVIRONMENT_UNSPECIFIED", "ENVIRONMENT_BROWSER"],
+                      "enum": [
+                        "ENVIRONMENT_UNSPECIFIED",
+                        "ENVIRONMENT_BROWSER"
+                      ],
                       "description": "The environment being operated"
                     }
                   }
@@ -88257,7 +93124,13 @@
                 "properties": {
                   "mode": {
                     "type": "string",
-                    "enum": ["MODE_UNSPECIFIED", "AUTO", "ANY", "NONE", "VALIDATED"],
+                    "enum": [
+                      "MODE_UNSPECIFIED",
+                      "AUTO",
+                      "ANY",
+                      "NONE",
+                      "VALIDATED"
+                    ],
                     "description": "Function calling mode"
                   },
                   "allowedFunctionNames": {
@@ -88647,7 +93520,10 @@
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["user", "model"],
+            "enum": [
+              "user",
+              "model"
+            ],
             "description": "The producer of the content. Must be either 'user' or 'model'"
           },
           "parts": {
@@ -89006,7 +93882,9 @@
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["default"]
+                      "enum": [
+                        "default"
+                      ]
                     }
                   }
                 }
@@ -89066,7 +93944,9 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["default"]
+                          "enum": [
+                            "default"
+                          ]
                         }
                       }
                     }
@@ -89105,7 +93985,10 @@
               },
               "trace": {
                 "type": "string",
-                "enum": ["enabled", "disabled"]
+                "enum": [
+                  "enabled",
+                  "disabled"
+                ]
               }
             }
           },
@@ -89124,7 +94007,10 @@
             "properties": {
               "latency": {
                 "type": "string",
-                "enum": ["standard", "optimized"]
+                "enum": [
+                  "standard",
+                  "optimized"
+                ]
               }
             }
           },
@@ -89150,7 +94036,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["reserved", "priority", "default", "flex"]
+                "enum": [
+                  "reserved",
+                  "priority",
+                  "default",
+                  "flex"
+                ]
               }
             }
           },
@@ -89223,7 +94114,10 @@
             "properties": {
               "latency": {
                 "type": "string",
-                "enum": ["standard", "optimized"]
+                "enum": [
+                  "standard",
+                  "optimized"
+                ]
               }
             }
           },
@@ -89232,7 +94126,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["reserved", "priority", "default", "flex"]
+                "enum": [
+                  "reserved",
+                  "priority",
+                  "default",
+                  "flex"
+                ]
               }
             }
           }
@@ -89240,11 +94139,17 @@
       },
       "BedrockMessage": {
         "type": "object",
-        "required": ["role", "content"],
+        "required": [
+          "role",
+          "content"
+        ],
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["user", "assistant"]
+            "enum": [
+              "user",
+              "assistant"
+            ]
           },
           "content": {
             "type": "array",
@@ -89265,7 +94170,12 @@
             "properties": {
               "format": {
                 "type": "string",
-                "enum": ["jpeg", "png", "gif", "webp"]
+                "enum": [
+                  "jpeg",
+                  "png",
+                  "gif",
+                  "webp"
+                ]
               },
               "source": {
                 "type": "object",
@@ -89283,7 +94193,17 @@
             "properties": {
               "format": {
                 "type": "string",
-                "enum": ["pdf", "csv", "doc", "docx", "xls", "xlsx", "html", "txt", "md"]
+                "enum": [
+                  "pdf",
+                  "csv",
+                  "doc",
+                  "docx",
+                  "xls",
+                  "xlsx",
+                  "html",
+                  "txt",
+                  "md"
+                ]
               },
               "name": {
                 "type": "string"
@@ -89331,7 +94251,10 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["success", "error"]
+                "enum": [
+                  "success",
+                  "error"
+                ]
               }
             }
           },
@@ -89379,7 +94302,9 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["default"]
+                "enum": [
+                  "default"
+                ]
               }
             }
           }
@@ -89455,7 +94380,11 @@
       },
       "BedrockBatchJobRequest": {
         "type": "object",
-        "required": ["roleArn", "inputDataConfig", "outputDataConfig"],
+        "required": [
+          "roleArn",
+          "inputDataConfig",
+          "outputDataConfig"
+        ],
         "properties": {
           "modelId": {
             "type": "string",
@@ -89610,7 +94539,10 @@
       },
       "CohereChatRequest": {
         "type": "object",
-        "required": ["model", "messages"],
+        "required": [
+          "model",
+          "messages"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -89631,7 +94563,9 @@
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["function"]
+                  "enum": [
+                    "function"
+                  ]
                 },
                 "function": {
                   "type": "object",
@@ -89652,7 +94586,11 @@
           },
           "tool_choice": {
             "type": "string",
-            "enum": ["AUTO", "NONE", "REQUIRED"],
+            "enum": [
+              "AUTO",
+              "NONE",
+              "REQUIRED"
+            ],
             "description": "Tool choice mode - AUTO lets the model decide, NONE disables tools, REQUIRED forces tool use"
           },
           "temperature": {
@@ -89688,7 +94626,11 @@
           },
           "safety_mode": {
             "type": "string",
-            "enum": ["CONTEXTUAL", "STRICT", "NONE"]
+            "enum": [
+              "CONTEXTUAL",
+              "STRICT",
+              "NONE"
+            ]
           },
           "log_probs": {
             "type": "boolean"
@@ -89701,7 +94643,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["enabled", "disabled"]
+                "enum": [
+                  "enabled",
+                  "disabled"
+                ]
               },
               "token_budget": {
                 "type": "integer",
@@ -89714,7 +94659,10 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["text", "json_object"],
+                "enum": [
+                  "text",
+                  "json_object"
+                ],
                 "description": "Response format type"
               },
               "schema": {
@@ -89733,7 +94681,14 @@
           },
           "finish_reason": {
             "type": "string",
-            "enum": ["COMPLETE", "STOP_SEQUENCE", "MAX_TOKENS", "TOOL_CALL", "ERROR", "TIMEOUT"]
+            "enum": [
+              "COMPLETE",
+              "STOP_SEQUENCE",
+              "MAX_TOKENS",
+              "TOOL_CALL",
+              "ERROR",
+              "TIMEOUT"
+            ]
           },
           "message": {
             "type": "object",
@@ -89745,11 +94700,18 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["text", "image_url", "thinking", "document"]
+                      "enum": [
+                        "text",
+                        "image_url",
+                        "thinking",
+                        "document"
+                      ]
                     },
                     "text": {
                       "type": "string"
@@ -89789,7 +94751,9 @@
                     },
                     "type": {
                       "type": "string",
-                      "enum": ["function"]
+                      "enum": [
+                        "function"
+                      ]
                     },
                     "function": {
                       "type": "object",
@@ -89884,11 +94848,18 @@
       },
       "CohereMessage": {
         "type": "object",
-        "required": ["role"],
+        "required": [
+          "role"
+        ],
         "properties": {
           "role": {
             "type": "string",
-            "enum": ["system", "user", "assistant", "tool"]
+            "enum": [
+              "system",
+              "user",
+              "assistant",
+              "tool"
+            ]
           },
           "content": {
             "oneOf": [
@@ -89899,11 +94870,18 @@
                 "type": "array",
                 "items": {
                   "type": "object",
-                  "required": ["type"],
+                  "required": [
+                    "type"
+                  ],
                   "properties": {
                     "type": {
                       "type": "string",
-                      "enum": ["text", "image_url", "thinking", "document"]
+                      "enum": [
+                        "text",
+                        "image_url",
+                        "thinking",
+                        "document"
+                      ]
                     },
                     "text": {
                       "type": "string"
@@ -89946,7 +94924,9 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": ["function"]
+                  "enum": [
+                    "function"
+                  ]
                 },
                 "function": {
                   "type": "object",
@@ -89973,7 +94953,10 @@
       },
       "CohereEmbeddingRequest": {
         "type": "object",
-        "required": ["model", "input_type"],
+        "required": [
+          "model",
+          "input_type"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -90009,11 +94992,18 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": ["type"],
+                    "required": [
+                      "type"
+                    ],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["text", "image_url", "thinking", "document"]
+                        "enum": [
+                          "text",
+                          "image_url",
+                          "thinking",
+                          "document"
+                        ]
                       },
                       "text": {
                         "type": "string"
@@ -90246,7 +95236,10 @@
       },
       "CohereCountTokensRequest": {
         "type": "object",
-        "required": ["text", "model"],
+        "required": [
+          "text",
+          "model"
+        ],
         "properties": {
           "model": {
             "type": "string",
@@ -90347,7 +95340,9 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ok"],
+            "enum": [
+              "ok"
+            ],
             "example": "ok"
           },
           "components": {
@@ -90412,7 +95407,10 @@
                 "description": "Whether to enforce virtual key authentication on inference requests"
               },
               "vk_rotation_cooldown": {
-                "type": ["string", "integer"],
+                "type": [
+                  "string",
+                  "integer"
+                ],
                 "minimum": 0,
                 "maximum": 2592000000000000,
                 "default": 0,
@@ -90535,7 +95533,11 @@
               },
               "mcp_server_auth_mode": {
                 "type": "string",
-                "enum": ["headers", "both", "oauth"],
+                "enum": [
+                  "headers",
+                  "both",
+                  "oauth"
+                ],
                 "default": "headers",
                 "description": "How /mcp authenticates inbound MCP clients. 'headers' (default): VK/api-key/session headers only, discovery disabled. 'both': accepts header credentials and Bifrost-issued JWTs, discovery enabled. 'oauth': Bifrost JWTs only — disables VK/header MCP access.\n"
               },
@@ -90648,7 +95650,11 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["http", "socks5", "tcp"]
+                "enum": [
+                  "http",
+                  "socks5",
+                  "tcp"
+                ]
               },
               "url": {
                 "type": "string"
@@ -90747,7 +95753,10 @@
                 "description": "Whether to enforce virtual key authentication on inference requests"
               },
               "vk_rotation_cooldown": {
-                "type": ["string", "integer"],
+                "type": [
+                  "string",
+                  "integer"
+                ],
                 "minimum": 0,
                 "maximum": 2592000000000000,
                 "default": 0,
@@ -90870,7 +95879,11 @@
               },
               "mcp_server_auth_mode": {
                 "type": "string",
-                "enum": ["headers", "both", "oauth"],
+                "enum": [
+                  "headers",
+                  "both",
+                  "oauth"
+                ],
                 "default": "headers",
                 "description": "How /mcp authenticates inbound MCP clients. 'headers' (default): VK/api-key/session headers only, discovery disabled. 'both': accepts header credentials and Bifrost-issued JWTs, discovery enabled. 'oauth': Bifrost JWTs only — disables VK/header MCP access.\n"
               },
@@ -90996,7 +96009,10 @@
       "LoginRequest": {
         "type": "object",
         "description": "Login request",
-        "required": ["username", "password"],
+        "required": [
+          "username",
+          "password"
+        ],
         "properties": {
           "username": {
             "type": "string"
@@ -91051,7 +96067,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["none", "http", "socks5", "environment"]
+                "enum": [
+                  "none",
+                  "http",
+                  "socks5",
+                  "environment"
+                ]
               },
               "url": {
                 "type": "string"
@@ -91177,7 +96198,11 @@
           },
           "provider_status": {
             "type": "string",
-            "enum": ["active", "error", "deleted"],
+            "enum": [
+              "active",
+              "error",
+              "deleted"
+            ],
             "description": "Status of the provider"
           },
           "status": {
@@ -91212,7 +96237,9 @@
       "AddProviderRequest": {
         "type": "object",
         "description": "Add provider request. Keys are managed separately via /api/providers/{provider}/keys.",
-        "required": ["provider"],
+        "required": [
+          "provider"
+        ],
         "properties": {
           "provider": {
             "$ref": "#/components/schemas/ModelProvider"
@@ -91229,7 +96256,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["none", "http", "socks5", "environment"]
+                "enum": [
+                  "none",
+                  "http",
+                  "socks5",
+                  "environment"
+                ]
               },
               "url": {
                 "type": "string"
@@ -91371,7 +96403,12 @@
             "properties": {
               "type": {
                 "type": "string",
-                "enum": ["none", "http", "socks5", "environment"]
+                "enum": [
+                  "none",
+                  "http",
+                  "socks5",
+                  "environment"
+                ]
               },
               "url": {
                 "type": "string"
@@ -91523,7 +96560,11 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["plain_text", "env", "vault"],
+                "enum": [
+                  "plain_text",
+                  "env",
+                  "vault"
+                ],
                 "description": "Source type of the value"
               }
             }
@@ -91575,7 +96616,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91594,7 +96639,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91613,7 +96662,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91632,7 +96685,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91651,7 +96708,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91683,7 +96744,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91702,7 +96767,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91721,7 +96790,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91740,7 +96813,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91765,7 +96842,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91784,7 +96865,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91803,7 +96888,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91822,7 +96911,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91841,7 +96934,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91888,7 +96985,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -91897,7 +96998,9 @@
                 "type": "string"
               }
             },
-            "required": ["url"]
+            "required": [
+              "url"
+            ]
           },
           "ollama_key_config": {
             "type": "object",
@@ -91917,13 +97020,19 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
               }
             },
-            "required": ["url"]
+            "required": [
+              "url"
+            ]
           },
           "sgl_key_config": {
             "type": "object",
@@ -91943,13 +97052,19 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
               }
             },
-            "required": ["url"]
+            "required": [
+              "url"
+            ]
           },
           "replicate_key_config": {
             "type": "object",
@@ -92120,15 +97235,25 @@
                 "description": "Plugin types indicating which interfaces the plugin implements",
                 "items": {
                   "type": "string",
-                  "enum": ["llm", "mcp", "http", "observability"]
+                  "enum": [
+                    "llm",
+                    "mcp",
+                    "http",
+                    "observability"
+                  ]
                 }
               }
             },
             "example": {
               "name": "my_custom_plugin",
               "status": "active",
-              "logs": ["plugin my_custom_plugin initialized successfully"],
-              "types": ["llm", "http"]
+              "logs": [
+                "plugin my_custom_plugin initialized successfully"
+              ],
+              "types": [
+                "llm",
+                "http"
+              ]
             }
           },
           "created_at": {
@@ -92155,8 +97280,13 @@
           "status": {
             "name": "my_custom_plugin",
             "status": "active",
-            "logs": ["plugin my_custom_plugin initialized successfully"],
-            "types": ["llm", "http"]
+            "logs": [
+              "plugin my_custom_plugin initialized successfully"
+            ],
+            "types": [
+              "llm",
+              "http"
+            ]
           }
         }
       },
@@ -92178,7 +97308,9 @@
       "CreatePluginRequest": {
         "type": "object",
         "description": "Create plugin request",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -92253,6 +97385,16 @@
             ],
             "description": "Connection state of an MCP client:\n- healthy: Bifrost's own periodic connection check (ping/list_tools for\n  sticky clients, list_tools for per-call clients) most recently\n  succeeded.\n- unstable: The periodic connection check most recently failed with a\n  transient-classified error. Purely informational — unlike\n  needs_reauth, this never gates execution; tool calls are still\n  attempted normally. Self-heals to healthy on the next successful\n  check, no human action required.\n- error: A data-consistency fallback used only when a client is\n  registered in the config store but missing from the runtime manager\n  entirely — a deeper anomaly than anything in the normal\n  connect/health-check lifecycle, which never assigns this value itself.\n- pending_verification: Declared (typically via config.json) but the one-time\n  admin verification has not been completed yet. Complete it via\n  POST /api/mcp/client/{id}/initiate-verification (auth_type oauth /\n  per_user_oauth) or POST /api/mcp/client/{id}/verify-headers\n  (auth_type per_user_headers).\n- needs_reauth: Setup completed at least once, but a credential an admin is\n  responsible for has permanently died and needs a human to repair it.\n  For shared OAuth clients the connection credential itself was\n  rejected/expired with no silent recovery; the state is sticky (the health\n  monitor will not clobber it) until an admin runs\n  POST /api/mcp/client/{id}/reauthorize. For per-user clients this is a\n  response-only projection — computed at list-time, never stored in the\n  runtime manager — meaning the retained admin discovery credential\n  needs repair; end-user credentials and tool calls keep working, only\n  periodic tool-list refresh pauses. Overlays onto both healthy and\n  unstable runtime readings, never onto disabled or\n  pending_verification. Repair via reauthorize (per_user_oauth),\n  verify-headers with fresh sample values (per_user_headers), or\n  verify-exchange (token_exchange, which re-exchanges the signed-in\n  admin's own identity token — no sample values to supply).\n- disabled: Client has been intentionally disabled; no connection or workers are active\n- degraded: A read-time cluster aggregate, never a single node's own\n  local state — multiple instances of a distributed deployment each\n  currently hold a different self-reported state for the same client.\n  Only meaningful for states that can genuinely vary per instance\n  (healthy, unstable, pending_verification); needs_reauth/disabled are\n  config-sourced facts expected to already agree everywhere. Never\n  appears in a single-instance deployment.\n"
           },
+          "last_failure": {
+            "$ref": "#/components/schemas/MCPConnectionFailure"
+          },
+          "node_states": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/MCPInstanceState"
+            },
+            "description": "Per-instance breakdown behind `state` in a distributed deployment:\ninstance ID -> that instance's own self-reported state and\nlast_failure. Present when instances disagree (`state` is then\n`degraded`) and when they all agree on `unstable`, so each instance's\nown reason is visible. Never present in a single-instance deployment.\n"
+          },
           "vk_configs": {
             "type": "array",
             "items": {
@@ -92298,7 +97440,12 @@
           },
           "connection_type": {
             "type": "string",
-            "enum": ["http", "stdio", "sse", "inprocess"],
+            "enum": [
+              "http",
+              "stdio",
+              "sse",
+              "inprocess"
+            ],
             "description": "Connection type for MCP client"
           },
           "connection_string": {
@@ -92402,7 +97549,9 @@
           },
           "token_exchange": {
             "type": "object",
-            "required": ["audience"],
+            "required": [
+              "audience"
+            ],
             "properties": {
               "audience": {
                 "type": "string",
@@ -92443,11 +97592,15 @@
                         "const": true
                       }
                     },
-                    "required": ["use_idp_credentials"]
+                    "required": [
+                      "use_idp_credentials"
+                    ]
                   }
                 },
                 "then": {
-                  "required": ["client_id"],
+                  "required": [
+                    "client_id"
+                  ],
                   "description": "client_id is required unless use_idp_credentials is true, in which\ncase the exchange uses the SSO login application's own credentials\ninstead.\n"
                 }
               }
@@ -92462,11 +97615,75 @@
           }
         }
       },
+      "MCPConnectionFailure": {
+        "type": "object",
+        "description": "The latest failure recorded by the instance serving the request for its\nown connection handling of this client: which step failed, the error it\nfailed with, when that last happened, and when the current run of\nfailures began. Present only after that instance has attempted a connect\nor check that failed. Absent while `healthy`, cleared the moment a check\npasses, and absent when a state changed without such an attempt, for\nexample `needs_reauth` projected from a credential row that died before\nthe next scheduled check ran. Describes only Bifrost's own connection\nchecks and connect attempts, never the outcome of real tool calls made\nthrough the client.\n",
+        "required": [
+          "stage",
+          "message",
+          "at",
+          "since"
+        ],
+        "properties": {
+          "stage": {
+            "type": "string",
+            "enum": [
+              "connect",
+              "ping",
+              "list_tools",
+              "tool_discovery",
+              "transport_lost",
+              "credential"
+            ],
+            "description": "The step that failed:\n- connect: establishing the shared connection (dial, initialize,\n  connect gate, or the initial list_tools a new connection must pass)\n- ping: the periodic check's ping over an existing sticky connection\n- list_tools: the periodic check's list_tools over an existing sticky\n  connection\n- tool_discovery: the periodic check's ephemeral connect-discover-close\n  cycle for per-call auth types\n- transport_lost: a live SSE connection dropped outside any check\n- credential: a credential the connection depends on was rejected\n  upstream or rotated by an admin\n"
+          },
+          "message": {
+            "type": "string",
+            "description": "The error the step failed with, whitespace-collapsed and capped at 512 characters."
+          },
+          "at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The most recent failed attempt. While a client is unstable the check\nretries every 10 seconds, so this keeps moving for as long as the\noutage lasts.\n"
+          },
+          "since": {
+            "type": "string",
+            "format": "date-time",
+            "description": "The first failed attempt of the current unhealthy run."
+          }
+        }
+      },
+      "MCPInstanceState": {
+        "type": "object",
+        "description": "One instance's own view of an MCP client in a distributed deployment.",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "enum": [
+              "healthy",
+              "unstable",
+              "error",
+              "pending_verification",
+              "needs_reauth",
+              "disabled"
+            ],
+            "description": "That instance's own self-reported connection state. Never `degraded`,\nwhich only ever exists as the aggregate above this map.\n"
+          },
+          "last_failure": {
+            "$ref": "#/components/schemas/MCPConnectionFailure"
+          }
+        }
+      },
       "ExecuteToolRequest": {
         "oneOf": [
           {
             "type": "object",
-            "required": ["function"],
+            "required": [
+              "function"
+            ],
             "properties": {
               "index": {
                 "type": "integer"
@@ -92495,7 +97712,9 @@
           {
             "type": "object",
             "description": "Responses format - uses ResponsesToolMessage schema",
-            "required": ["name"],
+            "required": [
+              "name"
+            ],
             "properties": {
               "call_id": {
                 "type": "string",
@@ -92561,7 +97780,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -92585,7 +97808,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -92624,7 +97851,9 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["pending_oauth"]
+            "enum": [
+              "pending_oauth"
+            ]
           },
           "message": {
             "type": "string"
@@ -92673,7 +97902,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "authorized", "failed"],
+            "enum": [
+              "pending",
+              "authorized",
+              "failed"
+            ],
             "description": "Current status of the OAuth flow:\n- pending: User has not yet authorized\n- authorized: User authorized and token is stored\n- failed: Authorization failed\n"
           },
           "created_at": {
@@ -92757,11 +97990,20 @@
           },
           "flow_mode": {
             "type": "string",
-            "enum": ["user", "vk", "session"]
+            "enum": [
+              "user",
+              "vk",
+              "session"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "authorized", "failed", "expired"]
+            "enum": [
+              "pending",
+              "authorized",
+              "failed",
+              "expired"
+            ]
           },
           "mcp_client": {
             "$ref": "#/components/schemas/MCPClientSummary"
@@ -92838,7 +98080,15 @@
       "MCPSessionRow": {
         "type": "object",
         "description": "One row on the MCP Sessions list. Covers OAuth tokens, header credentials,\nand pending flows (of either kind). Always-set fields are at the top;\nper-kind-only fields use omitempty.\n",
-        "required": ["id", "kind", "auth_kind", "auth_mode", "status", "created_at", "can_reauth"],
+        "required": [
+          "id",
+          "kind",
+          "auth_kind",
+          "auth_mode",
+          "status",
+          "created_at",
+          "can_reauth"
+        ],
         "properties": {
           "id": {
             "type": "string",
@@ -92846,17 +98096,28 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["token", "header", "flow"],
+            "enum": [
+              "token",
+              "header",
+              "flow"
+            ],
             "description": "Row type:\n- token: completed per-user OAuth credential\n- header: completed per-user-headers credential\n- flow: pending submission / consent flow (use auth_kind to disambiguate OAuth vs Headers)\n"
           },
           "auth_kind": {
             "type": "string",
-            "enum": ["oauth", "headers"],
+            "enum": [
+              "oauth",
+              "headers"
+            ],
             "description": "Disambiguates flow rows by which auth surface they belong to. For\n`kind=token` this is always `oauth`; for `kind=header` always `headers`.\n"
           },
           "auth_mode": {
             "type": "string",
-            "enum": ["user", "vk", "session"],
+            "enum": [
+              "user",
+              "vk",
+              "session"
+            ],
             "description": "Identity dimension this credential is keyed against"
           },
           "user_id": {
@@ -92884,7 +98145,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "orphaned", "pending", "needs_reauth", "needs_update"],
+            "enum": [
+              "active",
+              "orphaned",
+              "pending",
+              "needs_reauth",
+              "needs_update"
+            ],
             "description": "OAuth tokens use: active | orphaned | needs_reauth.\nHeader credentials use: active | orphaned | needs_update.\nFlow rows use: pending.\n"
           },
           "expires_at": {
@@ -92922,7 +98189,9 @@
       },
       "MCPSessionsListResponse": {
         "type": "object",
-        "required": ["sessions"],
+        "required": [
+          "sessions"
+        ],
         "properties": {
           "sessions": {
             "type": "array",
@@ -92935,7 +98204,10 @@
       "MCPSessionReauthResponse": {
         "type": "object",
         "description": "Response for POST /api/mcp/sessions/{id}/reauth. Returns the URL the caller\nmust visit to complete the fresh authentication / resubmission.\n",
-        "required": ["authorize_url", "session_id"],
+        "required": [
+          "authorize_url",
+          "session_id"
+        ],
         "properties": {
           "authorize_url": {
             "type": "string",
@@ -92951,7 +98223,10 @@
           },
           "kind": {
             "type": "string",
-            "enum": ["oauth", "headers"],
+            "enum": [
+              "oauth",
+              "headers"
+            ],
             "description": "Set only on header re-auth"
           }
         }
@@ -92974,11 +98249,19 @@
           },
           "flow_mode": {
             "type": "string",
-            "enum": ["user", "vk", "session"]
+            "enum": [
+              "user",
+              "vk",
+              "session"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["pending", "completed", "expired"]
+            "enum": [
+              "pending",
+              "completed",
+              "expired"
+            ]
           },
           "mcp_client": {
             "$ref": "#/components/schemas/MCPClientSummary",
@@ -93038,7 +98321,9 @@
       "MCPHeadersSubmitRequest": {
         "type": "object",
         "description": "Request body for PUT /api/mcp/per-user-headers/flows/{id}. The flow row\nidentifies the (mode, identity, mcp_client) triple, so the caller carries\nonly the values. Extra keys not in the live `per_user_header_keys` schema\nare dropped server-side.\n",
-        "required": ["headers"],
+        "required": [
+          "headers"
+        ],
         "properties": {
           "headers": {
             "type": "object",
@@ -93050,11 +98335,17 @@
       },
       "MCPHeadersSubmitResponse": {
         "type": "object",
-        "required": ["status", "credential_id", "updated_at"],
+        "required": [
+          "status",
+          "credential_id",
+          "updated_at"
+        ],
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["success"]
+            "enum": [
+              "success"
+            ]
           },
           "credential_id": {
             "type": "string"
@@ -93097,17 +98388,26 @@
             "type": "boolean"
           },
           "expires_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "Expiry timestamp. Requests using this virtual key are rejected once it passes. Null or absent means the key never expires."
           },
           "previous_value_expires_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "When set, the pre-rotation key value continues to authenticate until this timestamp (rotation grace period, configured via client vk_rotation_cooldown). Absent when no grace window is active."
           },
           "rotated_at": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "format": "date-time",
             "description": "Timestamp of the most recent value rotation. Absent if the key has never been rotated."
           },
@@ -93175,7 +98475,10 @@
       "VirtualKeyResponse": {
         "type": "object",
         "description": "Virtual key operation response",
-        "required": ["message", "virtual_key"],
+        "required": [
+          "message",
+          "virtual_key"
+        ],
         "properties": {
           "message": {
             "type": "string"
@@ -93209,7 +98512,10 @@
             "type": "string"
           },
           "weight": {
-            "type": ["number", "null"],
+            "type": [
+              "number",
+              "null"
+            ],
             "description": "Weight for provider load balancing. Null means excluded from weighted routing."
           },
           "allowed_models": {
@@ -93241,7 +98547,10 @@
             "$ref": "#/components/schemas/RateLimit"
           },
           "keys": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "description": "Associated API keys for this provider config. **Always null in the quota endpoint** — keys are intentionally not loaded here to keep the response lean and avoid exposing sensitive credentials. Use the admin virtual-key API to inspect actual key assignments.\n",
             "items": {
               "$ref": "#/components/schemas/TableKey"
@@ -93252,7 +98561,13 @@
       "VirtualKeyMCPConfig": {
         "type": "object",
         "description": "MCP configuration for a virtual key",
-        "required": ["id", "virtual_key_id", "mcp_client_id", "mcp_client", "tools_to_execute"],
+        "required": [
+          "id",
+          "virtual_key_id",
+          "mcp_client_id",
+          "mcp_client",
+          "tools_to_execute"
+        ],
         "properties": {
           "id": {
             "type": "integer"
@@ -93277,7 +98592,13 @@
       "ListVirtualKeysResponse": {
         "type": "object",
         "description": "List virtual keys response",
-        "required": ["virtual_keys", "count", "total_count", "limit", "offset"],
+        "required": [
+          "virtual_keys",
+          "count",
+          "total_count",
+          "limit",
+          "offset"
+        ],
         "properties": {
           "virtual_keys": {
             "type": "array",
@@ -93324,7 +98645,10 @@
             "description": "Whether the virtual key is active"
           },
           "budgets": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "description": "Overall budget quotas for this virtual key. Each budget also carries the actual per-model spend (from request logs) accumulated in its current cycle.\n",
             "items": {
               "description": "A virtual key budget with the actual per-model spend (from request logs) accumulated in its current cycle [last_reset, now]. The per-model totals reconcile with current_usage. The models list is empty when the logging plugin is not enabled.\n",
@@ -93334,7 +98658,9 @@
                 },
                 {
                   "type": "object",
-                  "required": ["per_model_usage"],
+                  "required": [
+                    "per_model_usage"
+                  ],
                   "properties": {
                     "per_model_usage": {
                       "type": "array",
@@ -93342,7 +98668,12 @@
                       "items": {
                         "type": "object",
                         "description": "One model's actual usage (from request logs) within a budget cycle",
-                        "required": ["model", "total_requests", "total_tokens", "total_cost"],
+                        "required": [
+                          "model",
+                          "total_requests",
+                          "total_tokens",
+                          "total_cost"
+                        ],
                         "properties": {
                           "model": {
                             "type": "string",
@@ -93385,7 +98716,10 @@
             ]
           },
           "provider_configs": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "description": "Per-provider budget quotas and rate limits (provider-level splits and limits)",
             "items": {
               "$ref": "#/components/schemas/VirtualKeyProviderConfig"
@@ -93397,7 +98731,9 @@
             "items": {
               "type": "object",
               "description": "Per-model budgets and rate limit (with current usage) for a model governed under a virtual key",
-              "required": ["model_name"],
+              "required": [
+                "model_name"
+              ],
               "properties": {
                 "model_name": {
                   "type": "string",
@@ -93408,7 +98744,10 @@
                   "description": "Provider this model config is scoped to; omitted when it applies to all providers"
                 },
                 "budgets": {
-                  "type": ["array", "null"],
+                  "type": [
+                    "array",
+                    "null"
+                  ],
                   "description": "Budget quotas for this model",
                   "items": {
                     "$ref": "#/components/schemas/Budget"
@@ -93432,7 +98771,9 @@
       "CreateVirtualKeyRequest": {
         "type": "object",
         "description": "Create virtual key request",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -93442,7 +98783,7 @@
           },
           "provider_configs": {
             "type": "array",
-            "description": "Provider configurations (empty means no providers allowed, deny-by-default)",
+            "description": "Provider configurations. When allow_all_providers is omitted or false, an empty list allows no providers (deny-by-default); when true, providers without a config are allowed with all models and keys.",
             "items": {
               "type": "object",
               "properties": {
@@ -93450,7 +98791,10 @@
                   "type": "string"
                 },
                 "weight": {
-                  "type": ["number", "null"],
+                  "type": [
+                    "number",
+                    "null"
+                  ],
                   "description": "Weight for load balancing. Null means excluded from weighted routing."
                 },
                 "allowed_models": {
@@ -93559,7 +98903,10 @@
                   "type": "string"
                 },
                 "weight": {
-                  "type": ["number", "null"],
+                  "type": [
+                    "number",
+                    "null"
+                  ],
                   "description": "Weight for load balancing. Null means excluded from weighted routing."
                 },
                 "allowed_models": {
@@ -93673,7 +99020,10 @@
             }
           },
           "virtual_keys": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "description": "Virtual keys assigned to this team. This field may be omitted or returned as null in some responses (for example, when a team is embedded inside a virtual-key response) to avoid nested `virtual_keys` recursion.\n",
             "items": {
               "$ref": "#/components/schemas/VirtualKey"
@@ -93692,7 +99042,10 @@
             "additionalProperties": true
           },
           "config_hash": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -93734,7 +99087,9 @@
       "CreateTeamRequest": {
         "type": "object",
         "description": "Create team request",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -93797,7 +99152,10 @@
             }
           },
           "virtual_keys": {
-            "type": ["array", "null"],
+            "type": [
+              "array",
+              "null"
+            ],
             "description": "Virtual keys owned by this customer. Omitted or returned as null by the paginated list endpoint (`GET /api/governance/customers` with `limit`/`offset`/`search`), which reports `virtual_key_count` instead; use the single-customer endpoint to retrieve the keys themselves.\n",
             "items": {
               "$ref": "#/components/schemas/VirtualKey"
@@ -93850,7 +99208,9 @@
       "CreateCustomerRequest": {
         "type": "object",
         "description": "Create customer request",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -93933,7 +99293,10 @@
           "override_mode": {
             "type": "string",
             "description": "How long the override stays active. `cycles` keeps it active for a finite number of\nreset windows; `forever` keeps it active until it is removed. Omitted when no override is set.\n",
-            "enum": ["cycles", "forever"]
+            "enum": [
+              "cycles",
+              "forever"
+            ]
           },
           "override_cycles_remaining": {
             "type": "integer",
@@ -93961,7 +99324,10 @@
             "description": "Provider config that owns this budget, when the budget is provider-config-scoped"
           },
           "config_hash": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -94006,11 +99372,17 @@
             "format": "date-time"
           },
           "request_max_limit": {
-            "type": ["integer", "null"],
+            "type": [
+              "integer",
+              "null"
+            ],
             "format": "int64"
           },
           "request_reset_duration": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "request_current_usage": {
             "type": "integer",
@@ -94021,7 +99393,10 @@
             "format": "date-time"
           },
           "config_hash": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -94066,7 +99441,10 @@
       "CreateBudgetRequest": {
         "type": "object",
         "description": "Create budget request",
-        "required": ["max_limit", "reset_duration"],
+        "required": [
+          "max_limit",
+          "reset_duration"
+        ],
         "properties": {
           "max_limit": {
             "type": "number"
@@ -94118,7 +99496,10 @@
             "additionalProperties": false
           },
           "calendar_aligned": {
-            "type": ["boolean", "null"],
+            "type": [
+              "boolean",
+              "null"
+            ],
             "description": "Set to true or false to enable or disable calendar-aligned resets. Only valid with reset durations that use day, week, month, quarter, or year suffixes (`d`, `w`, `M`, `Q`, `Y`); sub-day durations (e.g. `1h`, `30m`) are invalid with calendar alignment and the API rejects that combination. When enabling on an existing budget, alignment takes effect from the next period: the current window keeps its start and its accumulated usage, and the first aligned reset happens at the next boundary. Changing quarter_start_month on a calendar-aligned quarterly budget does not move last_reset directly; the new definition shifts where the current window starts, so the budget converges onto the new fiscal boundary on the next reset tick.\n"
           }
         }
@@ -94126,7 +99507,10 @@
       "BudgetOverrideRequest": {
         "type": "object",
         "description": "Replaces the active override on one budget. The override is additive: it does not change the\nbudget's `max_limit`, `current_usage`, or reset schedule. Sending this request against a budget\nthat already has an override replaces that override entirely.\n",
-        "required": ["amount", "mode"],
+        "required": [
+          "amount",
+          "mode"
+        ],
         "properties": {
           "amount": {
             "type": "number",
@@ -94135,7 +99519,10 @@
           "mode": {
             "type": "string",
             "description": "`cycles` keeps the override active for `cycles` reset windows starting with the current one.\n`forever` keeps it active until it is removed with a DELETE.\n",
-            "enum": ["cycles", "forever"]
+            "enum": [
+              "cycles",
+              "forever"
+            ]
           },
           "cycles": {
             "type": "integer",
@@ -94147,7 +99534,10 @@
       "BudgetOverrideResponse": {
         "type": "object",
         "description": "The persisted budget and the additive limit now in force.",
-        "required": ["budget", "effective_max_limit"],
+        "required": [
+          "budget",
+          "effective_max_limit"
+        ],
         "properties": {
           "budget": {
             "$ref": "#/components/schemas/Budget"
@@ -94228,21 +99618,34 @@
             "items": {
               "type": "object",
               "description": "A single weighted routing target within a routing rule",
-              "required": ["weight"],
+              "required": [
+                "weight"
+              ],
               "dependentRequired": {
-                "key_id": ["provider"]
+                "key_id": [
+                  "provider"
+                ]
               },
               "properties": {
                 "provider": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Target provider (omit or empty to use the incoming request provider)"
                 },
                 "model": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Target model (omit or empty to use the incoming request model)"
                 },
                 "key_id": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "UUID of the API key to pin for this target (omit for load-balanced key selection)"
                 },
                 "weight": {
@@ -94264,11 +99667,19 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["global", "team", "customer", "virtual_key"],
+            "enum": [
+              "global",
+              "team",
+              "customer",
+              "virtual_key"
+            ],
             "description": "Scope level for the rule"
           },
           "scope_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "ID for the scope (empty for global scope)"
           },
           "priority": {
@@ -94276,7 +99687,10 @@
             "description": "Priority for rule evaluation (lower number = higher priority)"
           },
           "query": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "description": "Visual rule tree structure from query builder"
           },
           "created_at": {
@@ -94294,10 +99708,14 @@
             "properties": {
               "scope": {
                 "type": "string",
-                "enum": ["global"]
+                "enum": [
+                  "global"
+                ]
               }
             },
-            "required": ["scope"],
+            "required": [
+              "scope"
+            ],
             "description": "Global scope routing rule"
           },
           {
@@ -94305,13 +99723,20 @@
             "properties": {
               "scope": {
                 "type": "string",
-                "enum": ["team", "customer", "virtual_key"]
+                "enum": [
+                  "team",
+                  "customer",
+                  "virtual_key"
+                ]
               },
               "scope_id": {
                 "type": "string"
               }
             },
-            "required": ["scope", "scope_id"],
+            "required": [
+              "scope",
+              "scope_id"
+            ],
             "description": "Scoped routing rule (requires scope_id)"
           }
         ]
@@ -94347,7 +99772,13 @@
       "CreateRoutingRuleRequest": {
         "type": "object",
         "description": "Request to create a routing rule",
-        "required": ["name", "cel_expression", "scope", "priority", "targets"],
+        "required": [
+          "name",
+          "cel_expression",
+          "scope",
+          "priority",
+          "targets"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -94372,21 +99803,34 @@
             "items": {
               "type": "object",
               "description": "A single weighted routing target within a routing rule",
-              "required": ["weight"],
+              "required": [
+                "weight"
+              ],
               "dependentRequired": {
-                "key_id": ["provider"]
+                "key_id": [
+                  "provider"
+                ]
               },
               "properties": {
                 "provider": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Target provider (omit or empty to use the incoming request provider)"
                 },
                 "model": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Target model (omit or empty to use the incoming request model)"
                 },
                 "key_id": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "UUID of the API key to pin for this target (omit for load-balanced key selection)"
                 },
                 "weight": {
@@ -94408,11 +99852,19 @@
           },
           "scope": {
             "type": "string",
-            "enum": ["global", "team", "customer", "virtual_key"],
+            "enum": [
+              "global",
+              "team",
+              "customer",
+              "virtual_key"
+            ],
             "description": "Scope level for the rule"
           },
           "scope_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "ID for the scope (required if scope is not global)"
           },
           "priority": {
@@ -94420,7 +99872,10 @@
             "description": "Priority for rule evaluation (lower number = higher priority)"
           },
           "query": {
-            "type": ["object", "null"],
+            "type": [
+              "object",
+              "null"
+            ],
             "description": "Visual rule tree structure"
           }
         },
@@ -94430,10 +99885,14 @@
             "properties": {
               "scope": {
                 "type": "string",
-                "enum": ["global"]
+                "enum": [
+                  "global"
+                ]
               }
             },
-            "required": ["scope"],
+            "required": [
+              "scope"
+            ],
             "description": "Global scope routing rule"
           },
           {
@@ -94441,13 +99900,20 @@
             "properties": {
               "scope": {
                 "type": "string",
-                "enum": ["team", "customer", "virtual_key"]
+                "enum": [
+                  "team",
+                  "customer",
+                  "virtual_key"
+                ]
               },
               "scope_id": {
                 "type": "string"
               }
             },
-            "required": ["scope", "scope_id"],
+            "required": [
+              "scope",
+              "scope_id"
+            ],
             "description": "Scoped routing rule (requires scope_id)"
           }
         ]
@@ -94475,21 +99941,34 @@
             "items": {
               "type": "object",
               "description": "A single weighted routing target within a routing rule",
-              "required": ["weight"],
+              "required": [
+                "weight"
+              ],
               "dependentRequired": {
-                "key_id": ["provider"]
+                "key_id": [
+                  "provider"
+                ]
               },
               "properties": {
                 "provider": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Target provider (omit or empty to use the incoming request provider)"
                 },
                 "model": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "Target model (omit or empty to use the incoming request model)"
                 },
                 "key_id": {
-                  "type": ["string", "null"],
+                  "type": [
+                    "string",
+                    "null"
+                  ],
                   "description": "UUID of the API key to pin for this target (omit for load-balanced key selection)"
                 },
                 "weight": {
@@ -94512,7 +99991,10 @@
             "type": "integer"
           },
           "query": {
-            "type": ["object", "null"]
+            "type": [
+              "object",
+              "null"
+            ]
           }
         }
       },
@@ -94549,7 +100031,11 @@
               },
               "type": {
                 "type": "string",
-                "enum": ["plain_text", "env", "vault"],
+                "enum": [
+                  "plain_text",
+                  "env",
+                  "vault"
+                ],
                 "description": "Source type of the value"
               }
             }
@@ -94561,14 +100047,23 @@
             }
           },
           "weight": {
-            "type": ["number", "null"]
+            "type": [
+              "number",
+              "null"
+            ]
           },
           "enabled": {
-            "type": ["boolean", "null"],
+            "type": [
+              "boolean",
+              "null"
+            ],
             "default": true
           },
           "use_for_batch_api": {
-            "type": ["boolean", "null"],
+            "type": [
+              "boolean",
+              "null"
+            ],
             "default": false
           },
           "created_at": {
@@ -94580,7 +100075,10 @@
             "format": "date-time"
           },
           "config_hash": {
-            "type": ["string", "null"]
+            "type": [
+              "string",
+              "null"
+            ]
           },
           "azure_endpoint": {
             "oneOf": [
@@ -94598,7 +100096,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94624,7 +100126,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94650,7 +100156,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94676,7 +100186,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94702,7 +100216,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94728,7 +100246,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94754,7 +100276,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94780,7 +100306,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94806,7 +100336,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94832,7 +100366,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94858,7 +100396,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94884,7 +100426,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94910,7 +100456,11 @@
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["plain_text", "env", "vault"],
+                    "enum": [
+                      "plain_text",
+                      "env",
+                      "vault"
+                    ],
                     "description": "Source type of the value"
                   }
                 }
@@ -94941,7 +100491,11 @@
           "scope": {
             "type": "string",
             "description": "Scope where this limit applies. `global` covers all traffic; `virtual_key` scopes to a single virtual key; `user` scopes to a single user (Enterprise only).",
-            "enum": ["global", "virtual_key", "user"],
+            "enum": [
+              "global",
+              "virtual_key",
+              "user"
+            ],
             "default": "global"
           },
           "scope_id": {
@@ -95017,7 +100571,9 @@
       "CreateModelConfigRequest": {
         "type": "object",
         "description": "Request to create a new model config",
-        "required": ["model_name"],
+        "required": [
+          "model_name"
+        ],
         "properties": {
           "model_name": {
             "type": "string",
@@ -95030,7 +100586,11 @@
           "scope": {
             "type": "string",
             "description": "Scope where this limit applies. Defaults to `global`.",
-            "enum": ["global", "virtual_key", "user"],
+            "enum": [
+              "global",
+              "virtual_key",
+              "user"
+            ],
             "default": "global"
           },
           "scope_id": {
@@ -95650,24 +101210,39 @@
             "$ref": "#/components/schemas/PricingOverrideScopeKind"
           },
           "user_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Required for user* scopes"
           },
           "virtual_key_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Required for virtual_key* scopes"
           },
           "provider_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Required for provider, virtual_key_provider, and user_provider scopes"
           },
           "provider_key_id": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Required for provider_key, virtual_key_provider_key, and user_provider_key scopes"
           },
           "match_type": {
             "type": "string",
-            "enum": ["exact", "wildcard"],
+            "enum": [
+              "exact",
+              "wildcard"
+            ],
             "description": "How the pattern is matched against the model name"
           },
           "pattern": {
@@ -95691,7 +101266,10 @@
             "description": "Decoded pricing fields (present in API responses)"
           },
           "config_hash": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Auto-managed hash for config-file-sourced overrides. Do not set manually."
           },
           "created_at": {
@@ -95707,7 +101285,13 @@
       "CreatePricingOverrideRequest": {
         "type": "object",
         "description": "Request body for creating a pricing override.",
-        "required": ["name", "scope_kind", "match_type", "pattern", "request_types"],
+        "required": [
+          "name",
+          "scope_kind",
+          "match_type",
+          "pattern",
+          "request_types"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -95734,7 +101318,10 @@
           },
           "match_type": {
             "type": "string",
-            "enum": ["exact", "wildcard"]
+            "enum": [
+              "exact",
+              "wildcard"
+            ]
           },
           "pattern": {
             "type": "string",
@@ -95782,7 +101369,10 @@
           },
           "match_type": {
             "type": "string",
-            "enum": ["exact", "wildcard"]
+            "enum": [
+              "exact",
+              "wildcard"
+            ]
           },
           "pattern": {
             "type": "string",
@@ -95843,12 +101433,21 @@
       "SkillSourceType": {
         "type": "string",
         "description": "Source backing for an attached skill file.",
-        "enum": ["url", "dataurl", "text", "upload"]
+        "enum": [
+          "url",
+          "dataurl",
+          "text",
+          "upload"
+        ]
       },
       "SkillFileEntry": {
         "type": "object",
         "description": "File entry used when creating or updating a skill version.",
-        "required": ["path", "source_type", "mime_type"],
+        "required": [
+          "path",
+          "source_type",
+          "mime_type"
+        ],
         "properties": {
           "path": {
             "type": "string",
@@ -96048,7 +101647,12 @@
       },
       "CreateSkillRequest": {
         "type": "object",
-        "required": ["name", "description", "skill_md_body", "version"],
+        "required": [
+          "name",
+          "description",
+          "skill_md_body",
+          "version"
+        ],
         "properties": {
           "name": {
             "type": "string",
@@ -96098,7 +101702,11 @@
       },
       "UpdateSkillRequest": {
         "type": "object",
-        "required": ["description", "skill_md_body", "version"],
+        "required": [
+          "description",
+          "skill_md_body",
+          "version"
+        ],
         "properties": {
           "description": {
             "type": "string",
@@ -96198,7 +101806,9 @@
       },
       "UploadSkillFileRequest": {
         "type": "object",
-        "required": ["file"],
+        "required": [
+          "file"
+        ],
         "properties": {
           "file": {
             "type": "string",
@@ -96270,17 +101880,25 @@
       },
       "BumpAllSkillsVersionRequest": {
         "type": "object",
-        "required": ["bump"],
+        "required": [
+          "bump"
+        ],
         "properties": {
           "bump": {
             "type": "string",
-            "enum": ["patch", "minor", "major"]
+            "enum": [
+              "patch",
+              "minor",
+              "major"
+            ]
           }
         }
       },
       "ShiftSkillVersionRequest": {
         "type": "object",
-        "required": ["version"],
+        "required": [
+          "version"
+        ],
         "properties": {
           "version": {
             "type": "string",
@@ -96345,7 +101963,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["processing", "success", "error"]
+            "enum": [
+              "processing",
+              "success",
+              "error"
+            ]
           },
           "object": {
             "type": "string"
@@ -96397,18 +102019,37 @@
           },
           "complexity_tier": {
             "type": "string",
-            "enum": ["SIMPLE", "MEDIUM", "COMPLEX", "REASONING"],
+            "enum": [
+              "SIMPLE",
+              "MEDIUM",
+              "COMPLEX",
+              "REASONING"
+            ],
             "description": "Complexity tier used for routing; null when no routing rule referenced complexity_tier. REASONING is historical-only — it was merged into COMPLEX and is never emitted for new requests, but survives in log rows recorded under the old scheme.",
             "nullable": true
           },
           "complexity_mechanism": {
-            "type": ["string", "null"],
-            "enum": ["semantic", "llm", "session", "skipped", null],
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "semantic",
+              "llm",
+              "session",
+              "skipped",
+              null
+            ],
             "description": "How the effective complexity tier was determined. session means retained session state supplied the tier; skipped means classification was demanded but produced no tier."
           },
           "complexity_score": {
             "type": "number",
             "description": "Similarity score of the nearest reference phrase behind the tier. Absent for llm, session, and skipped decisions.",
+            "nullable": true
+          },
+          "session_id": {
+            "type": "string",
+            "description": "Raw opaque Bifrost session ID resolved at ingress for key stickiness and request correlation.",
             "nullable": true
           },
           "stream": {
@@ -96490,11 +102131,22 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
+                  "enum": [
+                    "in_progress",
+                    "completed",
+                    "incomplete",
+                    "interpreting",
+                    "failed"
+                  ]
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["assistant", "user", "system", "developer"]
+                  "enum": [
+                    "assistant",
+                    "user",
+                    "system",
+                    "developer"
+                  ]
                 },
                 "content": {
                   "oneOf": [
@@ -96505,7 +102157,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -96548,11 +102202,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -96673,7 +102333,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -96716,11 +102378,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -96826,7 +102494,9 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["computer_screenshot"]
+                          "enum": [
+                            "computer_screenshot"
+                          ]
                         },
                         "file_id": {
                           "type": "string"
@@ -96860,11 +102530,16 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": ["type", "text"],
+                    "required": [
+                      "type",
+                      "text"
+                    ],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["summary_text"]
+                        "enum": [
+                          "summary_text"
+                        ]
                       },
                       "text": {
                         "type": "string"
@@ -96917,11 +102592,22 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["in_progress", "completed", "incomplete", "interpreting", "failed"]
+                  "enum": [
+                    "in_progress",
+                    "completed",
+                    "incomplete",
+                    "interpreting",
+                    "failed"
+                  ]
                 },
                 "role": {
                   "type": "string",
-                  "enum": ["assistant", "user", "system", "developer"]
+                  "enum": [
+                    "assistant",
+                    "user",
+                    "system",
+                    "developer"
+                  ]
                 },
                 "content": {
                   "oneOf": [
@@ -96932,7 +102618,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -96975,11 +102663,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -97100,7 +102794,9 @@
                       "type": "array",
                       "items": {
                         "type": "object",
-                        "required": ["type"],
+                        "required": [
+                          "type"
+                        ],
                         "properties": {
                           "type": {
                             "type": "string",
@@ -97143,11 +102839,17 @@
                           },
                           "input_audio": {
                             "type": "object",
-                            "required": ["format", "data"],
+                            "required": [
+                              "format",
+                              "data"
+                            ],
                             "properties": {
                               "format": {
                                 "type": "string",
-                                "enum": ["mp3", "wav"]
+                                "enum": [
+                                  "mp3",
+                                  "wav"
+                                ]
                               },
                               "data": {
                                 "type": "string"
@@ -97253,7 +102955,9 @@
                       "properties": {
                         "type": {
                           "type": "string",
-                          "enum": ["computer_screenshot"]
+                          "enum": [
+                            "computer_screenshot"
+                          ]
                         },
                         "file_id": {
                           "type": "string"
@@ -97287,11 +102991,16 @@
                   "type": "array",
                   "items": {
                     "type": "object",
-                    "required": ["type", "text"],
+                    "required": [
+                      "type",
+                      "text"
+                    ],
                     "properties": {
                       "type": {
                         "type": "string",
-                        "enum": ["summary_text"]
+                        "enum": [
+                          "summary_text"
+                        ]
                       },
                       "text": {
                         "type": "string"
@@ -97322,15 +103031,22 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["type"],
+              "required": [
+                "type"
+              ],
               "properties": {
                 "type": {
                   "type": "string",
-                  "enum": ["function", "custom"]
+                  "enum": [
+                    "function",
+                    "custom"
+                  ]
                 },
                 "function": {
                   "type": "object",
-                  "required": ["name"],
+                  "required": [
+                    "name"
+                  ],
                   "properties": {
                     "name": {
                       "type": "string"
@@ -97378,21 +103094,29 @@
                   "properties": {
                     "format": {
                       "type": "object",
-                      "required": ["type"],
+                      "required": [
+                        "type"
+                      ],
                       "properties": {
                         "type": {
                           "type": "string"
                         },
                         "grammar": {
                           "type": "object",
-                          "required": ["definition", "syntax"],
+                          "required": [
+                            "definition",
+                            "syntax"
+                          ],
                           "properties": {
                             "definition": {
                               "type": "string"
                             },
                             "syntax": {
                               "type": "string",
-                              "enum": ["lark", "regex"]
+                              "enum": [
+                                "lark",
+                                "regex"
+                              ]
                             }
                           }
                         }
@@ -97410,7 +103134,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["function"],
+              "required": [
+                "function"
+              ],
               "properties": {
                 "index": {
                   "type": "integer"
@@ -97561,11 +103287,19 @@
               },
               "sort_by": {
                 "type": "string",
-                "enum": ["timestamp", "latency", "tokens", "cost"]
+                "enum": [
+                  "timestamp",
+                  "latency",
+                  "tokens",
+                  "cost"
+                ]
               },
               "order": {
                 "type": "string",
-                "enum": ["asc", "desc"]
+                "enum": [
+                  "asc",
+                  "desc"
+                ]
               },
               "total_count": {
                 "type": "integer",
@@ -97668,7 +103402,9 @@
       "DeleteLogsRequest": {
         "type": "object",
         "description": "Delete logs request",
-        "required": ["ids"],
+        "required": [
+          "ids"
+        ],
         "properties": {
           "ids": {
             "type": "array",
@@ -97840,7 +103576,11 @@
       "AuditEventType": {
         "type": "string",
         "description": "Classifies the audit event.",
-        "enum": ["activity", "monitor", "control"]
+        "enum": [
+          "activity",
+          "monitor",
+          "control"
+        ]
       },
       "AuditAction": {
         "type": "string",
@@ -97866,7 +103606,11 @@
       "AuditOutcome": {
         "type": "string",
         "description": "The CADF outcome of the action.",
-        "enum": ["success", "failure", "pending"]
+        "enum": [
+          "success",
+          "failure",
+          "pending"
+        ]
       },
       "AuditResourceType": {
         "type": "string",
@@ -97911,7 +103655,10 @@
             "description": "Hostname or IP address associated with the resource."
           }
         },
-        "required": ["id", "typeURI"]
+        "required": [
+          "id",
+          "typeURI"
+        ]
       },
       "AuditReason": {
         "type": "object",
@@ -97948,7 +103695,11 @@
             "description": "Attachment data (typically a JSON string)."
           }
         },
-        "required": ["name", "contentType", "content"]
+        "required": [
+          "name",
+          "contentType",
+          "content"
+        ]
       },
       "AuditEvent": {
         "type": "object",
@@ -98083,7 +103834,14 @@
             "description": "Opaque cursor for the next page (cursor-based pagination)."
           }
         },
-        "required": ["audit_logs", "total", "page", "limit", "total_pages", "has_more"]
+        "required": [
+          "audit_logs",
+          "total",
+          "page",
+          "limit",
+          "total_pages",
+          "has_more"
+        ]
       },
       "AuditLogResponse": {
         "type": "object",
@@ -98093,7 +103851,9 @@
             "$ref": "#/components/schemas/AuditEvent"
           }
         },
-        "required": ["audit_log"]
+        "required": [
+          "audit_log"
+        ]
       },
       "AuditFilterKeyPair": {
         "type": "object",
@@ -98106,7 +103866,10 @@
             "type": "string"
           }
         },
-        "required": ["id", "name"]
+        "required": [
+          "id",
+          "name"
+        ]
       },
       "AuditFilterDataResponse": {
         "type": "object",
@@ -98197,16 +103960,27 @@
             "description": "The signature persisted with the event."
           }
         },
-        "required": ["valid", "computed", "stored"]
+        "required": [
+          "valid",
+          "computed",
+          "stored"
+        ]
       },
       "WebhookEvent": {
         "type": "string",
-        "enum": ["async_job.completed", "async_job.failed"],
+        "enum": [
+          "async_job.completed",
+          "async_job.failed"
+        ],
         "description": "A terminal async-job event a webhook endpoint can subscribe to:\n- async_job.completed: an async job finished successfully\n- async_job.failed: an async job finished with an error\n"
       },
       "WebhookEndpointRequest": {
         "type": "object",
-        "required": ["name", "url", "events"],
+        "required": [
+          "name",
+          "url",
+          "events"
+        ],
         "description": "Create or update body for a webhook endpoint. The signing secret is never\naccepted here — it is generated by the server and returned once at creation,\nand can only be changed through the rotate-secret endpoint.\n",
         "properties": {
           "name": {
@@ -98429,7 +104203,9 @@
       },
       "TestWebhookRequest": {
         "type": "object",
-        "required": ["event"],
+        "required": [
+          "event"
+        ],
         "properties": {
           "event": {
             "$ref": "#/components/schemas/WebhookEvent",
@@ -98456,7 +104232,12 @@
       },
       "WebhookDeliveryOutcome": {
         "type": "string",
-        "enum": ["delivered", "retryable_failure", "permanent_failure", "exhausted"],
+        "enum": [
+          "delivered",
+          "retryable_failure",
+          "permanent_failure",
+          "exhausted"
+        ],
         "description": "Outcome of a single delivery attempt:\n- delivered: the receiver returned 2xx\n- retryable_failure: failed but will be retried\n- permanent_failure: failed in a way that is not retried\n- exhausted: retries were used up without success\n"
       },
       "WebhookDelivery": {
@@ -98556,17 +104337,30 @@
       "NotificationSeverity": {
         "type": "string",
         "description": "Visual weight the dashboard gives the notification.",
-        "enum": ["info", "success", "warning", "error"]
+        "enum": [
+          "info",
+          "success",
+          "warning",
+          "error"
+        ]
       },
       "NotificationAudience": {
         "type": "string",
         "description": "Who the notification reaches. `all` is every dashboard user; `roles` limits\nit to the listed RBAC roles, enforced on both the list endpoint and the\nWebSocket fan-out.\n",
-        "enum": ["all", "roles"]
+        "enum": [
+          "all",
+          "roles"
+        ]
       },
       "NotificationInput": {
         "type": "object",
         "description": "A notification to publish. IDs and both timestamps are assigned by the\nserver and cannot be supplied.\n",
-        "required": ["audience", "severity", "title", "message"],
+        "required": [
+          "audience",
+          "severity",
+          "title",
+          "message"
+        ],
         "properties": {
           "audience": {
             "$ref": "#/components/schemas/NotificationAudience"
@@ -98609,7 +104403,15 @@
       "Notification": {
         "type": "object",
         "description": "A persisted dashboard notification.",
-        "required": ["id", "audience", "severity", "title", "message", "created_at", "expires_at"],
+        "required": [
+          "id",
+          "audience",
+          "severity",
+          "title",
+          "message",
+          "created_at",
+          "expires_at"
+        ],
         "properties": {
           "id": {
             "type": "string",
@@ -98654,7 +104456,9 @@
       "NotificationList": {
         "type": "object",
         "description": "A page of notifications, newest first, already filtered to what the caller's\nrole may see.\n",
-        "required": ["notifications"],
+        "required": [
+          "notifications"
+        ],
         "properties": {
           "notifications": {
             "type": "array",


### PR DESCRIPTION
## Summary

Adds documentation for the Projects feature in Bifrost Enterprise. Projects are a per-request access gate and accounting scope that answer "what is this call for?" rather than "who is calling?", composing with an already-authenticated principal via a request header. This PR introduces the full reference page and propagates project attribution fields across all observability integrations.

## Changes

- Added `docs/enterprise/projects.mdx` — a full reference covering the project model, membership modes, access rules (`intersect`/`union`), accounting modes (`both`, `project_only`, `principal_only`), budget tiers, split policies, calendar alignment, configuration via Web UI / `config.json` / API, attribution and reporting, and visibility/RBAC
- Registered the new page in `docs/docs.json` under the Enterprise navigation group
- Added a Projects card to `docs/enterprise/overview.mdx`
- Updated `docs/enterprise/data-access-control.mdx` to include projects as a scoped resource and added a dedicated row to the DAC scope table describing `own-data`, `team-data`, and `all-data` visibility for projects and their rosters
- Added `project_id` / `project_name` to the Prometheus MCP metric labels and default label documentation
- Added `project_id` / `project_name` to the OTel `mcp.client.operation.duration` dimension list
- Added `project_id` / `project_name` to the Datadog MCP metric tags and the content-logging attribution identifier warning
- Added `project_id` / `project_name` columns to the BigQuery governance attribution accordion (count updated from 14 to 16)
- Updated the Splunk attribution fields section to include project as a scalar attribution dimension alongside virtual key and user

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation to confirm:

- `enterprise/projects` appears in the sidebar under the Enterprise group, between MCP Tool Groups and the Guardrails group
- All cross-links (Data Access Control, RBAC, Budgets and Limits, config.json governance, Virtual Keys, Access Profiles) resolve correctly
- The DAC scope table renders with the new Projects row and correct column alignment
- Observability pages (Prometheus, OTel, Datadog, BigQuery, Splunk) reflect `project_id`/`project_name` in the appropriate label, tag, column, and dimension lists

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The projects page documents that a project never authenticates a request and cannot replace the caller's identity. The DAC section clarifies that roster visibility is scoped per role, so a user cannot enumerate members they are not permitted to see. No new secrets or PII handling is introduced by this documentation change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable