### PR TITLE
fix: forced tool choice capability flag

### DIFF
--- a/core/providers/anthropic/capability_overrides_test.go
+++ b/core/providers/anthropic/capability_overrides_test.go
@@ -322,3 +322,119 @@ func TestWebFetchVersion_OverrideAbsent_FallbackTakesOver(t *testing.T) {
 	assert.Equal(t, AnthropicToolTypeWebFetch20260309, webFetchTypeFor(t, "claude-opus-4-6-20250514"))
 	assert.Equal(t, AnthropicToolTypeWebFetch20250910, webFetchTypeFor(t, "claude-haiku-4-5-20251001"))
 }
+
+// Forced tool choice: Claude Fable 5.1 and Mythos 5.1 removed it, so
+// tool_choice "any" and "tool" return a 400. Both converters drop a forced
+// choice instead, leaving the model on the default "auto". The Responses
+// converter is shared with the count_tokens path, which enforces the same
+// validation upstream.
+
+func forcedToolChoiceResponsesRequest(model string, tc *schemas.ResponsesToolChoice) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.Anthropic,
+		Model:    model,
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("What is the weather in Tokyo?")},
+		}},
+		Params: &schemas.ResponsesParameters{ToolChoice: tc},
+	}
+}
+
+func forcedToolChoiceChatRequest(model string, tc *schemas.ChatToolChoice) *schemas.BifrostChatRequest {
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.Anthropic,
+		Model:    model,
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("What is the weather in Tokyo?")},
+		}},
+		Params: &schemas.ChatParameters{ToolChoice: tc},
+	}
+}
+
+func TestForcedToolChoice_DroppedOnFable51(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+
+	for _, model := range []string{"claude-fable-5-1", "claude-mythos-5-1"} {
+		t.Run(model+" responses any", func(t *testing.T) {
+			req, err := ToAnthropicResponsesRequest(ctx, forcedToolChoiceResponsesRequest(model,
+				&schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")}))
+			require.NoError(t, err)
+			assert.Nil(t, req.ToolChoice, "forced tool choice must be dropped on %s", model)
+		})
+
+		t.Run(model+" responses named tool", func(t *testing.T) {
+			req, err := ToAnthropicResponsesRequest(ctx, forcedToolChoiceResponsesRequest(model,
+				&schemas.ResponsesToolChoice{ResponsesToolChoiceStruct: &schemas.ResponsesToolChoiceStruct{
+					Type: schemas.ResponsesToolChoiceTypeFunction, Name: schemas.Ptr("get_weather")}}))
+			require.NoError(t, err)
+			assert.Nil(t, req.ToolChoice, "forced tool pin must be dropped on %s", model)
+		})
+
+		t.Run(model+" chat required", func(t *testing.T) {
+			req, err := ToAnthropicChatRequest(ctx, forcedToolChoiceChatRequest(model,
+				&schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("required")}))
+			require.NoError(t, err)
+			assert.Nil(t, req.ToolChoice, "forced tool choice must be dropped on %s", model)
+		})
+	}
+
+	t.Run("auto survives", func(t *testing.T) {
+		req, err := ToAnthropicResponsesRequest(ctx, forcedToolChoiceResponsesRequest("claude-fable-5-1",
+			&schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("auto")}))
+		require.NoError(t, err)
+		require.NotNil(t, req.ToolChoice)
+		assert.Equal(t, "auto", req.ToolChoice.Type)
+	})
+
+	t.Run("none survives", func(t *testing.T) {
+		req, err := ToAnthropicResponsesRequest(ctx, forcedToolChoiceResponsesRequest("claude-fable-5-1",
+			&schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("none")}))
+		require.NoError(t, err)
+		require.NotNil(t, req.ToolChoice)
+		assert.Equal(t, "none", req.ToolChoice.Type)
+	})
+}
+
+func TestForcedToolChoice_KeptOnFable5(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+
+	// Fable 5 (and every earlier Claude) still supports forced tool use.
+	req, err := ToAnthropicResponsesRequest(ctx, forcedToolChoiceResponsesRequest("claude-fable-5",
+		&schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")}))
+	require.NoError(t, err)
+	require.NotNil(t, req.ToolChoice)
+	assert.Equal(t, "any", req.ToolChoice.Type)
+
+	req, err = ToAnthropicResponsesRequest(ctx, forcedToolChoiceResponsesRequest("claude-opus-5",
+		&schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("required")}))
+	require.NoError(t, err)
+	require.NotNil(t, req.ToolChoice)
+	assert.Equal(t, "any", req.ToolChoice.Type)
+}
+
+func TestForcedToolChoice_DatasheetOutranksFallback(t *testing.T) {
+	ctx := schemas.NewBifrostContext(nil, schemas.NoDeadline)
+
+	t.Run("row re-enables forced tool use on fable 5.1", func(t *testing.T) {
+		yes := true
+		setOverride(t, "claude-fable-5-1", schemas.ModelCapabilities{SupportsForcedToolChoice: &yes})
+
+		req, err := ToAnthropicResponsesRequest(ctx, forcedToolChoiceResponsesRequest("claude-fable-5-1",
+			&schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")}))
+		require.NoError(t, err)
+		require.NotNil(t, req.ToolChoice)
+		assert.Equal(t, "any", req.ToolChoice.Type)
+	})
+
+	t.Run("row disables forced tool use on a model the fallback allows", func(t *testing.T) {
+		no := false
+		setOverride(t, "claude-opus-5", schemas.ModelCapabilities{SupportsForcedToolChoice: &no})
+
+		req, err := ToAnthropicResponsesRequest(ctx, forcedToolChoiceResponsesRequest("claude-opus-5",
+			&schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")}))
+		require.NoError(t, err)
+		assert.Nil(t, req.ToolChoice)
+	})
+}

--- a/core/providers/anthropic/chat.go
+++ b/core/providers/anthropic/chat.go
@@ -353,6 +353,10 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 	// capModel is the canonical model string used only for capability/version
 	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
 	caps := schemas.ResolveModelCaps(bifrostReq.Provider, capModel)
+	// Fable 5.1+ rejects tool_choice "any"/"tool" outright, so every forced
+	// choice below — the caller's and the synthetic structured-output pin — is
+	// dropped and the model answers under the default "auto".
+	forcedToolChoiceSupported := caps.SupportsForcedToolChoice(schemas.DefaultSupportsForcedToolChoice(capModel))
 
 	// Convert parameters
 	if bifrostReq.Params != nil {
@@ -590,7 +594,7 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 						(reasoningParams.MaxTokens != nil ||
 							(reasoningParams.Effort != nil && *reasoningParams.Effort != "none"))) ||
 						promotedThinking != nil
-					if !thinkingEnabled {
+					if !thinkingEnabled && forcedToolChoiceSupported {
 						anthropicReq.ToolChoice = &AnthropicToolChoice{
 							Type: "tool",
 							Name: responseFormatTool.Name,
@@ -642,8 +646,10 @@ func ToAnthropicChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bif
 			}
 		}
 
+		forcedToolChoiceRejected := !forcedToolChoiceSupported && bifrostReq.Params.ToolChoice.IsForced()
+
 		// Convert tool choice
-		if bifrostReq.Params.ToolChoice != nil {
+		if bifrostReq.Params.ToolChoice != nil && !forcedToolChoiceRejected {
 			toolChoice := &AnthropicToolChoice{}
 			if bifrostReq.Params.ToolChoice.ChatToolChoiceStr != nil {
 				switch schemas.ChatToolChoiceType(*bifrostReq.Params.ToolChoice.ChatToolChoiceStr) {

--- a/core/providers/anthropic/chat_test.go
+++ b/core/providers/anthropic/chat_test.go
@@ -1376,6 +1376,50 @@ func TestToAnthropicChatRequest_StructuredOutput_ToolConversion_NoThinking(t *te
 	}
 }
 
+// TestToAnthropicChatRequest_StructuredOutput_Fable51_NoForcedToolChoice mirrors the
+// thinking-enabled case for Fable 5.1 / Mythos 5.1: the synthetic tool is still
+// added, but the pin is not, because those models reject tool_choice "tool" and
+// "any" with a 400. With only the bf_so_* tool bound the model reaches it under
+// the default "auto".
+func TestToAnthropicChatRequest_StructuredOutput_Fable51_NoForcedToolChoice(t *testing.T) {
+	for _, provider := range toolConversionProviders {
+		for _, model := range []string{"claude-fable-5-1", "claude-mythos-5-1"} {
+			t.Run(string(provider)+"/"+model, func(t *testing.T) {
+				rf := makeSOResponseFormat("my_schema")
+				bifrostReq := &schemas.BifrostChatRequest{
+					Provider: provider,
+					Model:    model,
+					Input: []schemas.ChatMessage{
+						{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")}},
+					},
+					Params: &schemas.ChatParameters{ResponseFormat: &rf},
+				}
+
+				ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+				defer cancel()
+				result, err := ToAnthropicChatRequest(ctx, bifrostReq)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				var soTool *AnthropicTool
+				for i := range result.Tools {
+					if strings.HasPrefix(result.Tools[i].Name, "bf_so_") {
+						soTool = &result.Tools[i]
+						break
+					}
+				}
+				if soTool == nil {
+					t.Fatalf("expected the synthetic bf_so_* tool to still be added for %s/%s", provider, model)
+				}
+				if result.ToolChoice != nil {
+					t.Errorf("expected no forced ToolChoice for %s/%s, got %+v", provider, model, result.ToolChoice)
+				}
+			})
+		}
+	}
+}
+
 // TestToAnthropicChatRequest_StructuredOutput_ToolConversion_ThinkingEffort verifies that when
 // response_format=json_schema + reasoning_effort='medium' is sent to a tool-conversion provider,
 // Bifrost still adds the synthetic tool but does NOT set tool_choice (to avoid Anthropic's

--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -4225,6 +4225,10 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 	// lookups; the wire Model below stays exactly as the caller sent it.
 	capModel := schemas.ResolveCanonicalModel(ctx, bifrostReq.Model)
 	caps := schemas.ResolveModelCaps(bifrostReq.Provider, capModel)
+	// Fable 5.1+ rejects tool_choice "any"/"tool" outright, so every forced
+	// choice below — the caller's and the synthetic structured-output pin — is
+	// dropped and the model answers under the default "auto".
+	forcedToolChoiceSupported := caps.SupportsForcedToolChoice(schemas.DefaultSupportsForcedToolChoice(capModel))
 
 	anthropicReq := &AnthropicMessageRequest{
 		Model:     bifrostReq.Model,
@@ -4269,7 +4273,7 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 						thinkingEnabled := bifrostReq.Params.Reasoning != nil &&
 							(bifrostReq.Params.Reasoning.MaxTokens != nil ||
 								(bifrostReq.Params.Reasoning.Effort != nil && *bifrostReq.Params.Reasoning.Effort != "none"))
-						if !thinkingEnabled {
+						if !thinkingEnabled && forcedToolChoiceSupported {
 							anthropicReq.ToolChoice = &AnthropicToolChoice{
 								Type: "tool",
 								Name: responseFormatTool.Name,
@@ -4585,8 +4589,10 @@ func ToAnthropicResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schema
 			}
 		}
 
+		forcedToolChoiceRejected := !forcedToolChoiceSupported && bifrostReq.Params.ToolChoice.IsForced()
+
 		// Convert tool choice
-		if bifrostReq.Params.ToolChoice != nil {
+		if bifrostReq.Params.ToolChoice != nil && !forcedToolChoiceRejected {
 			anthropicToolChoice := convertResponsesToolChoiceToAnthropic(bifrostReq.Params.ToolChoice)
 			if anthropicToolChoice != nil {
 				anthropicReq.ToolChoice = anthropicToolChoice

--- a/core/providers/anthropic/responses_test.go
+++ b/core/providers/anthropic/responses_test.go
@@ -79,6 +79,51 @@ func TestToAnthropicResponsesRequest_StructuredOutput_ToolConversion(t *testing.
 	}
 }
 
+// TestToAnthropicResponsesRequest_StructuredOutput_Fable51_NoForcedToolChoice is the
+// Fable 5.1 counterpart: the synthetic tool is still added, but the pin is not,
+// because Fable 5.1 / Mythos 5.1 reject tool_choice "tool" and "any" with a 400.
+// The model reaches the tool under the default "auto" — with only the bf_so_*
+// tool bound there is nothing else it can call.
+func TestToAnthropicResponsesRequest_StructuredOutput_Fable51_NoForcedToolChoice(t *testing.T) {
+	for _, provider := range toolConversionProviders {
+		for _, model := range []string{"claude-fable-5-1", "claude-mythos-5-1"} {
+			t.Run(string(provider)+"/"+model, func(t *testing.T) {
+				req := &schemas.BifrostResponsesRequest{
+					Provider: provider,
+					Model:    model,
+					Input: []schemas.ResponsesMessage{
+						{
+							Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+							Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("Hello")},
+						},
+					},
+					Params: &schemas.ResponsesParameters{Text: makeResponsesTextFormat("my_schema")},
+				}
+
+				ctx := schemas.NewBifrostContext(nil, time.Time{})
+				result, err := ToAnthropicResponsesRequest(ctx, req)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+
+				found := false
+				for _, tool := range result.Tools {
+					if tool.Name == "bf_so_my_schema" {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected the synthetic tool to still be added for %s/%s", provider, model)
+				}
+				if result.ToolChoice != nil {
+					t.Errorf("expected no forced ToolChoice for %s/%s, got %+v", provider, model, result.ToolChoice)
+				}
+			})
+		}
+	}
+}
+
 // TestToAnthropicResponsesRequest_StructuredOutput_NativeOutputConfig_Anthropic is the
 // negative-case control: Anthropic itself supports output_config.format natively, so no
 // synthetic tool should be added. This is the branch that Azure incorrectly took before

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2724,6 +2724,12 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 			!caps.ToolChoiceStructSupported(!schemas.IsLlamaModelFamily(ctx, bifrostReq.Model)) {
 			bedrockToolChoice = nil
 		}
+		// Fable 5.1+ rejects forced tool use outright; drop both spellings so
+		// the model answers under Converse's default "auto".
+		if bedrockToolChoice != nil && (bedrockToolChoice.Any != nil || bedrockToolChoice.Tool != nil) &&
+			!caps.SupportsForcedToolChoice(schemas.DefaultSupportsForcedToolChoice(caps.Model())) {
+			bedrockToolChoice = nil
+		}
 		// Only attach tool_choice when tools are actually present. Bedrock
 		// Converse rejects a toolConfig that carries a toolChoice with an empty
 		// tools list (e.g. the requested tools were all filtered/skipped, like
@@ -2752,7 +2758,10 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 		thinkingEnabled := bifrostReq.Params.Reasoning != nil &&
 			(bifrostReq.Params.Reasoning.MaxTokens != nil ||
 				(bifrostReq.Params.Reasoning.Effort != nil && *bifrostReq.Params.Reasoning.Effort != "none"))
-		if !caps.SyntheticSOToolChoiceOmitted(schemas.IsLlamaModelFamily(ctx, bifrostReq.Model)) && !thinkingEnabled {
+		// Fable 5.1+ rejects a forced tool_choice outright, so the synthetic tool
+		// is left unpinned there too and reached under Converse's default "auto".
+		if !caps.SyntheticSOToolChoiceOmitted(schemas.IsLlamaModelFamily(ctx, bifrostReq.Model)) && !thinkingEnabled &&
+			caps.SupportsForcedToolChoice(schemas.DefaultSupportsForcedToolChoice(caps.Model())) {
 			bedrockReq.ToolConfig.ToolChoice = &BedrockToolChoice{
 				Tool: &BedrockToolChoiceTool{
 					Name: responsesStructuredOutputTool.ToolSpec.Name,

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -632,7 +632,10 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 		thinkingEnabled := bifrostReq.Params.Reasoning != nil &&
 			(bifrostReq.Params.Reasoning.MaxTokens != nil ||
 				(bifrostReq.Params.Reasoning.Effort != nil && *bifrostReq.Params.Reasoning.Effort != "none"))
-		if !caps.SyntheticSOToolChoiceOmitted(schemas.IsLlamaModelFamily(ctx, bifrostReq.Model)) && !thinkingEnabled {
+		// Fable 5.1+ rejects a forced tool_choice outright, so the synthetic tool
+		// is left unpinned there too and reached under Converse's default "auto".
+		if !caps.SyntheticSOToolChoiceOmitted(schemas.IsLlamaModelFamily(ctx, bifrostReq.Model)) && !thinkingEnabled &&
+			caps.SupportsForcedToolChoice(schemas.DefaultSupportsForcedToolChoice(caps.Model())) {
 			bedrockReq.ToolConfig.ToolChoice = &BedrockToolChoice{
 				Tool: &BedrockToolChoiceTool{
 					Name: responseFormatTool.ToolSpec.Name,
@@ -2333,6 +2336,12 @@ func convertToolConfigFromFiltered(ctx *schemas.BifrostContext, model string, ca
 			// (mirrors the synthetic-tool gate in convertChatParameters).
 			if toolChoice != nil && toolChoice.Tool != nil &&
 				!caps.ToolChoiceStructSupported(!schemas.IsLlamaModelFamily(ctx, model)) {
+				toolChoice = nil
+			}
+			// Fable 5.1+ rejects forced tool use outright; drop both spellings so
+			// the model answers under Converse's default "auto".
+			if toolChoice != nil && (toolChoice.Any != nil || toolChoice.Tool != nil) &&
+				!caps.SupportsForcedToolChoice(schemas.DefaultSupportsForcedToolChoice(caps.Model())) {
 				toolChoice = nil
 			}
 			if toolChoice != nil {

--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -48,6 +48,12 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		}
 		// Drop user field if it exceeds OpenAI's 64 character limit
 		openaiReq.ChatParameters.User = SanitizeUserField(openaiReq.ChatParameters.User)
+		// Fable 5.1+ rejects forced tool use outright. Drop the choice so the model
+		// answers under the default "auto" rather than the provider returning a 400.
+		if openaiReq.ChatParameters.ToolChoice.IsForced() &&
+			!caps.SupportsForcedToolChoice(schemas.DefaultSupportsForcedToolChoice(capModel)) {
+			openaiReq.ChatParameters.ToolChoice = nil
+		}
 		// The Anthropic integration emits the provider-generic forced tool choice "any".
 		// OpenAI accepts only "none", "auto" and "required" as string tool choices and
 		// rejects "any" with HTTP 400, so map it to "required" on a copy of the choice
@@ -55,7 +61,7 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		// natively keep it.
 		if tc := openaiReq.ChatParameters.ToolChoice; tc != nil && tc.ChatToolChoiceStr != nil &&
 			*tc.ChatToolChoiceStr == string(schemas.ChatToolChoiceTypeAny) &&
-			!toolChoiceAnySupported(bifrostReq.Provider, bifrostReq.Model) {
+			!caps.ToolChoiceAnySupported(toolChoiceAnySupported(bifrostReq.Provider, capModel)) {
 			openaiReq.ChatParameters.ToolChoice = &schemas.ChatToolChoice{
 				ChatToolChoiceStr: schemas.Ptr(string(schemas.ChatToolChoiceTypeRequired)),
 			}

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -513,6 +513,12 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 		}
 		// Drop user field if it exceeds OpenAI's 64 character limit
 		req.ResponsesParameters.User = SanitizeUserField(req.ResponsesParameters.User)
+		// Fable 5.1+ rejects forced tool use outright. Drop the choice so the model
+		// answers under the default "auto" rather than the provider returning a 400.
+		if req.ResponsesParameters.ToolChoice.IsForced() &&
+			!caps.SupportsForcedToolChoice(schemas.DefaultSupportsForcedToolChoice(capModel)) {
+			req.ResponsesParameters.ToolChoice = nil
+		}
 		// The Anthropic integration emits the provider-generic forced tool choice "any".
 		// OpenAI accepts only "none", "auto" and "required" as string tool choices and
 		// rejects "any" with HTTP 400, so map it to "required" on a copy of the choice
@@ -520,7 +526,7 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 		// natively keep it.
 		if tc := req.ResponsesParameters.ToolChoice; tc != nil && tc.ResponsesToolChoiceStr != nil &&
 			*tc.ResponsesToolChoiceStr == string(schemas.ResponsesToolChoiceTypeAny) &&
-			!toolChoiceAnySupported(bifrostReq.Provider, bifrostReq.Model) {
+			!caps.ToolChoiceAnySupported(toolChoiceAnySupported(bifrostReq.Provider, capModel)) {
 			req.ResponsesParameters.ToolChoice = &schemas.ResponsesToolChoice{
 				ResponsesToolChoiceStr: schemas.Ptr(string(schemas.ResponsesToolChoiceTypeRequired)),
 			}

--- a/core/providers/openai/toolchoiceany_test.go
+++ b/core/providers/openai/toolchoiceany_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/bytedance/sonic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -114,6 +115,13 @@ func TestToOpenAIResponsesRequest_ToolChoiceAnyBecomesRequired(t *testing.T) {
 			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
 			wantJSON:   `"any"`,
 		},
+		{
+			name:       "Fireworks keeps any",
+			provider:   schemas.Fireworks,
+			model:      "accounts/fireworks/models/kimi-k2-instruct",
+			toolChoice: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"any"`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -214,6 +222,13 @@ func TestToOpenAIChatRequest_ToolChoiceAnyBecomesRequired(t *testing.T) {
 			wantJSON:   `"any"`,
 		},
 		{
+			name:       "Fireworks keeps any",
+			provider:   schemas.Fireworks,
+			model:      "accounts/fireworks/models/kimi-k2-instruct",
+			toolChoice: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
+			wantJSON:   `"any"`,
+		},
+		{
 			name:       "non-Mistral model on Vertex is mapped to required",
 			provider:   schemas.Vertex,
 			model:      "moonshotai/kimi-k2-thinking-maas",
@@ -254,4 +269,116 @@ func TestToOpenAIChatRequest_ToolChoiceAnyDoesNotMutateInput(t *testing.T) {
 	if bifrostReq.Params.ToolChoice != toolChoice {
 		t.Fatal("caller's tool_choice pointer was replaced")
 	}
+}
+
+// setToolChoiceCaps installs a resolver answering for one (provider, model)
+// pair, so the converter takes its datasheet branch rather than the name-based
+// fallback in toolChoiceAnySupported / DefaultSupportsForcedToolChoice.
+func setToolChoiceCaps(t *testing.T, provider schemas.ModelProvider, model string, ov schemas.ModelCapabilities) {
+	t.Helper()
+	providerUtils.SetCapabilityResolver(func(p schemas.ModelProvider, m string) *schemas.ModelCapabilities {
+		if p == provider && m == model {
+			return &ov
+		}
+		return nil
+	})
+	t.Cleanup(func() { providerUtils.SetCapabilityResolver(nil) })
+}
+
+// TestToolChoiceAny_DatasheetOutranksFallback verifies the datasheet answers
+// first in both directions: a row can keep "any" on a provider whose fallback
+// would rewrite it, and rewrite it on one whose fallback would keep it.
+func TestToolChoiceAny_DatasheetOutranksFallback(t *testing.T) {
+	t.Run("row keeps any where the fallback would rewrite", func(t *testing.T) {
+		yes := true
+		setToolChoiceCaps(t, schemas.OpenAI, "gpt-4o", schemas.ModelCapabilities{ToolChoiceAnySupported: &yes})
+
+		result := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline),
+			chatToolChoiceRequest(schemas.OpenAI, "gpt-4o", &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")}))
+		if got := marshalToolChoice(t, result.ToolChoice); got != `"any"` {
+			t.Fatalf("tool_choice on the wire = %s, want \"any\"", got)
+		}
+	})
+
+	t.Run("row rewrites any where the fallback would keep it", func(t *testing.T) {
+		no := false
+		setToolChoiceCaps(t, schemas.Mistral, "mistral-large-latest", schemas.ModelCapabilities{ToolChoiceAnySupported: &no})
+
+		result := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline),
+			chatToolChoiceRequest(schemas.Mistral, "mistral-large-latest", &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")}))
+		if got := marshalToolChoice(t, result.ToolChoice); got != `"required"` {
+			t.Fatalf("tool_choice on the wire = %s, want \"required\"", got)
+		}
+	})
+}
+
+// TestForcedToolChoiceDroppedForFable51 covers Claude Fable 5.1 reached over an
+// OpenAI-compatible surface (Databricks, Bedrock Mantle): forced tool use
+// returns a 400 there, so the choice is dropped and the model answers under
+// the default "auto". Fable 5 still supports it and is untouched.
+func TestForcedToolChoiceDroppedForFable51(t *testing.T) {
+	forced := []struct {
+		name string
+		chat *schemas.ChatToolChoice
+		resp *schemas.ResponsesToolChoice
+	}{
+		{
+			name: "required",
+			chat: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("required")},
+			resp: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("required")},
+		},
+		{
+			name: "any",
+			chat: &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("any")},
+			resp: &schemas.ResponsesToolChoice{ResponsesToolChoiceStr: schemas.Ptr("any")},
+		},
+		{
+			name: "named function",
+			chat: &schemas.ChatToolChoice{ChatToolChoiceStruct: &schemas.ChatToolChoiceStruct{
+				Type: schemas.ChatToolChoiceTypeFunction, Function: &schemas.ChatToolChoiceFunction{Name: "get_weather"}}},
+			resp: &schemas.ResponsesToolChoice{ResponsesToolChoiceStruct: &schemas.ResponsesToolChoiceStruct{
+				Type: schemas.ResponsesToolChoiceTypeFunction, Name: schemas.Ptr("get_weather")}},
+		},
+	}
+
+	for _, tt := range forced {
+		t.Run("fable-5-1 drops "+tt.name, func(t *testing.T) {
+			chat := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline),
+				chatToolChoiceRequest(schemas.Databricks, "claude-fable-5-1", tt.chat))
+			if chat.ToolChoice != nil {
+				t.Errorf("chat tool_choice = %s, want it dropped", marshalToolChoice(t, chat.ToolChoice))
+			}
+			resp := ToOpenAIResponsesRequest(nil, responsesToolChoiceRequest(schemas.Databricks, "claude-fable-5-1", tt.resp))
+			if resp.ToolChoice != nil {
+				t.Errorf("responses tool_choice = %s, want it dropped", marshalToolChoice(t, resp.ToolChoice))
+			}
+		})
+
+		t.Run("fable-5 keeps "+tt.name, func(t *testing.T) {
+			chat := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline),
+				chatToolChoiceRequest(schemas.Databricks, "claude-fable-5", tt.chat))
+			if chat.ToolChoice == nil {
+				t.Error("chat tool_choice was dropped for fable-5, which supports forced tool use")
+			}
+		})
+	}
+
+	t.Run("auto survives on fable-5-1", func(t *testing.T) {
+		chat := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline),
+			chatToolChoiceRequest(schemas.Databricks, "claude-fable-5-1", &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("auto")}))
+		if got := marshalToolChoice(t, chat.ToolChoice); got != `"auto"` {
+			t.Fatalf("tool_choice on the wire = %s, want \"auto\"", got)
+		}
+	})
+
+	t.Run("datasheet can re-enable forced tool use", func(t *testing.T) {
+		yes := true
+		setToolChoiceCaps(t, schemas.Databricks, "claude-fable-5-1", schemas.ModelCapabilities{SupportsForcedToolChoice: &yes})
+
+		chat := ToOpenAIChatRequest(schemas.NewBifrostContext(nil, schemas.NoDeadline),
+			chatToolChoiceRequest(schemas.Databricks, "claude-fable-5-1", &schemas.ChatToolChoice{ChatToolChoiceStr: schemas.Ptr("required")}))
+		if got := marshalToolChoice(t, chat.ToolChoice); got != `"required"` {
+			t.Fatalf("tool_choice on the wire = %s, want \"required\"", got)
+		}
+	})
 }

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -248,13 +248,15 @@ func SanitizeUserField(user *string) *string {
 	return user
 }
 
-// toolChoiceAnySupported reports whether the target accepts the provider-generic
-// forced tool choice "any" on the wire. Mistral's API accepts "any" natively,
-// including Mistral models served through Vertex, so the OpenAI-only rewrite of
-// "any" to "required" must not run for those destinations.
+// toolChoiceAnySupported is the name-based fallback for
+// ModelCaps.ToolChoiceAnySupported, used when the datasheet says nothing. It
+// reports whether the target accepts the provider-generic forced tool choice
+// "any" on the wire. Mistral accepts it natively (including Mistral models
+// served through Vertex), and Fireworks documents it with "required" as an
+// alias; every other OpenAI-compatible destination rejects it with a 400.
 func toolChoiceAnySupported(provider schemas.ModelProvider, model string) bool {
 	switch provider {
-	case schemas.Mistral:
+	case schemas.Mistral, schemas.Fireworks:
 		return true
 	case schemas.Vertex:
 		return schemas.IsMistralModel(model)

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -989,6 +989,38 @@ type ChatToolChoice struct {
 	ChatToolChoiceStruct *ChatToolChoiceStruct
 }
 
+// IsForced reports whether the choice obliges the model to call a tool, in any
+// of its spellings — "any"/"required", a named function or custom tool, a
+// pinned server tool, or an allowed-tools set in "required" mode. Only "none"
+// and "auto" are unforced. Models that reject forced tool use (Fable 5.1+)
+// need the choice dropped; see ModelCaps.SupportsForcedToolChoice.
+func (ctc *ChatToolChoice) IsForced() bool {
+	if ctc == nil {
+		return false
+	}
+	if ctc.ChatToolChoiceStr != nil {
+		switch ChatToolChoiceType(*ctc.ChatToolChoiceStr) {
+		case ChatToolChoiceTypeNone, ChatToolChoiceTypeAuto:
+			return false
+		default:
+			return true
+		}
+	}
+	if ctc.ChatToolChoiceStruct != nil {
+		switch ctc.ChatToolChoiceStruct.Type {
+		case ChatToolChoiceTypeNone, ChatToolChoiceTypeAuto:
+			return false
+		case ChatToolChoiceTypeAllowedTools:
+			// The set is a constraint, not a forcing; only its mode forces.
+			return ctc.ChatToolChoiceStruct.AllowedTools != nil &&
+				ctc.ChatToolChoiceStruct.AllowedTools.Mode == string(ChatToolChoiceTypeRequired)
+		default:
+			return true
+		}
+	}
+	return false
+}
+
 // MarshalJSON implements custom JSON marshalling for ChatMessageContent.
 // It marshals either ContentStr or ContentBlocks directly without wrapping.
 func (ctc ChatToolChoice) MarshalJSON() ([]byte, error) {

--- a/core/schemas/modelcapabilities.go
+++ b/core/schemas/modelcapabilities.go
@@ -56,6 +56,7 @@ type ModelCapabilities struct {
 	SupportsReasoningContentBlocks  *bool `json:"supports_reasoning_content_blocks,omitempty"`
 	SupportsMultimodalToolOutput    *bool `json:"supports_multimodal_tool_output,omitempty"`
 	SupportsResponseSchemaWithTools *bool `json:"supports_response_schema_with_tools,omitempty"`
+	SupportsForcedToolChoice        *bool `json:"supports_forced_tool_choice,omitempty"` // false ⇒ tool_choice any/tool rejected (Fable 5.1+)
 
 	// Baseline request-surface flags. These drive the compat plugin's
 	// parameter allowlist rather than provider request shaping, so they are
@@ -223,6 +224,10 @@ type ModelCapabilities struct {
 	// Mistral: tool_choice struct form not supported, must collapse to "any" string.
 	// Mirrors UnsupportedFields["tool_choice_struct"].
 	ToolChoiceStructSupported *bool `json:"tool_choice_struct_supported,omitempty"`
+
+	// Endpoint accepts the forced tool choice "any" on the wire (Mistral,
+	// Fireworks). False ⇒ it must be spelled "required" instead.
+	ToolChoiceAnySupported *bool `json:"tool_choice_any_supported,omitempty"`
 
 	// Fireworks: keep `prediction` field through the openai-compat filter.
 	PreservesPrediction *bool `json:"preserves_prediction,omitempty"`

--- a/core/schemas/modelcaps.go
+++ b/core/schemas/modelcaps.go
@@ -297,6 +297,25 @@ func (c ModelCaps) ToolChoiceStructSupported(fallback bool) bool {
 	return fallback
 }
 
+// ToolChoiceAnySupported reports whether the endpoint accepts the forced tool
+// choice "any" on the wire. Providers without it need it spelled "required".
+func (c ModelCaps) ToolChoiceAnySupported(fallback bool) bool {
+	if c.record != nil && c.record.ToolChoiceAnySupported != nil {
+		return *c.record.ToolChoiceAnySupported
+	}
+	return fallback
+}
+
+// SupportsForcedToolChoice reports whether the model accepts a forced tool
+// choice at all — Anthropic "any"/"tool", OpenAI "required"/named function.
+// Models without it need the choice dropped so they answer under "auto".
+func (c ModelCaps) SupportsForcedToolChoice(fallback bool) bool {
+	if c.record != nil && c.record.SupportsForcedToolChoice != nil {
+		return *c.record.SupportsForcedToolChoice
+	}
+	return fallback
+}
+
 // SyntheticSOToolChoiceOmitted reports whether the synthetic structured-output
 // tool must be left unpinned, letting the model reach it under "auto" instead.
 func (c ModelCaps) SyntheticSOToolChoiceOmitted(fallback bool) bool {

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -2583,6 +2583,45 @@ type ResponsesToolChoice struct {
 	ResponsesToolChoiceStruct *ResponsesToolChoiceStruct
 }
 
+// IsForced reports whether the choice obliges the model to call a tool, in any
+// of its spellings — "any"/"required", a named function or custom tool, a
+// pinned server tool, or an allowed-tools set in "required" mode. Only "none"
+// and "auto" are unforced. Models that reject forced tool use (Fable 5.1+)
+// need the choice dropped; see ModelCaps.SupportsForcedToolChoice.
+func (tc *ResponsesToolChoice) IsForced() bool {
+	if tc == nil {
+		return false
+	}
+	if tc.ResponsesToolChoiceStr != nil {
+		return forcedResponsesToolChoiceMode(*tc.ResponsesToolChoiceStr)
+	}
+	if s := tc.ResponsesToolChoiceStruct; s != nil {
+		switch s.Type {
+		case ResponsesToolChoiceTypeNone, ResponsesToolChoiceTypeAuto:
+			return false
+		case ResponsesToolChoiceTypeAllowedTools:
+			// The set is a constraint, not a forcing; only its mode forces.
+			return s.Mode != nil && forcedResponsesToolChoiceMode(*s.Mode)
+		case "":
+			// Mode-only choice; it serializes as the bare mode string.
+			return s.Mode != nil && forcedResponsesToolChoiceMode(*s.Mode)
+		default:
+			return true
+		}
+	}
+	return false
+}
+
+// forcedResponsesToolChoiceMode reports whether a bare mode string forces a call.
+func forcedResponsesToolChoiceMode(mode string) bool {
+	switch ResponsesToolChoiceType(mode) {
+	case ResponsesToolChoiceTypeNone, ResponsesToolChoiceTypeAuto:
+		return false
+	default:
+		return true
+	}
+}
+
 // MarshalJSON implements custom JSON marshalling for ChatMessageContent.
 // It marshals either ContentStr or ContentBlocks directly without wrapping.
 func (tc ResponsesToolChoice) MarshalJSON() ([]byte, error) {

--- a/core/schemas/toolchoicemarshal_test.go
+++ b/core/schemas/toolchoicemarshal_test.go
@@ -90,3 +90,63 @@ func TestResponsesToolChoice_StringFormUnchanged(t *testing.T) {
 	require.NoError(t, err)
 	assert.JSONEq(t, `"auto"`, string(got))
 }
+
+// IsForced drives the Fable 5.1+ gate that drops a forced tool choice rather
+// than letting the provider reject it. Only "none" and "auto" are unforced;
+// an allowed-tools set is a constraint, so only its mode forces.
+
+func TestChatToolChoice_IsForced(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		choice *ChatToolChoice
+		want   bool
+	}{
+		{"nil", nil, false},
+		{"empty", &ChatToolChoice{}, false},
+		{"str auto", &ChatToolChoice{ChatToolChoiceStr: Ptr("auto")}, false},
+		{"str none", &ChatToolChoice{ChatToolChoiceStr: Ptr("none")}, false},
+		{"str any", &ChatToolChoice{ChatToolChoiceStr: Ptr("any")}, true},
+		{"str required", &ChatToolChoice{ChatToolChoiceStr: Ptr("required")}, true},
+		{"struct auto", &ChatToolChoice{ChatToolChoiceStruct: &ChatToolChoiceStruct{Type: ChatToolChoiceTypeAuto}}, false},
+		{"struct any", &ChatToolChoice{ChatToolChoiceStruct: &ChatToolChoiceStruct{Type: ChatToolChoiceTypeAny}}, true},
+		{"struct function", &ChatToolChoice{ChatToolChoiceStruct: &ChatToolChoiceStruct{
+			Type: ChatToolChoiceTypeFunction, Function: &ChatToolChoiceFunction{Name: "get_weather"}}}, true},
+		{"allowed_tools auto mode", &ChatToolChoice{ChatToolChoiceStruct: &ChatToolChoiceStruct{
+			Type: ChatToolChoiceTypeAllowedTools, AllowedTools: &ChatToolChoiceAllowedTools{Mode: "auto"}}}, false},
+		{"allowed_tools required mode", &ChatToolChoice{ChatToolChoiceStruct: &ChatToolChoiceStruct{
+			Type: ChatToolChoiceTypeAllowedTools, AllowedTools: &ChatToolChoiceAllowedTools{Mode: "required"}}}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.choice.IsForced())
+		})
+	}
+}
+
+func TestResponsesToolChoice_IsForced(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		choice *ResponsesToolChoice
+		want   bool
+	}{
+		{"nil", nil, false},
+		{"empty", &ResponsesToolChoice{}, false},
+		{"str auto", &ResponsesToolChoice{ResponsesToolChoiceStr: Ptr("auto")}, false},
+		{"str none", &ResponsesToolChoice{ResponsesToolChoiceStr: Ptr("none")}, false},
+		{"str any", &ResponsesToolChoice{ResponsesToolChoiceStr: Ptr("any")}, true},
+		{"str required", &ResponsesToolChoice{ResponsesToolChoiceStr: Ptr("required")}, true},
+		{"struct auto", &ResponsesToolChoice{ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{Type: ResponsesToolChoiceTypeAuto}}, false},
+		{"struct any", &ResponsesToolChoice{ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{Type: ResponsesToolChoiceTypeAny}}, true},
+		{"struct function", &ResponsesToolChoice{ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{
+			Type: ResponsesToolChoiceTypeFunction, Name: Ptr("get_weather")}}, true},
+		{"mode-only auto", &ResponsesToolChoice{ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{Mode: Ptr("auto")}}, false},
+		{"mode-only required", &ResponsesToolChoice{ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{Mode: Ptr("required")}}, true},
+		{"allowed_tools auto mode", &ResponsesToolChoice{ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{
+			Type: ResponsesToolChoiceTypeAllowedTools, Mode: Ptr("auto")}}, false},
+		{"allowed_tools required mode", &ResponsesToolChoice{ResponsesToolChoiceStruct: &ResponsesToolChoiceStruct{
+			Type: ResponsesToolChoiceTypeAllowedTools, Mode: Ptr("required")}}, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.choice.IsForced())
+		})
+	}
+}

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1862,6 +1862,29 @@ func IsMistralModel(model string) bool {
 	return strings.Contains(model, "mistral") || strings.Contains(model, "codestral")
 }
 
+// IsFable51 checks if the model is Claude Fable 5.1 or Claude Mythos 5.1, which
+// removed forced tool use: tool_choice "any" and "tool" (and their OpenAI
+// spellings) return a 400. Matches the Bedrock/Vertex/date-suffixed forms.
+//
+// Only the versions known to have dropped it are matched here; a later model
+// that also drops it is carried by the datasheet's supports_forced_tool_choice
+// rather than this fallback.
+//
+// Source: https://platform.claude.com/docs/en/models/fable-5-1/whats-new-fable-5-1
+func IsFable51(model string) bool {
+	m := strings.ToLower(model)
+	if !strings.Contains(m, "fable") && !strings.Contains(m, "mythos") {
+		return false
+	}
+	return strings.Contains(m, "5-1") || strings.Contains(m, "5.1")
+}
+
+// DefaultSupportsForcedToolChoice is the name-based fallback for
+// ModelCaps.SupportsForcedToolChoice, used when the datasheet says nothing.
+func DefaultSupportsForcedToolChoice(model string) bool {
+	return !IsFable51(model)
+}
+
 // IsLlamaModel checks if the model is a Meta Llama model.
 //
 // Used by the Bedrock provider to gate tool_choice handling: Bedrock Converse

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -144430,6 +144430,529 @@
           "description": "Every case above enters through the route that matches its target's own dialect. These cross it: an OpenAI-shaped request routed to Anthropic or Bedrock, and an Anthropic-shaped one routed to gpt-5.6.\n\nThe invariant is where injection lives. It runs at dispatch, on the neutral request, after the inbound dialect has already been parsed away and before the outbound one is written - so the marker's SPELLING must follow the target and its POSITION must follow the neutral transcript, regardless of what the caller spoke. An implementation that keyed either off the inbound shape would pass every native-route case in this folder and fail here.\n\n64.8.5 is the case that found a real bug: the Responses serializer gated its cache_control -> prompt_cache_breakpoint translation on bifrostReq.Provider, the key the request arrived under. A custom provider reports its own name, matched no branch, and fell to the default - where cache_control is stripped with nothing put in its place, silently returning the request to the implicit caching #6180 exists to escape. Fixed in this branch by resolving the base provider first, the way the injector and providers/utils already do.\n\n64.8.7-64.8.9 repeat 64.8.1 on the SDK-compat hosts. They are separate transport entry points, not aliases of /openai, so they reach dispatch independently and can regress alone."
         }
       ]
+    },
+    {
+      "name": "70. Forced tool choice capability flag (PR #6903 / #6887)",
+      "description": "tool_choice is gated by two independent capability questions, each datasheet-backed with a\nname-based fallback (schemas.ModelCaps.ToolChoiceAnySupported / SupportsForcedToolChoice):\n\n  1. WIRE DIALECT - does the endpoint accept the string \"any\"? Mistral and Fireworks do;\n     every other OpenAI-compatible destination rejects it with\n     \"Invalid value: 'any'. Supported values are: 'none', 'auto', and 'required'.\" (#6887).\n     The Anthropic integration emits \"any\", so OpenAI egress must respell it \"required\".\n\n  2. MODEL CAPABILITY - can the model be forced at all? Claude Fable 5.1 and Mythos 5.1\n     removed forced tool use: tool_choice {\"type\":\"any\"} and {\"type\":\"tool\"} return\n     400 'tool_choice: type \"tool\" and \"any\" are not supported for this model.'\n     Bifrost drops the forced choice so the model answers under the default \"auto\";\n     with the tool bound it still calls it. This covers the caller's tool_choice AND the\n     synthetic bf_so_* structured-output pin Bifrost adds itself on Vertex/Azure/Mantle.\n\nControls matter as much as the regressions here: Fable 5 and Sonnet 4.6 must keep being\nforced, or the gate is over-dropping and silently weakening every other model.",
+      "item": [
+        {
+          "name": "openai/gpt-4o-mini /anthropic/v1/messages tool_choice any is respelled required - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// #6887: the Anthropic integration emits the provider-generic \"any\", which OpenAI",
+                  "// rejects with 400. A 400 here IS the regression, so it must not be guarded away.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('the bare \"any\" tool choice did not reach OpenAI', function () {",
+                  "  pm.expect(pm.response.text()).to.not.include(\"Invalid value: 'any'\");",
+                  "});",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "pm.test('model returned a tool_use block', function () {",
+                  "  var types = (pm.response.json().content || []).map(function (c) { return c.type; });",
+                  "  pm.expect(types, 'content types: ' + JSON.stringify(types)).to.include('tool_use');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"openai/gpt-4o-mini\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in Tokyo?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather for a location.\",\n      \"input_schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"location\"\n        ]\n      }\n    }\n  ],\n  \"tool_choice\": {\n    \"type\": \"any\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-fable-5-1 /anthropic/v1/messages tool_choice any is dropped instead of 400 - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('forced tool choice was not forwarded to a model that rejects it', function () {",
+                  "  pm.expect(pm.response.text()).to.not.include('are not supported for this model');",
+                  "});",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-fable-5-1\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in Tokyo?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather for a location.\",\n      \"input_schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"location\"\n        ]\n      }\n    }\n  ],\n  \"tool_choice\": {\n    \"type\": \"any\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-fable-5-1 /anthropic/v1/messages tool_choice tool pin is dropped instead of 400 - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('forced tool choice was not forwarded to a model that rejects it', function () {",
+                  "  pm.expect(pm.response.text()).to.not.include('are not supported for this model');",
+                  "});",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-fable-5-1\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in Tokyo?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather for a location.\",\n      \"input_schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"location\"\n        ]\n      }\n    }\n  ],\n  \"tool_choice\": {\n    \"type\": \"tool\",\n    \"name\": \"get_weather\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-fable-5-1 /v1/chat/completions tool_choice required is dropped instead of 400 - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// OpenAI dialect in, Anthropic egress out: \"required\" maps to Anthropic \"any\",",
+                  "// which Fable 5.1 rejects. The gate must drop it before it reaches the wire.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('forced tool choice was not forwarded to a model that rejects it', function () {",
+                  "  pm.expect(pm.response.text()).to.not.include('are not supported for this model');",
+                  "});",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-fable-5-1\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in Tokyo?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather for a location.\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\"\n            }\n          },\n          \"required\": [\n            \"location\"\n          ]\n        }\n      }\n    }\n  ],\n  \"tool_choice\": \"required\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-fable-5-1 /anthropic/v1/messages streaming tool_choice any is dropped instead of 400 - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('forced tool choice was not forwarded to a model that rejects it', function () {",
+                  "  pm.expect(pm.response.text()).to.not.include('are not supported for this model');",
+                  "});",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "pm.test('stream reached a terminal event', function () {",
+                  "  pm.expect(pm.response.text()).to.include('message_stop');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-fable-5-1\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in Tokyo?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather for a location.\",\n      \"input_schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"location\"\n        ]\n      }\n    }\n  ],\n  \"tool_choice\": {\n    \"type\": \"any\"\n  },\n  \"stream\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-fable-5 /anthropic/v1/messages tool_choice any still forces a tool call - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Control: Fable 5 (not 5.1) still supports forced tool use. If the version gate",
+                  "// over-matches, the pin is dropped here and the model may answer in text instead.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "pm.test('model returned a tool_use block', function () {",
+                  "  var types = (pm.response.json().content || []).map(function (c) { return c.type; });",
+                  "  pm.expect(types, 'content types: ' + JSON.stringify(types)).to.include('tool_use');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-fable-5\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in Tokyo?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather for a location.\",\n      \"input_schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"location\"\n        ]\n      }\n    }\n  ],\n  \"tool_choice\": {\n    \"type\": \"any\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "anthropic/claude-fable-5-1 /anthropic/v1/messages tool_choice auto is untouched - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Only forced choices are dropped; \"auto\" and \"none\" pass through unchanged.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"anthropic/claude-fable-5-1\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in Tokyo?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"name\": \"get_weather\",\n      \"description\": \"Get the current weather for a location.\",\n      \"input_schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"location\": {\n            \"type\": \"string\"\n          }\n        },\n        \"required\": [\n          \"location\"\n        ]\n      }\n    }\n  ],\n  \"tool_choice\": {\n    \"type\": \"auto\"\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          }
+        },
+        {
+          "name": "vertex/claude-sonnet-4-6 /v1/chat/completions synthetic structured output stays pinned - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Control for the synthetic bf_so_* pin. Vertex rejects native output_config.format,",
+                  "// so Bifrost binds a synthetic tool and forces it. Sonnet 4.6 supports forced tool",
+                  "// use, so the pin must survive - if the Fable gate over-fires, structured output",
+                  "// silently degrades to free-form text here.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "pm.test('content is schema-valid JSON', function () {",
+                  "  var c = pm.response.json().choices[0].message.content;",
+                  "  var parsed = JSON.parse(c);",
+                  "  pm.expect(parsed, 'content: ' + c).to.have.property('city');",
+                  "  pm.expect(parsed, 'content: ' + c).to.have.property('temp_c');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/claude-sonnet-4-6\",\n  \"max_tokens\": 128,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Weather in Tokyo, make it up.\"\n    }\n  ],\n  \"response_format\": {\n    \"type\": \"json_schema\",\n    \"json_schema\": {\n      \"name\": \"weather\",\n      \"schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"city\": {\n            \"type\": \"string\"\n          },\n          \"temp_c\": {\n            \"type\": \"number\"\n          }\n        },\n        \"required\": [\n          \"city\",\n          \"temp_c\"\n        ],\n        \"additionalProperties\": false\n      }\n    }\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "vertex/claude-fable-5-1 /v1/chat/completions synthetic structured output drops the pin - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// The synthetic bf_so_* pin is a forced tool choice Bifrost adds itself, so it needs",
+                  "// the same gate as the caller's. Without it, structured output on Fable 5.1 over a",
+                  "// provider that lacks native output_config.format returns the same 400.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "// Account-scoped gating, not a product defect: Fable 5.1 on Vertex requires data",
+                  "// sharing enabled for the anthropic publisher, and is absent from projects without",
+                  "// it. Skip rather than fail so this case starts asserting once the project is set up.",
+                  "var gated = /data.sharing|does not have access|was not found/i;",
+                  "if (pm.response.code >= 400 && gated.test(pm.response.text())) { return; }",
+                  "pm.test('forced tool choice was not forwarded to a model that rejects it', function () {",
+                  "  pm.expect(pm.response.text()).to.not.include('are not supported for this model');",
+                  "});",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"vertex/claude-fable-5-1\",\n  \"max_tokens\": 128,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Weather in Tokyo, make it up.\"\n    }\n  ],\n  \"response_format\": {\n    \"type\": \"json_schema\",\n    \"json_schema\": {\n      \"name\": \"weather\",\n      \"schema\": {\n        \"type\": \"object\",\n        \"properties\": {\n          \"city\": {\n            \"type\": \"string\"\n          },\n          \"temp_c\": {\n            \"type\": \"number\"\n          }\n        },\n        \"required\": [\n          \"city\",\n          \"temp_c\"\n        ],\n        \"additionalProperties\": false\n      }\n    }\n  }\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        },
+        {
+          "name": "fireworks/kimi-k2p6 /v1/chat/completions tool_choice any is preserved natively - PR #6903",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "// Fireworks documents \"any\" with \"required\" as its alias, so the dialect fallback",
+                  "// keeps \"any\" here rather than respelling it. Either spelling is accepted upstream;",
+                  "// what this pins is that the rewrite is provider-aware and not unconditional.",
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('request succeeded', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"fireworks/accounts/fireworks/models/kimi-k2p6\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"What is the weather in Tokyo?\"\n    }\n  ],\n  \"tools\": [\n    {\n      \"type\": \"function\",\n      \"function\": {\n        \"name\": \"get_weather\",\n        \"description\": \"Get the current weather for a location.\",\n        \"parameters\": {\n          \"type\": \"object\",\n          \"properties\": {\n            \"location\": {\n              \"type\": \"string\"\n            }\n          },\n          \"required\": [\n            \"location\"\n          ]\n        }\n      }\n    }\n  ],\n  \"tool_choice\": \"any\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Claude Fable 5.1 and Mythos 5.1 removed support for forced tool use — sending `tool_choice` as `"any"`, `"required"`, or a named function pin causes the API to return a 400. This PR adds a capability gate (`SupportsForcedToolChoice`) that detects these models and silently drops the forced choice across all provider surfaces (Anthropic native, Bedrock Converse, and OpenAI-compatible), letting the model answer under the default `"auto"` instead of failing the request.

## Changes

- Added `IsFable51` / `DefaultSupportsForcedToolChoice` name-based fallbacks in `schemas/utils.go` that match `fable-5-1`, `mythos-5-1`, and their date-suffixed/Bedrock/Vertex variants.
- Added `SupportsForcedToolChoice *bool` to `ModelCapabilities` and a corresponding `ModelCaps.SupportsForcedToolChoice(fallback bool)` accessor so the datasheet can override the name-based fallback in either direction.
- Added `IsForced()` methods to `ChatToolChoice` and `ResponsesToolChoice` covering all spellings: bare mode strings (`"any"`, `"required"`), named function/tool structs, and allowed-tools sets whose mode is `"required"`.
- Applied the gate in the Anthropic chat and responses converters, the Bedrock responses converter and `convertToolConfigFromFiltered`, and the OpenAI chat and responses converters.
- Added `ToolChoiceAnySupported *bool` to `ModelCapabilities` and a `ModelCaps.ToolChoiceAnySupported(fallback bool)` accessor; the OpenAI converters now consult the datasheet first before falling back to the name-based `toolChoiceAnySupported` helper.
- Extended `toolChoiceAnySupported` to include Fireworks, which documents `"any"` as a supported alias for `"required"`.
- Added comprehensive tests: `IsForced` unit tests for both choice types, forced-tool-choice drop tests for Fable 5.1 across Anthropic and OpenAI surfaces, datasheet-overrides-fallback tests in both directions, and Fireworks `"any"` preservation tests.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./core/providers/anthropic/... ./core/providers/openai/... ./core/providers/bedrock/...
```

Expected: all tests pass, including the new `TestForcedToolChoice_*`, `TestChatToolChoice_IsForced`, `TestResponsesToolChoice_IsForced`, `TestForcedToolChoiceDroppedForFable51`, and `TestToolChoiceAny_DatasheetOutranksFallback` suites.

To verify the datasheet override path, install a capability resolver via `providerUtils.SetCapabilityResolver` with `SupportsForcedToolChoice: &true/false` and confirm the converter respects it over the name-based fallback.

## Breaking changes

- [x] No

The change is purely additive for callers. Requests that previously would have received a 400 from Fable 5.1 now succeed silently with the forced choice dropped. Existing models unaffected by `IsFable51` are unchanged.

## Security considerations

None. No auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable