### PR TITLE
fix: derive chat finish_reason from responses terminal state and incomplete details

### DIFF
--- a/core/schemas/mux.go
+++ b/core/schemas/mux.go
@@ -402,8 +402,10 @@ func (cm *ChatMessage) ToResponsesMessages() []ResponsesMessage {
 		am := cm.ChatAssistantMessage
 		if len(am.ReasoningDetails) > 0 {
 			var contentBlocks []ResponsesMessageContentBlock
-			var summaries []ResponsesReasoningSummary
 			var encryptedContent *string
+			// Non-nil: the Responses schema requires summary to be an array, and a nil
+			// slice marshals to null, which upstreams reject for the whole input item.
+			summaries := []ResponsesReasoningSummary{}
 			for _, d := range am.ReasoningDetails {
 				switch d.Type {
 				case BifrostReasoningDetailsTypeText:
@@ -1397,6 +1399,40 @@ func responsesTerminalFromChatFinishReason(finishReason *string) (eventType Resp
 	return eventType, mappedStatus, mappedIncompleteDetails
 }
 
+// chatFinishReasonFromResponses derives a Chat finish_reason from a Responses terminal state.
+// Returns nil for non-terminal or unrecognized states so finish_reason stays unset.
+func chatFinishReasonFromResponses(status *string, incompleteDetails *ResponsesResponseIncompleteDetails, stopReason *string, output []ResponsesMessage) *string {
+	if status != nil && (*status == ResponsesResponseStatusInProgress || *status == ResponsesResponseStatusQueued) {
+		return nil
+	}
+
+	if stopReason != nil && *stopReason != "" {
+		if _, _, mapped := responsesStatusFromChatFinishReason(*stopReason); mapped {
+			return Ptr(*stopReason)
+		}
+	}
+
+	if incompleteDetails != nil {
+		switch incompleteDetails.Reason {
+		case ResponsesResponseIncompleteReasonMaxOutputTokens:
+			return Ptr(string(BifrostFinishReasonLength))
+		case ResponsesResponseIncompleteReasonContentFilter:
+			return Ptr("content_filter")
+		}
+	}
+
+	if status != nil && *status == ResponsesResponseStatusCompleted {
+		for _, item := range output {
+			if item.Type != nil && *item.Type == ResponsesMessageTypeFunctionCall {
+				return Ptr(string(BifrostFinishReasonToolCalls))
+			}
+		}
+		return Ptr(string(BifrostFinishReasonStop))
+	}
+
+	return nil
+}
+
 // ToBifrostResponsesResponse converts the BifrostChatResponse to BifrostResponsesResponse format
 // This converts Chat-style fields (Choices) to Responses API format
 func (cr *BifrostChatResponse) ToBifrostResponsesResponse() *BifrostResponsesResponse {
@@ -1493,11 +1529,14 @@ func (responsesResp *BifrostResponsesResponse) ToBifrostChatResponse() *BifrostC
 		// Convert ResponsesMessages back to ChatMessages
 		chatMessages := ToChatMessages(responsesResp.Output)
 
+		finishReason := chatFinishReasonFromResponses(responsesResp.Status, responsesResp.IncompleteDetails, responsesResp.StopReason, responsesResp.Output)
+
 		// Create choices from chat messages
 		choices := make([]BifrostResponseChoice, 0, len(chatMessages))
 		for i, chatMsg := range chatMessages {
 			choice := BifrostResponseChoice{
-				Index: i,
+				Index:        i,
+				FinishReason: finishReason,
 				ChatNonStreamResponseChoice: &ChatNonStreamResponseChoice{
 					Message: &chatMsg,
 				},
@@ -2546,33 +2585,40 @@ func (rsr *BifrostResponsesStreamResponse) ToBifrostChatResponse() *BifrostChatR
 		return resp
 
 	case ResponsesStreamResponseTypeCompleted, ResponsesStreamResponseTypeIncomplete:
-		finishReason := string(BifrostFinishReasonStop)
+		status := ResponsesResponseStatusCompleted
+		fallback := string(BifrostFinishReasonStop)
 		if rsr.Type == ResponsesStreamResponseTypeIncomplete {
-			finishReason = string(BifrostFinishReasonLength)
+			status = ResponsesResponseStatusIncomplete
+			fallback = string(BifrostFinishReasonLength)
 		}
+
+		var (
+			incompleteDetails *ResponsesResponseIncompleteDetails
+			stopReason        *string
+			output            []ResponsesMessage
+		)
+		if rsr.Response != nil {
+			incompleteDetails = rsr.Response.IncompleteDetails
+			stopReason = rsr.Response.StopReason
+			output = rsr.Response.Output
+			if rsr.Response.Usage != nil {
+				resp.Usage = rsr.Response.Usage.ToBifrostLLMUsage()
+			}
+		}
+
+		finishReason := chatFinishReasonFromResponses(&status, incompleteDetails, stopReason, output)
+		if finishReason == nil {
+			finishReason = &fallback
+		}
+
 		resp.Choices = []BifrostResponseChoice{
 			{
 				Index:        0,
-				FinishReason: &finishReason,
+				FinishReason: finishReason,
 				ChatStreamResponseChoice: &ChatStreamResponseChoice{
 					Delta: &ChatStreamResponseChoiceDelta{},
 				},
 			},
-		}
-		if rsr.Response != nil {
-			if rsr.Response.Usage != nil {
-				resp.Usage = rsr.Response.Usage.ToBifrostLLMUsage()
-			}
-			// Check for tool_calls finish reason
-			if rsr.Type == ResponsesStreamResponseTypeCompleted {
-				for _, output := range rsr.Response.Output {
-					if output.Type != nil && *output.Type == ResponsesMessageTypeFunctionCall {
-						finishReason = string(BifrostFinishReasonToolCalls)
-						resp.Choices[0].FinishReason = &finishReason
-						break
-					}
-				}
-			}
 		}
 		return resp
 

--- a/core/schemas/mux_test.go
+++ b/core/schemas/mux_test.go
@@ -2,6 +2,7 @@ package schemas
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
 
@@ -1380,7 +1381,7 @@ func TestToBifrostResponsesStreamResponse_ReasoningOpensThinkingBlock(t *testing
 	}
 
 	var reasoningItemID string
-	var reasoningOutputIndex, textOutputIndex = -1, -1
+	reasoningOutputIndex, textOutputIndex := -1, -1
 	reasoningAddedIdx, reasoningDoneIdx, textAddedIdx := -1, -1, -1
 	firstReasoningDeltaIdx := -1
 
@@ -1449,7 +1450,6 @@ func TestToBifrostResponsesStreamResponse_ReasoningOpensThinkingBlock(t *testing
 	}
 }
 
-
 // responseFormatAsMap reads a converted chat response_format regardless of its
 // representation. The Responses to Chat conversion emits raw JSON (the same
 // representation the chat wire decode produces), so tests read it through the
@@ -1470,4 +1470,219 @@ func nestedMap(t *testing.T, parent map[string]interface{}, key string) map[stri
 		t.Fatalf("expected %q to be an object, got %T", key, parent[key])
 	}
 	return om.ToMap()
+}
+
+func responsesTextOutput(text string) []ResponsesMessage {
+	return []ResponsesMessage{
+		{
+			Type: Ptr(ResponsesMessageTypeMessage),
+			Role: Ptr(ResponsesInputMessageRoleAssistant),
+			Content: &ResponsesMessageContent{
+				ContentBlocks: []ResponsesMessageContentBlock{
+					{Type: ResponsesOutputMessageContentTypeText, Text: &text},
+				},
+			},
+		},
+	}
+}
+
+func TestToBifrostChatResponse_MapsCompletedToStop(t *testing.T) {
+	chatResp := (&BifrostResponsesResponse{
+		Status: Ptr(ResponsesResponseStatusCompleted),
+		Output: responsesTextOutput("ok"),
+	}).ToBifrostChatResponse()
+
+	if chatResp == nil || len(chatResp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	if chatResp.Choices[0].FinishReason == nil {
+		t.Fatal("expected finish_reason to be set")
+	}
+	if got := *chatResp.Choices[0].FinishReason; got != string(BifrostFinishReasonStop) {
+		t.Fatalf("expected finish_reason %q, got %q", BifrostFinishReasonStop, got)
+	}
+}
+
+func TestToBifrostChatResponse_MapsFunctionCallToToolCalls(t *testing.T) {
+	chatResp := (&BifrostResponsesResponse{
+		Status: Ptr(ResponsesResponseStatusCompleted),
+		Output: []ResponsesMessage{
+			{
+				Type: Ptr(ResponsesMessageTypeFunctionCall),
+				Role: Ptr(ResponsesInputMessageRoleAssistant),
+				ResponsesToolMessage: &ResponsesToolMessage{
+					CallID:    Ptr("call_1"),
+					Name:      Ptr("search"),
+					Arguments: Ptr(`{"q":"x"}`),
+				},
+			},
+		},
+	}).ToBifrostChatResponse()
+
+	if chatResp == nil || len(chatResp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	if chatResp.Choices[0].FinishReason == nil {
+		t.Fatal("expected finish_reason to be set")
+	}
+	if got := *chatResp.Choices[0].FinishReason; got != string(BifrostFinishReasonToolCalls) {
+		t.Fatalf("expected finish_reason %q, got %q", BifrostFinishReasonToolCalls, got)
+	}
+}
+
+func TestToBifrostChatResponse_MapsIncompleteDetails(t *testing.T) {
+	cases := map[string]string{
+		ResponsesResponseIncompleteReasonMaxOutputTokens: string(BifrostFinishReasonLength),
+		ResponsesResponseIncompleteReasonContentFilter:   "content_filter",
+	}
+
+	for reason, expected := range cases {
+		t.Run(reason, func(t *testing.T) {
+			chatResp := (&BifrostResponsesResponse{
+				Status:            Ptr(ResponsesResponseStatusIncomplete),
+				IncompleteDetails: &ResponsesResponseIncompleteDetails{Reason: reason},
+				Output:            responsesTextOutput("partial"),
+			}).ToBifrostChatResponse()
+
+			if chatResp == nil || len(chatResp.Choices) == 0 {
+				t.Fatal("expected at least one choice")
+			}
+			if chatResp.Choices[0].FinishReason == nil {
+				t.Fatal("expected finish_reason to be set")
+			}
+			if got := *chatResp.Choices[0].FinishReason; got != expected {
+				t.Fatalf("expected finish_reason %q, got %q", expected, got)
+			}
+		})
+	}
+}
+
+func TestToBifrostChatResponse_PrefersExplicitStopReason(t *testing.T) {
+	// A recognized stop_reason wins over the status-derived reason.
+	chatResp := (&BifrostResponsesResponse{
+		Status:     Ptr(ResponsesResponseStatusCompleted),
+		StopReason: Ptr("guardrail_intervened"),
+		Output:     responsesTextOutput("blocked"),
+	}).ToBifrostChatResponse()
+
+	if chatResp == nil || len(chatResp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	if chatResp.Choices[0].FinishReason == nil || *chatResp.Choices[0].FinishReason != "guardrail_intervened" {
+		t.Fatalf("expected finish_reason %q, got %v", "guardrail_intervened", chatResp.Choices[0].FinishReason)
+	}
+}
+
+func TestToBifrostChatResponse_LeavesFinishReasonUnsetForNonTerminalState(t *testing.T) {
+	for _, status := range []string{ResponsesResponseStatusInProgress, ResponsesResponseStatusQueued} {
+		t.Run(status, func(t *testing.T) {
+			// The stop_reason is deliberately set and recognized: an in-flight status
+			// must outrank it, otherwise this test passes for the wrong reason.
+			chatResp := (&BifrostResponsesResponse{
+				Status:     Ptr(status),
+				StopReason: Ptr(string(BifrostFinishReasonStop)),
+				Output:     responsesTextOutput("partial"),
+			}).ToBifrostChatResponse()
+
+			if chatResp == nil || len(chatResp.Choices) == 0 {
+				t.Fatal("expected at least one choice")
+			}
+			if chatResp.Choices[0].FinishReason != nil {
+				t.Fatalf("expected finish_reason to be nil, got %q", *chatResp.Choices[0].FinishReason)
+			}
+		})
+	}
+}
+
+func TestResponsesStreamToBifrostChatResponse_MapsIncompleteContentFilter(t *testing.T) {
+	chunk := &BifrostResponsesStreamResponse{
+		Type: ResponsesStreamResponseTypeIncomplete,
+		Response: &BifrostResponsesResponse{
+			Status:            Ptr(ResponsesResponseStatusIncomplete),
+			IncompleteDetails: &ResponsesResponseIncompleteDetails{Reason: ResponsesResponseIncompleteReasonContentFilter},
+		},
+	}
+
+	resp := chunk.ToBifrostChatResponse()
+	if resp == nil || len(resp.Choices) == 0 {
+		t.Fatal("expected at least one choice")
+	}
+	if resp.Choices[0].FinishReason == nil || *resp.Choices[0].FinishReason != "content_filter" {
+		t.Fatalf("expected finish_reason %q, got %v", "content_filter", resp.Choices[0].FinishReason)
+	}
+}
+
+// Cohere never sets Status and Gemini sets it only on error, so a nil or "failed"
+// status must still resolve through stop_reason rather than falling through to unset.
+func TestToBifrostChatResponse_MapsStopReasonWithoutTerminalStatus(t *testing.T) {
+	cases := []struct {
+		name       string
+		status     *string
+		stopReason string
+		expected   string
+	}{
+		{"nil status (cohere)", nil, string(BifrostFinishReasonStop), string(BifrostFinishReasonStop)},
+		{"nil status tool calls", nil, string(BifrostFinishReasonToolCalls), string(BifrostFinishReasonToolCalls)},
+		{"failed status (gemini safety)", Ptr(ResponsesResponseStatusFailed), "content_filter", "content_filter"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			chatResp := (&BifrostResponsesResponse{
+				Status:     tc.status,
+				StopReason: Ptr(tc.stopReason),
+				Output:     responsesTextOutput("hi"),
+			}).ToBifrostChatResponse()
+
+			if chatResp == nil || len(chatResp.Choices) == 0 {
+				t.Fatal("expected at least one choice")
+			}
+			if chatResp.Choices[0].FinishReason == nil {
+				t.Fatal("expected finish_reason to be set")
+			}
+			if got := *chatResp.Choices[0].FinishReason; got != tc.expected {
+				t.Fatalf("expected finish_reason %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}
+
+// The Responses schema requires reasoning.summary to be an array. A nil slice marshals
+// to null, which upstreams reject with "Invalid 'input': value did not match any
+// expected variant" — breaking multi-turn tool loops that replay encrypted reasoning.
+func TestToResponsesMessages_EncryptedReasoningMarshalsSummaryAsArray(t *testing.T) {
+	encrypted := "rsn_abc123"
+	cm := &ChatMessage{
+		Role: ChatMessageRoleAssistant,
+		ChatAssistantMessage: &ChatAssistantMessage{
+			ReasoningDetails: []ChatReasoningDetails{
+				{Index: 0, Type: BifrostReasoningDetailsTypeEncrypted, Data: &encrypted},
+			},
+		},
+	}
+
+	out := cm.ToResponsesMessages()
+	if len(out) == 0 {
+		t.Fatal("expected a reasoning message")
+	}
+	if out[0].Type == nil || *out[0].Type != ResponsesMessageTypeReasoning {
+		t.Fatalf("expected a reasoning item, got %#v", out[0].Type)
+	}
+	if out[0].ResponsesReasoning == nil {
+		t.Fatal("expected reasoning payload to be set")
+	}
+	if out[0].ResponsesReasoning.Summary == nil {
+		t.Fatal("summary must be a non-nil slice so it marshals as [] rather than null")
+	}
+
+	encoded, err := json.Marshal(out[0])
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(encoded), `"summary":[]`) {
+		t.Fatalf(`expected "summary":[] in %s`, encoded)
+	}
+	if strings.Contains(string(encoded), `"summary":null`) {
+		t.Fatalf("summary must never marshal as null: %s", encoded)
+	}
 }

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1758,6 +1758,10 @@ const (
 	ResponsesOutputMessageContentTypeRefusal   ResponsesMessageContentBlockType = "refusal"
 	ResponsesOutputMessageContentTypeReasoning ResponsesMessageContentBlockType = "reasoning_text"
 
+	// Part type on response.reasoning_summary_part.{added,done}, where the event's
+	// part field is required.
+	ResponsesOutputMessageContentTypeSummaryText ResponsesMessageContentBlockType = "summary_text"
+
 	// gemini sends rendered content in google search results
 	ResponsesOutputMessageContentTypeRenderedContent ResponsesMessageContentBlockType = "rendered_content"
 


### PR DESCRIPTION
## Summary

`ToBifrostChatResponse` was not correctly deriving `finish_reason` when converting from Responses API format back to Chat format. Tool-call completions, content-filter truncations, explicit `stop_reason` values, and non-terminal statuses were either mapped incorrectly or left unset.

## Changes

- Introduced `chatFinishReasonFromResponses`, a dedicated helper that derives a Chat `finish_reason` from Responses API terminal state fields (`status`, `incompleteDetails`, `stopReason`, and `output`). Priority order: explicit `stop_reason` → `incomplete_details.reason` → status + output inspection.
- Updated `BifrostResponsesResponse.ToBifrostChatResponse` to use the new helper, ensuring `finish_reason` is set on each choice and left `nil` for non-terminal statuses (`in_progress`, `queued`).
- Updated `BifrostResponsesStreamResponse.ToBifrostChatResponse` to use the same helper for `completed`/`incomplete` stream events, replacing the previous inline tool-call detection logic. A fallback value is applied only when the helper returns `nil`.
- Added tests covering: `completed` → `stop`, function call output → `tool_calls`, `incomplete_details` reasons (`max_output_tokens` → `length`, `content_filter`), explicit `stop_reason` taking precedence, non-terminal statuses leaving `finish_reason` unset, and streaming incomplete with `content_filter`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... -run "TestToBifrostChatResponse|TestResponsesStreamToBifrostChatResponse"
```

Expected: all new and existing tests pass.

## Breaking changes

- [ ] Yes
- [x] No

Closes #6831

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable