### PR TITLE
fix: preserve budget state across edits

### DIFF
--- a/transports/bifrost-http/handlers/governance.go
+++ b/transports/bifrost-http/handlers/governance.go
@@ -2906,9 +2906,9 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 		// below, so combined `calendar_aligned + budgets/rate_limit` updates see
 		// the final persisted state.
 
-		// Multi-budget reconciliation: match by reset_duration, preserve usage on update,
-		// create new budgets for new durations, delete unmatched existing budgets.
-		// Mirrors VK multi-budget handling above.
+		// Multi-budget reconciliation: prefer stable IDs and fall back to
+		// reset_duration for clients that do not send them. Preserve usage on
+		// update, create new budgets, and delete unmatched existing budgets.
 		if req.Budgets != nil {
 			// Validate incoming budgets
 			seenDurations := make(map[string]bool)
@@ -2925,16 +2925,18 @@ func (h *GovernanceHandler) updateTeam(ctx *fasthttp.RequestCtx) {
 				seenDurations[b.ResetDuration] = true
 			}
 
-			existingByDuration := make(map[string]configstoreTables.TableBudget)
-			for _, existing := range team.Budgets {
-				existingByDuration[existing.ResetDuration] = existing
-			}
+			existingByID, existingByDuration := buildBudgetLookup(team.Budgets, req.Budgets)
 
 			var reconciledBudgets []configstoreTables.TableBudget
 			matchedIDs := make(map[string]bool)
 			for _, b := range req.Budgets {
-				if existing, found := existingByDuration[b.ResetDuration]; found {
+				existing, found, err := findExistingBudget(b, existingByID, existingByDuration)
+				if err != nil {
+					return err
+				}
+				if found {
 					existing.MaxLimit = b.MaxLimit
+					existing.ResetDuration = b.ResetDuration
 					applyResetConfigToExistingBudget(&existing, b)
 					// LastReset is preserved on update: the reset boundary only ever
 					// moves forward, and never as a side effect of a config write.

--- a/transports/bifrost-http/handlers/governance_test.go
+++ b/transports/bifrost-http/handlers/governance_test.go
@@ -669,6 +669,41 @@ func reconcileBudgetRequestsForTest(existing []configstoreTables.TableBudget, re
 	return reconciled, nil
 }
 
+func TestTeamBudgetFrequencyChangePreservesUsageWhenRequested(t *testing.T) {
+	originalLastReset := time.Now().Add(-2 * time.Hour)
+	reconciled, err := reconcileBudgetRequestsForTest(
+		[]configstoreTables.TableBudget{
+			{
+				ID:            "team-budget-1",
+				MaxLimit:      100,
+				ResetDuration: "1M",
+				CurrentUsage:  100,
+				LastReset:     originalLastReset,
+			},
+		},
+		[]CreateBudgetRequest{
+			{
+				ID:            "team-budget-1",
+				MaxLimit:      150,
+				ResetDuration: "1d",
+			},
+		},
+		false,
+	)
+	if err != nil {
+		t.Fatalf("expected reconcile to succeed: %v", err)
+	}
+	if len(reconciled) != 1 {
+		t.Fatalf("expected one budget, got %d", len(reconciled))
+	}
+	if reconciled[0].ID != "team-budget-1" || reconciled[0].ResetDuration != "1d" || reconciled[0].MaxLimit != 150 {
+		t.Fatalf("expected same team budget to be updated, got %#v", reconciled[0])
+	}
+	if reconciled[0].CurrentUsage != 100 || !reconciled[0].LastReset.Equal(originalLastReset) {
+		t.Fatalf("expected team usage and last reset to be preserved, got %#v", reconciled[0])
+	}
+}
+
 func TestVirtualKeyBudgetFrequencyChangePreservesUsageWhenRequested(t *testing.T) {
 	originalLastReset := time.Now().Add(-2 * time.Hour)
 	reconciled, err := reconcileBudgetRequestsForTest(

--- a/ui/app/workspace/governance/views/teamSheet.tsx
+++ b/ui/app/workspace/governance/views/teamSheet.tsx
@@ -284,6 +284,7 @@ export default function TeamSheet({ team, onSave, onCancel }: TeamSheetProps) {
 		const submittableBudgets = formData.budgets
 			.filter((r) => r.maxLimit !== undefined && r.maxLimit !== null)
 			.map((r) => ({
+				id: team?.budgets?.some((budget) => budget.id === r.id) ? r.id : undefined,
 				max_limit: r.maxLimit as number,
 				reset_duration: r.resetDuration,
 				// Only quarterly windows may carry a quarter definition; the API rejects it elsewhere.

--- a/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/governanceFormFragment.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/lib/store";
 import { ModelProvider } from "@/lib/types/config";
 import { CreateBudgetRequest, ProviderGovernance } from "@/lib/types/governance";
+import { budgetSignature } from "@/lib/utils/governance";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
@@ -31,6 +32,7 @@ const budgetLineSchema = z.object({
 	id: z.string().optional(),
 	max_limit: z.number({ error: "Budget limit must be a number" }).nonnegative("Budget limit cannot be negative").optional(),
 	reset_duration: z.string().min(1, "Reset duration is required"),
+	reset_config: z.object({ quarter_start_month: z.number().optional() }).optional(),
 });
 
 const formSchema = z.object({
@@ -60,6 +62,7 @@ function governanceToFormValues(provGov: ProviderGovernance | undefined): FormDa
 			id: b.id,
 			max_limit: b.max_limit,
 			reset_duration: b.reset_duration,
+			reset_config: b.reset_config,
 		})),
 		calendarAligned: provGov.calendar_aligned ?? false,
 		tokenMaxLimit: provGov.rate_limit?.token_max_limit ?? undefined,
@@ -118,15 +121,10 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 	// A budget config change on existing provider governance is when clearing
 	// accumulated spend becomes a meaningful choice.
 	const budgetsChanged = (data: FormData) => {
-		const signature = (rows: { max_limit?: number | null; reset_duration?: string }[]) =>
-			[...rows]
-				.map((r) => `${r.max_limit ?? ""}:${r.reset_duration ?? ""}`)
-				.sort()
-				.join("|");
 		const existing = providerGovernance?.budgets ?? [];
 		if (existing.length === 0) return false;
 		const next = data.budgets.filter((b) => b.max_limit !== undefined && b.max_limit > 0);
-		return signature(next) !== signature(existing);
+		return budgetSignature(next) !== budgetSignature(existing);
 	};
 
 	const onSubmit = async (data: FormData) => {
@@ -151,6 +149,7 @@ export function GovernanceFormFragment({ provider }: GovernanceFormFragmentProps
 					id: b.id,
 					max_limit: b.max_limit!,
 					reset_duration: b.reset_duration,
+					reset_config: b.reset_config,
 				}));
 			} else if (hadBudgets) {
 				budgetsPayload = [];


### PR DESCRIPTION
## Summary

Fix two governance budget edit paths that could silently lose persisted state:

1. Editing a team budget's reset frequency could replace the stored budget
   instead of updating it, resetting accumulated usage even when the user chose
   to preserve usage.
2. Editing a provider budget could discard a quarterly budget's
   `quarter_start_month`, changing its reset calendar to the default January
   schedule.

## Changes

- Include persisted team budget IDs in update requests. Temporary IDs used for
  newly added UI rows are still omitted.
- Reconcile team budgets by stable ID first, matching the pattern used by other
  governance entities.
- Retain `reset_duration` matching as a compatibility fallback for clients that
  do not send budget IDs.
- Preserve and submit provider budget `reset_config` values.
- Use the shared budget signature when detecting provider budget changes so
  fiscal-quarter changes also trigger the preserve/reset usage choice.
- Add focused coverage for preserving a team budget's identity, usage, and last
  reset when its frequency changes.

### Team budget example

Before this change, the team form omitted the persisted budget ID:

```text
stored budget
┌──────────┬─────────┬───────────┬────────┐
│ ID       │ limit   │ frequency │ usage  │
├──────────┼─────────┼───────────┼────────┤
│ budget-a │ $100    │ monthly   │ $40    │
└──────────┴─────────┴───────────┴────────┘
                         │
                         │ user changes monthly → weekly
                         ▼
request: { limit: $150, frequency: weekly }
                         │
                         │ no ID; weekly does not match monthly
                         ▼
delete budget-a + create budget-b
┌──────────┬─────────┬───────────┬────────┐
│ budget-b │ $150    │ weekly    │ $0     │
└──────────┴─────────┴───────────┴────────┘
```

The backend was not explicitly clearing usage. It interpreted the changed
frequency as a removed monthly budget and a new weekly budget. The replacement
budget naturally started at zero.

The request now includes the persisted ID:

```text
request: { ID: budget-a, limit: $150, frequency: weekly }
                         │
                         │ stable ID matches the existing row
                         ▼
update budget-a in place
┌──────────┬─────────┬───────────┬────────┐
│ budget-a │ $150    │ weekly    │ $40    │
└──────────┴─────────┴───────────┴────────┘
```

The reconciliation order is now:

```text
request contains an ID?
├─ yes → match the existing budget by ID
└─ no  → fall back to matching by reset duration

matched → update the existing row and preserve usage unless reset was requested
unmatched → create a new budget
```

This keeps current clients correct while preserving amount-only updates from
older clients that do not send IDs.

### Quarterly provider budget example

A quarterly provider budget can define a fiscal quarter start:

```json
{
  "reset_duration": "1Q",
  "reset_config": {
    "quarter_start_month": 2
  }
}
```

Previously, the standalone provider governance form dropped `reset_config` while
loading and saving the budget:

```text
saved February schedule
          │
          │ open and save an unrelated budget edit
          ▼
request omits reset_config
          │
          ▼
backend clears the saved configuration
          │
          ▼
default January schedule
```

The form now round-trips `reset_config`. A real quarter-start change is also
included in budget change detection, so the existing preserve/reset usage dialog
appears before saving it.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Focused backend reconciliation coverage
go test ./transports/bifrost-http/handlers -run 'TestTeamBudgetFrequencyChangePreservesUsageWhenRequested|TestVirtualKeyBudgetFrequencyChangePreservesUsageWhenRequested|TestProviderBudgetFrequencyChangePreservesUsageWhenRequested|TestBudgetFrequencyChangeResetsUsageWhenRequested' -count=1

# UI type checking
cd ui
npm run typecheck
```

Expected results:

- all focused Go tests pass;
- UI type checking passes;
- changing a team budget's frequency with preserve usage retains its ID, current
  usage, and last-reset timestamp;
- changing it with reset usage clears usage through the explicit reset path;
- opening and saving a quarterly provider budget retains its configured quarter
  start;
- changing only the quarter start is recognized as a budget change.

No new configuration or environment variables are introduced.

## Screenshots/Recordings

Not applicable. The change corrects update behavior without adding or changing
UI elements.

## Breaking changes

- [ ] Yes
- [x] No

Requests without budget IDs continue to use reset-duration matching for
compatibility.

## Related issues

Closes #6914

## Security considerations

No security implications. This change does not alter authentication,
authorization, secrets, or PII handling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
