### PR TITLE
docs: add throughput histograms, user rankings, and `/inspect` endpoint to OpenAPI spec and docs nav

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -60,7 +60,9 @@
           {
             "group": "Overview",
             "icon": "book-open-cover",
-            "pages": ["overview"]
+            "pages": [
+              "overview"
+            ]
           },
           {
             "group": "Quick Start",
@@ -100,7 +102,9 @@
           {
             "group": "Release Cadence",
             "icon": "calendar",
-            "pages": ["release-cadence"]
+            "pages": [
+              "release-cadence"
+            ]
           },
           {
             "group": "Migration Guides",
@@ -111,16 +115,18 @@
             ]
           },
           {
-            "group":"Migrate from other Gateway",
-            "icon":"arrow-up",
-            "pages":[
+            "group": "Migrate from other Gateway",
+            "icon": "arrow-up",
+            "pages": [
               "migration-guides/litellm"
             ]
           },
           {
             "group": "SDK Integrations",
             "icon": "plug",
-            "pages": ["integrations/what-is-an-integration"]
+            "pages": [
+              "integrations/what-is-an-integration"
+            ]
           },
           {
             "group": "Providers & Guides",
@@ -216,7 +222,10 @@
               {
                 "group": "Writing Plugins",
                 "icon": "code",
-                "pages": ["plugins/writing-go-plugin", "plugins/writing-wasm-plugin"]
+                "pages": [
+                  "plugins/writing-go-plugin",
+                  "plugins/writing-wasm-plugin"
+                ]
               },
               "plugins/migration-guide"
             ]
@@ -262,7 +271,10 @@
               {
                 "group": "Plugins",
                 "icon": "puzzle-piece",
-                "pages": ["features/plugins/mocker", "features/plugins/jsonparser"]
+                "pages": [
+                  "features/plugins/mocker",
+                  "features/plugins/jsonparser"
+                ]
               }
             ]
           }
@@ -275,7 +287,9 @@
           {
             "group": "Getting Started",
             "icon": "rocket",
-            "pages": ["enterprise/overview"]
+            "pages": [
+              "enterprise/overview"
+            ]
           },
           {
             "group": "Moving from OSS",
@@ -291,12 +305,17 @@
           {
             "group": "Release Cadence",
             "icon": "calendar",
-            "pages": ["enterprise/release-cadence"]
+            "pages": [
+              "enterprise/release-cadence"
+            ]
           },
           {
             "group": "Migration Guides",
             "icon": "arrow-up-right-dots",
-            "pages": ["enterprise/migration-guides/v2.0.0", "enterprise/migration-guides/v1.4.0"]
+            "pages": [
+              "enterprise/migration-guides/v2.0.0",
+              "enterprise/migration-guides/v1.4.0"
+            ]
           },
           {
             "group": "Features",
@@ -306,12 +325,9 @@
               "enterprise/access-profiles",
               "enterprise/rbac",
               "enterprise/data-access-control",
-<<<<<<< HEAD
               "enterprise/virtual-mcps",
-=======
               "enterprise/mcp-tool-groups",
               "enterprise/projects",
->>>>>>> 15c99a742 (docs: add enterprise Projects page)
               {
                 "group": "Guardrails",
                 "icon": "road-barrier",
@@ -361,7 +377,9 @@
           {
             "group": "Security",
             "icon": "shield",
-            "pages": ["security"]
+            "pages": [
+              "security"
+            ]
           }
         ]
       },
@@ -371,27 +389,42 @@
         "groups": [
           {
             "group": "Overview",
-            "pages": ["edge/overview", "edge/how-it-works"]
+            "pages": [
+              "edge/overview",
+              "edge/how-it-works"
+            ]
           },
           {
             "group": "Governance & Control",
             "icon": "shield-halved",
-            "pages": ["edge/app-governance", "edge/mcp-governance", "edge/security"]
+            "pages": [
+              "edge/app-governance",
+              "edge/mcp-governance",
+              "edge/security"
+            ]
           },
           {
             "group": "Admin controls",
             "icon": "sliders",
-            "pages": ["edge/admin-devices", "edge/admin-approvals", "edge/admin-configurations"]
+            "pages": [
+              "edge/admin-devices",
+              "edge/admin-approvals",
+              "edge/admin-configurations"
+            ]
           },
           {
             "group": "Deployment",
             "icon": "cloud-arrow-up",
-            "pages": ["edge/deployment-mdm"]
+            "pages": [
+              "edge/deployment-mdm"
+            ]
           },
           {
             "group": "Reference",
             "icon": "list",
-            "pages": ["edge/supported-applications"]
+            "pages": [
+              "edge/supported-applications"
+            ]
           }
         ]
       },
@@ -402,7 +435,10 @@
           {
             "group": "Runbooks",
             "icon": "book-open",
-            "pages": ["runbooks/claude-code-bedrock", "runbooks/codex-bedrock"]
+            "pages": [
+              "runbooks/claude-code-bedrock",
+              "runbooks/codex-bedrock"
+            ]
           },
           {
             "group": "CLI Agents & Editors",
@@ -455,7 +491,9 @@
               {
                 "group": "GenAI SDK",
                 "icon": "diamond",
-                "pages": ["integrations/genai-sdk/overview"]
+                "pages": [
+                  "integrations/genai-sdk/overview"
+                ]
               },
               "integrations/litellm-sdk",
               "integrations/langchain-sdk",
@@ -471,37 +509,50 @@
                 "group": "Okta",
                 "icon": "/media/okta-icon.svg",
                 "collapsed": true,
-                "pages": ["enterprise/setting-up-okta/oidc", "enterprise/setting-up-okta/scim"]
+                "pages": [
+                  "enterprise/setting-up-okta/oidc",
+                  "enterprise/setting-up-okta/scim"
+                ]
               },
               {
                 "group": "Microsoft Entra",
                 "icon": "microsoft",
                 "collapsed": true,
-                "pages": ["enterprise/setting-up-entra/oidc"]
+                "pages": [
+                  "enterprise/setting-up-entra/oidc"
+                ]
               },
               {
                 "group": "Zitadel",
                 "icon": "/media/zitadel-icon.svg",
                 "collapsed": true,
-                "pages": ["enterprise/setting-up-zitadel/oidc"]
+                "pages": [
+                  "enterprise/setting-up-zitadel/oidc"
+                ]
               },
               {
                 "group": "Keycloak",
                 "icon": "/media/keycloak-icon.svg",
                 "collapsed": true,
-                "pages": ["enterprise/setting-up-keycloak/oidc"]
+                "pages": [
+                  "enterprise/setting-up-keycloak/oidc"
+                ]
               },
               {
                 "group": "Google Workspace",
                 "icon": "google",
                 "collapsed": true,
-                "pages": ["enterprise/setting-up-google-workspace"]
+                "pages": [
+                  "enterprise/setting-up-google-workspace"
+                ]
               },
               {
                 "group": "Auth0",
                 "icon": "/media/auth0-icon.svg",
                 "collapsed": true,
-                "pages": ["enterprise/setting-up-auth0/oidc"]
+                "pages": [
+                  "enterprise/setting-up-auth0/oidc"
+                ]
               },
               {
                 "group": "Generic OIDC",
@@ -671,7 +722,9 @@
           {
             "group": "Authentication",
             "icon": "key",
-            "pages": ["api/procuring-api-keys"]
+            "pages": [
+              "api/procuring-api-keys"
+            ]
           },
           {
             "group": "Inference",
@@ -679,17 +732,23 @@
               {
                 "group": "Models",
                 "expanded": false,
-                "pages": ["GET /v1/models"]
+                "pages": [
+                  "GET /v1/models"
+                ]
               },
               {
                 "group": "Chat Completions",
                 "expanded": false,
-                "pages": ["POST /v1/chat/completions"]
+                "pages": [
+                  "POST /v1/chat/completions"
+                ]
               },
               {
                 "group": "Text Completions",
                 "expanded": false,
-                "pages": ["POST /v1/completions"]
+                "pages": [
+                  "POST /v1/completions"
+                ]
               },
               {
                 "group": "Responses",
@@ -706,22 +765,31 @@
               {
                 "group": "OCR",
                 "expanded": false,
-                "pages": ["POST /v1/ocr"]
+                "pages": [
+                  "POST /v1/ocr"
+                ]
               },
               {
                 "group": "Rerank",
                 "expanded": false,
-                "pages": ["POST /v1/rerank"]
+                "pages": [
+                  "POST /v1/rerank"
+                ]
               },
               {
                 "group": "Embeddings",
                 "expanded": false,
-                "pages": ["POST /v1/embeddings"]
+                "pages": [
+                  "POST /v1/embeddings"
+                ]
               },
               {
                 "group": "Audio",
                 "expanded": false,
-                "pages": ["POST /v1/audio/speech", "POST /v1/audio/transcriptions"]
+                "pages": [
+                  "POST /v1/audio/speech",
+                  "POST /v1/audio/transcriptions"
+                ]
               },
               {
                 "group": "Images",
@@ -747,12 +815,16 @@
               {
                 "group": "Count Tokens",
                 "expanded": false,
-                "pages": ["POST /v1/responses/input_tokens"]
+                "pages": [
+                  "POST /v1/responses/input_tokens"
+                ]
               },
               {
                 "group": "Compaction",
                 "expanded": false,
-                "pages": ["POST /v1/responses/compact"]
+                "pages": [
+                  "POST /v1/responses/compact"
+                ]
               },
               {
                 "group": "Batch",
@@ -1072,7 +1144,9 @@
               {
                 "group": "Health",
                 "expanded": false,
-                "pages": ["GET /health"]
+                "pages": [
+                  "GET /health"
+                ]
               },
               {
                 "group": "Configuration",
@@ -1203,6 +1277,8 @@
                   "GET /api/logs/histogram/cost/by-provider",
                   "GET /api/logs/histogram/tokens/by-provider",
                   "GET /api/logs/histogram/latency/by-provider",
+                  "GET /api/logs/histogram/throughput",
+                  "GET /api/logs/histogram/throughput/by-provider",
                   "GET /api/logs/histogram/cost/by-dimension",
                   "GET /api/logs/histogram/tokens/by-dimension",
                   "GET /api/logs/histogram/latency/by-dimension",
@@ -1210,6 +1286,7 @@
                   "GET /api/logs/filterdata",
                   "GET /api/logs/rankings",
                   "GET /api/logs/rankings/by-dimension",
+                  "GET /api/logs/rankings/users",
                   "GET /api/logs/dashboard",
                   "POST /api/logs/recalculate-cost",
                   "GET /api/logs/recalculate-cost/status",
@@ -1283,12 +1360,20 @@
               {
                 "group": "Vault",
                 "expanded": false,
-                "pages": ["POST /api/vault/flush-cache"]
+                "pages": [
+                  "POST /api/vault/flush-cache"
+                ]
               },
               {
                 "group": "Infrastructure",
                 "expanded": false,
-                "pages": ["GET /ws", "GET /mcp", "POST /mcp", "GET /metrics"]
+                "pages": [
+                  "GET /ws",
+                  "GET /mcp",
+                  "POST /mcp",
+                  "GET /metrics",
+                  "POST /inspect"
+                ]
               },
               {
                 "group": "Webhooks",
@@ -1309,7 +1394,10 @@
               {
                 "group": "Notifications",
                 "expanded": false,
-                "pages": ["GET /api/notifications", "POST /api/notifications"]
+                "pages": [
+                  "GET /api/notifications",
+                  "POST /api/notifications"
+                ]
               }
             ]
           },
@@ -1478,7 +1566,10 @@
               {
                 "group": "Budgets & Rate Limits",
                 "expanded": false,
-                "pages": ["GET /api/governance/budgets", "GET /api/governance/rate-limits"]
+                "pages": [
+                  "GET /api/governance/budgets",
+                  "GET /api/governance/rate-limits"
+                ]
               },
               {
                 "group": "Model Configs",
@@ -1566,7 +1657,9 @@
               {
                 "group": "Customers",
                 "expanded": false,
-                "pages": ["GET /api/customers/{customer_id}/teams"]
+                "pages": [
+                  "GET /api/customers/{customer_id}/teams"
+                ]
               },
               {
                 "group": "RBAC",
@@ -1915,7 +2008,10 @@
               },
               {
                 "group": "September 2025",
-                "pages": ["changelogs/v1.2.22", "changelogs/v1.2.21"]
+                "pages": [
+                  "changelogs/v1.2.22",
+                  "changelogs/v1.2.21"
+                ]
               }
             ]
           },
@@ -2021,7 +2117,10 @@
               "changelogs/cli-v0.10.6",
               {
                 "group": "May 2026",
-                "pages": ["changelogs/cli-v0.10.5", "changelogs/cli-v0.10.4"]
+                "pages": [
+                  "changelogs/cli-v0.10.5",
+                  "changelogs/cli-v0.10.4"
+                ]
               },
               {
                 "group": "March 2026",

--- a/docs/enterprise/access-profiles.mdx
+++ b/docs/enterprise/access-profiles.mdx
@@ -307,6 +307,7 @@ curl -X POST "http://localhost:8080/api/governance/model-configs" \
 
 ## Next steps
 
+- **[Projects](/enterprise/projects)** - Scope access and spend to a piece of work rather than to a person, chosen per request.
 - **[Data Access Control](/enterprise/data-access-control)** - Scope which profiles each operator can see.
 - **[RBAC](/enterprise/rbac)** - Define the roles that profiles auto-attach to.
 - **[Virtual Keys](/features/governance/virtual-keys)** - Understand the underlying virtual key concept.

--- a/docs/enterprise/projects.mdx
+++ b/docs/enterprise/projects.mdx
@@ -544,6 +544,8 @@ curl -X DELETE "$BIFROST_URL/api/governance/projects/$PROJECT_ID" \
 
 Members are removed with the project.
 
+For every endpoint, body shape and error code, see the **Projects** section of the [API Reference](/api-reference).
+
 </Tab>
 </Tabs>
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -83888,6 +83888,588 @@
         }
       }
     },
+    "/api/logs/histogram/throughput": {
+      "get": {
+        "operationId": "getLogsThroughputHistogram",
+        "summary": "Get throughput histogram",
+        "description": "Returns time-bucketed token-generation throughput in tokens per second. The bucket size is derived from the requested window.",
+        "tags": [
+          "Logging"
+        ],
+        "parameters": [
+          {
+            "name": "providers",
+            "in": "query",
+            "description": "Comma-separated list of providers to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "models",
+            "in": "query",
+            "description": "Comma-separated list of models to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Comma-separated list of statuses to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "objects",
+            "in": "query",
+            "description": "Comma-separated list of object types to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "selected_key_ids",
+            "in": "query",
+            "description": "Comma-separated list of selected key IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "virtual_key_ids",
+            "in": "query",
+            "description": "Comma-separated list of virtual key IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "team_ids",
+            "in": "query",
+            "description": "Comma-separated list of team IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customer_ids",
+            "in": "query",
+            "description": "Comma-separated list of customer IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_ids",
+            "in": "query",
+            "description": "Comma-separated list of user IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "business_unit_ids",
+            "in": "query",
+            "description": "Comma-separated list of business unit IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_ids",
+            "in": "query",
+            "description": "Comma-separated list of project IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "routing_rule_ids",
+            "in": "query",
+            "description": "Comma-separated list of routing rule IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "routing_engine_used",
+            "in": "query",
+            "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_time",
+            "in": "query",
+            "description": "Start time filter (RFC3339 format)",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end_time",
+            "in": "query",
+            "description": "End time filter (RFC3339 format)",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "description": "Relative time period filter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "min_latency",
+            "in": "query",
+            "description": "Minimum latency filter",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "max_latency",
+            "in": "query",
+            "description": "Maximum latency filter",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "min_tokens",
+            "in": "query",
+            "description": "Minimum tokens filter",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "max_tokens",
+            "in": "query",
+            "description": "Maximum tokens filter",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "min_cost",
+            "in": "query",
+            "description": "Minimum cost filter",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "max_cost",
+            "in": "query",
+            "description": "Maximum cost filter",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "missing_cost_only",
+            "in": "query",
+            "description": "Only show logs with missing cost",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "content_search",
+            "in": "query",
+            "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Time-bucketed token-generation throughput.",
+                  "properties": {
+                    "buckets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "One time bucket of token-generation throughput.",
+                        "properties": {
+                          "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "tokens_per_second": {
+                            "type": "number"
+                          },
+                          "total_completion_tokens": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "total_requests": {
+                            "type": "integer",
+                            "format": "int64"
+                          }
+                        }
+                      }
+                    },
+                    "bucket_size_seconds": {
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "Bucket width, derived from the requested window."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/logs/histogram/throughput/by-provider": {
+      "get": {
+        "operationId": "getLogsProviderThroughputHistogram",
+        "summary": "Get throughput histogram by provider",
+        "description": "Returns time-bucketed tokens per second with a per-provider breakdown.",
+        "tags": [
+          "Logging"
+        ],
+        "parameters": [
+          {
+            "name": "providers",
+            "in": "query",
+            "description": "Comma-separated list of providers to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "models",
+            "in": "query",
+            "description": "Comma-separated list of models to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Comma-separated list of statuses to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "objects",
+            "in": "query",
+            "description": "Comma-separated list of object types to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "selected_key_ids",
+            "in": "query",
+            "description": "Comma-separated list of selected key IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "virtual_key_ids",
+            "in": "query",
+            "description": "Comma-separated list of virtual key IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "team_ids",
+            "in": "query",
+            "description": "Comma-separated list of team IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customer_ids",
+            "in": "query",
+            "description": "Comma-separated list of customer IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_ids",
+            "in": "query",
+            "description": "Comma-separated list of user IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "business_unit_ids",
+            "in": "query",
+            "description": "Comma-separated list of business unit IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_ids",
+            "in": "query",
+            "description": "Comma-separated list of project IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "routing_rule_ids",
+            "in": "query",
+            "description": "Comma-separated list of routing rule IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "routing_engine_used",
+            "in": "query",
+            "description": "Comma-separated list of routing engines to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_time",
+            "in": "query",
+            "description": "Start time filter (RFC3339 format)",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end_time",
+            "in": "query",
+            "description": "End time filter (RFC3339 format)",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "description": "Relative time period filter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "min_latency",
+            "in": "query",
+            "description": "Minimum latency filter",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "max_latency",
+            "in": "query",
+            "description": "Maximum latency filter",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "min_tokens",
+            "in": "query",
+            "description": "Minimum tokens filter",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "max_tokens",
+            "in": "query",
+            "description": "Maximum tokens filter",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "min_cost",
+            "in": "query",
+            "description": "Minimum cost filter",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "max_cost",
+            "in": "query",
+            "description": "Maximum cost filter",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "missing_cost_only",
+            "in": "query",
+            "description": "Only show logs with missing cost",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "content_search",
+            "in": "query",
+            "description": "Search in request/response content",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "request_id",
+            "in": "query",
+            "description": "Exact lookup on a log ID (which is the request ID). Takes precedence over the time range — start_time/end_time/period are ignored when it is set. roots_only is ignored too, so an ID naming a fallback child returns that child rather than collapsing it into its root.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "description": "Time-bucketed throughput with a per-provider breakdown.",
+                  "properties": {
+                    "buckets": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "One time bucket of throughput, broken down by provider.",
+                        "properties": {
+                          "timestamp": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "by_provider": {
+                            "type": "object",
+                            "description": "Keyed by provider name.",
+                            "additionalProperties": {
+                              "type": "object",
+                              "description": "Throughput figures for one provider within a bucket.",
+                              "properties": {
+                                "tokens_per_second": {
+                                  "type": "number"
+                                },
+                                "total_completion_tokens": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                },
+                                "total_requests": {
+                                  "type": "integer",
+                                  "format": "int64"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "bucket_size_seconds": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "providers": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Providers present across the returned buckets."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/logs/rankings": {
       "get": {
         "operationId": "getModelRankings",
@@ -84664,6 +85246,254 @@
                       "type": "integer",
                       "format": "int64",
                       "description": "Requests credited to every dimension value they touch; the sum can\nexceed the real request count. Only set for fan-out dimensions.\n"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/logs/rankings/users": {
+      "get": {
+        "operationId": "getUserRankings",
+        "x-mint": {
+          "metadata": {
+            "tag": "Enterprise"
+          },
+          "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
+        },
+        "summary": "Get user usage rankings",
+        "description": "Returns users ranked by spend, tokens and request volume, with trend percentages versus the previous comparable period. Only requests that resolved to a user are counted.",
+        "tags": [
+          "Logging"
+        ],
+        "parameters": [
+          {
+            "name": "providers",
+            "in": "query",
+            "description": "Comma-separated list of providers to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "models",
+            "in": "query",
+            "description": "Comma-separated list of models to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "aliases",
+            "in": "query",
+            "description": "Comma-separated list of model aliases to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Comma-separated list of statuses to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "objects",
+            "in": "query",
+            "description": "Comma-separated list of object types to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "selected_key_ids",
+            "in": "query",
+            "description": "Comma-separated list of selected key IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "virtual_key_ids",
+            "in": "query",
+            "description": "Comma-separated list of virtual key IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "routing_rule_ids",
+            "in": "query",
+            "description": "Comma-separated list of routing rule IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "team_ids",
+            "in": "query",
+            "description": "Comma-separated list of team IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "customer_ids",
+            "in": "query",
+            "description": "Comma-separated list of customer IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "user_ids",
+            "in": "query",
+            "description": "Comma-separated list of user IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "business_unit_ids",
+            "in": "query",
+            "description": "Comma-separated list of business unit IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "project_ids",
+            "in": "query",
+            "description": "Comma-separated list of project IDs to filter by",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_time",
+            "in": "query",
+            "description": "Start time filter (RFC3339 format)",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end_time",
+            "in": "query",
+            "description": "End time filter (RFC3339 format)",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "period",
+            "in": "query",
+            "description": "Relative time period filter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of ranked rows to return. Defaults to 100. Ignored when\n`all=true`.\n",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 100
+            }
+          },
+          {
+            "name": "all",
+            "in": "query",
+            "description": "When true, returns every ranked entity with no row cap. Intended for\nexports (CSV / PDF), which must not be truncated.\n",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User rankings retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "rankings": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "One user's usage totals, with its trend.",
+                        "properties": {
+                          "user_id": {
+                            "type": "string"
+                          },
+                          "total_requests": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "total_tokens": {
+                            "type": "integer",
+                            "format": "int64"
+                          },
+                          "total_cost": {
+                            "type": "number"
+                          },
+                          "trend": {
+                            "type": "object",
+                            "description": "Change versus the previous comparable period.",
+                            "properties": {
+                              "has_previous_period": {
+                                "type": "boolean",
+                                "description": "False when there is no earlier window to compare against."
+                              },
+                              "requests_trend": {
+                                "type": "number"
+                              },
+                              "tokens_trend": {
+                                "type": "number"
+                              },
+                              "cost_trend": {
+                                "type": "number"
+                              }
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 }
@@ -91302,13 +92132,90 @@
       "get": {
         "operationId": "websocketConnect",
         "summary": "WebSocket connection",
-        "description": "Upgrades to a WebSocket connection for real-time updates.\nServer pushes log events, MCP log events, and store update notifications.\nHeartbeat pings are sent every 30 seconds.\n",
+        "description": "Upgrades to a WebSocket connection for real-time updates.\nServer pushes log events, MCP log events, and store update notifications.\nHeartbeat pings are sent every 30 seconds.\n\nEvery message is an envelope with a `type` discriminator. Two carry\ngovernance-project state:\n\n- `store_update` names the resources that changed, so a client holding a\n  cached list can refetch it. A project create, edit, delete or member\n  change sends `{\"type\": \"store_update\", \"tags\": [\"Projects\"]}`.\n- `redivision_progress` reports an equal-split project recalculating\n  every member's share of every cap. Its `operation_id` matches the\n  `redivision_job_id` returned by the project and member routes, and by\n  a user deletion, so a client can follow the job it started.\n\nThe message shapes are documented as `StoreUpdateMessage` and\n`RedivisionProgressMessage`; they arrive over the socket rather than as\nan HTTP response body.\n",
         "tags": [
           "Infrastructure"
         ],
         "responses": {
           "101": {
-            "description": "WebSocket upgrade successful"
+            "description": "WebSocket upgrade successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "description": "Names the resources that changed, so a client holding a cached list knows to refetch it. Project creates, edits, deletes and member changes all send `tags: [\"Projects\"]`.",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "store_update"
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Resource names, matching the dashboard's cache tags, for example `Projects`, `VirtualKeys`, `Providers`, `MCPClients`.",
+                          "example": [
+                            "Projects"
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "type": "object",
+                      "description": "Envelope carrying a redivision progress update.",
+                      "properties": {
+                        "type": {
+                          "type": "string",
+                          "const": "redivision_progress"
+                        },
+                        "data": {
+                          "type": "object",
+                          "description": "Progress of one equal-split project recalculating every member's share of every cap it holds.",
+                          "properties": {
+                            "operation_id": {
+                              "type": "string",
+                              "description": "The job this reports on, matching the `redivision_job_id` returned by the project and member routes, or one of the `redivision_job_ids` returned by a user deletion."
+                            },
+                            "project_id": {
+                              "type": "string"
+                            },
+                            "phase": {
+                              "type": "string",
+                              "enum": [
+                                "redividing",
+                                "completed",
+                                "error"
+                              ]
+                            },
+                            "total": {
+                              "type": "integer",
+                              "description": "Members in the roster when the job started."
+                            },
+                            "processed": {
+                              "type": "integer"
+                            },
+                            "succeeded": {
+                              "type": "integer"
+                            },
+                            "failed": {
+                              "type": "integer"
+                            },
+                            "message": {
+                              "type": "string",
+                              "description": "A closing summary on `completed`, or the failure text on `error`. A project deleted between queueing and running completes without work."
+                            }
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "description": "One of the server-pushed message envelopes. Listed here because the spec has nowhere else to describe a socket payload."
+                }
+              }
+            }
           }
         }
       }
@@ -91465,6 +92372,168 @@
               "text/plain": {
                 "schema": {
                   "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/inspect": {
+      "post": {
+        "operationId": "inspectRequest",
+        "x-mint": {
+          "metadata": {
+            "tag": "Enterprise"
+          },
+          "content": "<Note>\n  This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.\n</Note>\n"
+        },
+        "summary": "Inspect a request without forwarding it",
+        "description": "Runs the pre-model plugin checks against a request and answers whether\nforwarding it upstream is allowed, without calling any provider. Intended\nfor an intercepting proxy that holds the original request and needs a\nverdict before releasing it.\n\nPlugins that mutate execution or depend on a provider call are skipped.\n\nUnlike the inference routes, this endpoint takes its request context in\nthe body rather than in HTTP headers: entries in `metadata` are read as\nthe request's headers, so `{\"x-bf-project-id\": \"...\"}` scopes the\ninspected request to a governance project exactly as the header would.\nWhen called with `phase: \"response\"` and `log: true`, the resolved\nproject is recorded on the log row this endpoint writes.\n",
+        "tags": [
+          "Infrastructure"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "A request to evaluate, plus the context the caller would otherwise have sent as HTTP headers.",
+                "required": [
+                  "phase"
+                ],
+                "properties": {
+                  "phase": {
+                    "type": "string",
+                    "enum": [
+                      "request",
+                      "response"
+                    ],
+                    "description": "`request` evaluates before the upstream call; `response` reports the outcome afterwards, which is the phase that can write a log row."
+                  },
+                  "log": {
+                    "type": "boolean",
+                    "description": "Write a log row for this call. Honoured on the `response` phase, where the row carries the resolved governance project."
+                  },
+                  "request_id": {
+                    "type": "string"
+                  },
+                  "session_id": {
+                    "type": "string"
+                  },
+                  "request": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "The Bifrost request being inspected."
+                  },
+                  "response": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "The upstream response, on the `response` phase."
+                  },
+                  "error": {
+                    "$ref": "#/components/schemas/BifrostError"
+                  },
+                  "metadata": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "description": "Read as the inspected request's headers, lowercased. This is how a caller scopes the inspection to a governance project, with `x-bf-project-id` or `x-bf-project-name`."
+                  },
+                  "plugin_logs": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "description": "One line a plugin recorded while evaluating the request.",
+                      "properties": {
+                        "plugin_name": {
+                          "type": "string"
+                        },
+                        "level": {
+                          "type": "string"
+                        },
+                        "message": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "integer",
+                          "format": "int64",
+                          "description": "Unix milliseconds."
+                        }
+                      }
+                    },
+                    "description": "Lines carried over from an earlier phase."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ManagementBearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Verdict returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "allow": {
+                      "type": "boolean",
+                      "description": "Whether forwarding the original request is permitted."
+                    },
+                    "reason": {
+                      "type": "string",
+                      "description": "Why it was refused. Absent when allowed."
+                    },
+                    "plugin_logs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "description": "One line a plugin recorded while evaluating the request.",
+                        "properties": {
+                          "plugin_name": {
+                            "type": "string"
+                          },
+                          "level": {
+                            "type": "string"
+                          },
+                          "message": {
+                            "type": "string"
+                          },
+                          "timestamp": {
+                            "type": "integer",
+                            "format": "int64",
+                            "description": "Unix milliseconds."
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BifrostError"
                 }
               }
             }

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -1164,10 +1164,16 @@ paths:
     $ref: "./paths/management/logging.yaml#/logs-dropped"
   /api/logs/filterdata:
     $ref: "./paths/management/logging.yaml#/logs-filterdata"
+  /api/logs/histogram/throughput:
+    $ref: "./paths/management/logging.yaml#/logs-histogram-throughput"
+  /api/logs/histogram/throughput/by-provider:
+    $ref: "./paths/management/logging.yaml#/logs-histogram-throughput-by-provider"
   /api/logs/rankings:
     $ref: "./paths/management/logging.yaml#/logs-rankings"
   /api/logs/rankings/by-dimension:
     $ref: "./paths/management/logging.yaml#/logs-rankings-by-dimension"
+  /api/logs/rankings/users:
+    $ref: "./paths/management/logging.yaml#/logs-rankings-users"
   /api/logs/dashboard:
     $ref: "./paths/management/logging.yaml#/logs-dashboard"
   /api/logs/recalculate-cost:
@@ -1256,6 +1262,8 @@ paths:
     $ref: "./paths/management/infrastructure.yaml#/mcp-server"
   /metrics:
     $ref: "./paths/management/infrastructure.yaml#/metrics"
+  /inspect:
+    $ref: "./paths/management/inspect.yaml#/inspect"
 
   # Webhooks
   /api/webhooks:

--- a/docs/openapi/paths/management/infrastructure.yaml
+++ b/docs/openapi/paths/management/infrastructure.yaml
@@ -8,11 +8,35 @@ websocket:
       Upgrades to a WebSocket connection for real-time updates.
       Server pushes log events, MCP log events, and store update notifications.
       Heartbeat pings are sent every 30 seconds.
+
+      Every message is an envelope with a `type` discriminator. Two carry
+      governance-project state:
+
+      - `store_update` names the resources that changed, so a client holding a
+        cached list can refetch it. A project create, edit, delete or member
+        change sends `{"type": "store_update", "tags": ["Projects"]}`.
+      - `redivision_progress` reports an equal-split project recalculating
+        every member's share of every cap. Its `operation_id` matches the
+        `redivision_job_id` returned by the project and member routes, and by
+        a user deletion, so a client can follow the job it started.
+
+      The message shapes are documented as `StoreUpdateMessage` and
+      `RedivisionProgressMessage`; they arrive over the socket rather than as
+      an HTTP response body.
     tags:
       - Infrastructure
     responses:
       '101':
         description: WebSocket upgrade successful
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '../../schemas/management/infrastructure.yaml#/StoreUpdateMessage'
+                - $ref: '../../schemas/management/infrastructure.yaml#/RedivisionProgressMessage'
+              description: >-
+                One of the server-pushed message envelopes. Listed here because
+                the spec has nowhere else to describe a socket payload.
 
 mcp-server:
   post:

--- a/docs/openapi/paths/management/inspect.yaml
+++ b/docs/openapi/paths/management/inspect.yaml
@@ -1,0 +1,48 @@
+# Paths for the inspect endpoint.
+
+inspect:
+  post:
+    operationId: inspectRequest
+    x-mint:
+      metadata:
+        tag: Enterprise
+      content: |
+        <Note>
+          This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
+        </Note>
+    summary: Inspect a request without forwarding it
+    description: |
+      Runs the pre-model plugin checks against a request and answers whether
+      forwarding it upstream is allowed, without calling any provider. Intended
+      for an intercepting proxy that holds the original request and needs a
+      verdict before releasing it.
+
+      Plugins that mutate execution or depend on a provider call are skipped.
+
+      Unlike the inference routes, this endpoint takes its request context in
+      the body rather than in HTTP headers: entries in `metadata` are read as
+      the request's headers, so `{"x-bf-project-id": "..."}` scopes the
+      inspected request to a governance project exactly as the header would.
+      When called with `phase: "response"` and `log: true`, the resolved
+      project is recorded on the log row this endpoint writes.
+    tags:
+      - Infrastructure
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/inspect.yaml#/InspectEnvelope'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Verdict returned
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/inspect.yaml#/InspectResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'

--- a/docs/openapi/paths/management/logging.yaml
+++ b/docs/openapi/paths/management/logging.yaml
@@ -771,6 +771,103 @@ logs-histogram-latency-by-provider:
       "500":
         $ref: "../../openapi.yaml#/components/responses/InternalError"
 
+logs-histogram-throughput:
+  get:
+    operationId: getLogsThroughputHistogram
+    summary: Get throughput histogram
+    description: >-
+      Returns time-bucketed token-generation throughput in tokens per second.
+      The bucket size is derived from the requested window.
+    tags:
+      - Logging
+    parameters:
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/team_ids"
+      - $ref: "#/_histogram-parameters/customer_ids"
+      - $ref: "#/_histogram-parameters/user_ids"
+      - $ref: "#/_histogram-parameters/business_unit_ids"
+      - $ref: '#/_histogram-parameters/project_ids'
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/period"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      "200":
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../../schemas/management/logging.yaml#/ThroughputHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
+
+logs-histogram-throughput-by-provider:
+  get:
+    operationId: getLogsProviderThroughputHistogram
+    summary: Get throughput histogram by provider
+    description: >-
+      Returns time-bucketed tokens per second with a per-provider breakdown.
+    tags:
+      - Logging
+    parameters:
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/team_ids"
+      - $ref: "#/_histogram-parameters/customer_ids"
+      - $ref: "#/_histogram-parameters/user_ids"
+      - $ref: "#/_histogram-parameters/business_unit_ids"
+      - $ref: '#/_histogram-parameters/project_ids'
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/routing_engine_used"
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/period"
+      - $ref: "#/_histogram-parameters/min_latency"
+      - $ref: "#/_histogram-parameters/max_latency"
+      - $ref: "#/_histogram-parameters/min_tokens"
+      - $ref: "#/_histogram-parameters/max_tokens"
+      - $ref: "#/_histogram-parameters/min_cost"
+      - $ref: "#/_histogram-parameters/max_cost"
+      - $ref: "#/_histogram-parameters/missing_cost_only"
+      - $ref: "#/_histogram-parameters/content_search"
+      - $ref: "#/_histogram-parameters/request_id"
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      "200":
+        description: Successful response
+        content:
+          application/json:
+            schema:
+              $ref: "../../schemas/management/logging.yaml#/ProviderThroughputHistogramResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
+
 # Shared histogram filter parameters
 _histogram-parameters:
   providers:
@@ -1529,6 +1626,56 @@ logs-rankings-by-dimension:
           application/json:
             schema:
               $ref: "../../schemas/management/logging.yaml#/DimensionRankingResult"
+      "400":
+        $ref: "../../openapi.yaml#/components/responses/BadRequest"
+      "500":
+        $ref: "../../openapi.yaml#/components/responses/InternalError"
+
+logs-rankings-users:
+  get:
+    operationId: getUserRankings
+    x-mint:
+      metadata:
+        tag: Enterprise
+      content: |
+        <Note>
+          This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
+        </Note>
+    summary: Get user usage rankings
+    description: >-
+      Returns users ranked by spend, tokens and request volume, with trend
+      percentages versus the previous comparable period. Only requests that
+      resolved to a user are counted.
+    tags:
+      - Logging
+    parameters:
+      - $ref: "#/_histogram-parameters/providers"
+      - $ref: "#/_histogram-parameters/models"
+      - $ref: "#/_histogram-parameters/aliases"
+      - $ref: "#/_histogram-parameters/status"
+      - $ref: "#/_histogram-parameters/objects"
+      - $ref: "#/_histogram-parameters/selected_key_ids"
+      - $ref: "#/_histogram-parameters/virtual_key_ids"
+      - $ref: "#/_histogram-parameters/routing_rule_ids"
+      - $ref: "#/_histogram-parameters/team_ids"
+      - $ref: "#/_histogram-parameters/customer_ids"
+      - $ref: "#/_histogram-parameters/user_ids"
+      - $ref: "#/_histogram-parameters/business_unit_ids"
+      - $ref: '#/_histogram-parameters/project_ids'
+      - $ref: "#/_histogram-parameters/start_time"
+      - $ref: "#/_histogram-parameters/end_time"
+      - $ref: "#/_histogram-parameters/period"
+      - $ref: '#/_ranking-parameters/limit'
+      - $ref: '#/_ranking-parameters/all'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      "200":
+        description: User rankings retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: "../../schemas/management/logging.yaml#/UserRankingResult"
       "400":
         $ref: "../../openapi.yaml#/components/responses/BadRequest"
       "500":

--- a/docs/openapi/schemas/management/infrastructure.yaml
+++ b/docs/openapi/schemas/management/infrastructure.yaml
@@ -1,0 +1,67 @@
+# Schemas for infrastructure endpoints, including the messages the dashboard
+# WebSocket pushes to connected clients.
+
+StoreUpdateMessage:
+  type: object
+  description: >-
+    Names the resources that changed, so a client holding a cached list knows
+    to refetch it. Project creates, edits, deletes and member changes all send
+    `tags: ["Projects"]`.
+  properties:
+    type:
+      type: string
+      const: store_update
+    tags:
+      type: array
+      items:
+        type: string
+      description: >-
+        Resource names, matching the dashboard's cache tags, for example
+        `Projects`, `VirtualKeys`, `Providers`, `MCPClients`.
+      example:
+        - Projects
+
+RedivisionProgress:
+  type: object
+  description: >-
+    Progress of one equal-split project recalculating every member's share of
+    every cap it holds.
+  properties:
+    operation_id:
+      type: string
+      description: >-
+        The job this reports on, matching the `redivision_job_id` returned by
+        the project and member routes, or one of the `redivision_job_ids`
+        returned by a user deletion.
+    project_id:
+      type: string
+    phase:
+      type: string
+      enum:
+        - redividing
+        - completed
+        - error
+    total:
+      type: integer
+      description: Members in the roster when the job started.
+    processed:
+      type: integer
+    succeeded:
+      type: integer
+    failed:
+      type: integer
+    message:
+      type: string
+      description: >-
+        A closing summary on `completed`, or the failure text on `error`. A
+        project deleted between queueing and running completes without work.
+
+RedivisionProgressMessage:
+  type: object
+  description: Envelope carrying a redivision progress update.
+  properties:
+    type:
+      type: string
+      const: redivision_progress
+    data:
+      $ref: '#/RedivisionProgress'

--- a/docs/openapi/schemas/management/inspect.yaml
+++ b/docs/openapi/schemas/management/inspect.yaml
@@ -1,0 +1,78 @@
+# Schemas for the inspect endpoint.
+
+PluginLogEntry:
+  type: object
+  description: One line a plugin recorded while evaluating the request.
+  properties:
+    plugin_name:
+      type: string
+    level:
+      type: string
+    message:
+      type: string
+    timestamp:
+      type: integer
+      format: int64
+      description: Unix milliseconds.
+
+InspectEnvelope:
+  type: object
+  description: >-
+    A request to evaluate, plus the context the caller would otherwise have
+    sent as HTTP headers.
+  required:
+    - phase
+  properties:
+    phase:
+      type: string
+      enum:
+        - request
+        - response
+      description: >-
+        `request` evaluates before the upstream call; `response` reports the
+        outcome afterwards, which is the phase that can write a log row.
+    log:
+      type: boolean
+      description: >-
+        Write a log row for this call. Honoured on the `response` phase, where
+        the row carries the resolved governance project.
+    request_id:
+      type: string
+    session_id:
+      type: string
+    request:
+      type: object
+      additionalProperties: true
+      description: The Bifrost request being inspected.
+    response:
+      type: object
+      additionalProperties: true
+      description: The upstream response, on the `response` phase.
+    error:
+      $ref: '../../schemas/inference/common.yaml#/BifrostError'
+    metadata:
+      type: object
+      additionalProperties: true
+      description: >-
+        Read as the inspected request's headers, lowercased. This is how a
+        caller scopes the inspection to a governance project, with
+        `x-bf-project-id` or `x-bf-project-name`.
+    plugin_logs:
+      type: array
+      items:
+        $ref: '#/PluginLogEntry'
+      description: Lines carried over from an earlier phase.
+
+InspectResponse:
+  type: object
+  properties:
+    allow:
+      type: boolean
+      description: Whether forwarding the original request is permitted.
+    reason:
+      type: string
+      description: Why it was refused. Absent when allowed.
+    plugin_logs:
+      type: array
+      items:
+        $ref: '#/PluginLogEntry'

--- a/docs/openapi/schemas/management/logging.yaml
+++ b/docs/openapi/schemas/management/logging.yaml
@@ -1489,3 +1489,114 @@ DashboardResult:
         $ref: '#/DimensionRankingResult'
     mcp:
       $ref: '#/DashboardMCP'
+
+ThroughputHistogramBucket:
+  type: object
+  description: One time bucket of token-generation throughput.
+  properties:
+    timestamp:
+      type: string
+      format: date-time
+    tokens_per_second:
+      type: number
+    total_completion_tokens:
+      type: integer
+      format: int64
+    total_requests:
+      type: integer
+      format: int64
+
+ThroughputHistogramResult:
+  type: object
+  description: Time-bucketed token-generation throughput.
+  properties:
+    buckets:
+      type: array
+      items:
+        $ref: '#/ThroughputHistogramBucket'
+    bucket_size_seconds:
+      type: integer
+      format: int64
+      description: Bucket width, derived from the requested window.
+
+ProviderThroughputStats:
+  type: object
+  description: Throughput figures for one provider within a bucket.
+  properties:
+    tokens_per_second:
+      type: number
+    total_completion_tokens:
+      type: integer
+      format: int64
+    total_requests:
+      type: integer
+      format: int64
+
+ProviderThroughputHistogramBucket:
+  type: object
+  description: One time bucket of throughput, broken down by provider.
+  properties:
+    timestamp:
+      type: string
+      format: date-time
+    by_provider:
+      type: object
+      description: Keyed by provider name.
+      additionalProperties:
+        $ref: '#/ProviderThroughputStats'
+
+ProviderThroughputHistogramResult:
+  type: object
+  description: Time-bucketed throughput with a per-provider breakdown.
+  properties:
+    buckets:
+      type: array
+      items:
+        $ref: '#/ProviderThroughputHistogramBucket'
+    bucket_size_seconds:
+      type: integer
+      format: int64
+    providers:
+      type: array
+      items:
+        type: string
+      description: Providers present across the returned buckets.
+
+UserRankingTrend:
+  type: object
+  description: Change versus the previous comparable period.
+  properties:
+    has_previous_period:
+      type: boolean
+      description: False when there is no earlier window to compare against.
+    requests_trend:
+      type: number
+    tokens_trend:
+      type: number
+    cost_trend:
+      type: number
+
+UserRankingEntry:
+  type: object
+  description: One user's usage totals, with its trend.
+  properties:
+    user_id:
+      type: string
+    total_requests:
+      type: integer
+      format: int64
+    total_tokens:
+      type: integer
+      format: int64
+    total_cost:
+      type: number
+    trend:
+      $ref: '#/UserRankingTrend'
+
+UserRankingResult:
+  type: object
+  properties:
+    rankings:
+      type: array
+      items:
+        $ref: '#/UserRankingEntry'


### PR DESCRIPTION
## Summary

Adds three new API endpoints to the logging and infrastructure surface, documents the WebSocket message shapes for governance-project events, and links the Projects page from the access-profiles docs.

## Changes

- Added `GET /api/logs/histogram/throughput` — returns time-bucketed token-generation throughput (tokens per second) with configurable window-derived bucket sizes.
- Added `GET /api/logs/histogram/throughput/by-provider` — same throughput histogram with a per-provider breakdown in each bucket.
- Added `GET /api/logs/rankings/users` (Enterprise) — ranks users by spend, tokens, and request volume with trend percentages versus the previous comparable period.
- Added `POST /inspect` (Enterprise) — runs pre-model plugin checks against a request without forwarding it upstream, returning an allow/deny verdict. Accepts request context in the body rather than HTTP headers, supports `request` and `response` phases, and can optionally write a log row on the response phase.
- Expanded the `GET /ws` WebSocket description to document the `store_update` and `redivision_progress` message envelopes, including their schemas (`StoreUpdateMessage`, `RedivisionProgressMessage`, `RedivisionProgress`).
- Added new OpenAPI schemas: `ThroughputHistogramBucket`, `ThroughputHistogramResult`, `ProviderThroughputStats`, `ProviderThroughputHistogramBucket`, `ProviderThroughputHistogramResult`, `UserRankingEntry`, `UserRankingTrend`, `UserRankingResult`, `InspectEnvelope`, `InspectResponse`, `PluginLogEntry`.
- Added a link to the Projects page from the access-profiles next-steps section.
- Added a reference to the API Reference from the Projects page.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Validate the new endpoints against a running Bifrost instance:

```sh
# Throughput histogram
curl -H "Authorization: Bearer $TOKEN" \
  "$BIFROST_URL/api/logs/histogram/throughput?period=24h"

# Throughput histogram by provider
curl -H "Authorization: Bearer $TOKEN" \
  "$BIFROST_URL/api/logs/histogram/throughput/by-provider?period=24h"

# User rankings (Enterprise)
curl -H "Authorization: Bearer $TOKEN" \
  "$BIFROST_URL/api/logs/rankings/users?period=7d&limit=10"

# Inspect endpoint (Enterprise) — request phase
curl -X POST "$BIFROST_URL/inspect" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"phase":"request","metadata":{"x-bf-project-id":"<project-id>"},"request":{...}}'
```

Expected: `200` responses with the documented schemas. The inspect endpoint should return `{"allow": true}` for a permitted request and `{"allow": false, "reason": "..."}` for a blocked one.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `POST /inspect` endpoint requires `ManagementBearerAuth`. Request context (including governance project scoping via `x-bf-project-id`) is passed in the body rather than HTTP headers; callers should ensure the `metadata` field is not populated from untrusted input without validation.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable