### PR TITLE
docs: replace business-unit team membership with user membership (M:N) and add user VK creation policy endpoint

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1421,10 +1421,7 @@
                   "GET /api/governance/teams/{team_id}/customers",
                   "POST /api/governance/teams/{team_id}/customers",
                   "DELETE /api/governance/teams/{team_id}/customers/{customer_id}",
-                  "GET /api/governance/customers/{customer_id}/teams",
-                  "GET /api/governance/business-units/{business_unit_id}/teams",
-                  "POST /api/governance/business-units/{business_unit_id}/teams",
-                  "DELETE /api/governance/business-units/{business_unit_id}/teams/{team_id}"
+                  "GET /api/governance/customers/{customer_id}/teams"
                 ]
               },
               {
@@ -1445,6 +1442,7 @@
                   "PUT /api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override",
                   "DELETE /api/governance/virtual-keys/{vk_id}/budgets/{budget_id}/override",
                   "GET /api/governance/users/{user_id}/virtual-keys",
+                  "POST /api/governance/users/{user_id}/virtual-keys",
                   "GET /api/governance/users/email/{email}/virtual-keys"
                 ]
               },
@@ -1469,6 +1467,7 @@
                   "DELETE /api/governance/users/{user_id}",
                   "GET /api/governance/users/email/{email}",
                   "GET /api/governance/users/me/permissions",
+                  "GET /api/governance/users/me/vk-creation-policy",
                   "PUT /api/governance/users/{user_id}/role",
                   "POST /api/governance/users/{user_id}/governance",
                   "PUT /api/governance/users/{user_id}/governance",
@@ -1484,6 +1483,9 @@
                   "GET /api/governance/business-units/{business_unit_id}",
                   "PUT /api/governance/business-units/{business_unit_id}",
                   "DELETE /api/governance/business-units/{business_unit_id}",
+                  "GET /api/governance/business-units/{business_unit_id}/users",
+                  "POST /api/governance/business-units/{business_unit_id}/users",
+                  "DELETE /api/governance/business-units/{business_unit_id}/users/{user_id}",
                   "POST /api/governance/business-units/{business_unit_id}/governance",
                   "PUT /api/governance/business-units/{business_unit_id}/governance",
                   "DELETE /api/governance/business-units/{business_unit_id}/governance",

--- a/docs/openapi/openapi.yaml
+++ b/docs/openapi/openapi.yaml
@@ -733,6 +733,8 @@ paths:
     $ref: "./paths/management/users.yaml#/users-by-id"
   /api/governance/users/me/permissions:
     $ref: "./paths/management/users.yaml#/users-me-permissions"
+  /api/governance/users/me/vk-creation-policy:
+    $ref: "./paths/management/governanceextensions.yaml#/user-vk-creation-policy"
   /api/governance/users/{user_id}/role:
     $ref: "./paths/management/users.yaml#/users-role"
   /api/governance/users/{user_id}/teams:
@@ -883,10 +885,10 @@ paths:
     $ref: "./paths/management/businessunits.yaml#/business-units"
   /api/governance/business-units/{business_unit_id}:
     $ref: "./paths/management/businessunits.yaml#/business-units-by-id"
-  /api/governance/business-units/{business_unit_id}/teams:
-    $ref: "./paths/management/businessunits.yaml#/business-units-teams"
-  /api/governance/business-units/{business_unit_id}/teams/{team_id}:
-    $ref: "./paths/management/businessunits.yaml#/business-units-team-by-id"
+  /api/governance/business-units/{business_unit_id}/users:
+    $ref: "./paths/management/businessunits.yaml#/business-units-users"
+  /api/governance/business-units/{business_unit_id}/users/{user_id}:
+    $ref: "./paths/management/businessunits.yaml#/business-units-user-by-id"
   /api/governance/business-units/{business_unit_id}/governance:
     $ref: "./paths/management/businessunits.yaml#/business-units-governance"
   /api/governance/business-units/{business_unit_id}/customers:

--- a/docs/openapi/paths/management/accessprofiles.yaml
+++ b/docs/openapi/paths/management/accessprofiles.yaml
@@ -790,6 +790,9 @@ users-access-profile-budget-override:
 users-access-profile-virtual-keys:
   post:
     operationId: addUserAccessProfileVirtualKey
+    deprecated: true
+    x-bifrost-successor: '/api/governance/users/{user_id}/virtual-keys'
+    x-bifrost-removal: following-major-release
     x-mint:
       metadata:
         tag: Enterprise
@@ -797,7 +800,18 @@ users-access-profile-virtual-keys:
         <Note>
           This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
         </Note>
-    summary: Add an extra virtual key under a user's access profile
+        <Warning>
+          **Deprecated.** Use [`POST /api/governance/users/{user_id}/virtual-keys`](/api-reference/governance/mint-an-extra-virtual-key-for-a-user)
+          instead. This path still works and behaves identically, but will be removed in a future major release.
+        </Warning>
+    summary: Add an extra virtual key under a user's access profile (deprecated)
+    description: |
+      Issues an additional virtual key for the user. 
+
+      Virtual keys are scoped to the **user**, not to one access profile: what a request may do with
+      the key is resolved at request time from whichever of the user's active profiles grant it. So
+      `profile_id` is ignored — the key minted is the same whichever profile is named, and it is not
+      bound to that profile or removed with it. The user must hold at least one access profile.
     tags:
       - Access Profiles
     parameters:
@@ -809,6 +823,9 @@ users-access-profile-virtual-keys:
       - name: profile_id
         in: path
         required: true
+        description: >
+          Ignored. Kept so the path shape stays valid for existing clients; keys are user-scoped, so
+          any value produces the same result.
         schema:
           type: integer
     requestBody:
@@ -826,8 +843,16 @@ users-access-profile-virtual-keys:
           application/json:
             schema:
               $ref: '../../schemas/management/accessprofiles.yaml#/AddVirtualKeyResponse'
+      '400':
+        $ref: '../../openapi.yaml#/components/responses/BadRequest'
       '404':
-        description: User access profile not found
+        description: User has no access profiles
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
+      '409':
+        description: A virtual key with this name already exists
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/docs/openapi/paths/management/businessunits.yaml
+++ b/docs/openapi/paths/management/businessunits.yaml
@@ -1,10 +1,13 @@
 # Paths for Business Unit management (Enterprise).
 #
-# Business units are organizational groupings above teams (1:N with teams) with
-# their own governance (budget + rate limit). They live entirely under
-# /api/governance/business-units, mirroring the other governance entities; the
-# budget + rate-limit configuration is nested under /{id}/governance. Implemented
-# in bifrost-enterprise/handlers/businessunits.go.
+# Business units are organizational groupings that own governance (budget + rate
+# limit). Membership is a many-to-many relation with users: a user may belong to
+# several business units, and each membership edge carries its own provenance
+# (manual / SCIM / OIDC) so one sync channel never clears another's. They live
+# entirely under /api/governance/business-units, mirroring the other governance
+# entities; the budget + rate-limit configuration is nested under
+# /{id}/governance, and the member roster under /{id}/users. Implemented in
+# bifrost-enterprise/handlers/businessunits.go.
 
 # ---- Business Unit CRUD ----
 
@@ -19,7 +22,7 @@ business-units:
           This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
         </Note>
     summary: List business units
-    description: Returns a paginated list of business units, each with its team count.
+    description: Returns a paginated list of business units, each with its user count.
     tags:
       - Governance
     parameters:
@@ -105,7 +108,7 @@ business-units-by-id:
           This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
         </Note>
     summary: Get business unit
-    description: Returns a specific business unit by ID, including governance and team count.
+    description: Returns a specific business unit by ID, including governance and user count.
     tags:
       - Governance
     parameters:
@@ -192,8 +195,9 @@ business-units-by-id:
         </Note>
     summary: Delete business unit
     description: |
-      Deletes a business unit. Any teams assigned to it are atomically unassigned
-      as part of the deletion.
+      Deletes a business unit. Every user membership of it is atomically removed as part of the
+      deletion, and each affected user's governance is refreshed so the business unit stops
+      applying to their requests.
     tags:
       - Governance
     parameters:
@@ -221,11 +225,11 @@ business-units-by-id:
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 
-# ---- Business Unit - Team Association ----
+# ---- Business Unit - User Membership (M:N) ----
 
-business-units-teams:
+business-units-users:
   get:
-    operationId: listBusinessUnitTeams
+    operationId: listBusinessUnitUsers
     x-mint:
       metadata:
         tag: Enterprise
@@ -233,8 +237,11 @@ business-units-teams:
         <Note>
           This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
         </Note>
-    summary: List business unit teams
-    description: Returns a paginated list of teams assigned to the business unit.
+    summary: List business unit users
+    description: |
+      Returns a paginated list of users that belong to the business unit, each with the
+      provenance of its membership edge so a caller can tell an admin assignment apart from
+      an identity-provider-synced one.
     tags:
       - Governance
     parameters:
@@ -253,7 +260,7 @@ business-units-teams:
           default: 0
       - name: limit
         in: query
-        description: Maximum number of teams to return (max 100)
+        description: Maximum number of users to return (max 100)
         schema:
           type: integer
           minimum: 1
@@ -261,7 +268,7 @@ business-units-teams:
           default: 20
       - name: search
         in: query
-        description: Case-insensitive search by team name
+        description: Case-insensitive search by user name or email
         schema:
           type: string
     security:
@@ -272,7 +279,7 @@ business-units-teams:
         content:
           application/json:
             schema:
-              $ref: '../../schemas/management/governance.yaml#/BusinessUnitTeamsResponse'
+              $ref: '../../schemas/management/governance.yaml#/BusinessUnitUsersResponse'
       '404':
         description: Business unit not found
         content:
@@ -283,7 +290,7 @@ business-units-teams:
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 
   post:
-    operationId: assignTeamToBusinessUnit
+    operationId: assignUserToBusinessUnit
     x-mint:
       metadata:
         tag: Enterprise
@@ -291,10 +298,10 @@ business-units-teams:
         <Note>
           This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
         </Note>
-    summary: Assign team to business unit
+    summary: Assign user to business unit
     description: |
-      Assigns an existing team to the business unit. Returns 409 if the team is
-      already assigned to a different business unit.
+      Assigns an existing user to the business unit. Membership is many-to-many, so a user may
+      belong to several business units and there is no conflict to reject.
     tags:
       - Governance
     parameters:
@@ -309,12 +316,12 @@ business-units-teams:
       content:
         application/json:
           schema:
-            $ref: '../../schemas/management/governance.yaml#/AssignTeamToBusinessUnitRequest'
+            $ref: '../../schemas/management/governance.yaml#/AssignUserToBusinessUnitRequest'
     security:
       - ManagementBearerAuth: []
     responses:
       '200':
-        description: Team assigned to business unit
+        description: User assigned to business unit
         content:
           application/json:
             schema:
@@ -322,13 +329,7 @@ business-units-teams:
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
       '404':
-        description: Business unit or team not found
-        content:
-          application/json:
-            schema:
-              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
-      '409':
-        description: Team is already assigned to another business unit
+        description: Business unit or user not found
         content:
           application/json:
             schema:
@@ -336,9 +337,9 @@ business-units-teams:
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 
-business-units-team-by-id:
+business-units-user-by-id:
   delete:
-    operationId: removeTeamFromBusinessUnit
+    operationId: removeUserFromBusinessUnit
     x-mint:
       metadata:
         tag: Enterprise
@@ -346,8 +347,8 @@ business-units-team-by-id:
         <Note>
           This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
         </Note>
-    summary: Remove team from business unit
-    description: Unassigns a team from the business unit.
+    summary: Remove user from business unit
+    description: Removes a user's membership of the business unit.
     tags:
       - Governance
     parameters:
@@ -357,17 +358,17 @@ business-units-team-by-id:
         description: Business unit ID
         schema:
           type: string
-      - name: team_id
+      - name: user_id
         in: path
         required: true
-        description: Team ID
+        description: User ID
         schema:
           type: string
     security:
       - ManagementBearerAuth: []
     responses:
       '200':
-        description: Team removed from business unit
+        description: User removed from business unit
         content:
           application/json:
             schema:
@@ -375,7 +376,7 @@ business-units-team-by-id:
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
       '404':
-        description: Business unit or team not found
+        description: Membership not found
         content:
           application/json:
             schema:

--- a/docs/openapi/paths/management/governance.yaml
+++ b/docs/openapi/paths/management/governance.yaml
@@ -908,9 +908,7 @@ model-configs:
           type: string
       - name: scope
         in: query
-        description: >-
           Comma-separated scopes to filter by. `project`, `access_profile` and
-          the legacy `user` are Enterprise only.
         schema:
           type: string
       - name: scope_id
@@ -944,7 +942,13 @@ model-configs:
   post:
     operationId: createModelConfig
     summary: Create model config
-    description: Creates a new model configuration with budget and rate limit settings.
+    description: |
+      Creates a new model configuration with budget and rate limit settings.
+
+      `scope: "user"` is rejected with 403. It is retired as a creatable scope — per-model
+      budgets for a person are now declared on an access profile and materialize per user as
+      `access_profile`-scoped limits. Existing `user`-scoped rows keep working and stay editable
+      through the update endpoint.
     tags:
       - Governance
     requestBody:
@@ -964,6 +968,14 @@ model-configs:
               $ref: '../../schemas/management/governance.yaml#/ModelConfigResponse'
       '400':
         $ref: '../../openapi.yaml#/components/responses/BadRequest'
+      '403':
+        description: |
+          The requested scope cannot be assigned to a new limit. Returned for
+          `scope: "user"`, which is retired in favour of access-profile per-model budgets.
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/common.yaml#/ErrorResponse'
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/docs/openapi/paths/management/governanceextensions.yaml
+++ b/docs/openapi/paths/management/governanceextensions.yaml
@@ -111,6 +111,9 @@ user-virtual-keys:
           This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
         </Note>
     summary: List virtual keys available to a user
+    description: |
+      Returns every virtual key assigned to the user, independent of access profiles, so
+      directly-assigned standalone keys are visible alongside profile-issued ones.
     tags: [Users, Virtual Keys]
     parameters:
       - name: user_id
@@ -131,7 +134,102 @@ user-virtual-keys:
                   type: array
                   items:
                     type: object
-                    additionalProperties: true
+                    properties:
+                      id: { type: string }
+                      name: { type: string }
+                      value: { type: string }
+                      is_access_profile_managed:
+                        type: boolean
+                        description: >
+                          True when an access profile governs this key, in which case its policy
+                          is edit-locked and changed by editing and propagating the profile.
+  post:
+    operationId: addUserVirtualKey
+    x-mint:
+      metadata:
+        tag: Enterprise
+      content: |
+        <Note>
+          This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
+        </Note>
+    summary: Mint an extra virtual key for a user
+    description: |
+      Issues an additional virtual key for the user.
+
+      Virtual keys are scoped to the **user**, not to any one access profile: what a request may
+      do with the key is read from whichever of the user's active profiles grants it, and each of
+      those profiles is a separate routing candidate the request may be served by. The user must
+      therefore hold at least one access profile — the request returns 404 otherwise — but the key
+      is not tied to the profile that happened to be current when it was minted, and it survives
+      that profile being detached as long as the user still holds another.
+    tags: [Users, Virtual Keys]
+    parameters:
+      - name: user_id
+        in: path
+        required: true
+        schema: { type: string }
+    requestBody:
+      required: false
+      content:
+        application/json:
+          schema:
+            $ref: '../../schemas/management/accessprofiles.yaml#/AddVirtualKeyRequest'
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Virtual key created.
+        content:
+          application/json:
+            schema:
+              $ref: '../../schemas/management/accessprofiles.yaml#/AddVirtualKeyResponse'
+      '404':
+        description: User has no access profiles
+      '409':
+        description: A virtual key with this name already exists
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
+
+user-vk-creation-policy:
+  get:
+    operationId: getMyVirtualKeyCreationPolicy
+    x-mint:
+      metadata:
+        tag: Enterprise
+      content: |
+        <Note>
+          This endpoint is available in [Bifrost Enterprise](https://www.getmaxim.ai/bifrost/enterprise) only.
+        </Note>
+    summary: Get the calling user's virtual-key creation policy
+    description: |
+      Reports whether virtual keys the **calling** user creates will be adopted into one of their
+      access profiles, and if so which one. The create form uses this to lock the policy fields
+      up front rather than letting a user author a policy that is about to be overwritten.
+
+      Self-scoped: it always describes the caller and takes no user ID. Returns
+      `{"governed": false}` when the caller has no per-user identity (local admin or password
+      auth) or when no profile they hold has **Govern virtual keys created by members** enabled.
+      When more than one of their profiles has it on, the first such profile governs.
+    tags: [Users, Virtual Keys]
+    security:
+      - ManagementBearerAuth: []
+    responses:
+      '200':
+        description: Virtual-key creation policy for the calling user
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [governed]
+              properties:
+                governed:
+                  type: boolean
+                  description: Whether an access profile will adopt keys this user creates.
+                profile_name:
+                  type: string
+                  description: Name of the governing access profile. Present only when `governed` is true.
+      '500':
+        $ref: '../../openapi.yaml#/components/responses/InternalError'
 
 team-customers:
   get:

--- a/docs/openapi/paths/management/governancelegacy.yaml
+++ b/docs/openapi/paths/management/governancelegacy.yaml
@@ -433,6 +433,11 @@ legacy-user-virtual-keys:
     operationId: listUserVirtualKeysLegacy
     x-bifrost-successor: '/api/governance/users/{user_id}/virtual-keys'
     x-bifrost-removal: following-major-release
+  post:
+    $ref: './governanceextensions.yaml#/user-virtual-keys/post'
+    operationId: addUserVirtualKeyLegacy
+    x-bifrost-successor: '/api/governance/users/{user_id}/virtual-keys'
+    x-bifrost-removal: following-major-release
 
 legacy-user-access-profile-budget-override:
   put:
@@ -457,7 +462,7 @@ legacy-users-access-profile-virtual-keys:
   post:
     $ref: './accessprofiles.yaml#/users-access-profile-virtual-keys/post'
     operationId: addUserAccessProfileVirtualKeyLegacy
-    x-bifrost-successor: '/api/governance/users/{user_id}/access-profiles/{profile_id}/virtual-keys'
+    x-bifrost-successor: '/api/governance/users/{user_id}/virtual-keys'
     x-bifrost-removal: following-major-release
 
 legacy-users-access-profile-virtual-key-by-id:

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -631,6 +631,7 @@ VirtualKeyQuotaResponse:
     - is_active
     - budgets
     - rate_limit
+    - rate_limits
     - provider_configs
     - model_configs
   properties:
@@ -648,9 +649,23 @@ VirtualKeyQuotaResponse:
       items:
         $ref: '#/VirtualKeyBudgetUsage'
     rate_limit:
+      description: >
+        The single effective rate limit for this key. For a key managed by an enterprise access
+        profile this is the tightest-per-dimension merge of every profile governing the key, and
+        carries the real usage. Kept for readers that expect one value; see `rate_limits` for the
+        unmerged list.
       oneOf:
         - $ref: '#/RateLimit'
         - type: 'null'
+    rate_limits:
+      type: array
+      description: >
+        Every rate limit `rate_limit` was merged from, each tagged with its source, so a caller can
+        see which one is actually binding rather than only the merged result. A user may hold
+        several enterprise access profiles at once, each contributing its own rate limit, so this
+        can carry more than one entry. Always present; empty when the key has no rate limit at all.
+      items:
+        $ref: '#/SourcedRateLimit'
     provider_configs:
       type: [array, 'null']
       description: Per-provider budget quotas and rate limits (provider-level splits and limits)
@@ -681,6 +696,35 @@ VirtualKeyBudgetUsage:
           description: Per-model actual usage within this budget's current cycle
           items:
             $ref: '#/VirtualKeyModelSpend'
+        source_type:
+          type: string
+          description: >
+            What governs this budget when it did not come from the virtual key's own rows — e.g.
+            `access_profile`. Omitted when there is nothing to disambiguate.
+        source_id:
+          type: string
+          description: ID of the source named by `source_type`.
+        source_name:
+          type: string
+          description: Human-readable label for `source_id`.
+
+SourcedRateLimit:
+  description: >
+    A rate limit tagged with what governs it. The source fields are empty when there is nothing to
+    disambiguate, e.g. a virtual key's own rate-limit row.
+  allOf:
+    - $ref: '#/RateLimit'
+    - type: object
+      properties:
+        source_type:
+          type: string
+          description: What governs this rate limit — e.g. `access_profile`.
+        source_id:
+          type: string
+          description: ID of the source named by `source_type`.
+        source_name:
+          type: string
+          description: Human-readable label for `source_id`.
 
 VirtualKeyModelSpend:
   type: object
@@ -999,8 +1043,9 @@ BusinessUnitListItem:
       type: string
     name:
       type: string
-    team_count:
+    user_count:
       type: integer
+      description: Number of users that belong to this business unit.
     customer_count:
       type: integer
     created_at:
@@ -1035,14 +1080,15 @@ ListBusinessUnitsResponse:
 
 BusinessUnitDetailResponse:
   type: object
-  description: Single business unit with governance and team count
+  description: Single business unit with governance and user count
   properties:
     id:
       type: string
     name:
       type: string
-    team_count:
+    user_count:
       type: integer
+      description: Number of users that belong to this business unit.
     budget:
       $ref: '#/Budget'
     rate_limit:
@@ -1072,26 +1118,26 @@ BusinessUnitMutationResponse:
     name:
       type: string
 
-AssignTeamToBusinessUnitRequest:
+AssignUserToBusinessUnitRequest:
   type: object
-  description: Request to assign a team to a business unit
+  description: Request to assign a user to a business unit
   required:
-    - team_id
+    - user_id
   properties:
-    team_id:
+    user_id:
       type: string
 
-BusinessUnitTeamsResponse:
+BusinessUnitUsersResponse:
   type: object
-  description: Paginated list of teams assigned to a business unit
+  description: Paginated list of users that belong to a business unit
   required:
-    - teams
+    - users
     - count
     - total_count
     - limit
     - offset
   properties:
-    teams:
+    users:
       type: array
       items:
         type: object
@@ -1100,6 +1146,15 @@ BusinessUnitTeamsResponse:
             type: string
           name:
             type: string
+          email:
+            type: string
+          source:
+            type: string
+            description: >
+              Provenance of this user's membership edge. `manual` means an admin or `config.json`
+              assigned it and no claims sync will clear it; the synced values
+              (`scim_user_attribute`, `scim_group_attribute`, `attribute_mapping`, `scim`) mean an
+              identity provider owns it. Empty on legacy unstamped edges, which are treated as synced.
     count:
       type: integer
     total_count:
@@ -1476,14 +1531,24 @@ ModelConfig:
     scope_id:
       type: string
       nullable: true
-      description: >-
-        ID of the scope target, for example a virtual key id, a project id, or
-        the user's access-profile assignment id. Required when scope is not
-        `global`.
+      description: >
+        ID of the scope target — a virtual key ID for `virtual_key`, a user access profile ID for
+        `access_profile`, a user ID for legacy `user` rows. Required when scope is not `global`.
     scope_name:
       type: string
       nullable: true
       description: Resolved human-readable name of the scope target (read-only, set by server).
+    source_type:
+      type: string
+      description: >
+        What materialized this limit, when it was not authored directly — e.g. `access_profile`.
+        Read-only; omitted for limits with no upstream source.
+    source_id:
+      type: string
+      description: ID of the source named by `source_type` (read-only).
+    source_name:
+      type: string
+      description: Human-readable label for `source_id` (read-only).
     calendar_aligned:
       type: boolean
       description: When true, all budgets reset at clean calendar boundaries (midnight UTC for day, Monday for week, 1st for month, Jan 1 for year).

--- a/docs/openapi/schemas/management/users.yaml
+++ b/docs/openapi/schemas/management/users.yaml
@@ -39,7 +39,26 @@ UserObject:
       description: Teams the user belongs to.
       items:
         $ref: '#/UserTeamSummaryEntry'
+    business_units:
+      type: array
+      description: >
+        Business units the user belongs to. Membership is many-to-many and belongs to the user, so
+        this is the authoritative list; manage it under
+        `/api/governance/business-units/{business_unit_id}/users`.
+      items:
+        $ref: '#/UserBusinessUnitSummaryEntry'
+    access_profiles:
+      type: array
+      description: >
+        Every access profile the user holds, one per assignment source. All of them are enforced —
+        their budgets, rate limits, and provider access combine.
+      items:
+        $ref: '#/AccessProfile'
     access_profile:
+      description: >
+        Deprecated. A single-value summary of the highest-precedence profile
+        (`attribute_mapping` > `role_default` > `manual`), kept for clients written before a user
+        could hold several. It grants nothing on its own — read `access_profiles` instead.
       $ref: '#/AccessProfile'
 
 CreateUserRequest:
@@ -146,14 +165,17 @@ UserTeamSummaryEntry:
     name:
       type: string
       description: Team name
-    business_unit_id:
+
+UserBusinessUnitSummaryEntry:
+  type: object
+  description: A business unit the user belongs to.
+  properties:
+    id:
       type: string
-      nullable: true
-      description: Business unit ID associated with this team (if any)
-    business_unit_name:
+      description: Business unit ID
+    name:
       type: string
-      nullable: true
-      description: Business unit name associated with this team (if any)
+      description: Business unit name
 
 UserTeamEntry:
   type: object


### PR DESCRIPTION
## Summary

Docs for the business unit membership model from a team-based association to a direct user-based many-to-many relationship, and adds new virtual key management endpoints and a virtual-key creation policy endpoint for users.

## Changes

- **Business units now relate directly to users (M:N) instead of teams (1:N).** The `/api/governance/business-units/{business_unit_id}/teams` and `/teams/{team_id}` endpoints are replaced by `/users` and `/users/{user_id}`. Each membership edge carries a provenance field (`manual`, `scim`, `scim_group_attribute`, etc.) so different sync channels cannot clear each other's assignments. Deleting a business unit now atomically removes all user memberships and refreshes affected users' governance.
- **`POST /api/governance/users/{user_id}/virtual-keys`** **is introduced** as the canonical endpoint for minting extra virtual keys for a user. Keys are user-scoped, not profile-scoped — they survive profile detachment as long as the user holds at least one profile.
- **`GET /api/governance/users/me/vk-creation-policy`** **is introduced** to let the calling user discover whether any of their access profiles will adopt newly created virtual keys, and which profile governs if so.
- **`POST /api/governance/users/{user_id}/access-profiles/{profile_id}/virtual-keys`** **is deprecated** in favour of the new user-scoped endpoint. The `profile_id` path parameter is now documented as ignored. The legacy path under `/api/governance/users/{user_id}/access-profiles/{profile_id}/virtual-keys` is updated to point to the new successor.
- **`scope: "user"`** **is retired as a creatable scope for model configs.** `POST /api/governance/model-configs` now returns 403 for that scope. Existing `user`\-scoped rows remain readable and editable.
- **`VirtualKeyQuotaResponse`** **gains a** **`rate_limits`** **array** alongside the existing `rate_limit` field, exposing each unmerged rate limit with its source so callers can identify which limit is actually binding when a user holds multiple access profiles.
- **`VirtualKeyBudgetUsage`** **and** **`ModelConfig`** **gain** **`source_type`,** **`source_id`, and** **`source_name`** **fields** to surface the upstream access profile or other entity that materialized a given limit.
- **`UserObject`** **gains** **`business_units`** **and** **`access_profiles`** **arrays.** The existing `access_profile` field is deprecated in favour of `access_profiles`, which lists every profile the user holds rather than only the highest-precedence one.
- **`UserTeamSummaryEntry`** **drops** **`business_unit_id`** **and** **`business_unit_name`** since business unit membership is now a direct user relationship, not derived from team membership.
- **`GET /api/governance/users/{user_id}/virtual-keys`** **response schema is tightened** to enumerate `id`, `name`, `value`, and `is_access_profile_managed` rather than `additionalProperties: true`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./...
```

- Verify `GET /api/governance/business-units/{id}/users` returns users with a `source` field.
- Verify `POST /api/governance/business-units/{id}/users` accepts multiple users without conflict.
- Verify `DELETE /api/governance/business-units/{id}/users/{user_id}` removes only the targeted membership.
- Verify `POST /api/governance/users/{user_id}/virtual-keys` returns 404 when the user holds no access profiles and 409 on a duplicate name.
- Verify `GET /api/governance/users/me/vk-creation-policy` returns `{"governed": false}` for users with no governing profile and includes `profile_name` when one applies.
- Verify `POST /api/governance/model-configs` with `scope: "user"` returns 403.
- Verify `VirtualKeyQuotaResponse` includes a populated `rate_limits` array.

## Breaking changes

- [x] Yes
- [ ] No

The `/api/governance/business-units/{business_unit_id}/teams` and `/teams/{team_id}` endpoints are removed. Callers must migrate to the `/users` and `/users/{user_id}` equivalents. The `team_count` field on business unit responses is replaced by `user_count`. `UserTeamSummaryEntry` no longer carries `business_unit_id` or `business_unit_name`. Creating model configs with `scope: "user"` now returns 403.

## Related issues

## Security considerations

The new `GET /api/governance/users/me/vk-creation-policy` endpoint is self-scoped to the calling user and requires `ManagementBearerAuth`, so it cannot be used to inspect another user's policy. All new business unit user membership endpoints require the same bearer auth as the rest of the governance API.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable