### PR TITLE
fix: preserve plugin created_at timestamp on update

### DIFF
--- a/framework/configstore/rdb.go
+++ b/framework/configstore/rdb.go
@@ -3367,6 +3367,7 @@ func (s *RDBConfigStore) UpdatePlugin(ctx context.Context, plugin *tables.TableP
 		if plugin.Version == 0 {
 			plugin.Version = existing.Version
 		}
+		plugin.CreatedAt = existing.CreatedAt
 		if err := txDB.WithContext(ctx).Delete(&existing).Error; err != nil {
 			if localTx {
 				txDB.Rollback()


### PR DESCRIPTION
## Summary

When updating a plugin, the `CreatedAt` timestamp was being lost during the delete-and-recreate operation, causing the plugin's original creation time to be overwritten. This fix preserves the original `CreatedAt` value from the existing record.

## Changes

- During `UpdatePlugin`, the `CreatedAt` field is now copied from the existing plugin record before the delete step, ensuring the creation timestamp is retained through the update cycle.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

1. Create a plugin and note its `CreatedAt` timestamp.
2. Perform an update on the plugin (e.g., change its version or configuration).
3. Verify that the `CreatedAt` timestamp on the updated plugin matches the original value.

```sh
go test ./framework/configstore/...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable