### PR TITLE
docs: add `virtual_mcps` to project schema, note API membership, and tighten wording from "grants" to "allows"

### DIFF
--- a/docs/deployment-guides/config-json/governance.mdx
+++ b/docs/deployment-guides/config-json/governance.mdx
@@ -317,7 +317,7 @@ Define organizational entities and attach rate limits directly. Team budgets ref
 Declare projects that requests opt into for access and accounting. A project composes with what the caller already holds, spends against its own budgets, the calling principal's, or both as `accounting_mode` directs, and can divide every budget and rate limit it holds equally between its members.
 
 <Note>
-`governance.projects` is an enterprise capability. Members are added from the dashboard: a project declared here starts with none, and membership cannot be declared in the file. The schema rejects a `members` key.
+`governance.projects` is an enterprise capability. Members are added from the dashboard or the API: a project declared here starts with none, and membership cannot be declared in the file. The schema rejects a `members` key.
 </Note>
 
 ```json
@@ -343,7 +343,8 @@ Declare projects that requests opt into for access and accounting. A project com
             ]
           }
         ],
-        "mcp_configs": [{ "mcp_client_name": "github", "tools_to_execute": ["*"] }]
+        "mcp_configs": [{ "mcp_client_name": "github", "tools_to_execute": ["*"] }],
+        "virtual_mcps": [{ "virtual_mcp_id": 3 }]
       }
     ]
   }
@@ -359,7 +360,7 @@ Requests reference a project by name with the `x-bf-project-name` header.
 | `name` | Yes | Unique project name. Declarations are matched to stored projects by name |
 | `description` | No | Free-form description |
 | `is_active` | No | Defaults to `true` |
-| `expires_at` | No | RFC 3339 timestamp after which the project grants nothing |
+| `expires_at` | No | RFC 3339 timestamp after which the project allows nothing |
 | `access_rule` | Yes | `union` leaves the caller's own access untouched (a project with no provider or MCP config then only accounts for spend); `intersect` permits only what both the caller and the project allow |
 | `membership_mode` | No | `explicit` (default) consults the membership rows; `open` lets any caller opt in. An open project cannot use `split_policy: equal` |
 | `accounting_mode` | No | Which ledgers spend lands on: `both` (default), `project_only`, or `principal_only` |
@@ -368,7 +369,8 @@ Requests reference a project by name with the `x-bf-project-name` header.
 | `budgets` | No | Project-level spend caps, each with `max_limit` and `reset_duration` |
 | `rate_limit` | No | Request and token limits: `request_max_limit`, `request_reset_duration`, `token_max_limit`, `token_reset_duration` |
 | `provider_configs` | No | One entry per provider, see below |
-| `mcp_configs` | No | One entry per MCP client: `mcp_client_name` (as declared under `mcp.client_configs`) and `tools_to_execute` (`["*"]` grants every tool; empty or omitted grants none, regardless of the top-level `version`) |
+| `mcp_configs` | No | One entry per MCP client: `mcp_client_name` (as declared under `mcp.client_configs`) and `tools_to_execute` (`["*"]` allows every tool; empty or omitted allows none, regardless of the top-level `version`) |
+| `virtual_mcps` | No | Virtual MCPs assigned to the project, one `virtual_mcp_id` per entry. A scoped request can reach each at its `/mcp/<slug>` endpoint |
 
 Budgets and rate limits inside a project are declared without ids.
 
@@ -376,7 +378,7 @@ Budgets and rate limits inside a project are declared without ids.
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `provider_name` | Yes | Provider this entry grants. A project names each provider at most once |
+| `provider_name` | Yes | Provider this entry allows. A project names each provider at most once |
 | `all_models_allowed` | No | Allow every model of the provider |
 | `allowed_models` | No | Allowed model names, ignored when `all_models_allowed` is true |
 | `blacklisted_models` | No | Models blocked even if allowed; `["*"]` blocks all |
@@ -392,6 +394,7 @@ Budgets and rate limits inside a project are declared without ids.
 - **Edits keep spend.** Budgets are paired with their stored rows by `reset_duration` (in declared order when a duration appears twice), provider configs by `provider_name`, model budgets by `model_name`, and MCP configs by client. A paired row is updated in place, so raising a cap does not forgive what was already spent against it. A budget, provider, or client the file stops declaring is removed.
 - **Equal splits redivide in the background.** Changing a cap or the split policy of a project with `split_policy: equal` queues a recalculation of every member's share, which runs shortly after startup.
 - **Members are never touched.** The file cannot add or remove members; the schema rejects a `members` key on a project.
+- **Rate limits must divide by the stored roster.** On a project with `split_policy: equal`, a declared token or request cap smaller than the number of members it already has is refused, at whichever tier is too small, rather than stored and left to fail mid-redivision. Raise the cap or shrink the roster.
 - **With `source_of_truth: "config.json"`** and `governance.projects` present, declarations always overwrite the database and projects the file does not declare are deleted, members included.
 
 ---

--- a/docs/enterprise/projects.mdx
+++ b/docs/enterprise/projects.mdx
@@ -432,7 +432,7 @@ Projects can be declared in `governance.projects`, which is useful for seeding t
 ```
 
 <Note>
-Membership cannot be declared in the file. A project declared here starts with no members, and the schema rejects a `members` key. Add the roster from the dashboard or the API. Virtual MCP assignments are likewise dashboard and API only.
+Membership cannot be declared in the file. A project declared here starts with no members, and the schema rejects a `members` key. Add the roster from the dashboard or the API. Virtual MCPs can be assigned with `virtual_mcps`, but only by database-assigned id, so a file meant to be portable across environments should leave those to the dashboard or the API too.
 </Note>
 
 Projects are reconciled by **name**: a name the database does not have is created, and a name it does have is updated only when the declaration has actually changed, so dashboard edits survive until the file changes. Edits keep spend, and a child the file stops declaring is removed. With `source_of_truth` set to `config.json`, declarations always overwrite the database and projects the file does not declare are deleted, members included.

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -7743,7 +7743,7 @@
     },
     "project": {
       "type": "object",
-      "description": "A project declared under governance.projects: what it grants, what it may spend, and how that is divided between its members. Members themselves are added from the dashboard.",
+      "description": "A project declared under governance.projects: what it allows, what it may spend, and how that is divided between its members. Members themselves are added from the dashboard or the API.",
       "allOf": [
         {
           "if": {
@@ -7774,17 +7774,17 @@
         },
         "is_active": {
           "type": "boolean",
-          "description": "Whether the project grants and accounts for anything",
+          "description": "Whether the project allows and accounts for anything",
           "default": true
         },
         "expires_at": {
           "type": "string",
           "format": "date-time",
-          "description": "When the project stops granting anything; omit to never expire"
+          "description": "When the project stops allowing anything; omit to never expire"
         },
         "access_rule": {
           "type": "string",
-          "description": "How the project's grants compose with the grants a caller already holds: union leaves the caller's own access untouched (a project with no provider or MCP config then only accounts for spend), intersect permits only what both allow.",
+          "description": "How the project's own access composes with the access a caller already holds: union leaves the caller's own access untouched (a project with no provider or MCP config then only accounts for spend), intersect permits only what both allow.",
           "enum": ["union", "intersect"]
         },
         "membership_mode": {
@@ -7807,7 +7807,7 @@
         },
         "calendar_aligned": {
           "type": "boolean",
-          "description": "Snap the project's budget and rate-limit reset windows to calendar boundaries (day, week, month, year) instead of rolling from first use",
+          "description": "Snap the project's budget and rate-limit reset windows to calendar boundaries (day, week, month, quarter, year) instead of rolling from first use. Windows shorter than a day cannot be aligned and stay rolling.",
           "default": false
         },
         "budgets": {
@@ -7822,20 +7822,40 @@
         },
         "provider_configs": {
           "type": "array",
-          "description": "Per-provider grants and accounting, one entry per provider",
+          "description": "Per-provider access and accounting, one entry per provider",
           "items": {
             "$ref": "#/$defs/project_provider_config"
           }
         },
         "mcp_configs": {
           "type": "array",
-          "description": "MCP clients the project grants, one entry per client",
+          "description": "MCP clients the project allows, one entry per client",
           "items": {
             "$ref": "#/$defs/project_mcp_config"
+          }
+        },
+        "virtual_mcps": {
+          "type": "array",
+          "description": "Virtual MCPs assigned to the project, one entry per assignment. A request scoped to the project can reach each one at its /mcp/<slug> endpoint.",
+          "items": {
+            "$ref": "#/$defs/project_virtual_mcp"
           }
         }
       },
       "required": ["name", "access_rule"],
+      "additionalProperties": false
+    },
+    "project_virtual_mcp": {
+      "type": "object",
+      "description": "A virtual MCP assigned to a project. Assignments are a set, so a repeated id is ignored rather than doubled.",
+      "properties": {
+        "virtual_mcp_id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Virtual MCP ID. Ids are assigned by the database, so a file that has to be portable across environments should assign virtual MCPs from the dashboard or the API instead."
+        }
+      },
+      "required": ["virtual_mcp_id"],
       "additionalProperties": false
     },
     "project_budget": {
@@ -8011,11 +8031,11 @@
       "properties": {
         "mcp_client_name": {
           "type": "string",
-          "description": "Name of the MCP client (as declared under mcp.client_configs) the project grants. Resolved to the stored client on startup; a name that matches no client is refused."
+          "description": "Name of the MCP client (as declared under mcp.client_configs) the project allows. Resolved to the stored client on startup; a name that matches no client is refused."
         },
         "tools_to_execute": {
           "type": "array",
-          "description": "Tools of the client the project grants. Use [\"*\"] to grant every tool; empty array or omitted grants none, regardless of the top-level version.",
+          "description": "Tools of the client the project may execute. Use [\"*\"] to allow every tool; empty array or omitted allows none, regardless of the top-level version.",
           "items": {
             "type": "string"
           }


### PR DESCRIPTION
## Summary

Adds `virtual_mcps` as a declarable field on projects in `config.json`, documents the new validation rule that rejects rate limit caps too small to divide equally across existing members, and replaces "grants" with "allows" throughout the schema and docs for consistency.

## Changes

- Added `virtual_mcps` array to the `project` schema definition, with a new `project_virtual_mcp` object type requiring a `virtual_mcp_id` integer. A scoped request can reach each assigned virtual MCP at its `/mcp/<slug>` endpoint. Repeated ids are treated as a set and not doubled.
- Noted in docs that virtual MCP assignments can be declared by id in the file, but portable configs should leave them to the dashboard or API since ids are database-assigned and will differ across environments.
- Added a new behavioral note: on a project with `split_policy: equal`, a declared token or request cap smaller than the current member count is refused at the offending tier rather than stored and left to fail during redivision.
- Updated the `calendar_aligned` description to include `quarter` as a supported boundary and to clarify that sub-day windows stay rolling.
- Updated the `governance.projects` note to reflect that members can be added from the dashboard or the API.
- Replaced "grants" with "allows" across schema descriptions and documentation for consistent terminology.
- Changed `expires_at` description from "grants nothing" to "allows nothing" for the same consistency.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Validate the updated schema accepts a project with a `virtual_mcps` entry and rejects unknown keys:

```sh
# Confirm schema validation passes with virtual_mcps declared
# Example project snippet:
# "virtual_mcps": [{ "virtual_mcp_id": 3 }]

# Confirm schema rejects a project with a members key (existing behavior, unchanged)
# Confirm a project with split_policy: equal and a cap smaller than its member count is refused at startup
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Virtual MCP id references are resolved server-side against stored records; an unrecognized id is refused rather than silently ignored.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable