### PR TITLE
docs: update docs for virtual mcps config json changes

### DIFF
--- a/core/schemas/mcp.go
+++ b/core/schemas/mcp.go
@@ -209,6 +209,11 @@ type MCPConfig struct {
 	ToolManagerConfig *MCPToolManagerConfig `json:"tool_manager_config,omitempty"` // MCP tool manager configuration
 	ToolSyncInterval  time.Duration         `json:"tool_sync_interval,omitempty"`  // Global default interval for syncing tools from MCP servers (0 = use default 10 min)
 
+	// VirtualMCPs are Virtual MCP definitions declared in config.json: named bundles of tools from one
+	// or more MCP clients, served at /mcp/<endpoint_slug> and assignable to virtual keys. Reconciled
+	// into the config store at load. This is the canonical key; mcp.tool_groups is a deprecated alias.
+	VirtualMCPs []VirtualMCPConfig `json:"virtual_mcps,omitempty"`
+
 	// Function to fetch a new request ID for each tool call result message in agent mode,
 	// this is used to ensure that the tool call result messages are unique and can be tracked in plugins or by the user.
 	// This id is attached to ctx.Value(schemas.BifrostContextKeyRequestID) in the agent mode.
@@ -223,6 +228,35 @@ type MCPConfig struct {
 	// ReleasePluginPipeline releases a plugin pipeline back to the pool.
 	// This should be called after the plugin pipeline is no longer needed.
 	ReleasePluginPipeline func(pipeline interface{}) `json:"-"`
+}
+
+// VirtualMCPConfig is a Virtual MCP declared in config.json (mcp.virtual_mcps). It reconciles into a
+// Virtual MCP in the config store: a bundle of tools from one or more MCP clients, served at
+// /mcp/<endpoint_slug> and attachable to virtual keys.
+type VirtualMCPConfig struct {
+	// ID, when set, updates the Virtual MCP with this DB id rather than matching by name.
+	ID uint `json:"id,omitempty"`
+	// Name is the display name (required, unique).
+	Name string `json:"name"`
+	// EndpointSlug is the URL-safe path the Virtual MCP is served at (/mcp/<slug>). Honored on create
+	// only (immutable after); derived from the name when omitted. Unique across Virtual MCPs and MCP clients.
+	EndpointSlug string `json:"endpoint_slug,omitempty"`
+	// Description is free text.
+	Description *string `json:"description,omitempty"`
+	// Enabled defaults to true when omitted; a disabled Virtual MCP is not served.
+	Enabled *bool `json:"enabled,omitempty"`
+	// Tools are the per-client tool specs the Virtual MCP exposes (required).
+	Tools []MCPToolSpecConfig `json:"tools"`
+	// VirtualKeyIDs are the virtual keys this Virtual MCP is attached to (reachable through them).
+	VirtualKeyIDs []string `json:"virtual_key_ids,omitempty"`
+}
+
+// MCPToolSpecConfig names a source MCP client (by id or name) and which of its tools a Virtual MCP
+// exposes: ["*"] = all (including future tools), [] = none, a named list = only those.
+type MCPToolSpecConfig struct {
+	MCPClientID   string   `json:"mcp_client_id,omitempty"`
+	MCPClientName string   `json:"mcp_client_name,omitempty"`
+	ToolNames     []string `json:"tool_names,omitempty"`
 }
 
 // UnmarshalJSON supports Go duration strings (e.g. "10m") for tool_sync_interval.

--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -398,6 +398,45 @@ The schema enforces these pairings: `oauth_config` is rejected on non-OAuth auth
 
 Clients declared with `auth_type` in `{oauth, per_user_oauth, per_user_headers, token_exchange}` boot into a **`pending_verification`** state. The MCP Gateway UI surfaces an **Authorize** / **Verify** CTA on each pending row; one admin click runs the same verification flow the Web UI Create form uses, after which the client transitions to `healthy`. The same steps are scriptable via `POST /api/mcp/client/{id}/initiate-verification` (OAuth types), `POST /api/mcp/client/{id}/verify-headers` (per-user headers), or `POST /api/mcp/client/{id}/verify-exchange` (token exchange). Verified state is server-side and survives restarts and config re-syncs. Immutable fields (`auth_type`, `connection_type`, `connection_string`, `stdio_config`, `oauth_config`) cannot be changed after creation — file edits to them are ignored with a boot warning naming the fields, matching the update API; delete and re-declare the client to change them. See [MCP Auth](/mcp/auth/overview) and [Connections, States & Lifecycles](/mcp/connections).
 
+### `mcp.virtual_mcps`
+
+Virtual MCPs bundle tools from one or more `client_configs` into a single endpoint served at `/mcp/<endpoint_slug>` and attachable to virtual keys. Reconciled into the config store at load.
+
+```json
+{
+  "mcp": {
+    "virtual_mcps": [
+      {
+        "name": "Support Tools",
+        "endpoint_slug": "support-tools",
+        "enabled": true,
+        "tools": [
+          { "mcp_client_name": "zendesk", "tool_names": ["*"] },
+          { "mcp_client_name": "docs-search", "tool_names": ["query", "get_page"] }
+        ],
+        "virtual_key_ids": ["vk-support"]
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | Positive integer (>= 1). When set, the reconciler matches by this ID first and falls back to name when no stored vMCP has that ID; a name match keeps its existing stored ID |
+| `name` | string | Required. Display name (unique) |
+| `endpoint_slug` | string | Lowercase URL-safe kebab-case (pattern `^[a-z0-9]+(-[a-z0-9]+)*$`) path served at `/mcp/<endpoint_slug>`. Derived from the name when omitted; immutable after creation; unique across vMCPs and direct MCP clients |
+| `description` | string | Free text |
+| `enabled` | boolean | Defaults to `true`. A disabled vMCP is not served |
+| `tools` | array | Required, at least one entry. Each item needs `mcp_client_id` or `mcp_client_name`, plus `tool_names` (`["*"]` = all current and future tools, `[]` = none) |
+| `virtual_key_ids` | string[] | Virtual keys the vMCP is attached to |
+
+When `source_of_truth` is `config.json` and `mcp.virtual_mcps` is present, it is authoritative for vMCPs: any stored vMCP absent from it is removed, and an explicit `"virtual_mcps": []` prunes them all. Omitting `mcp.virtual_mcps` leaves stored vMCPs unchanged. In `split` mode the file creates and updates vMCPs but never prunes runtime-managed ones. See [Source of Truth](/deployment-guides/config-json/source-of-truth).
+
+<Note>
+`mcp.tool_groups` is the deprecated former name for this key, kept for backward compatibility. It carries legacy attachment arrays (`team_ids`, `customer_ids`, `user_ids`, `provider_names`, `api_key_ids`) and does not expose `endpoint_slug`. Prefer `mcp.virtual_mcps`; when both are present, `mcp.virtual_mcps` wins and `mcp.tool_groups` is ignored.
+</Note>
+
 ---
 
 ## `websocket`

--- a/docs/mcp/virtual-mcps.mdx
+++ b/docs/mcp/virtual-mcps.mdx
@@ -175,7 +175,7 @@ curl -X POST http://localhost:8080/api/mcp/virtual-mcps \
 | `endpoint_slug` | string | No | Honored on create only; derived from `name` when omitted; immutable after |
 | `description` | string | No | Free text |
 | `enabled` | boolean | No | Defaults to `true` |
-| `tools` | array | Yes | Tool specs: `mcp_client_id` + `tool_names` (`["*"]` = all, `[]` = none) |
+| `tools` | array | Yes | Tool specs: `mcp_client_id` + `tool_names` (`["*"]` = all current and future tools, `[]` = none) |
 
 <Note>
 Unknown `mcp_client_id`s are rejected on save. Unknown tool **names** are not validated on save; they're enforced at call time. A slug already used by another vMCP or a direct MCP client returns `409`.
@@ -184,18 +184,19 @@ Unknown `mcp_client_id`s are rejected on save. Unknown tool **names** are not va
 </Tab>
 <Tab title="config.json">
 
-Virtual MCPs are declared under `mcp.tool_groups` (the config key retains its original name for backward compatibility):
+Virtual MCPs are declared under `mcp.virtual_mcps`. They are reconciled into the config store at load and served at `/mcp/<endpoint_slug>`:
 
 ```json
 {
   "mcp": {
-    "tool_groups": [
+    "virtual_mcps": [
       {
         "name": "Support Tools",
+        "endpoint_slug": "support-tools",
         "description": "Ticketing + docs search",
         "enabled": true,
         "tools": [
-          { "mcp_client_name": "zendesk", "tool_names": [] },
+          { "mcp_client_name": "zendesk", "tool_names": ["*"] },
           { "mcp_client_name": "docs-search", "tool_names": ["query", "get_page"] }
         ],
         "virtual_key_ids": ["vk-support"]
@@ -207,16 +208,21 @@ Virtual MCPs are declared under `mcp.tool_groups` (the config key retains its or
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `id` | integer | No | When set, the reconciler updates the group with this ID instead of matching by name |
-| `name` | string | Yes | Group name |
+| `id` | integer | No | Positive integer (>= 1). When set, the reconciler matches by this ID first and falls back to name when no stored vMCP has that ID; a name match keeps its existing stored ID |
+| `name` | string | Yes | Display name (unique) |
+| `endpoint_slug` | string | No | Lowercase URL-safe kebab-case (pattern `^[a-z0-9]+(-[a-z0-9]+)*$`) path served at `/mcp/<endpoint_slug>`. Derived from the name when omitted; immutable after creation; unique across vMCPs and direct MCP clients |
 | `description` | string | No | Free text |
-| `enabled` | boolean | No | Defaults to `true` |
-| `tools` | array | Yes | Each item needs `mcp_client_id` or `mcp_client_name`, plus `tool_names` (empty = all tools) |
-| `virtual_key_ids` | string[] | No | Virtual keys the group is attached to |
+| `enabled` | boolean | No | Defaults to `true`. A disabled vMCP is not served |
+| `tools` | array | Yes | At least one entry. Each item needs `mcp_client_id` or `mcp_client_name`, plus `tool_names` (`["*"]` = all current and future tools, `[]` = none) |
+| `virtual_key_ids` | string[] | No | Virtual keys the vMCP is attached to |
 
-<Warning>
-The config.json schema for `mcp.tool_groups` does not yet expose `endpoint_slug` (the slug is derived from the name on this path), and it still carries the legacy attachment arrays (`team_ids`, `customer_ids`, `user_ids`, `provider_names`, `api_key_ids`). The Web UI and API model the feature around slug-addressing and virtual-key / access-profile attachment; prefer those for new setups.
-</Warning>
+When `source_of_truth` is `config.json` and `mcp.virtual_mcps` is present, it is authoritative for vMCPs: any stored vMCP absent from it is removed, and an explicit `"virtual_mcps": []` prunes them all. Omitting `mcp.virtual_mcps` leaves stored vMCPs unchanged. In `split` mode the file creates and updates vMCPs but never prunes runtime-managed ones.
+
+<Note>
+`mcp.tool_groups` is the deprecated former name for this key and is kept for backward compatibility. It carries legacy attachment arrays (`team_ids`, `customer_ids`, `user_ids`, `provider_names`, `api_key_ids`) and does not expose `endpoint_slug`. Prefer `mcp.virtual_mcps` for new setups; when both keys are present, `mcp.virtual_mcps` wins and `mcp.tool_groups` is ignored.
+</Note>
+
+The same fields are available in the Helm chart under `bifrost.mcp.virtualMcps` (camelCase keys, e.g. `endpointSlug`, `virtualKeyIds`), which renders into `mcp.virtual_mcps`.
 
 </Tab>
 </Tabs>

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -114,6 +114,7 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 - Added `bifrost.alerting` for declarative alert channels and rules. Supports `history_retention_days`, `webhook_network` (`allow_http`, `allow_private_network`), `channels[]` (slack, microsoft_teams, pagerduty, webhook), and `rules[]` (CEL-expression-based, governance-scope-aware). Renders into `alerting`.
 - `postgresql.external.port` now accepts a string in addition to an integer, enabling env-variable substitution via `env.VAR_NAME` references when mounting port from a Kubernetes secret. Renders into `postgres_config.port`.
 - `bifrost.mcp.toolGroups[*].id` — optional integer DB ID for an existing MCP tool group. When set, the reconciler updates the group by ID instead of matching by name. Renders into `mcp.tool_groups[*].id`.
+- Added `bifrost.mcp.virtualMcps` for declarative Virtual MCPs: named bundles of tools from one or more MCP clients, served at `/mcp/<endpointSlug>` and attachable to virtual keys. Supports `id`, `name`, `endpointSlug`, `description`, `enabled`, `tools[]` (`mcpClientId`/`mcpClientName`, `toolNames`), and `virtualKeyIds`. Renders into `mcp.virtual_mcps`. This is the canonical key; `bifrost.mcp.toolGroups` (rendering `mcp.tool_groups`) is deprecated and kept for backward compatibility.
 
 ### 2.1.26
 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1414,6 +1414,30 @@ false
 {{- end }}
 {{- $_ := set $mcpConfig "tool_groups" $toolGroups }}
 {{- end }}
+{{- if hasKey .Values.bifrost.mcp "virtualMcps" }}
+{{- $virtualMcps := list }}
+{{- range .Values.bifrost.mcp.virtualMcps }}
+{{- $vmcp := dict "name" .name }}
+{{- if .id }}{{- $_ := set $vmcp "id" .id }}{{- end }}
+{{- if .endpointSlug }}{{- $_ := set $vmcp "endpoint_slug" .endpointSlug }}{{- end }}
+{{- if hasKey . "enabled" }}{{- $_ := set $vmcp "enabled" .enabled }}{{- end }}
+{{- if .description }}{{- $_ := set $vmcp "description" .description }}{{- end }}
+{{- if .tools }}
+{{- $tools := list }}
+{{- range .tools }}
+{{- $tool := dict }}
+{{- if .mcpClientId }}{{- $_ := set $tool "mcp_client_id" .mcpClientId }}{{- end }}
+{{- if .mcpClientName }}{{- $_ := set $tool "mcp_client_name" .mcpClientName }}{{- end }}
+{{- if .toolNames }}{{- $_ := set $tool "tool_names" .toolNames }}{{- end }}
+{{- $tools = append $tools $tool }}
+{{- end }}
+{{- $_ := set $vmcp "tools" $tools }}
+{{- end }}
+{{- if .virtualKeyIds }}{{- $_ := set $vmcp "virtual_key_ids" .virtualKeyIds }}{{- end }}
+{{- $virtualMcps = append $virtualMcps $vmcp }}
+{{- end }}
+{{- $_ := set $mcpConfig "virtual_mcps" $virtualMcps }}
+{{- end }}
 {{- $_ := set $config "mcp" $mcpConfig }}
 {{- end }}
 {{- /* Plugins - as array per schema */ -}}
@@ -2511,11 +2535,21 @@ Call this template at the beginning of deployment/stateful templates
 {{- end }}
 {{- if .Values.bifrost.mcp.toolGroups }}
 {{- range $idx, $group := .Values.bifrost.mcp.toolGroups }}
-{{- if not $group.name }}
+{{- if not (trim (default "" $group.name)) }}
 {{- fail (printf "ERROR: bifrost.mcp.toolGroups[%d].name is required." $idx) }}
 {{- end }}
 {{- if not $group.tools }}
 {{- fail (printf "ERROR: bifrost.mcp.toolGroups[%d].tools is required for group '%s'." $idx $group.name) }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.bifrost.mcp.virtualMcps }}
+{{- range $idx, $vmcp := .Values.bifrost.mcp.virtualMcps }}
+{{- if not (trim (default "" $vmcp.name)) }}
+{{- fail (printf "ERROR: bifrost.mcp.virtualMcps[%d].name is required." $idx) }}
+{{- end }}
+{{- if not $vmcp.tools }}
+{{- fail (printf "ERROR: bifrost.mcp.virtualMcps[%d].tools is required for Virtual MCP '%s'." $idx $vmcp.name) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -1386,7 +1386,7 @@ false
 {{- if hasKey .Values.bifrost.mcp "toolSyncInterval" }}
 {{- $_ := set $mcpConfig "tool_sync_interval" .Values.bifrost.mcp.toolSyncInterval }}
 {{- end }}
-{{- if .Values.bifrost.mcp.toolGroups }}
+{{- if hasKey .Values.bifrost.mcp "toolGroups" }}
 {{- $toolGroups := list }}
 {{- range .Values.bifrost.mcp.toolGroups }}
 {{- $group := dict "name" .name }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -6945,7 +6945,7 @@
               },
               "toolNames": {
                 "type": "array",
-                "description": "Tool names to allow. Empty means all tools from this MCP client.",
+                "description": "Tool names to expose. [\"*\"] means all tools (including future ones); [] means none; a named list means only those tools.",
                 "items": {
                   "type": "string"
                 }

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -761,9 +761,17 @@
                 }
               ]
             },
+            "virtualMcps": {
+              "type": "array",
+              "description": "Virtual MCPs: named bundles of tools from one or more MCP clients, served at /mcp/<endpointSlug> and attachable to virtual keys. Renders into mcp.virtual_mcps. Canonical key; supersedes the deprecated toolGroups alias.",
+              "items": {
+                "$ref": "#/$defs/virtualMcpConfig"
+              }
+            },
             "toolGroups": {
               "type": "array",
-              "description": "Enterprise MCP tool groups with optional governance associations",
+              "description": "DEPRECATED: use virtualMcps instead. Enterprise MCP tool groups with optional governance associations. Renders into mcp.tool_groups.",
+              "deprecated": true,
               "items": {
                 "$ref": "#/$defs/mcpToolGroupConfig"
               }
@@ -6825,8 +6833,82 @@
         }
       ]
     },
+    "virtualMcpConfig": {
+      "type": "object",
+      "description": "A Virtual MCP: a named bundle of tools from one or more MCP clients, served at /mcp/<endpointSlug> and attachable to virtual keys. Renders into mcp.virtual_mcps[].",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "DB ID of this Virtual MCP. When set, the reconciler updates the existing Virtual MCP with this ID rather than matching by name. Maps to mcp.virtual_mcps[].id in config.json."
+        },
+        "name": {
+          "type": "string",
+          "description": "Virtual MCP display name (unique)"
+        },
+        "endpointSlug": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "URL-safe path the Virtual MCP is served at (/mcp/<endpointSlug>). Honored on create only (immutable after); derived from the name when omitted. Unique across Virtual MCPs and MCP clients. Maps to mcp.virtual_mcps[].endpoint_slug."
+        },
+        "description": {
+          "type": "string",
+          "description": "Virtual MCP description"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the Virtual MCP is enabled. A disabled Virtual MCP is not served.",
+          "default": true
+        },
+        "tools": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Per-client tool specs the Virtual MCP exposes",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mcpClientId": {
+                "type": "string",
+                "description": "MCP client ID"
+              },
+              "mcpClientName": {
+                "type": "string",
+                "description": "MCP client name (resolved to client_id at startup)"
+              },
+              "toolNames": {
+                "type": "array",
+                "description": "Tool names to expose. [\"*\"] means all tools (including future ones); [] means none; a named list means only those tools.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "required": ["mcpClientId"]
+              },
+              {
+                "required": ["mcpClientName"]
+              }
+            ],
+            "additionalProperties": false
+          }
+        },
+        "virtualKeyIds": {
+          "type": "array",
+          "description": "Virtual keys this Virtual MCP is attached to. Maps to mcp.virtual_mcps[].virtual_key_ids.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["name", "tools"],
+      "additionalProperties": false
+    },
     "mcpToolGroupConfig": {
       "type": "object",
+      "description": "DEPRECATED: use virtualMcpConfig (bifrost.mcp.virtualMcps) instead.",
+      "deprecated": true,
       "properties": {
         "id": {
           "type": "integer",
@@ -6888,30 +6970,40 @@
         },
         "teamIds": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtualKeyIds instead.",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
         },
         "customerIds": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtualKeyIds instead.",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
         },
         "userIds": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtualKeyIds instead.",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
         },
         "providerNames": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtualKeyIds instead.",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
         },
         "apiKeyIds": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtualKeyIds instead.",
+          "deprecated": true,
           "items": {
             "type": "integer"
           }

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -536,7 +536,18 @@ bifrost:
       #     authorizationServerUrl: ""                   # optional — override exchange endpoint (e.g. Okta custom AS)
       #     scopes: []                                   # optional; include 'offline_access' for refresh tokens
     # toolSyncInterval: "10m"   # Global tool sync interval (Go duration string, e.g. "10m", "1h", "0s")
-    # Assign groups of MCP tools to virtual keys / access profiles.
+    # Virtual MCPs: bundle tools from one or more MCP clients into a single endpoint
+    # served at /mcp/<endpointSlug> and attach it to virtual keys.
+    # virtualMcps:
+    #   - id: 5                        # Optional: DB ID of an existing Virtual MCP; when set, reconciler updates it by ID instead of name
+    #     name: "Platform Tools"
+    #     endpointSlug: "platform-tools"  # Optional; derived from name when omitted. Immutable after creation.
+    #     enabled: true
+    #     tools:
+    #       - mcpClientName: "github"
+    #         toolNames: ["create_pull_request", "list_issues"]
+    #     virtualKeyIds: ["<vk-id>"]
+    # toolGroups (DEPRECATED): use virtualMcps instead. Kept for backward compatibility.
     # toolGroups:
     #   - id: 5                        # Optional: DB ID of an existing group; when set, reconciler updates it by ID instead of name
     #     name: "Platform Tools"

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -198,6 +198,7 @@ type ConfigData struct {
 
 	presentSections           map[string]bool
 	presentGovernanceSections map[string]bool
+	presentMCPSections        map[string]bool
 	SkillsRegistry            *SkillsRegistryConfig `json:"skills_registry,omitempty"`
 }
 
@@ -387,6 +388,13 @@ func (cd *ConfigData) sectionPresent(name string) bool {
 	}
 }
 
+// mcpSectionPresent reports whether a field under the top-level "mcp" object was explicitly
+// provided in config.json (e.g. "virtual_mcps", "client_configs"). Used to decide whether
+// config.json is the source of truth for that MCP subsection.
+func (cd *ConfigData) mcpSectionPresent(name string) bool {
+	return cd.presentMCPSections[name]
+}
+
 // governanceSectionPresent reports whether a governance collection was explicitly provided.
 func (cd *ConfigData) governanceSectionPresent(name string) bool {
 	if cd == nil || cd.Governance == nil {
@@ -484,6 +492,16 @@ func (cd *ConfigData) UnmarshalJSON(data []byte) error {
 			cd.presentGovernanceSections = make(map[string]bool, len(rawGovernanceFields))
 			for key := range rawGovernanceFields {
 				cd.presentGovernanceSections[key] = true
+			}
+		}
+	}
+	cd.presentMCPSections = nil
+	if rawMCP, ok := raw["mcp"]; ok && len(rawMCP) > 0 {
+		var rawMCPFields map[string]json.RawMessage
+		if err := json.Unmarshal(rawMCP, &rawMCPFields); err == nil {
+			cd.presentMCPSections = make(map[string]bool, len(rawMCPFields))
+			for key := range rawMCPFields {
+				cd.presentMCPSections[key] = true
 			}
 		}
 	}
@@ -1816,6 +1834,21 @@ func loadMCPConfig(ctx context.Context, config *Config, configData *ConfigData) 
 		}
 	}
 	applyMCPGlobalSettingsToClientConfig(ctx, config, configData.MCP, configData.isConfigJSONSourceOfTruth() && configData.sectionPresent("mcp"))
+
+	// Reconcile Virtual MCPs declared under mcp.virtual_mcps. This runs after client configs are
+	// synced so tool specs can resolve their source MCP clients by name. forceFileSync makes
+	// config.json authoritative for the virtual_mcps subsection.
+	if configData.MCP != nil {
+		forceFileSync := configData.isConfigJSONSourceOfTruth() && configData.mcpSectionPresent("virtual_mcps")
+		if err := reconcileVirtualMCPsConfig(ctx, config.ConfigStore, configData.MCP.VirtualMCPs, forceFileSync); err != nil {
+			logger.Warn("failed to reconcile virtual MCPs from config.json: %v", err)
+		}
+		if forceFileSync {
+			if err := pruneVirtualMCPsConfigToFile(ctx, config.ConfigStore, configData.MCP.VirtualMCPs); err != nil {
+				logger.Warn("failed to prune virtual MCPs from config.json source of truth: %v", err)
+			}
+		}
+	}
 }
 
 // pinMCPClientImmutableFields rewrites a file-declared client so that fields

--- a/transports/bifrost-http/lib/config_test.go
+++ b/transports/bifrost-http/lib/config_test.go
@@ -16204,6 +16204,7 @@ func TestGenerateMCPClientHash_RuntimeVsMigrationParity(t *testing.T) {
 		mcpToSave := tables.TableMCPClient{
 			ClientID:       uuid.New().String(),
 			Name:           "Test MCP StdioConfig " + uuid.New().String(),
+			EndpointSlug:   "stdio-" + uuid.New().String(),
 			ConnectionType: "stdio",
 			StdioConfig:    stdioConfig,
 			ToolsToExecute: []string{},
@@ -16251,6 +16252,7 @@ func TestGenerateMCPClientHash_RuntimeVsMigrationParity(t *testing.T) {
 		mcpToSave := tables.TableMCPClient{
 			ClientID:         uuid.New().String(),
 			Name:             "Test MCP Tools " + uuid.New().String(),
+			EndpointSlug:     "tools-" + uuid.New().String(),
 			ConnectionType:   "sse",
 			ConnectionString: schemas.NewSecretVar(connStr),
 			ToolsToExecute:   tools,
@@ -16285,6 +16287,7 @@ func TestGenerateMCPClientHash_RuntimeVsMigrationParity(t *testing.T) {
 		mcpToSave := tables.TableMCPClient{
 			ClientID:         uuid.New().String(),
 			Name:             "Test MCP Headers " + uuid.New().String(),
+			EndpointSlug:     "headers-" + uuid.New().String(),
 			ConnectionType:   "sse",
 			ConnectionString: schemas.NewSecretVar(connStr),
 			ToolsToExecute:   []string{},
@@ -16321,6 +16324,7 @@ func TestGenerateMCPClientHash_RuntimeVsMigrationParity(t *testing.T) {
 		mcpToSave := tables.TableMCPClient{
 			ClientID:       uuid.New().String(),
 			Name:           "Test MCP AllFields " + uuid.New().String(),
+			EndpointSlug:   "allfields-" + uuid.New().String(),
 			ConnectionType: "stdio",
 			StdioConfig:    stdioConfig,
 			ToolsToExecute: tools,
@@ -16348,6 +16352,7 @@ func TestGenerateMCPClientHash_RuntimeVsMigrationParity(t *testing.T) {
 		mcpToSave := tables.TableMCPClient{
 			ClientID:         uuid.New().String(),
 			Name:             "Test MCP TxFind " + uuid.New().String(),
+			EndpointSlug:     "txfind-" + uuid.New().String(),
 			ConnectionType:   "sse",
 			ConnectionString: schemas.NewSecretVar(connStr),
 			ToolsToExecute:   tools,
@@ -22342,4 +22347,145 @@ func TestGetMCPClientBySlugSkipsDisabled(t *testing.T) {
 
 	_, _, ok = c.GetMCPClientBySlug("dead-slug")
 	require.False(t, ok, "a disabled client's slug must not resolve")
+}
+
+// TestReconcileVirtualMCPsConfig covers the config.json → store reconciliation for
+// mcp.virtual_mcps: create (with explicit slug + name-resolved tool client + VK attach),
+// idempotent no-op on unchanged hash, update on change, and prune of absent entries.
+func TestReconcileVirtualMCPsConfig(t *testing.T) {
+	initTestLogger()
+	ctx := context.Background()
+	store := createTestSQLiteConfigStore(t, createTempDir(t))
+
+	// Source MCP client (resolved by name) and a VK to attach to.
+	require.NoError(t, store.CreateMCPClientConfig(ctx, &schemas.MCPClientConfig{
+		ID: "client-1", Name: "github", ConnectionType: schemas.MCPConnectionTypeHTTP,
+	}))
+	require.NoError(t, store.CreateVirtualKey(ctx, &tables.TableVirtualKey{
+		ID: "vk-1", Name: "test-vk", Value: *schemas.NewSecretVar("vk_test123"), IsActive: schemas.Ptr(true),
+	}))
+
+	fileVMCPs := []schemas.VirtualMCPConfig{
+		{
+			Name:         "Platform Tools",
+			EndpointSlug: "platform-tools",
+			Enabled:      schemas.Ptr(true),
+			Tools: []schemas.MCPToolSpecConfig{
+				{MCPClientName: "github", ToolNames: []string{"create_pull_request"}},
+			},
+			VirtualKeyIDs: []string{"vk-1"},
+		},
+	}
+
+	// Create.
+	require.NoError(t, reconcileVirtualMCPsConfig(ctx, store, fileVMCPs, true))
+
+	vmcps, _, err := store.GetVirtualMCPsPaginated(ctx, configstore.VirtualMCPsQueryParams{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, vmcps, 1)
+	created := vmcps[0]
+	require.Equal(t, "Platform Tools", created.Name)
+	require.Equal(t, "platform-tools", created.EndpointSlug)
+	require.True(t, created.Enabled)
+	require.Len(t, created.ParsedTools, 1)
+	require.Equal(t, "client-1", created.ParsedTools[0].MCPClientID, "tool client name should resolve to client ID")
+	require.NotEmpty(t, created.ConfigHash)
+
+	vkIDs, err := store.GetVirtualKeyIDsForVirtualMCP(ctx, created.ID)
+	require.NoError(t, err)
+	require.Equal(t, []string{"vk-1"}, vkIDs)
+
+	// Idempotent: unchanged file, hash matches, no error and slug unchanged.
+	require.NoError(t, reconcileVirtualMCPsConfig(ctx, store, fileVMCPs, false))
+	after, _, err := store.GetVirtualMCPsPaginated(ctx, configstore.VirtualMCPsQueryParams{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, after, 1)
+	require.Equal(t, created.ConfigHash, after[0].ConfigHash)
+
+	// Update: disable it and detach the VK.
+	fileVMCPs[0].Enabled = schemas.Ptr(false)
+	fileVMCPs[0].VirtualKeyIDs = nil
+	require.NoError(t, reconcileVirtualMCPsConfig(ctx, store, fileVMCPs, true))
+	updated, err := store.GetVirtualMCPByID(ctx, created.ID)
+	require.NoError(t, err)
+	require.False(t, updated.Enabled)
+	require.Equal(t, "platform-tools", updated.EndpointSlug, "endpoint_slug is immutable across updates")
+	vkIDs, err = store.GetVirtualKeyIDsForVirtualMCP(ctx, created.ID)
+	require.NoError(t, err)
+	require.Empty(t, vkIDs)
+
+	// Prune: absent from file removes it.
+	require.NoError(t, pruneVirtualMCPsConfigToFile(ctx, store, nil))
+	remaining, _, err := store.GetVirtualMCPsPaginated(ctx, configstore.VirtualMCPsQueryParams{Limit: 100})
+	require.NoError(t, err)
+	require.Empty(t, remaining)
+}
+
+// TestReconcileVirtualMCPsConfig_DerivesSlugFromName verifies an omitted endpoint_slug is
+// derived from the name.
+func TestReconcileVirtualMCPsConfig_DerivesSlugFromName(t *testing.T) {
+	initTestLogger()
+	ctx := context.Background()
+	store := createTestSQLiteConfigStore(t, createTempDir(t))
+
+	require.NoError(t, store.CreateMCPClientConfig(ctx, &schemas.MCPClientConfig{
+		ID: "client-1", Name: "github", ConnectionType: schemas.MCPConnectionTypeHTTP,
+	}))
+
+	require.NoError(t, reconcileVirtualMCPsConfig(ctx, store, []schemas.VirtualMCPConfig{
+		{
+			Name:  "My Tools",
+			Tools: []schemas.MCPToolSpecConfig{{MCPClientID: "client-1", ToolNames: []string{"*"}}},
+		},
+	}, true))
+
+	vmcps, _, err := store.GetVirtualMCPsPaginated(ctx, configstore.VirtualMCPsQueryParams{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, vmcps, 1)
+	require.Equal(t, "my-tools", vmcps[0].EndpointSlug)
+}
+
+// TestGenerateVirtualMCPHash_StableOrdering verifies the hash is independent of tool,
+// tool-name, and virtual-key-id declaration order, so reconcile treats reordered configs
+// as unchanged.
+func TestGenerateVirtualMCPHash_StableOrdering(t *testing.T) {
+	desc := "bundle"
+	tools1 := []configstoreTables.MCPToolSpec{
+		{MCPClientID: "a", ToolNames: []string{"t2", "t1"}},
+		{MCPClientID: "b", ToolNames: []string{"t3"}},
+	}
+	tools2 := []configstoreTables.MCPToolSpec{
+		{MCPClientID: "b", ToolNames: []string{"t3"}},
+		{MCPClientID: "a", ToolNames: []string{"t1", "t2"}},
+	}
+	h1 := GenerateVirtualMCPHash("vmcp", &desc, true, tools1, []string{"vk-2", "vk-1"})
+	h2 := GenerateVirtualMCPHash("vmcp", &desc, true, tools2, []string{"vk-1", "vk-2"})
+	require.Equal(t, h1, h2, "hash must be stable across ordering")
+
+	// A material change (enabled) must change the hash.
+	require.NotEqual(t, h1, GenerateVirtualMCPHash("vmcp", &desc, false, tools1, []string{"vk-1", "vk-2"}))
+}
+
+// TestReconcileVirtualMCPsConfig_DedupeNameAndID verifies duplicate names are rejected even when
+// the entries carry different IDs (not just repeated IDs), so a second write never races the DB's
+// unique-name constraint.
+func TestReconcileVirtualMCPsConfig_DedupeNameAndID(t *testing.T) {
+	initTestLogger()
+	ctx := context.Background()
+	store := createTestSQLiteConfigStore(t, createTempDir(t))
+	require.NoError(t, store.CreateMCPClientConfig(ctx, &schemas.MCPClientConfig{
+		ID: "client-1", Name: "github", ConnectionType: schemas.MCPConnectionTypeHTTP,
+	}))
+
+	tool := []schemas.MCPToolSpecConfig{{MCPClientID: "client-1", ToolNames: []string{"*"}}}
+	// Same name, different ID-ness: the second must be skipped by name, not slip through on the ID key.
+	require.NoError(t, reconcileVirtualMCPsConfig(ctx, store, []schemas.VirtualMCPConfig{
+		{Name: "Dup", Tools: tool},
+		{Name: "Dup", ID: 5, Tools: tool},
+	}, true))
+
+	vmcps, _, err := store.GetVirtualMCPsPaginated(ctx, configstore.VirtualMCPsQueryParams{Limit: 100})
+	require.NoError(t, err)
+	require.Len(t, vmcps, 1, "duplicate name with a different ID must be deduped")
+	require.Equal(t, "Dup", vmcps[0].Name)
 }

--- a/transports/bifrost-http/lib/config_virtual_mcp.go
+++ b/transports/bifrost-http/lib/config_virtual_mcp.go
@@ -1,0 +1,276 @@
+package lib
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+)
+
+// reconcileVirtualMCPsConfig performs hash-based reconciliation of Virtual MCPs (mcp.virtual_mcps)
+// between config.json and the config store. Tool specs resolve their source MCP client by id or by
+// name; a Virtual MCP whose client cannot be resolved is skipped so a bad entry doesn't block the
+// rest. When forceFileSync is true, config.json is authoritative and every file entry is written
+// even if its hash matches the stored row.
+func reconcileVirtualMCPsConfig(ctx context.Context, store configstore.ConfigStore, fileVMCPs []schemas.VirtualMCPConfig, forceFileSync bool) error {
+	if store == nil || len(fileVMCPs) == 0 {
+		return nil
+	}
+
+	dbByName := make(map[string]configstoreTables.TableVirtualMCP)
+	dbByID := make(map[uint]configstoreTables.TableVirtualMCP)
+	offset := 0
+	const pageSize = 100
+	for {
+		batch, totalCount, err := store.GetVirtualMCPsPaginated(ctx, configstore.VirtualMCPsQueryParams{
+			Limit:  pageSize,
+			Offset: offset,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get virtual MCPs from store: %w", err)
+		}
+		for _, vmcp := range batch {
+			dbByName[vmcp.Name] = vmcp
+			dbByID[vmcp.ID] = vmcp
+		}
+		offset += len(batch)
+		if int64(offset) >= totalCount || len(batch) == 0 {
+			break
+		}
+	}
+
+	// Names are unique in the store, and IDs select the row to reconcile. Track them separately so a
+	// duplicate name with a different ID is caught too, not just a repeated ID.
+	seenNames := map[string]struct{}{}
+	seenIDs := map[uint]struct{}{}
+vmcpLoop:
+	for _, fileVMCP := range fileVMCPs {
+		if strings.TrimSpace(fileVMCP.Name) == "" {
+			logger.Warn("skipping virtual MCP with missing name in config.json")
+			continue
+		}
+		if _, dup := seenNames[fileVMCP.Name]; dup {
+			logger.Warn("duplicate virtual MCP %q in config.json; skipping duplicate entry", fileVMCP.Name)
+			continue
+		}
+		if fileVMCP.ID != 0 {
+			if _, dup := seenIDs[fileVMCP.ID]; dup {
+				logger.Warn("duplicate virtual MCP ID %d in config.json; skipping duplicate entry", fileVMCP.ID)
+				continue
+			}
+			seenIDs[fileVMCP.ID] = struct{}{}
+		}
+		seenNames[fileVMCP.Name] = struct{}{}
+
+		parsedTools := make([]configstoreTables.MCPToolSpec, 0, len(fileVMCP.Tools))
+		for _, tool := range fileVMCP.Tools {
+			clientID := strings.TrimSpace(tool.MCPClientID)
+			if clientID == "" && strings.TrimSpace(tool.MCPClientName) != "" {
+				client, err := store.GetMCPClientByName(ctx, strings.TrimSpace(tool.MCPClientName))
+				if err != nil {
+					logger.Warn("skipping virtual MCP %q: failed to resolve MCP client %q: %v", fileVMCP.Name, tool.MCPClientName, err)
+					continue vmcpLoop
+				}
+				clientID = client.ClientID
+			}
+			if clientID == "" {
+				logger.Warn("skipping virtual MCP %q: tool entry missing mcp_client_id and mcp_client_name", fileVMCP.Name)
+				continue vmcpLoop
+			}
+			parsedTools = append(parsedTools, configstoreTables.MCPToolSpec{
+				MCPClientID: clientID,
+				ToolNames:   tool.ToolNames,
+			})
+		}
+
+		// Enabled defaults to true when omitted.
+		enabled := true
+		if fileVMCP.Enabled != nil {
+			enabled = *fileVMCP.Enabled
+		}
+
+		target := configstoreTables.TableVirtualMCP{
+			Name:         fileVMCP.Name,
+			EndpointSlug: strings.TrimSpace(fileVMCP.EndpointSlug),
+			Description:  fileVMCP.Description,
+			Enabled:      enabled,
+			ParsedTools:  parsedTools,
+		}
+		fileHash := GenerateVirtualMCPHash(fileVMCP.Name, fileVMCP.Description, enabled, parsedTools, fileVMCP.VirtualKeyIDs)
+		target.ConfigHash = fileHash
+
+		// When id is provided, match by DB id first; fall back to name.
+		var dbVMCP configstoreTables.TableVirtualMCP
+		var exists bool
+		if fileVMCP.ID != 0 {
+			dbVMCP, exists = dbByID[fileVMCP.ID]
+		}
+		if !exists {
+			dbVMCP, exists = dbByName[fileVMCP.Name]
+		}
+
+		if !exists {
+			logger.Info("new virtual MCP from config.json: %s", fileVMCP.Name)
+			if fileVMCP.ID != 0 {
+				target.ID = fileVMCP.ID
+			}
+			if err := store.CreateVirtualMCP(ctx, &target); err != nil {
+				logger.Warn("skipping virtual MCP %q: failed to create: %v", fileVMCP.Name, err)
+				continue
+			}
+			reconcileVirtualMCPVirtualKeys(ctx, store, target.ID, fileVMCP.Name, fileVMCP.VirtualKeyIDs)
+			continue
+		}
+
+		if !forceFileSync && dbVMCP.ConfigHash == fileHash {
+			logger.Debug("virtual MCP hash matches for %s, keeping stored config", fileVMCP.Name)
+			// The hash covers virtual_key_ids, and it is persisted before the VK diff below runs, so a
+			// prior attach/detach that failed (logged, not returned) leaves a matching hash. Re-run the
+			// idempotent diff here so it retries on a later load instead of being skipped forever.
+			reconcileVirtualMCPVirtualKeys(ctx, store, dbVMCP.ID, fileVMCP.Name, fileVMCP.VirtualKeyIDs)
+			continue
+		}
+
+		logger.Info("virtual MCP hash mismatch for %s, syncing from config.json", fileVMCP.Name)
+		target.ID = dbVMCP.ID
+		// EndpointSlug is immutable; UpdateVirtualMCP omits it, so the stored slug is preserved.
+		if err := store.UpdateVirtualMCP(ctx, &target); err != nil {
+			logger.Warn("skipping virtual MCP %q: failed to update: %v", fileVMCP.Name, err)
+			continue
+		}
+		reconcileVirtualMCPVirtualKeys(ctx, store, target.ID, fileVMCP.Name, fileVMCP.VirtualKeyIDs)
+	}
+
+	return nil
+}
+
+// reconcileVirtualMCPVirtualKeys diffs a Virtual MCP's desired VK attachments against the stored
+// set, attaching the missing and detaching the extra.
+func reconcileVirtualMCPVirtualKeys(ctx context.Context, store configstore.ConfigStore, vmcpID uint, vmcpName string, desiredVKs []string) {
+	current, err := store.GetVirtualKeyIDsForVirtualMCP(ctx, vmcpID)
+	if err != nil {
+		logger.Warn("failed to load VK attachments for virtual MCP %q: %v", vmcpName, err)
+		return
+	}
+	currentSet := make(map[string]bool, len(current))
+	for _, id := range current {
+		currentSet[id] = true
+	}
+	desiredSet := make(map[string]bool, len(desiredVKs))
+	for _, id := range desiredVKs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		desiredSet[id] = true
+		if !currentSet[id] {
+			if err := store.AttachVirtualMCPToVirtualKey(ctx, vmcpID, id); err != nil {
+				logger.Warn("failed to attach virtual MCP %q to VK %q: %v", vmcpName, id, err)
+			}
+		}
+	}
+	for id := range currentSet {
+		if !desiredSet[id] {
+			if err := store.DetachVirtualMCPFromVirtualKey(ctx, vmcpID, id); err != nil {
+				logger.Warn("failed to detach virtual MCP %q from VK %q: %v", vmcpName, id, err)
+			}
+		}
+	}
+}
+
+// pruneVirtualMCPsConfigToFile removes Virtual MCPs absent from config.json when config.json is the
+// source of truth for mcp.virtual_mcps.
+func pruneVirtualMCPsConfigToFile(ctx context.Context, store configstore.ConfigStore, fileVMCPs []schemas.VirtualMCPConfig) error {
+	if store == nil {
+		return nil
+	}
+	keepByName := make(map[string]bool, len(fileVMCPs))
+	keepByID := make(map[uint]bool, len(fileVMCPs))
+	for _, vmcp := range fileVMCPs {
+		if vmcp.Name != "" {
+			keepByName[vmcp.Name] = true
+		}
+		if vmcp.ID != 0 {
+			keepByID[vmcp.ID] = true
+		}
+	}
+
+	offset := 0
+	const pageSize = 100
+	toDelete := make([]configstoreTables.TableVirtualMCP, 0)
+	for {
+		batch, totalCount, err := store.GetVirtualMCPsPaginated(ctx, configstore.VirtualMCPsQueryParams{
+			Limit:  pageSize,
+			Offset: offset,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to get virtual MCPs from store: %w", err)
+		}
+		for _, dbVMCP := range batch {
+			if keepByID[dbVMCP.ID] || (dbVMCP.Name != "" && keepByName[dbVMCP.Name]) {
+				continue
+			}
+			toDelete = append(toDelete, dbVMCP)
+		}
+		offset += len(batch)
+		if int64(offset) >= totalCount || len(batch) == 0 {
+			break
+		}
+	}
+	for _, dbVMCP := range toDelete {
+		logger.Info("removing virtual MCP %q absent from config.json source of truth", dbVMCP.Name)
+		if err := store.DeleteVirtualMCP(ctx, dbVMCP.ID); err != nil {
+			return fmt.Errorf("failed to delete virtual MCP %q: %w", dbVMCP.Name, err)
+		}
+	}
+	return nil
+}
+
+// GenerateVirtualMCPHash generates a SHA256 hash from a Virtual MCP config payload. Tools and
+// virtual key IDs are sorted so the hash is stable regardless of declaration order.
+func GenerateVirtualMCPHash(name string, description *string, enabled bool, tools []configstoreTables.MCPToolSpec, virtualKeyIDs []string) string {
+	h := sha256.New()
+	fmt.Fprintf(h, "name:%s\n", name)
+	if description != nil {
+		fmt.Fprintf(h, "description:%s\n", *description)
+	}
+	fmt.Fprintf(h, "enabled:%t\n", enabled)
+
+	sortedTools := append([]configstoreTables.MCPToolSpec(nil), tools...)
+	sort.Slice(sortedTools, func(i, j int) bool {
+		if sortedTools[i].MCPClientID != sortedTools[j].MCPClientID {
+			return sortedTools[i].MCPClientID < sortedTools[j].MCPClientID
+		}
+		left := append([]string(nil), sortedTools[i].ToolNames...)
+		right := append([]string(nil), sortedTools[j].ToolNames...)
+		sort.Strings(left)
+		sort.Strings(right)
+		for idx := 0; idx < len(left) && idx < len(right); idx++ {
+			if left[idx] != right[idx] {
+				return left[idx] < right[idx]
+			}
+		}
+		return len(left) < len(right)
+	})
+	for _, tool := range sortedTools {
+		fmt.Fprintf(h, "tool.mcp_client_id:%s\n", tool.MCPClientID)
+		toolNames := append([]string(nil), tool.ToolNames...)
+		sort.Strings(toolNames)
+		for _, toolName := range toolNames {
+			fmt.Fprintf(h, "tool.name:%s\n", toolName)
+		}
+	}
+
+	vkIDs := append([]string(nil), virtualKeyIDs...)
+	sort.Strings(vkIDs)
+	for _, id := range vkIDs {
+		fmt.Fprintf(h, "vk:%s\n", id)
+	}
+
+	return fmt.Sprintf("%x", h.Sum(nil))
+}

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -1548,9 +1548,17 @@
             }
           ]
         },
+        "virtual_mcps": {
+          "type": "array",
+          "description": "Virtual MCPs: named bundles of tools from one or more MCP clients, served at /mcp/<endpoint_slug> and attachable to virtual keys. Canonical key; supersedes the deprecated tool_groups alias.",
+          "items": {
+            "$ref": "#/$defs/virtual_mcp_config"
+          }
+        },
         "tool_groups": {
           "type": "array",
-          "description": "Enterprise MCP tool groups with optional governance associations",
+          "description": "DEPRECATED: use virtual_mcps instead. Enterprise MCP tool groups with optional governance associations. Kept for backward compatibility.",
+          "deprecated": true,
           "items": {
             "$ref": "#/$defs/mcp_tool_group_config"
           }
@@ -6025,8 +6033,82 @@
         }
       }
     },
+    "virtual_mcp_config": {
+      "type": "object",
+      "description": "A Virtual MCP: a named bundle of tools from one or more MCP clients, served at /mcp/<endpoint_slug> and attachable to virtual keys.",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "DB ID of this Virtual MCP. When set, the reconciler updates the existing Virtual MCP with this ID rather than matching by name."
+        },
+        "name": {
+          "type": "string",
+          "description": "Virtual MCP display name (unique)"
+        },
+        "endpoint_slug": {
+          "type": "string",
+          "pattern": "^[a-z0-9]+(-[a-z0-9]+)*$",
+          "description": "URL-safe path the Virtual MCP is served at (/mcp/<endpoint_slug>). Honored on create only (immutable after); derived from the name when omitted. Unique across Virtual MCPs and MCP clients."
+        },
+        "description": {
+          "type": "string",
+          "description": "Virtual MCP description"
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether the Virtual MCP is enabled. A disabled Virtual MCP is not served.",
+          "default": true
+        },
+        "tools": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Per-client tool specs the Virtual MCP exposes",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mcp_client_id": {
+                "type": "string",
+                "description": "MCP client ID"
+              },
+              "mcp_client_name": {
+                "type": "string",
+                "description": "MCP client name (resolved to client_id at startup)"
+              },
+              "tool_names": {
+                "type": "array",
+                "description": "Tool names to expose. [\"*\"] means all tools (including future ones); [] means none; a named list means only those tools.",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "oneOf": [
+              {
+                "required": ["mcp_client_id"]
+              },
+              {
+                "required": ["mcp_client_name"]
+              }
+            ],
+            "additionalProperties": false
+          }
+        },
+        "virtual_key_ids": {
+          "type": "array",
+          "description": "Virtual keys this Virtual MCP is attached to.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["name", "tools"],
+      "additionalProperties": false
+    },
     "mcp_tool_group_config": {
       "type": "object",
+      "description": "DEPRECATED: use virtual_mcp_config (mcp.virtual_mcps) instead.",
+      "deprecated": true,
       "properties": {
         "id": {
           "type": "integer",
@@ -6088,30 +6170,40 @@
         },
         "team_ids": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtual_key_ids instead.",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
         },
         "customer_ids": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtual_key_ids instead.",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
         },
         "user_ids": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtual_key_ids instead.",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
         },
         "provider_names": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtual_key_ids instead.",
+          "deprecated": true,
           "items": {
             "type": "string"
           }
         },
         "api_key_ids": {
           "type": "array",
+          "description": "DEPRECATED: attach Virtual MCPs to virtual keys via virtual_key_ids instead.",
+          "deprecated": true,
           "items": {
             "type": "integer"
           }

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -6145,7 +6145,7 @@
               },
               "tool_names": {
                 "type": "array",
-                "description": "Tool names to allow. Empty means all tools from this MCP client.",
+                "description": "Tool names to expose. [\"*\"] means all tools (including future ones); [] means none; a named list means only those tools.",
                 "items": {
                   "type": "string"
                 }

--- a/transports/schema_test/config_schema_test.go
+++ b/transports/schema_test/config_schema_test.go
@@ -937,6 +937,82 @@ func TestSchemaMCPClientEndpointSlug(t *testing.T) {
 	})
 }
 
+func TestSchemaMCPVirtualMCPs(t *testing.T) {
+	schema := loadSchema(t)
+
+	t.Run("mcp includes virtual_mcps property", func(t *testing.T) {
+		_, found := navigateJSON(schema, "properties", "mcp", "properties", "virtual_mcps")
+		if !found {
+			t.Error("mcp is missing 'virtual_mcps' property — MCPConfig Go struct defines this field")
+		}
+	})
+
+	t.Run("virtual_mcp_config def includes endpoint_slug property", func(t *testing.T) {
+		_, found := navigateJSON(schema, "$defs", "virtual_mcp_config", "properties", "endpoint_slug")
+		if !found {
+			t.Error("$defs/virtual_mcp_config is missing 'endpoint_slug' — VirtualMCPConfig Go struct serializes this field")
+		}
+	})
+
+	t.Run("virtual_mcps entry with explicit endpoint_slug validates", func(t *testing.T) {
+		compiled := compileSchema(t)
+		config := `{
+			"mcp": {
+				"virtual_mcps": [
+					{
+						"name": "Platform Tools",
+						"endpoint_slug": "platform-tools",
+						"enabled": true,
+						"tools": [
+							{"mcp_client_name": "github", "tool_names": ["create_pull_request"]}
+						],
+						"virtual_key_ids": ["vk-1"]
+					}
+				]
+			}
+		}`
+		if err := validateConfig(t, compiled, config); err != nil {
+			t.Errorf("virtual_mcps entry should be valid, got: %v", err)
+		}
+	})
+
+	t.Run("virtual_mcps entry with non-url-safe endpoint_slug rejected", func(t *testing.T) {
+		compiled := compileSchema(t)
+		config := `{
+			"mcp": {
+				"virtual_mcps": [
+					{"name": "Bad Slug", "endpoint_slug": "Not A Slug", "tools": [{"mcp_client_id": "c1"}]}
+				]
+			}
+		}`
+		if err := validateConfig(t, compiled, config); err == nil {
+			t.Error("non-url-safe endpoint_slug must be rejected by the schema")
+		}
+	})
+
+	t.Run("virtual_mcps entry missing required name/tools rejected", func(t *testing.T) {
+		compiled := compileSchema(t)
+		config := `{"mcp": {"virtual_mcps": [{"endpoint_slug": "x"}]}}`
+		if err := validateConfig(t, compiled, config); err == nil {
+			t.Error("virtual_mcps entry without name and tools must be rejected")
+		}
+	})
+
+	t.Run("deprecated tool_groups still validates for backward compatibility", func(t *testing.T) {
+		compiled := compileSchema(t)
+		config := `{
+			"mcp": {
+				"tool_groups": [
+					{"name": "Legacy", "tools": [{"mcp_client_name": "github"}], "team_ids": ["t-1"]}
+				]
+			}
+		}`
+		if err := validateConfig(t, compiled, config); err != nil {
+			t.Errorf("deprecated tool_groups should still validate, got: %v", err)
+		}
+	})
+}
+
 func TestSchemaVKRotationCooldownBounds(t *testing.T) {
 	compiled := compileSchema(t)
 


### PR DESCRIPTION
## Summary

Promotes `mcp.virtual_mcps` as the canonical config.json key for declaring Virtual MCPs, replacing the deprecated `mcp.tool_groups` key. This updates both the schema reference and the Virtual MCPs guide to reflect the new key name, document `endpoint_slug` support, and clarify backward-compatibility behavior.

## Changes

- Replaced references to `mcp.tool_groups` with `mcp.virtual_mcps` in the Virtual MCPs guide, including an updated example snippet that uses the new key and demonstrates `endpoint_slug` and wildcard `tool_names` (`["*"]`)
- Added a new `### mcp.virtual_mcps` section to the schema reference with a full field table, a JSON example, and source-of-truth behavior notes
- Documented `endpoint_slug` as a first-class field: URL-safe, derived from name when omitted, immutable after creation, and unique across vMCPs and direct MCP clients
- Clarified `tool_names` semantics: `["*"]` selects all tools, `[]` selects none (previously described as "empty = all tools")
- Replaced the old `<Warning>` block (which flagged missing `endpoint_slug` support) with a `<Note>` block that formally marks `mcp.tool_groups` as deprecated, describes its legacy attachment arrays, and states that `mcp.virtual_mcps` wins when both keys are present
- Added a note that the same fields are available in the Helm chart under `bifrost.mcp.virtualMcps` with camelCase keys

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for:
- `docs/deployment-guides/config-json/schema-reference.mdx` — confirm the new `mcp.virtual_mcps` section appears with the correct table, example, and deprecation note
- `docs/mcp/virtual-mcps.mdx` — confirm the config.json tab shows `mcp.virtual_mcps`, includes `endpoint_slug`, uses `["*"]` for wildcard tools, and displays the deprecation note instead of the old warning

## Breaking changes

- [ ] Yes
- [x] No

`mcp.tool_groups` remains supported for backward compatibility. When both keys are present, `mcp.virtual_mcps` takes precedence.

## Related issues

## Security considerations

None. This is a documentation-only change.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable