### PR TITLE
docs: add roles, business units, access profile mappings, and multi-profile docs across enterprise guides

### DIFF
--- a/docs/deployment-guides/config-json/schema-reference.mdx
+++ b/docs/deployment-guides/config-json/schema-reference.mdx
@@ -22,10 +22,10 @@ This page is a concise reference for every top-level key in `config.json`. Click
 | `encryption_key` | string | Optional AES-256 key (derived via Argon2id). Accepts `env.VAR` prefix and is also read from `BIFROST_ENCRYPTION_KEY`. If omitted, data is stored in plaintext. | [Client](/deployment-guides/config-json/client#encryption-key) |
 | `client` | object | Worker pool, logging, CORS, auth enforcement, header filtering, MCP, compat shims | [Client](/deployment-guides/config-json/client) |
 | `providers` | object | LLM provider API keys, network settings, concurrency | [Providers](/deployment-guides/config-json/providers) |
-| `governance` | object | Admin auth, virtual keys, budgets, rate limits, routing rules, customers, teams | [Governance](/deployment-guides/config-json/governance) |
+| `governance` | object | Admin auth, virtual keys, budgets, rate limits, routing rules, customers, teams, roles and business units | [Governance](/deployment-guides/config-json/governance) |
 | `alerting` | object | Alert channels, CEL-based rules, history retention, and webhook network controls *(enterprise only)* | [Alerting](/deployment-guides/config-json/alerting) |
 | `guardrails_config` | object | Content moderation providers and CEL-based rules *(enterprise only)* | [Guardrails](/deployment-guides/config-json/guardrails) |
-| `access_profiles` | array | Access profile templates for enterprise RBAC/governance controls *(enterprise only)* | [Enterprise Governance](/enterprise/advanced-governance) |
+| `access_profiles` | array | Access profile templates for enterprise RBAC/governance controls *(enterprise only)* | [Access Profiles](/enterprise/access-profiles) |
 | `cluster_config` | object | Cluster mode settings: gossip, peers, and auto-discovery backends *(enterprise only)* | [Cluster](/deployment-guides/config-json/cluster) |
 | `config_store` | object | Configuration database backend - SQLite, PostgreSQL, or disabled (file-only mode) | [Storage](/deployment-guides/config-json/storage#config_store) |
 | `logs_store` | object | Request/response log database - SQLite, PostgreSQL + optional S3/GCS offload | [Storage](/deployment-guides/config-json/storage#logs_store) |
@@ -186,6 +186,83 @@ Enterprise-only. Defines access profile templates that can later be attached to 
   ]
 }
 ```
+
+---
+
+## `governance.roles`
+
+Enterprise-only. Declares RBAC roles, the access profiles they grant, their data access scope, and their permissions.
+
+```json
+{
+  "governance": {
+    "roles": [
+      {
+        "name": "engineer",
+        "description": "Product engineers",
+        "dac": "team-data",
+        "entity_dac": { "PromptRepository": "all-data" },
+        "access_profiles": ["Engineering Baseline", "Opus Pilot"],
+        "permissions": [
+          { "resource": "VirtualKeys", "operation": "View" },
+          { "resource": "PromptRepository", "operation": "Create" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Role name. Identity field — renaming declares a different role. |
+| `description` | string | Optional free-text description. |
+| `dac` | string | Role-level [data access scope](/enterprise/data-access-control): `own-data`, `team-data`, or `all-data`. |
+| `entity_dac` | object | Per-resource scope overrides, keyed by resource name (same names as `permissions`, below). Resources not listed follow `dac`. Applied as a **full replace** — removing `entity_dac` clears every override on the next sync. |
+| `access_profiles` | string[] | Names of every [access profile](/enterprise/access-profiles) this role grants. A role grants **all** of them, and users with the role receive each one. |
+| `access_profile` | string | **Deprecated** — single-profile form, kept for existing files. Ignored whenever `access_profiles` is set. |
+| `permissions` | array | `{ resource, operation }` pairs granted to the role. Both values are case-sensitive — see below. |
+
+Resource and operation names must match Bifrost's own spelling exactly. Resources are PascalCase - `VirtualKeys`, `PromptRepository`, `Teams`, `Customers`, `BusinessUnits`, `AccessProfiles`, `Users`, `RBAC`, `APIKeys`, `Logs`, `AuditLogs`, `MCPGateway`, `RoutingRules`, `GuardrailsConfig`, and so on. Operations are normally `Create`, `View`, `Update`, and `Delete`; a few resources add their own, such as `Reveal` on `Logs`, `Download` on `AuditLogs`, and `CreateStandalone` on `VirtualKeys`.
+
+<Warning>
+  A permission Bifrost does not recognise is skipped with a warning in the startup logs, not
+  rejected. A misspelling like `virtual_keys` or `read` leaves the role without that permission
+  instead of failing the sync, so check the logs after editing this section.
+</Warning>
+
+The `access_profiles` list is the full set of profiles the role grants. On each sync Bifrost attaches any that are missing and removes any that are no longer listed, so editing the list is how you change what a role grants. Note that an explicit empty list (`"access_profiles": []`) means "grant nothing" and removes every profile from the role — leaving the field out entirely is different, and falls back to the deprecated `access_profile`.
+
+<Note>
+  Switching a role from `access_profile: "X"` to `access_profiles: ["X"]` is a no-op — Bifrost treats
+  the two as the same declaration, so nothing re-syncs on upgrade.
+</Note>
+
+---
+
+## `governance.business_units`
+
+Enterprise-only. Declares business unit **definitions** and their governance.
+
+```json
+{
+  "governance": {
+    "business_units": [
+      {
+        "id": "bu-platform",
+        "name": "Platform"
+      }
+    ]
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Stable identifier, referenced by other config rows. |
+| `name` | string | Display name. |
+
+This section defines business units, not who belongs to them. Members are users, and they are added by an admin or by your identity provider — not from `config.json`, which cannot reference users that do not exist yet at startup. See [User Provisioning](/enterprise/user-provisioning#business-unit-membership).
 
 ---
 

--- a/docs/enterprise/access-profiles.mdx
+++ b/docs/enterprise/access-profiles.mdx
@@ -6,7 +6,9 @@ icon: "id-card"
 
 ## Overview
 
-An **Access Profile** is a reusable policy template that describes what a user,team or business unit is allowed to do once they are granted access. When you assign a profile to an entity (directly or by attaching it to a role they hold), Bifrost Enterprise creates a per-user copy of the policy and automatically issues a virtual key for them. The virtual key carries the policy's provider list, model whitelist, budgets, rate limits, and MCP tool access. Users never need to be handed raw keys, and operators never need to write keys by hand.
+An **Access Profile** is a reusable policy template that describes what a user,team or business unit is allowed to do once they are granted access. When you assign a profile to an entity (directly or by attaching it to a role they hold), Bifrost Enterprise creates a per-user copy of the policy and automatically issues a virtual key for them. Every request made with that key is governed by the profile's provider list, model whitelist, budgets, rate limits, and MCP tool access. Because the profile is consulted on each request, editing it takes effect straight away - there is no need to reissue anyone's key. Users never need to be handed raw keys, and operators never need to write keys by hand.
+
+A user can hold **several access profiles at once**. Together they decide what the user can reach, and one of them pays for each request - see [Multiple profiles per user](#multiple-profiles-per-user).
 
 <Info>
   For rest of the article we will focus on access profiles for users. But the same principles apply
@@ -17,9 +19,10 @@ An **Access Profile** is a reusable policy template that describes what a user,t
 
 - **Reusable policy** - Define a profile once (for example, "Engineering") and apply it to every user in a role.
 - **Per-user enforcement** - Each user gets an independent copy with isolated budget and rate-limit counters.
-- **Role-default auto-assignment** - Mark a profile as a role's default and new users in that role are provisioned automatically.
+- **Layered access** - A user can hold several profiles at once. What they can reach adds up, and if one profile's budget runs out another can cover their requests.
+- **Role auto-assignment** - Attach profiles to a role and users gaining that role are provisioned automatically.
 - **Safe propagation** - Edit the template, then push selected fields (budgets only, MCP only, and so on) to every user copy in one call.
-- **Managed virtual keys** - Auto-issued keys are write-protected so a user cannot weaken their own policy by editing the key directly.
+- **Managed virtual keys** - Auto-issued keys are write-protected, so a user cannot weaken their own policy by editing the key directly.
 - **Govern user-created keys** - Optionally bring every virtual key a member creates under the profile automatically, not just the auto-issued key.
 - **Audit and versioning** - Every change to a profile is recorded with a full snapshot history.
 
@@ -48,17 +51,35 @@ flowchart LR
 ```
 
 1. **Template** - The Access Profile is the policy you author. Each policy lives once in the workspace.
-2. **User copy** - When a user becomes eligible for a profile, Bifrost clones the template into a per-user copy with fresh budget and rate-limit counters. Each user accumulates usage independently.
-3. **Virtual key** - Bifrost issues a virtual key whose provider configs, budgets, rate limit, and MCP configs are built from the user copy. The key is marked profile-managed so it cannot be edited around the policy.
+2. **How it is granted** - A user gets a profile in one of three ways: you attach it to them by hand, their role grants it, or their identity provider attributes match a mapping rule. Bifrost remembers which, so removing one grant never disturbs the others.
+3. **User copy** - Bifrost copies the template to the user, with its own budget and rate-limit counters. Each user's usage is tracked separately, and a user can hold several profiles at once.
+4. **Virtual key** - Bifrost issues a virtual key to the user. The key belongs to the user rather than to one profile, so it keeps working as their profiles change, and what it may do comes from whichever profiles they currently hold. It is locked against direct edits so the policy cannot be worked around.
+5. **Per-model limits** - Per-model budgets set on the profile appear for each assigned user as their own read-only limit. See [Model Limits](/features/governance/model-limits#per-user-model-limits-enterprise).
 
-### Role-default auto-assignment
+### Multiple profiles per user
 
-When an Access Profile is attached to a role and marked as the default for that role, two flows kick in:
+A user can hold more than one access profile at a time - one from their role, say, and another attached by hand. The profiles do not merge into a single blended policy. Instead:
+
+**Access adds up.** The user can use any provider and any model that *any* of their profiles allows. Giving someone an extra profile can only widen what they can reach; to narrow it, remove a profile or tighten the template.
+
+**One profile pays for each request.** Bifrost picks one of the profiles that allows the request and charges it - its budget, its rate limit, and any per-model limit it sets. The user's other profiles are not charged, and their usage is unaffected.
+
+**If one profile is out of budget, another covers the request.** A user whose Engineering budget is spent keeps working if another of their profiles can still fund the request. Only when every profile that allows the request has run out is the request blocked, and the message names the profile that was tried.
+
+**Usage is tracked per profile.** Each profile has its own counters, so spending against one never eats into another's remaining budget.
+
+<Note>
+  Budgets on a user's teams, customers, and business units are charged for every request they make,
+  no matter which profile paid for it. Those are separate from profile budgets, not an alternative
+  to them.
+</Note>
+
+### Role auto-assignment
+
+A role can grant **any number** of access profiles. When a role is attached to one or more profiles, two flows kick in:
 
 - **Existing users in that role** - Optionally provisioned at attach time.
 - **Users gaining the role later** - Automatically provisioned the moment their role changes.
-
-Role changes only replace assignments that came from a role default. Profiles assigned directly to a user (not via a role default) are preserved across role changes.
 
 ### Managed virtual keys
 
@@ -75,7 +96,6 @@ A few things to know:
 - **Off by default**, and set per profile — flipping it on one profile does not affect others.
 - **Applies to identified users only.** The creator must sign in with their own identity (SSO/SCIM). Keys created from the local admin account or a raw API key are left as ordinary standalone keys.
 - **Create-time only.** Turning the toggle on does not sweep up keys a member already created. To bring an existing key under the profile, assign it to the user from the key's edit sheet — it is adopted into their profile on assignment.
-- **One profile per key.** If a member belongs to more than one profile with the toggle on, the earliest-assigned profile governs the key; policies from multiple profiles are not merged.
 
 ---
 
@@ -124,6 +144,7 @@ In the **Allowed Providers** accordion, add providers from the multi-select. For
 - **Provider Budget** - Add one or more budget lines. Each line has a **max limit** and a **reset duration** (`1h`, `1d`, `1w`, `1M`, `1Q`, `1Y`). You can stack multiple lines with different durations (for example, a hard hourly cap plus a softer monthly cap). A quarterly line can also carry a fiscal quarter start - see [Quarterly budgets](/features/governance/budget-and-limits#quarterly-budgets-and-fiscal-quarters).
 - **Maximum Tokens** - Per-provider token rate limit.
 - **Maximum Requests** - Per-provider request rate limit.
+- **Per-model budgets** - Optionally cap individual models under this provider. These are separate from the provider budget above; each assigned user gets their own copy, counted separately. See [Give one user a per-model budget](#give-one-user-a-per-model-budget).
 
 ### Configure global budget and rate limits
 
@@ -135,7 +156,7 @@ Flip **Align to calendar cycle** to reset budgets and rate limits at the start o
 
 ### Toggle member-key governance
 
-Flip **Govern virtual keys created by members** so any virtual key a member of this profile creates is automatically placed under the profile — same providers, model whitelist, budgets, rate limits, and MCP access, attached to the creator, and locked from direct edits. Leave it off (default) to let members create standalone keys freely. See [Govern virtual keys created by members](#govern-virtual-keys-created-by-members) for the full behavior and its limits.
+Flip **Govern virtual keys created by members** so any virtual key a member of this profile creates is automatically placed under the profile - same providers, model whitelist, budgets, rate limits, and MCP access, attached to the creator, and locked from direct edits. Leave it off (default) to let members create standalone keys freely. See [Govern virtual keys created by members](#govern-virtual-keys-created-by-members) for the full behavior and its limits.
 
 ### Configure MCP tool access
 
@@ -158,7 +179,7 @@ Flip **Govern virtual keys created by members** so any virtual key a member of t
 
 ### Save and assign
 
-Click **Create**. To make the profile take effect for users, attach it to one or more roles from the Roles page:
+Click **Create**. To make the profile take effect for users, attach it to one or more roles from the Roles page, attach it to a user directly from their User Detail Sheet, or map it from an IdP attribute (see [Attribute mappings](/enterprise/user-provisioning#attribute-mappings)). A user can hold profiles from all three sources at once.
 
 <Frame>
   <img
@@ -191,11 +212,7 @@ By default, propagation **preserves usage**: existing users keep their accumulat
 
 ### Extend individual budgets for a user
 
-Access profile budgets apply uniformly to everyone assigned the template. When you need a one-off override for a specific user — without touching the template for the rest of the role — you can attach an additional per-model budget or rate limit directly to that user via [Model Limits](/features/governance/model-limits).
-
-For example, if Alice is on the Engineering profile but you want to add a separate $20/month cap on Claude Opus just for her, you can create a user-scoped model limit for Alice without changing what the Engineering profile gives everyone else. These limits stack independently alongside the profile budget; both must pass for a request to be allowed, and they are not affected by profile propagation. See [Give one user an individual per-model budget](#give-one-user-an-individual-per-model-budget) for steps for the above.
-
-To temporarily raise the profile budget itself for one user, add a **budget override** from the User Detail Sheet instead. An override is additive and leaves the base limit, current usage, and reset schedule untouched:
+Access profile budgets apply uniformly to everyone assigned the template. To make an exception for one person, add a **budget override** from the User Detail Sheet. An override is additive and leaves the base limit, current usage, and reset schedule untouched:
 
 ```text
 Effective limit = Base budget + Override amount
@@ -258,7 +275,7 @@ Profiles can be cloned into new templates, propagated to user copies one field s
 ### Auto-assign Engineering profile to the Engineer role
 
 1. Create the profile through the UI or API with the desired provider configs, budgets, and MCP access.
-2. From the Engineer role, attach the profile and mark it default for new users. Toggle "Apply to existing users" to backfill current members.
+2. From the Engineer role, attach the profile. Toggle "Apply to existing users" to backfill current members.
 3. Bifrost issues a virtual key for every member of the Engineer role and continues to auto-issue for any user who later gains the role.
 
 ### Force every key an Engineer creates onto the Engineering policy
@@ -266,7 +283,7 @@ Profiles can be cloned into new templates, propagated to user copies one field s
 Prerequisite: the Engineering profile is already assigned to the Engineer role (see the example above), so members have it to govern their keys.
 
 1. Edit the Engineering profile and turn on **Govern virtual keys created by members**. Save.
-2. From now on, whenever an Engineer (signed in via SSO) creates a virtual key, it is placed under the Engineering profile automatically — same providers, model whitelist, budgets, rate limits, and MCP access — attached to them and locked from direct edits.
+2. From now on, whenever an Engineer (signed in via SSO) creates a virtual key, it is placed under the Engineering profile automatically - same providers, model whitelist, budgets, rate limits, and MCP access - attached to them and locked from direct edits.
 3. To bring keys they created earlier under the policy too, open each key and assign it to the user; it is adopted into their profile on assignment.
 
 ### Raise the monthly budget without resetting accumulated usage
@@ -312,4 +329,6 @@ curl -X POST "http://localhost:8080/api/governance/model-configs" \
 - **[RBAC](/enterprise/rbac)** - Define the roles that profiles auto-attach to.
 - **[Virtual Keys](/features/governance/virtual-keys)** - Understand the underlying virtual key concept.
 - **[Virtual MCPs](/enterprise/virtual-mcps)** - Bundle MCP tools for reuse inside profiles.
+- **[MCP Tool Groups](/enterprise/mcp-tool-groups)** - Bundle MCP tools for reuse inside profiles.
+- **[Model Limits](/features/governance/model-limits#per-user-model-limits-enterprise)** - How a profile's per-model budgets surface as per-user limits.
 - **[Audit Logs](/enterprise/audit-logs)** - Cross-reference profile changes with downstream impact.

--- a/docs/enterprise/setting-up-auth0/oidc.mdx
+++ b/docs/enterprise/setting-up-auth0/oidc.mdx
@@ -235,8 +235,8 @@ Same wildcard support as team mappings.
 
 - Use a specific value (e.g. `platform`) to map that exact claim value to a named Bifrost business unit
 - Use `${*}` to extract a substring as the business unit name - e.g. `Bifrost Playground: ${*} BU` matches `Bifrost Playground: Alpha BU` and creates business unit **Alpha**
-- When a rule matches, the resolved business unit is assigned to all of that user's teams
-- Manually assigned teams are left unchanged
+- When a rule matches, the resolved business unit is assigned to the user. All matching rules apply, so a user can belong to several business units at once
+- A business unit you assign by hand is never removed by a sync, and one granted from a claim stays even if that claim later stops appearing - remove it by hand or change the mapping
 
 <Frame caption="Attribute Mapping - map the roles claim values from Auth0 to Bifrost roles, and optionally map groups to teams and business units.">
   <img src="/media/user-provisioning/auth0/bifrost-attribute-mapping.png" alt="Bifrost Attribute Mapping screen showing role mappings (roles = Engineering → Admin, roles = Marketing → Viewer) and team mapping with wildcard" />

--- a/docs/enterprise/setting-up-entra/oidc.mdx
+++ b/docs/enterprise/setting-up-entra/oidc.mdx
@@ -350,7 +350,7 @@ Same wildcard support as team mappings.
 
 - Use a specific value (e.g. `platform`) to map that exact claim value to a named Bifrost business unit
 - Use `${*}` to extract a substring as the business unit name
-- When a rule matches, the resolved business unit is assigned to all of that user's teams
+- When a rule matches, the resolved business unit is assigned to the user. All matching rules apply, so a user can belong to several business units at once
 
 <Frame caption="Attribute Mapping - configure role, team, and business unit rules based on the claims Entra sends.">
   <img src="/media/user-provisioning/entra/bifrost-attribute-setup.png" alt="Bifrost Attribute Mapping screen showing role, team, and business unit mapping rules" />

--- a/docs/enterprise/setting-up-generic-oidc/oidc.mdx
+++ b/docs/enterprise/setting-up-generic-oidc/oidc.mdx
@@ -195,7 +195,7 @@ Map a claim value to a Bifrost team. All matching rules apply.
 
 **Attribute-to-Business Unit Mappings**
 
-Same wildcard support as team mappings. When a rule matches, the resolved business unit is assigned to all of that user's teams.
+Same wildcard support as team mappings. When a rule matches, the resolved business unit is assigned to the user, and all matching rules apply, so a user can belong to several business units at once.
 
 <Frame caption="Attribute Mapping - configure role, team, and business unit rules based on the claims your IdP sends.">
   <img src="/media/user-provisioning/generic-oidc/bifrost-attribute-setup.png" alt="Bifrost Attribute Mapping screen showing role and team mapping rules configured for the generic OIDC provider" />

--- a/docs/enterprise/setting-up-google-workspace/oidc.mdx
+++ b/docs/enterprise/setting-up-google-workspace/oidc.mdx
@@ -243,8 +243,8 @@ Same wildcard support as team mappings.
 
 - Use a specific value (e.g. `platform`) to map that exact claim value to a named Bifrost business unit
 - Use `${*}` to extract a substring as the business unit name - e.g. `Bifrost Playground: ${*} BU` matches `Bifrost Playground: Alpha BU` and creates business unit **Alpha**
-- When a rule matches, the resolved business unit is assigned to all of that user's teams
-- Manually assigned teams are left unchanged
+- When a rule matches, the resolved business unit is assigned to the user. All matching rules apply, so a user can belong to several business units at once
+- A business unit you assign by hand is never removed by a sync, and one granted from a claim stays even if that claim later stops appearing - remove it by hand or change the mapping
 
 <Frame caption="Attribute Mapping - configure role, team, and business unit rules based on the claims Google sends.">
   <img src="/media/user-provisioning/attribute-to-entity-mapping.png" alt="Bifrost Attribute Mapping screen showing role, team, and business unit mapping rules" />

--- a/docs/enterprise/setting-up-keycloak/oidc.mdx
+++ b/docs/enterprise/setting-up-keycloak/oidc.mdx
@@ -286,8 +286,8 @@ Same wildcard support as team mappings. Three value formats work:
 - **Exact value** - maps a specific claim value to a fixed business unit name
 - **`*`** - syncs the claim value directly as the business unit name
 - **`/${*}`** - extracts the group name from Keycloak's full group path, same as team mappings (e.g. `/${*}` on `/Engineering` → business unit **Engineering**)
-- When a rule matches, the resolved business unit is assigned to all of that user's teams
-- Manually assigned teams are left unchanged
+- When a rule matches, the resolved business unit is assigned to the user. All matching rules apply, so a user can belong to several business units at once
+- A business unit you assign by hand is never removed by a sync, and one granted from a claim stays even if that claim later stops appearing - remove it by hand or change the mapping
 
 <Frame caption="Attribute Mapping - role rules use realm_access.roles, team rules use groups with /${*} to extract the team name from Keycloak's full group path.">
   <img src="/media/user-provisioning/keycloak/bifrost-keycloak-attribute-mapping.png" alt="Bifrost Attribute Mapping screen showing realm_access.roles mapped to Admin and Viewer roles, and groups mapped with /${*} wildcard to extract team names" />

--- a/docs/enterprise/setting-up-okta/oidc.mdx
+++ b/docs/enterprise/setting-up-okta/oidc.mdx
@@ -314,8 +314,8 @@ Same wildcard support as team mappings.
 
 - Use a specific value (e.g. `platform`) to map that exact claim value to a named Bifrost business unit
 - Use `${*}` to extract a substring as the business unit name - e.g. `Bifrost Playground: ${*} BU` matches `Bifrost Playground: Alpha BU` and creates business unit **Alpha**
-- When a rule matches, the resolved business unit is assigned to all of that user's teams
-- Manually assigned teams are left unchanged
+- When a rule matches, the resolved business unit is assigned to the user. All matching rules apply, so a user can belong to several business units at once
+- A business unit you assign by hand is never removed by a sync, and one granted from a claim stays even if that claim later stops appearing - remove it by hand or change the mapping
 
 <Frame caption="Attribute Mapping - configure role, team, and business unit rules based on the claims Okta sends.">
   <img src="/media/user-provisioning/okta/bifrost-attribute-setup.png" alt="Bifrost Attribute Mapping screen showing role, team, and business unit mapping rules" />

--- a/docs/enterprise/setting-up-zitadel/oidc.mdx
+++ b/docs/enterprise/setting-up-zitadel/oidc.mdx
@@ -266,8 +266,8 @@ Same wildcard support as team mappings.
 
 - Use a specific value (e.g. `platform`) to map that exact claim value to a named Bifrost business unit
 - Use `${*}` to extract a substring as the business unit name - e.g. `Bifrost Playground: ${*} BU` matches `Bifrost Playground: Alpha BU` and creates business unit **Alpha**
-- When a rule matches, the resolved business unit is assigned to all of that user's teams
-- Manually assigned teams are left unchanged
+- When a rule matches, the resolved business unit is assigned to the user. All matching rules apply, so a user can belong to several business units at once
+- A business unit you assign by hand is never removed by a sync, and one granted from a claim stays even if that claim later stops appearing - remove it by hand or change the mapping
 
 <Frame caption="Attribute Mapping - map urn:zitadel:iam:org:project:roles values to Bifrost roles, and map groups to teams and business units.">
   <img src="/media/user-provisioning/zitadel/zitadel-attribute-mapping.png" alt="Bifrost Attribute Mapping screen showing role mappings for urn:zitadel:iam:org:project:roles and team mapping with wildcard for groups" />

--- a/docs/enterprise/user-provisioning.mdx
+++ b/docs/enterprise/user-provisioning.mdx
@@ -1,6 +1,6 @@
 ---
 title: "User Provisioning (OIDC + SCIM)"
-description: "Authenticate users, sync teams, and provision roles and business units from your identity provider using OAuth 2.0 / OIDC, background directory sync, and inbound SCIM 2.0."
+description: "Authenticate users, sync teams, and provision roles, business units, and access profiles from your identity provider using OAuth 2.0 / OIDC, background directory sync, and inbound SCIM 2.0."
 icon: "users-gear"
 ---
 
@@ -12,6 +12,7 @@ Bifrost Enterprise connects your organization's identity provider to Bifrost thr
 - **Automatic role assignment** using custom claims, app roles, or group-to-role mappings
 - **Team synchronization** from IdP groups into Bifrost teams
 - **Business unit mapping** from IdP attributes to Bifrost business units
+- **Access profile mapping** from IdP attributes to Bifrost access profiles
 - **Bulk user provisioning** with filter-preview before import
 - **Background lifecycle reconciliation** every **24 hours** for imported users
 - **OIDC session refresh checks** every **15 minutes** to confirm users are still active with the IdP
@@ -73,9 +74,9 @@ Pick your IdP to follow a step-by-step setup guide. All providers share the same
 1. **Login** — Bifrost redirects unauthenticated users to the provider's authorization endpoint (Authorization Code flow).
 2. **Token exchange** — on callback, Bifrost exchanges the code for an access token and refresh token, stores them in an `HttpOnly` cookie / server session, and validates the JWT against the provider's JWKS.
 3. **Identity extraction** — configurable JWT claims (`userIdField`, `rolesField`, `teamIdsField`) are mapped to a Bifrost user, role, and teams. Provider-specific app roles or custom attributes override claim lookup.
-4. **Attribute mapping** — optional `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` translate arbitrary claim values (e.g., a department string or Okta group name) into Bifrost roles, teams, or business units.
+4. **Attribute mapping** — optional `attributeRoleMappings`, `attributeTeamMappings`, `attributeBusinessUnitMappings`, and `attributeAccessProfileMappings` translate arbitrary claim values (e.g., a department string or Okta group name) into Bifrost roles, teams, business units, or access profiles.
 5. **Session refresh checks** — every 15 minutes, Bifrost refreshes the OIDC session. If the session cannot be refreshed, Bifrost checks with the OIDC server whether the user is still active.
-6. **Background reconciliation** — Bifrost periodically calls the configured provider's directory APIs to reconcile imported users and mapped roles, teams, and business units.
+6. **Background reconciliation** — Bifrost periodically calls the configured provider's directory APIs to reconcile imported users and mapped roles, teams, business units, and access profiles.
 7. **Bulk import** — admins can preview users matching a filter and bulk-import them via the dashboard, which calls the provider's user directory API.
 8. **Daily sync** — Bifrost reconciles imported users every 24 hours.
 9. **SCIM push** — IdPs configured with a SCIM provisioning connector can push user creates, updates, and deletes to Bifrost in real time via `/scim/v2`.
@@ -91,13 +92,14 @@ Pick your IdP to follow a step-by-step setup guide. All providers share the same
 | **JWKS validation** | JWTs are validated against the provider's published JWKS keys; configuration is cached and auto-refreshed. |
 | **Role mapping** | Map from a claim value (string or array) to Admin / Developer / Viewer or a custom role. Highest-privilege wins when multiple match. |
 | **Team mapping** | Map multiple claim values to Bifrost teams in a single pass (a user can belong to many teams). |
-| **Business unit mapping** | Same as team mapping but scoped to business units. |
+| **Business unit mapping** | Map claim values to Bifrost business units. All matching rules apply, and a user can belong to many. |
+| **Access profile mapping** | Map claim values to [access profiles](/enterprise/access-profiles). All matching rules apply, and the user holds every profile they match. |
 | **Provisioning preview** | Preview up to 50 users matching filters (groups, roles, departments) before importing. |
 | **Bulk import** | Import matched users into Bifrost with role + team + BU assignments applied. |
 | **Team sync** | Sync IdP groups as Bifrost teams with a single action. |
 | **Business unit sync** | Sync IdP organizational units as Bifrost business units. |
 | **Inbound SCIM 2.0** | IdPs push user and group changes to Bifrost via `/scim/v2` in real time. Bearer-token authenticated. |
-| **SCIM attribute mapping** | SCIM user attributes (including enterprise extension fields) drive role, team, and BU assignments automatically on every SCIM write. |
+| **SCIM attribute mapping** | SCIM user attributes (including enterprise extension fields) drive role, team, business unit, and access profile assignments automatically on every SCIM write. |
 | **Deprovisioning** | Bifrost checks user status during each 15-minute OIDC session refresh and reconciles imported users against the provider directory every 24 hours. SCIM DELETE/deactivation (`active: false`) is also handled immediately. Users that are inactive, disabled, unassigned, or missing from the source set are decommissioned locally. |
 | **API key pass-through** | Requests using Bifrost API keys (`bfst-*`) bypass OIDC user-provisioning middleware so inference traffic is not affected. |
 
@@ -109,7 +111,7 @@ Bifrost's lifecycle model combines source-side reconciliation, OIDC session vali
 
 Every **15 minutes**, Bifrost refreshes active OIDC sessions. If a session cannot be refreshed, Bifrost checks with the OIDC server whether the user is still active; if the provider reports the user is inactive, Bifrost decommissions that user locally.
 
-After users are imported, Bifrost also uses the configured provider credentials to sync with the IdP in the background every **24 hours**. That sync updates mapped roles, teams, and business units, and decommissions imported users that are disabled, unassigned, or no longer present in the provider source set.
+After users are imported, Bifrost also uses the configured provider credentials to sync with the IdP in the background every **24 hours**. That sync updates mapped roles, teams, business units, and access profiles, and decommissions imported users that are disabled, unassigned, or no longer present in the provider source set.
 
 When an IdP SCIM connector is configured, user deactivation and deletion are also handled immediately as the IdP pushes changes.
 
@@ -167,6 +169,7 @@ Fields marked **env.\* supported** accept `"env.VAR_NAME"` in addition to a lite
 | Role mappings | `attributeRoleMappings` | No | **Plain only** | Array of `{ attribute, value, role }` objects |
 | Team mappings | `attributeTeamMappings` | No | **Plain only** | Array of `{ attribute, value, team, attributeType, attributeValue }` objects |
 | Business unit mappings | `attributeBusinessUnitMappings` | No | **Plain only** | Array of `{ attribute, value, businessUnit, attributeType, attributeValue }` objects |
+| Access profile mappings | `attributeAccessProfileMappings` | No | **Plain only** | Array of `{ attribute, value, accessProfile }` objects. One rule per profile; all matching rules apply. |
 
 ### Microsoft Entra ID
 
@@ -182,6 +185,7 @@ Fields marked **env.\* supported** accept `"env.VAR_NAME"` in addition to a lite
 | Role mappings | `attributeRoleMappings` | No | **Plain only** | Array of `{ attribute, value, role }` objects |
 | Team mappings | `attributeTeamMappings` | No | **Plain only** | Array of `{ attribute, value, team, attributeType, attributeValue }` objects |
 | Business unit mappings | `attributeBusinessUnitMappings` | No | **Plain only** | Array of `{ attribute, value, businessUnit, attributeType, attributeValue }` objects |
+| Access profile mappings | `attributeAccessProfileMappings` | No | **Plain only** | Array of `{ attribute, value, accessProfile }` objects. One rule per profile; all matching rules apply. |
 
 ### Keycloak
 
@@ -196,6 +200,7 @@ Fields marked **env.\* supported** accept `"env.VAR_NAME"` in addition to a lite
 | Role mappings | `attributeRoleMappings` | No | **Plain only** | Array of `{ attribute, value, role }` objects |
 | Team mappings | `attributeTeamMappings` | No | **Plain only** | Array of `{ attribute, value, team, attributeType, attributeValue }` objects |
 | Business unit mappings | `attributeBusinessUnitMappings` | No | **Plain only** | Array of `{ attribute, value, businessUnit, attributeType, attributeValue }` objects |
+| Access profile mappings | `attributeAccessProfileMappings` | No | **Plain only** | Array of `{ attribute, value, accessProfile }` objects. One rule per profile; all matching rules apply. |
 
 ### Zitadel
 
@@ -212,6 +217,7 @@ Fields marked **env.\* supported** accept `"env.VAR_NAME"` in addition to a lite
 | Role mappings | `attributeRoleMappings` | No | **Plain only** | Array of `{ attribute, value, role }` objects |
 | Team mappings | `attributeTeamMappings` | No | **Plain only** | Array of `{ attribute, value, team, attributeType, attributeValue }` objects |
 | Business unit mappings | `attributeBusinessUnitMappings` | No | **Plain only** | Array of `{ attribute, value, businessUnit, attributeType, attributeValue }` objects |
+| Access profile mappings | `attributeAccessProfileMappings` | No | **Plain only** | Array of `{ attribute, value, accessProfile }` objects. One rule per profile; all matching rules apply. |
 
 ### Google Workspace
 
@@ -231,6 +237,7 @@ Fields marked **env.\* supported** accept `"env.VAR_NAME"` in addition to a lite
 | Role mappings | `attributeRoleMappings` | No | **Plain only** | Array of `{ attribute, value, role }` objects |
 | Team mappings | `attributeTeamMappings` | No | **Plain only** | Array of `{ attribute, value, team, attributeType, attributeValue }` objects |
 | Business unit mappings | `attributeBusinessUnitMappings` | No | **Plain only** | Array of `{ attribute, value, businessUnit, attributeType, attributeValue }` objects |
+| Access profile mappings | `attributeAccessProfileMappings` | No | **Plain only** | Array of `{ attribute, value, accessProfile }` objects. One rule per profile; all matching rules apply. |
 
 ## Configuring from the dashboard
 
@@ -243,7 +250,7 @@ Fields marked **env.\* supported** accept `"env.VAR_NAME"` in addition to a lite
 </Frame>
 
 4. Click **Verify** to test credentials end-to-end. Bifrost will reach the provider's JWKS / directory endpoint and report any failures.
-5. Configure **Attribute → Role / Team / Business Unit** mappings as needed.
+5. Configure **Attribute → Role / Team / Business Unit / Access Profile** mappings as needed.
 6. Toggle **Enabled** and click **Save Configuration**.
 
 <Warning>
@@ -271,19 +278,49 @@ Each mapping is an ordered rule:
 ```
 
 Rules are evaluated top-to-bottom:
-- **Role mappings** — first match wins. Set a fallback with `"value": "*"` at the end.
-- **Team mappings** and **business unit mappings** — all matching rules apply, so a user with `department=Platform` and `group=sre` can be placed on multiple teams.
+- **Role mappings** — first match wins, because a user holds exactly one role. Set a fallback with `"value": "*"` at the end.
+- **Team mappings**, **business unit mappings**, and **access profile mappings** — all matching rules apply, so a user with `department=Platform` and `group=sre` can be placed on multiple teams, business units, and access profiles at once.
 
 Claim values can be strings, arrays, or nested objects — Bifrost resolves dotted paths (e.g., `realm_access.roles`).
 
+### Access profile mappings
+
+`attributeAccessProfileMappings` grant [access profiles](/enterprise/access-profiles) from claim values, using the same rule shape as team and business unit mappings:
+
+```json
+{
+  "attribute": "department",
+  "value": "Engineering",
+  "accessProfile": "Engineering Baseline"
+}
+```
+
+**Every matching rule applies.** A user matching three rules holds all three profiles at once, and what they can reach is the sum of what each grants. A rule never replaces a profile granted by another rule, or one you assigned by hand — it only adds. See [Multiple profiles per user](/enterprise/access-profiles#multiple-profiles-per-user) for how a user's profiles behave once they hold several.
+
+Write one rule per profile. To grant two profiles from the same claim value, write two rules with the same `attribute` and `value` and different `accessProfile` names. In the dashboard you do this in one row by picking several profiles; `config.json` stores them as separate rules, so the file will have more entries than the screen shows.
+
+Every sync re-checks these rules. A profile the user still matches is left alone, keeping its budget and accumulated usage; newly matched profiles are added, and ones they no longer match are removed. Profiles they hold by hand or through their role are never affected. A profile granted this way cannot be detached from the user directly — change the mapping or the underlying attribute instead.
+
+
 ### `attributeType` field
 
-Team and business unit mappings have an optional `attributeType` field:
+Mappings have an optional `attributeType` field:
 
 | Value | Meaning |
 | --- | --- |
 | `"user"` (default) | Match against JWT claims or SCIM user attributes (e.g. `department`, `title`). |
 | `"group"` | Match against the `displayName` of groups pushed via SCIM. Use this when your IdP pushes group membership via SCIM rather than embedding group names in the user token. |
+
+A **role** mapping can use `attributeType: "group"` too, so you can assign a role from group membership alone. `"value": "*"` works here and matches any group, which is useful as a catch-all giving every SCIM-provisioned group member a baseline role:
+
+```json
+{
+  "attribute": "groups",
+  "value": "*",
+  "role": "developer",
+  "attributeType": "group"
+}
+```
 
 ```json
 {
@@ -319,6 +356,24 @@ You only need `attributeValue` when a single mapping rule must cover both OIDC a
 ```
 
 If you only use OIDC (no inbound SCIM push), `attributeValue` has no effect.
+
+### Business unit membership
+
+A user can belong to any number of business units at once. Bifrost remembers how each membership was granted — by an admin, by SCIM, or from an OIDC claim — and uses that to decide what a later sync is allowed to change, so one source never quietly undoes another's work.
+
+| Granted by | How it is added | How it is removed |
+| --- | --- | --- |
+| An admin | Assigned from the dashboard or the API | By an admin. A sync never removes it. |
+| SCIM | A SCIM user attribute or group push | By SCIM, when the attribute or group no longer points at that business unit |
+| An OIDC claim | A business unit mapping matching a claim in the user's token | By an admin, or by changing the mapping — see below |
+
+What this means in practice:
+
+- **SCIM keeps its own assignments up to date.** Each push re-checks them: units the user still matches are added or kept, and ones they no longer match are removed.
+- **Claim-based assignments are only ever added, never withdrawn automatically.** If a user's token stops carrying the attribute that granted a business unit, they keep it. This is deliberate — a single token missing an attribute should not silently remove someone's access. Remove it by changing the mapping or removing the membership yourself.
+- **Turning SCIM on later is safe.** SCIM takes over managing an assignment that came from a claim rather than adding a duplicate.
+
+To view or change memberships from the API, use `GET` and `POST /api/governance/business-units/{id}/users` and `DELETE /api/governance/business-units/{id}/users/{user_id}`. The list response tells you how each member was granted, so you can tell an admin assignment from one your identity provider manages.
 
 ### SCIM attribute suggestions
 
@@ -369,7 +424,7 @@ The provisioning token is generated per SCIM provider and can be rotated from th
 
 ### How SCIM writes trigger governance updates
 
-Every SCIM create, replace, or patch immediately re-evaluates the user's `attributeRoleMappings`, `attributeTeamMappings`, and `attributeBusinessUnitMappings` against the current SCIM attributes. Changes to role, team, or business unit assignments are committed to the database and broadcast to all cluster nodes before the SCIM response is returned.
+Every SCIM create, replace, or patch immediately re-evaluates the user's `attributeRoleMappings`, `attributeTeamMappings`, `attributeBusinessUnitMappings`, and `attributeAccessProfileMappings` against the current SCIM attributes. Changes to role, team, business unit, or access profile assignments are committed to the database and broadcast to all cluster nodes before the SCIM response is returned.
 
 Only SCIM-managed memberships are affected — any manually assigned teams or roles are preserved.
 

--- a/docs/features/governance/model-limits.mdx
+++ b/docs/features/governance/model-limits.mdx
@@ -16,7 +16,7 @@ They are the unified control plane for all model-level governance in Bifrost:
 - **Per-model limits** — enforce fine-grained caps on individual models for any of the above scopes
 
 <Note>
-The `user` scope is available in Bifrost Enterprise. Support for **customer** and **team** scopes is coming soon.
+The `access_profile` scope is available in Bifrost Enterprise. Support for **customer** and **team** scopes is coming soon.
 </Note>
 
 ---
@@ -25,11 +25,11 @@ The `user` scope is available in Bifrost Enterprise. Support for **customer** an
 
 Every model limit has a **scope** that determines the audience it applies to.
 
-| Scope | Who it applies to | Scope Target required? |
-|-------|-------------------|----------------------|
-| `global` | All traffic through Bifrost | No |
-| `virtual_key` | All requests made with a specific virtual key | Yes — the virtual key ID |
-| `user` | All requests made by a specific user (Enterprise only) | Yes — the user ID |
+| Scope | Who it applies to | Scope Target required? | Created how? |
+|-------|-------------------|----------------------|--------------|
+| `global` | All traffic through Bifrost | No | By you |
+| `virtual_key` | All requests made with a specific virtual key | Yes — the virtual key ID | By you |
+| `user` | All requests made by a specific user (Enterprise only) | Yes — the user | Created for you when a profile sets a per-model budget |
 
 **Scope + model name combinations:**
 
@@ -40,7 +40,6 @@ Every model limit has a **scope** that determines the audience it applies to.
 | `*` (All Models) | `anthropic` | `virtual_key` | That VK's Anthropic-only budget |
 | `gpt-4o` | `openai` | `global` | Hard cap on gpt-4o usage across all traffic |
 | `claude-3-5-sonnet-20241022` | _(none)_ | `virtual_key` | Per-VK cap on a specific model |
-
 ---
 
 ## Configuration
@@ -55,7 +54,7 @@ Navigate to **Budget & Limits → Model Limits** in the Bifrost dashboard.
 The table shows all configured model limits with their current usage. Use the toolbar to find what you need:
 
 - **Search** — filter by model name
-- **Scope** dropdown — show only `global` or `virtual_key` limits
+- **Scope** dropdown — narrow to `Global`, `Virtual Key`, or `User`. `User` covers both limits set on a user directly and those that came from their access profile.
 - **Provider** dropdown — show only limits for a specific provider
 
 The **Scope Target** column links directly back to the parent entity (e.g. clicking a virtual key badge takes you to that VK).
@@ -68,7 +67,7 @@ Click **Add Model Limit** to open the configuration sheet.
 
 1. **Provider** — select a specific provider or leave as _All Providers_
 2. **Model Name** — search and select a model, or pick _All Models_ to cover every model for the chosen provider/scope
-3. **Scope** — choose `Global` or `Virtual Key`
+3. **Scope** — choose `Global` or `Virtual Key` or `User`
 4. **Scope Target** — appears when scope is `Virtual Key`; select the target virtual key
 5. **Budget** — add one or more budget lines, each with a dollar cap and reset duration. Multiple budgets per limit are supported (e.g. `$50/day` + `$500/month`).
 6. **Rate Limits** — optionally set token and/or request limits with their own reset durations
@@ -105,7 +104,7 @@ curl "http://localhost:8080/api/governance/model-configs?scope=virtual_key&provi
 | `limit` | integer | Page size |
 | `offset` | integer | Page offset |
 | `search` | string | Filter by model name (case-insensitive) |
-| `scope` | string | Filter by scope (`global`, `virtual_key`) |
+| `scope` | string | Filter by scope. Accepts a comma-separated list, so `user,access_profile` returns both the limits set on a user directly and those that came from their access profiles — which is what the dashboard's `User` filter sends. Unknown values are ignored. |
 | `provider` | string | Filter by provider name |
 | `from_memory` | boolean | Read from in-memory cache (faster, may lag DB by one poll cycle) |
 
@@ -140,6 +139,23 @@ curl "http://localhost:8080/api/governance/model-configs?scope=virtual_key&provi
 }
 ```
 
+A limit Bifrost created from an access profile, rather than one you wrote yourself, also carries
+read-only `source_*` fields naming the profile it came from:
+
+```json
+{
+  "id": "mc_def456",
+  "model_name": "claude-opus-4-8",
+  "provider": "anthropic",
+  "scope": "access_profile",
+  "scope_id": "uap_789",
+  "scope_name": "alice@example.com",
+  "source_type": "access_profile",
+  "source_id": "12",
+  "source_name": "Engineering"
+}
+```
+
 ### Create a model limit
 
 ```bash
@@ -166,7 +182,7 @@ curl -X POST "http://localhost:8080/api/governance/model-configs" \
 |-------|------|----------|-------------|
 | `model_name` | string | Yes | Model name, or `*` for all models |
 | `provider` | string | No | Provider name; omit to cover all providers |
-| `scope` | string | No | `global` (default) or `virtual_key` |
+| `scope` | string | No | `global` (default) or `virtual_key`. `user` returns `403` (retired); `access_profile` is system-generated and cannot be created here. |
 | `scope_id` | string | Conditional | Required when `scope` is not `global` |
 | `budgets` | array | No | One or more budget lines (each needs `max_limit` + `reset_duration`) |
 | `rate_limit` | object | No | Token and/or request rate limits |
@@ -255,7 +271,7 @@ Model limits are declared under `governance.model_configs`. Each entry reference
 | `id` | string | Yes | Unique identifier |
 | `model_name` | string | Yes | Model name, or `*` for all models |
 | `provider` | string | No | Provider name; omit to apply to all providers |
-| `scope` | string | No | `global` (default) or `virtual_key` |
+| `scope` | string | No | `global` (default) or `virtual_key`. Declaring `user` or `access_profile` here is not supported — per-user model limits come from an access profile. |
 | `scope_id` | string | Conditional | Required when `scope` is not `global` |
 | `budget_ids` | string[] | No | List of `governance.budgets` IDs to attach. Supports multiple budgets (e.g. daily + monthly). Replaces `budget_id`. |
 | `budget_id` | string | No | Deprecated — single budget reference. Use `budget_ids` instead. |


### PR DESCRIPTION
## Summary

Documents the new `governance.roles` and `governance.business_units` config.json sections, expands access profile documentation to cover multiple-profile-per-user behavior, and adds `attributeAccessProfileMappings` as a first-class IdP attribute mapping type across all supported OIDC providers.

## Changes

- Added `governance.roles` schema reference covering RBAC role declarations, `access_profiles` (plural), `entity_dac`, and `permissions` field semantics, including a warning about unrecognised permission names being silently skipped.
- Added `governance.business_units` schema reference explaining that this section defines units only — membership is managed separately via admin or IdP, not from `config.json`.
- Updated the `access_profiles` link in the schema reference table to point to the new `/enterprise/access-profiles` page instead of the old advanced-governance page.
- Rewrote the access profiles overview to explain that a user can hold several profiles simultaneously, that access adds up across profiles, that one profile pays per request, and that a depleted profile falls back to another.
- Removed the "one profile per key" restriction from the member-key governance section, which no longer applies.
- Added `attributeAccessProfileMappings` to the user provisioning flow for all six IdP guides (Auth0, Entra, Keycloak, Zitadel, Google Workspace, Generic OIDC), including config table rows, rule evaluation notes, and a dedicated section explaining how profile grants from different sources (role, hand-assignment, IdP claim) coexist without interfering.
- Corrected business unit mapping behavior across all IdP guides: a matched rule now assigns the unit to the user directly (not to their teams), all matching rules apply, and manually assigned units are never removed by a sync.
- Added a business unit membership provenance table explaining how admin, SCIM, and OIDC-claim grants are tracked and removed independently.
- Updated model limits docs to reflect that `user`-scoped limits are now created automatically from access profile per-model budgets (`access_profile` scope), retired direct `user` scope creation via the API, and documented the `source_*` fields on profile-generated limits.
- Added `attributeAccessProfileMappings` to the SCIM write re-evaluation description and the provisioning feature table.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation pages for:

- `docs/deployment-guides/config-json/schema-reference.mdx` — confirm `governance.roles` and `governance.business_units` sections appear with correct field tables and code examples.
- `docs/enterprise/access-profiles.mdx` — confirm the multiple-profiles-per-user section renders, the flowchart step numbering is correct, and the removed "one profile per key" note is gone.
- `docs/enterprise/user-provisioning.mdx` — confirm `attributeAccessProfileMappings` appears in all provider config tables and the new access profile mappings and business unit membership sections render correctly.
- All six IdP OIDC guides — confirm business unit mapping bullets reflect the corrected per-user (not per-team) assignment behavior.
- `docs/features/governance/model-limits.mdx` — confirm the `access_profile` scope row appears in the scope table and the `source_*` fields example renders.

## Screenshots/Recordings

N/A — documentation only.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. Documentation changes only.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable