### PR TITLE
feat(observability): emit settled batch/video cost to trace connectors

### DIFF
--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -559,6 +559,114 @@ func attachBatchResultsDisplay(entry *logstore.Log, batchResp *schemas.BifrostBa
 
 func (p *LoggerPlugin) EmitAggregateLog(ctx context.Context, entry *logstore.Log) {
 	p.makePostWriteCallback(nil)(entry)
+	p.emitSettlementSpan(ctx, entry)
+}
+
+// emitSettlementSpan mirrors a settled batch/video aggregate cost row onto a
+// one-span trace so the trace-fed observability connectors (Datadog, BigQuery,
+// Splunk, OTEL, Kafka, Pub/Sub) record its cost and tokens.
+//
+// Batch and video cost is computed asynchronously — by the sweeper, and inline on
+// the results/retrieve response — on a path that runs with the plugin pipeline
+// skipped (BifrostContextKeySkipPluginPipeline) and so never produces a span through
+// TracingMiddleware. Without this bridge that cost lands only in the log store and
+// governance budgets, invisible to every span-based connector (which read cost off
+// gen_ai.usage.cost on a span). This is the single seam that reaches all of them,
+// since the tracer's CompleteAndFlushTrace is the only path to a connector's Inject.
+//
+// It fires once per settled aggregate row (EmitAggregateLog is called exactly once
+// per successfully written row, after the row is claimed and marked), so settlement
+// retries never double-count cost.
+//
+// The span is a single non-attempt root span: cost/tokens are read off the trace's
+// root span when it carries no llm.call/retry attempt span, so the connectors record
+// this settled cost without also counting it as a second request against the
+// synchronous batch-create/video-generate call that already produced a live span.
+func (p *LoggerPlugin) emitSettlementSpan(ctx context.Context, entry *logstore.Log) {
+	if entry == nil || entry.Cost == nil || *entry.Cost <= 0 {
+		return
+	}
+	p.mu.Lock()
+	tracer := p.settlementTracer
+	p.mu.Unlock()
+	if tracer == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	traceID := tracer.CreateTrace("")
+	if traceID == "" {
+		return
+	}
+	// Seed the trace ID into the context so StartSpan attaches the span to this
+	// trace (StartSpanID resolves the trace from context, not from a parameter).
+	spanCtx := context.WithValue(ctx, schemas.BifrostContextKeyTraceID, traceID)
+	// SpanKindUnspecified keeps this off the connectors' llm.call/retry attempt loop
+	// (so no request/latency metric is emitted); the cost still flows because it is
+	// the trace's only span and therefore its root, which the metric path reads when
+	// no attempt span is present.
+	_, handle := tracer.StartSpan(spanCtx, entry.Object, schemas.SpanKindUnspecified)
+	if handle == nil {
+		tracer.CompleteAndFlushTrace(traceID)
+		return
+	}
+
+	setStr := func(key, val string) {
+		if val != "" {
+			tracer.SetAttribute(handle, key, val)
+		}
+	}
+	setStrPtr := func(key string, val *string) {
+		if val != nil {
+			setStr(key, *val)
+		}
+	}
+
+	// Cost + usage — the reason this bridge exists.
+	tracer.SetAttribute(handle, schemas.AttrUsageCost, *entry.Cost)
+	if entry.PromptTokens > 0 {
+		tracer.SetAttribute(handle, schemas.AttrInputTokens, entry.PromptTokens)
+	}
+	if entry.CompletionTokens > 0 {
+		tracer.SetAttribute(handle, schemas.AttrOutputTokens, entry.CompletionTokens)
+	}
+	if entry.TotalTokens > 0 {
+		tracer.SetAttribute(handle, schemas.AttrTotalTokens, entry.TotalTokens)
+	}
+
+	// Model / provider / method — the identity of the priced call. Object carries the
+	// request type string ("batch_results", "video_retrieve") that connectors read
+	// from request.type, matching the aggregate log row.
+	setStr(schemas.AttrProviderName, entry.Provider)
+	setStr(schemas.AttrRequestModel, entry.Model)
+	setStr(schemas.AttrResponseModel, entry.Model)
+	setStr(schemas.AttrLegacyRequestType, entry.Object)
+
+	// Enrichment dimensions — so settled cost filters by the same team/customer/vk/etc.
+	// as live traffic. Read off the aggregate log row rather than the request context
+	// (there is none at settlement time).
+	setStr(schemas.AttrBifrostSelectedKeyID, entry.SelectedKeyID)
+	setStr(schemas.AttrBifrostSelectedKeyName, entry.SelectedKeyName)
+	setStrPtr(schemas.AttrBifrostVirtualKeyID, entry.VirtualKeyID)
+	setStrPtr(schemas.AttrBifrostVirtualKeyName, entry.VirtualKeyName)
+	setStrPtr(schemas.AttrBifrostRoutingRuleID, entry.RoutingRuleID)
+	setStrPtr(schemas.AttrBifrostRoutingRuleName, entry.RoutingRuleName)
+	setStrPtr(schemas.AttrBifrostTeamID, entry.TeamID)
+	setStrPtr(schemas.AttrBifrostTeamName, entry.TeamName)
+	setStrPtr(schemas.AttrBifrostCustomerID, entry.CustomerID)
+	setStrPtr(schemas.AttrBifrostCustomerName, entry.CustomerName)
+	setStrPtr(schemas.AttrBifrostBusinessUnitID, entry.BusinessUnitID)
+	setStrPtr(schemas.AttrBifrostBusinessUnitName, entry.BusinessUnitName)
+	setStrPtr(schemas.AttrBifrostProjectID, entry.ProjectID)
+	setStrPtr(schemas.AttrBifrostProjectName, entry.ProjectName)
+	setStrPtr(schemas.AttrBifrostUserID, entry.UserID)
+	setStrPtr(schemas.AttrBifrostUserName, entry.UserName)
+	setStrPtr(schemas.AttrBifrostAlias, entry.Alias)
+
+	tracer.EndSpan(handle, schemas.SpanStatusOk, "")
+	tracer.CompleteAndFlushTrace(traceID)
 }
 
 func (p *LoggerPlugin) recordBatchJobLifecycle(entry *logstore.Log, result *schemas.BifrostResponse) {
@@ -1072,6 +1180,7 @@ type LoggerPlugin struct {
 	logger                       schemas.Logger
 	logCallback                  LogCallback
 	batchUsageReporter           jobaccounting.UsageReporter
+	settlementTracer             schemas.Tracer     // Emits a span for each settled batch/video aggregate cost row so trace-fed connectors (Datadog/BigQuery/Splunk/OTEL/Kafka/Pub-Sub) see its cost; nil disables the bridge
 	mcpToolLogCallback           MCPToolLogCallback // Callback for MCP tool log entries
 	droppedRequests              atomic.Int64
 	cleanupTicker                *time.Ticker          // Ticker for cleaning up old processing logs
@@ -1284,6 +1393,16 @@ func (p *LoggerPlugin) SetBatchUsageReporter(reporter jobaccounting.UsageReporte
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.batchUsageReporter = reporter
+}
+
+// SetSettlementTracer wires the tracer that emitSettlementSpan uses to forward
+// settled batch/video cost to the observability connectors. Called at bootstrap and
+// on reload (the logging plugin instance is rebuilt when the plugin reloads, so the
+// handle must be re-set alongside the usage reporter); nil safely disables the bridge.
+func (p *LoggerPlugin) SetSettlementTracer(tracer schemas.Tracer) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.settlementTracer = tracer
 }
 
 func (p *LoggerPlugin) StartBatchAccountingSweeper(fetcher jobaccounting.BatchResultFetcher, interval time.Duration, kvStore schemas.KVStore) context.CancelFunc {

--- a/plugins/logging/operations_test.go
+++ b/plugins/logging/operations_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/framework/modelcatalog/datasheet"
 	"github.com/maximhq/bifrost/framework/streaming"
+	"github.com/maximhq/bifrost/framework/tracing"
 )
 
 type testLogger struct{}
@@ -511,6 +512,141 @@ func TestEmitAggregateLogRunsCallback(t *testing.T) {
 	if callbacks != 1 {
 		t.Fatalf("callback count after emit = %d, want 1", callbacks)
 	}
+}
+
+// captureObsPlugin is a minimal ObservabilityPlugin that extracts the attributes of
+// the first cost-bearing span in each injected trace. It copies the values out
+// synchronously (the tracer recycles the trace after Inject returns) and hands them
+// to the test over a channel.
+type captureObsPlugin struct {
+	spans chan map[string]any
+}
+
+func (c *captureObsPlugin) GetName() string { return "capture-obs" }
+func (c *captureObsPlugin) Cleanup() error  { return nil }
+func (c *captureObsPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
+	if trace == nil {
+		return nil
+	}
+	spans := trace.Spans
+	if trace.RootSpan != nil {
+		spans = append(spans, trace.RootSpan)
+	}
+	for _, span := range spans {
+		if span == nil {
+			continue
+		}
+		if _, ok := span.Attributes[schemas.AttrUsageCost]; !ok {
+			continue
+		}
+		attrs := make(map[string]any, len(span.Attributes))
+		for k, v := range span.Attributes {
+			attrs[k] = v
+		}
+		select {
+		case c.spans <- attrs:
+		default:
+		}
+		return nil
+	}
+	return nil
+}
+
+// TestEmitAggregateLogEmitsSettlementSpan verifies the settlement→observability
+// bridge: a settled aggregate cost row is mirrored onto a span carrying the cost,
+// tokens, request type, and enrichment dimensions, so the trace-fed connectors
+// (Datadog/BigQuery/Splunk/OTEL/Kafka/Pub-Sub) can record batch/video cost that the
+// async settlement path would otherwise keep out of the tracing pipeline entirely.
+func TestEmitAggregateLogEmitsSettlementSpan(t *testing.T) {
+	logger := testLogger{}
+	tracer := tracing.NewTracer(tracing.NewTraceStore(time.Minute, logger), nil, logger)
+	capture := &captureObsPlugin{spans: make(chan map[string]any, 1)}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{capture}, nil)
+
+	plugin := &LoggerPlugin{ctx: context.Background()}
+	plugin.SetSettlementTracer(tracer)
+
+	cost := 0.0123
+	teamID := "team-42"
+	vkID := "vk-7"
+	entry := &logstore.Log{
+		ID:               "batch-cost:openai:settlement-span",
+		Timestamp:        time.Now().UTC(),
+		Object:           string(schemas.BatchResultsRequest),
+		Provider:         string(schemas.OpenAI),
+		Model:            "gpt-4o-mini",
+		Status:           "success",
+		Cost:             &cost,
+		PromptTokens:     100,
+		CompletionTokens: 50,
+		TotalTokens:      150,
+		TeamID:           &teamID,
+		VirtualKeyID:     &vkID,
+	}
+	plugin.EmitAggregateLog(context.Background(), entry)
+
+	select {
+	case attrs := <-capture.spans:
+		if got, _ := attrs[schemas.AttrUsageCost].(float64); got != cost {
+			t.Fatalf("span cost = %v, want %v", attrs[schemas.AttrUsageCost], cost)
+		}
+		if got, _ := attrs[schemas.AttrLegacyRequestType].(string); got != string(schemas.BatchResultsRequest) {
+			t.Fatalf("span request.type = %q, want %q", got, schemas.BatchResultsRequest)
+		}
+		if got, _ := attrs[schemas.AttrProviderName].(string); got != string(schemas.OpenAI) {
+			t.Fatalf("span provider = %q, want %q", got, schemas.OpenAI)
+		}
+		if got, _ := attrs[schemas.AttrRequestModel].(string); got != "gpt-4o-mini" {
+			t.Fatalf("span model = %q, want gpt-4o-mini", got)
+		}
+		if got, _ := attrs[schemas.AttrTotalTokens].(int); got != 150 {
+			t.Fatalf("span total tokens = %v, want 150", attrs[schemas.AttrTotalTokens])
+		}
+		if got, _ := attrs[schemas.AttrBifrostTeamID].(string); got != teamID {
+			t.Fatalf("span team_id = %q, want %q", got, teamID)
+		}
+		if got, _ := attrs[schemas.AttrBifrostVirtualKeyID].(string); got != vkID {
+			t.Fatalf("span virtual_key_id = %q, want %q", got, vkID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no settlement span injected to the observability connector")
+	}
+}
+
+// TestEmitAggregateLogSkipsSettlementSpanWithoutCost verifies an unpriced aggregate
+// row emits no span (nothing for a connector to record), and that a nil tracer is a
+// safe no-op rather than a panic.
+func TestEmitAggregateLogSkipsSettlementSpanWithoutCost(t *testing.T) {
+	logger := testLogger{}
+	tracer := tracing.NewTracer(tracing.NewTraceStore(time.Minute, logger), nil, logger)
+	capture := &captureObsPlugin{spans: make(chan map[string]any, 1)}
+	tracer.SetObservabilityPlugins([]schemas.ObservabilityPlugin{capture}, nil)
+
+	plugin := &LoggerPlugin{ctx: context.Background()}
+	plugin.SetSettlementTracer(tracer)
+
+	entry := &logstore.Log{
+		ID:        "batch-cost:openai:no-cost",
+		Timestamp: time.Now().UTC(),
+		Object:    string(schemas.BatchResultsRequest),
+		Provider:  string(schemas.OpenAI),
+		Model:     "gpt-4o-mini",
+		Status:    "success",
+		// Cost intentionally nil.
+	}
+	plugin.EmitAggregateLog(context.Background(), entry)
+
+	select {
+	case <-capture.spans:
+		t.Fatal("unpriced aggregate row must not emit a settlement span")
+	case <-time.After(200 * time.Millisecond):
+	}
+
+	// Nil tracer must not panic.
+	plugin.SetSettlementTracer(nil)
+	cost := 1.0
+	entry.Cost = &cost
+	plugin.EmitAggregateLog(context.Background(), entry)
 }
 
 func TestPostLLMHookStreamingErrorPreservesHeaderMetadata(t *testing.T) {

--- a/transports/bifrost-http/server/batchaccounting.go
+++ b/transports/bifrost-http/server/batchaccounting.go
@@ -114,10 +114,39 @@ func (s *BifrostHTTPServer) WireBatchAccountingSweeper() {
 		}
 	}
 	loggerPlugin.SetBatchUsageReporter(usageReporter)
+	// Wire the tracer so settled batch/video cost reaches the observability connectors
+	// (see LoggerPlugin.emitSettlementSpan). Reload re-runs this against the rebuilt
+	// logging plugin; at first bootstrap the tracing middleware does not exist yet, so
+	// the guard skips here and setSettlementTracer is called again once it is created.
+	s.setSettlementTracer()
 	loggerPlugin.StartBatchAccountingSweeper(&bifrostBatchResultFetcher{client: s.Client}, time.Minute, s.Config.KVStore)
 	// Video jobs finish in minutes, not hours, so their sweeper runs on a much
 	// tighter tick than the batch one.
 	loggerPlugin.StartVideoAccountingSweeper(&bifrostVideoRetriever{client: s.Client}, 30*time.Second, s.Config.KVStore)
+}
+
+// setSettlementTracer hands the logging plugin the tracer it uses to forward settled
+// batch/video cost to the observability connectors (see LoggerPlugin.emitSettlementSpan).
+// It is a no-op until the tracing middleware exists, so it is safe to call before
+// bootstrap has created it (the bootstrap path calls it again once it has). The tracer
+// instance is stable across reloads; only the logging plugin is rebuilt, so this
+// re-set on reload is what keeps the bridge live after a logging-plugin reload.
+func (s *BifrostHTTPServer) setSettlementTracer() {
+	if s == nil || s.Config == nil || s.TracingMiddleware == nil {
+		return
+	}
+	loggerPlugin, err := lib.FindPluginAs[*logging.LoggerPlugin](s.Config, logging.PluginName)
+	if err != nil || loggerPlugin == nil {
+		return
+	}
+	// Concrete nil-check on *tracing.Tracer before it becomes a schemas.Tracer, so a
+	// missing tracer stays a nil interface (not a non-nil interface wrapping a nil
+	// pointer, which would defeat emitSettlementSpan's nil guard and panic).
+	tracer := s.TracingMiddleware.GetTracer()
+	if tracer == nil {
+		return
+	}
+	loggerPlugin.SetSettlementTracer(tracer)
 }
 
 type bifrostVideoRetriever struct {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -2939,6 +2939,10 @@ func (s *BifrostHTTPServer) Bootstrap(ctx context.Context) error {
 	tracer.SetObservabilityPlugins(observabilityPlugins, s.CollectObservabilityLimits())
 	s.Client.SetTracer(tracer)
 	s.TracingMiddleware = handlers.NewTracingMiddleware(tracer)
+	// The batch/video sweepers were wired before the tracer existed (WireBatchAccountingSweeper
+	// runs earlier in bootstrap), so hand the logging plugin its settlement tracer now that it
+	// does — this is what lets settled batch/video cost reach the observability connectors.
+	s.setSettlementTracer()
 	// TransportInterceptor runs AFTER the auth middlewares so HTTPTransportPreHook observes an
 	// authenticated request, and inside TracingMiddleware so the tracing defer runs AFTER
 	// transport post-hooks (capturing HTTPTransportPostHook plugin logs).


### PR DESCRIPTION
## Problem

Calls settled through the **Batch API** and **video generation** are priced correctly (batch even applies the 50% batch-rate ratio), but that cost **never reaches Datadog** — or any other trace-fed connector (BigQuery, Splunk, OTEL, Kafka, Pub/Sub).

Root cause: two parallel cost pipelines with no bridge.

- **Synchronous requests** → the tracer stamps `gen_ai.usage.cost` on a span → connectors read it off the span.
- **Batch/video** cost is computed **asynchronously** by the job-accounting sweeper (and inline on the results/retrieve response). That path runs with `BifrostContextKeySkipPluginPipeline=true`, so it **never produces a span** through `TracingMiddleware`. The correct cost lands only in the log store + governance budgets — invisible to every span-based connector.

(Batch additionally has no `BatchResultsResponse` case in the synchronous `extractCostInput`, so even a live results call would stamp `0` — but this PR sidesteps that by bridging from the settlement's already-correct cost.)

## Fix

Bridge the two paths at the single point settlement already emits one callback per priced row: `LoggerPlugin.EmitAggregateLog`. It now mirrors each settled aggregate cost row onto a **one-span trace** and flushes it via `Tracer.CompleteAndFlushTrace` — the only path that reaches every connector's `Inject`. **Connectors need no change**; cost arrives through the span path they already consume.

The synthesized span:
- carries `gen_ai.usage.cost`, tokens, model/provider, `request.type`, and the enrichment dimensions (team/customer/vk/business-unit/user/routing) read off the aggregate log row, so settled cost is attributed the same way as live traffic;
- is a **non-attempt root span** (`SpanKindUnspecified`): cost is read via the connectors' root-span fallback, so it is **not** double-counted as a second request/latency sample against the synchronous batch-create/video-generate call that already produced a live span;
- fires **once per settled row** (after the row is claimed + marked), so settlement retries never double-count;
- no-ops when the row is unpriced or no tracer is wired.

Covers **both batch and video** (both settle through `EmitAggregateLog`, via the sweeper and the inline results/retrieve paths).

The logging plugin is handed the tracer at bootstrap and re-handed it on reload (the plugin instance is rebuilt), mirroring the existing batch-usage-reporter wiring.

## Tests

- `TestEmitAggregateLogEmitsSettlementSpan` — a settled row produces a span carrying cost, tokens, request type, provider/model, and enrichment dims, delivered to a capture connector via the real tracer.
- `TestEmitAggregateLogSkipsSettlementSpanWithoutCost` — unpriced rows emit nothing; nil tracer is a safe no-op.
- Full `plugins/logging` suite + `go vet` on the changed transports packages pass.

## Follow-ups (not in this PR)

- Add the `BatchResultsResponse` case to `extractCostInput` for completeness on the live path.
- Prevention guards: a `RequestType` exhaustiveness test for pricing and a "billable ⇒ cost reaches a connector" conformance test, extending the existing `EnrichmentDim` parity harness — so the next async modality can't silently slip through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)