### PR TITLE
fix(logstore): make filterdata search case-insensitive across all backends

### DIFF
--- a/framework/logstore/clickhousestore_test.go
+++ b/framework/logstore/clickhousestore_test.go
@@ -497,6 +497,11 @@ func TestClickHouseSearchAndStats(t *testing.T) {
 	models, err := store.GetDistinctModels(ctx, 10, "")
 	require.NoError(t, err)
 	assert.ElementsMatch(t, []string{"gpt-4o", "claude-sonnet-4-5"}, models)
+
+	// ClickHouse LIKE is case-sensitive; the filterdata search must not be.
+	upper, err := store.GetDistinctModels(ctx, 10, "GPT")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"gpt-4o"}, upper)
 }
 
 func TestClickHouseDeleteLogs(t *testing.T) {

--- a/framework/logstore/logstoreparity_test.go
+++ b/framework/logstore/logstoreparity_test.go
@@ -19,8 +19,7 @@ package logstore
 // column-mapping or dialect-SQL defect in any one of them fails here). Known,
 // deliberate divergences are NOT
 // asserted here: multi-value team_ids array *filtering* (postgres-only; the
-// other backends match the scalar column), ILIKE
-// case-insensitivity (fixtures use exact case), FTS-vs-LIKE content search
+// other backends match the scalar column), FTS-vs-LIKE content search
 // semantics (the fixture term matches under all three), and inc_number
 // (Postgres-assigned; NULL elsewhere - excluded from projections).
 //
@@ -36,6 +35,7 @@ import (
 	"math"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -129,6 +129,15 @@ type parityLogSpec struct {
 	toolCallNames              *string
 }
 
+// splitCSVPtr mirrors the BeforeSave hook, which rebuilds tool_call_names from
+// the virtual slice and would otherwise drop the fixture's column value.
+func splitCSVPtr(p *string) []string {
+	if p == nil || *p == "" {
+		return nil
+	}
+	return strings.Split(*p, ",")
+}
+
 func (s parityLogSpec) toLog(base time.Time) *Log {
 	ts := base.Add(-time.Duration(s.offsetSec) * time.Second)
 	return &Log{
@@ -161,6 +170,7 @@ func (s parityLogSpec) toLog(base time.Time) *Log {
 		StopReason:            s.stopReason,
 		RoutingEnginesUsedStr: s.routing,
 		ToolCallNamesStr:      s.toolCallNames,
+		ToolCallNames:         splitCSVPtr(s.toolCallNames),
 		ComplexityTier:        s.tier,
 		ComplexityMechanism:   s.mechanism,
 		ComplexityScore:       s.tierScore,
@@ -779,6 +789,53 @@ func TestLogStoreParity(t *testing.T) {
 		}
 		for name, call := range calls {
 			t.Run(name, func(t *testing.T) { assertParity(t, stores, 1e-6, call) })
+		}
+
+		// Filterdata search must be case-insensitive on every backend. The
+		// needles are deliberately cased against the fixtures ("gpt-4o",
+		// "VK One", "search") so a bare LIKE on ClickHouse or non-ASCII SQLite
+		// would return nothing and break parity with Postgres ILIKE.
+		caseCalls := map[string]struct {
+			call func(context.Context, LogStore) (any, error)
+			want any
+		}{
+			"models_upper": {
+				call: func(ctx context.Context, s LogStore) (any, error) {
+					return sorted(s.GetDistinctModels(ctx, 50, "GPT-4O"))
+				},
+				want: []string{"gpt-4o", "gpt-4o-mini"},
+			},
+			"tool_call_names_upper": {
+				call: func(ctx context.Context, s LogStore) (any, error) {
+					return sorted(s.GetDistinctToolCallNames(ctx, 50, "SEARCH"))
+				},
+				want: []string{"search"},
+			},
+			"key_pairs_lower": {
+				call: func(ctx context.Context, s LogStore) (any, error) {
+					pairs, err := s.GetDistinctKeyPairs(ctx, "virtual_key_id", "virtual_key_name", 50, "vk one")
+					if err != nil {
+						return nil, err
+					}
+					names := make([]string, 0, len(pairs))
+					for _, p := range pairs {
+						names = append(names, p.Name)
+					}
+					sort.Strings(names)
+					return names, nil
+				},
+				want: []string{"VK One"},
+			},
+		}
+		for name, tc := range caseCalls {
+			t.Run(name, func(t *testing.T) {
+				assertParity(t, stores, 1e-6, tc.call)
+				for backend, store := range stores {
+					got, err := tc.call(context.Background(), store)
+					require.NoError(t, err, backend)
+					assert.Equal(t, tc.want, got, backend)
+				}
+			})
 		}
 	})
 

--- a/framework/logstore/rdb.go
+++ b/framework/logstore/rdb.go
@@ -4035,12 +4035,20 @@ func (s *RDBLogStore) Flush(ctx context.Context, since time.Time) error {
 	return nil
 }
 
+// applyLikeFilter adds a case-insensitive substring match on column. Postgres
+// gets ILIKE; every other dialect lowers both sides, since SQLite LIKE is only
+// case-insensitive for ASCII and ClickHouse LIKE is fully case-sensitive.
+// ClickHouse's lower() folds ASCII only, so it gets lowerUTF8 to match the
+// Unicode-aware strings.ToLower applied to the needle.
 func (s *RDBLogStore) applyLikeFilter(q *gorm.DB, column, search string) *gorm.DB {
-	pattern := "%" + search + "%"
-	if s.db.Dialector.Name() == "postgres" {
-		return q.Where(fmt.Sprintf("%s ILIKE ?", column), pattern)
+	lower := "LOWER"
+	switch s.db.Dialector.Name() {
+	case "postgres":
+		return q.Where(fmt.Sprintf("%s ILIKE ?", column), "%"+search+"%")
+	case "clickhouse":
+		lower = "lowerUTF8"
 	}
-	return q.Where(fmt.Sprintf("%s LIKE ?", column), pattern)
+	return q.Where(fmt.Sprintf("%s(%s) LIKE ?", lower, column), "%"+strings.ToLower(search)+"%")
 }
 
 // GetDistinctModels returns all unique non-empty model values using SELECT DISTINCT.


### PR DESCRIPTION
## Summary

`GetDistinctModels`, `GetDistinctToolCallNames`, and `GetDistinctKeyPairs` filterdata searches were case-sensitive on ClickHouse (and partially on SQLite), causing mismatches with Postgres's `ILIKE` behaviour. This PR makes all three backends case-insensitive by routing Postgres through `ILIKE` and all other dialects through `LOWER(column) LIKE LOWER(needle)`.

## Changes

- `applyLikeFilter` now wraps both the column and the search term in `LOWER()` for non-Postgres dialects instead of emitting a bare `LIKE`, fixing ClickHouse (fully case-sensitive) and SQLite (only ASCII case-insensitive).
- Added a ClickHouse-specific test asserting that an upper-case needle (`"GPT"`) still matches `"gpt-4o"`.
- Added cross-backend parity test cases (`models_upper`, `tool_call_names_upper`, `key_pairs_lower`) that deliberately use mis-cased needles and assert identical results across all three backends.
- Removed the note in the parity test comment that listed `ILIKE` case-insensitivity as a known, accepted divergence between backends.
- Fixed `parityLogSpec.toLog` to populate `ToolCallNames` (the slice field) from the CSV string pointer so the `BeforeSave` hook does not silently drop fixture values.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./framework/logstore/... -run TestClickHouseSearchAndStats
go test ./framework/logstore/... -run TestLogStoreParity
```

All three backends should return matching results when the search needle is cased differently from the stored value.

## Breaking changes

- [x] No

## Security considerations

Search terms are still passed as parameterised query arguments; wrapping them in `LOWER()` does not introduce any SQL injection surface.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable