### PR TITLE
fix(ui): misc layout and styling fixes for providers, sheets, and classifier status badge

### DIFF
--- a/ui/app/workspace/complexity-router/views/classifierStatusBadge.tsx
+++ b/ui/app/workspace/complexity-router/views/classifierStatusBadge.tsx
@@ -3,8 +3,8 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { SEMANTIC_STATUS_LABELS, SemanticStatusInfo } from "@/lib/types/complexityRouter";
 import { cn } from "@/lib/utils";
-import type { VariantProps } from "class-variance-authority";
 import { Link } from "@tanstack/react-router";
+import type { VariantProps } from "class-variance-authority";
 import { ArrowRight, CircleAlert, CircleCheck, CircleDashed, LoaderCircle, RefreshCw } from "lucide-react";
 import type { ReactNode } from "react";
 import { semanticWarmupFailureMessage, semanticWarmupImpactMessage } from "./classifierStatusBadge.utils";
@@ -133,7 +133,7 @@ export function ClassifierStatusBadge({
 				</button>
 			</PopoverTrigger>
 
-			<PopoverContent align="end" className="w-80 space-y-2.5 p-3 text-xs leading-relaxed" data-testid="complexity-router-semantic-status">
+			<PopoverContent align="end" className="w-80 space-y-2.5 p-3 text-xs leading-relaxed z-0" data-testid="complexity-router-semantic-status">
 				<p className="text-muted-foreground">{summary}</p>
 
 				{status?.serving_previous && state === "warming" && (

--- a/ui/app/workspace/complexity-router/views/embeddingConfigSheet.tsx
+++ b/ui/app/workspace/complexity-router/views/embeddingConfigSheet.tsx
@@ -114,9 +114,9 @@ export default function EmbeddingConfigSheet({
 	return (
 		<Sheet open={open} onOpenChange={onOpenChange}>
 			<SheetContent className="flex flex-col p-0" data-testid="complexity-router-embedding-sheet">
-				<SheetHeader className="flex flex-col items-start gap-1 px-6 py-4" headerClassName="bg-card z-10 mb-0 border-b">
+				<SheetHeader className="flex flex-col items-start gap-1 py-4" headerClassName="bg-card z-10 mb-0 border-b px-4 md:px-6">
 					<SheetTitle>Embedding configuration</SheetTitle>
-					<SheetDescription className="text-xs">
+					<SheetDescription>
 						The model that embeds requests and reference phrases. API keys are inherited from the provider&apos;s main configuration.
 					</SheetDescription>
 				</SheetHeader>

--- a/ui/app/workspace/mcp-registry/library/views/mcpLibrarySettingsSheet.tsx
+++ b/ui/app/workspace/mcp-registry/library/views/mcpLibrarySettingsSheet.tsx
@@ -111,7 +111,7 @@ export function MCPLibrarySettingsSheet({ open, onClose }: MCPLibrarySettingsShe
 	return (
 		<Sheet open={open} onOpenChange={(sheetOpen) => !sheetOpen && onClose()}>
 			<SheetContent className="flex w-full flex-col overflow-x-hidden px-0">
-				<SheetHeader className="flex flex-col items-start px-4 pt-8 md:px-7">
+				<SheetHeader className="flex flex-col items-start pt-8" headerClassName="px-4 md:px-6">
 					<SheetTitle>MCP Library Settings</SheetTitle>
 					<SheetDescription>Configure the sync source and interval for the MCP server catalog.</SheetDescription>
 				</SheetHeader>

--- a/ui/app/workspace/providers/page.tsx
+++ b/ui/app/workspace/providers/page.tsx
@@ -84,14 +84,14 @@ export default function Providers() {
 	// Hidden (unreleased) providers are excluded too, since the user cannot add them yet.
 	const activeCollision = collisionsHydrated
 		? findCustomProviderCollisions(configuredProviders).find((c) => {
-				const key = normalizeProviderName(c.customName);
-				return (
-					c.knownProvider !== DATABRICKS_PROVIDER &&
-					!HiddenProviders.has(c.knownProvider) &&
-					!dismissedCollisions.has(key) &&
-					!handledCollisions.has(key)
-				);
-			})
+			const key = normalizeProviderName(c.customName);
+			return (
+				c.knownProvider !== DATABRICKS_PROVIDER &&
+				!HiddenProviders.has(c.knownProvider) &&
+				!dismissedCollisions.has(key) &&
+				!handledCollisions.has(key)
+			);
+		})
 		: undefined;
 
 	// Open the migration dialog when the selected provider is a custom provider named exactly
@@ -281,12 +281,12 @@ export default function Providers() {
 			/>
 			<div
 				className={cn(
-					"w-full flex-col md:flex md:h-[calc(var(--app-content-viewport)_-_70px)] md:w-[300px]",
+					"w-full flex-col md:flex md:h-[calc(var(--app-content-viewport)_-_55px)] md:w-[300px]",
 					mobileDetailOpen ? "hidden" : "flex",
 				)}
 			>
 				<TooltipProvider>
-					<div className="flex min-h-0 flex-1 flex-col rounded-md bg-zinc-50/50 md:p-4 dark:bg-zinc-800/20">
+					<div className="flex min-h-0 flex-1 flex-col rounded-md bg-zinc-50/50 md:p-4 md:pb-0 dark:bg-zinc-800/20">
 						{/* Pinned lane title */}
 						<div className="text-muted-foreground mb-2 shrink-0 text-xs font-medium">Configured Providers</div>
 
@@ -337,26 +337,26 @@ export default function Providers() {
 							) : (
 								<div
 									data-testid="providers-lane-empty"
-									className="flex h-full flex-col items-center justify-center gap-2 px-4 py-8 text-center"
+									className="flex flex-col items-center justify-center gap-2 px-4 py-8 text-center"
 								>
 									<Server className="text-muted-foreground h-8 w-8" strokeWidth={1} />
 									<div className="text-muted-foreground text-xs">No providers configured yet</div>
 								</div>
 							)}
-						</div>
 
-						{/* Pinned add action */}
-						{hasProviderCreateAccess ? (
-							<div className="shrink-0 pt-3">
-								<AddProviderDropdown
-									disabled={!hasProviderCreateAccess}
-									existingInSidebar={existingInSidebarNames}
-									knownProviders={knownProviders}
-									onSelectKnownProvider={handleSelectKnownProvider}
-									onAddCustomProvider={() => setShowCustomProviderSheet(true)}
-								/>
-							</div>
-						) : null}
+							{/* Add action: follows the last provider, sticks to the bottom once the list overflows */}
+							{hasProviderCreateAccess ? (
+								<div className="sticky bottom-0 bg-zinc-50/50 backdrop-blur-sm dark:bg-zinc-800/20">
+									<AddProviderDropdown
+										disabled={!hasProviderCreateAccess}
+										existingInSidebar={existingInSidebarNames}
+										knownProviders={knownProviders}
+										onSelectKnownProvider={handleSelectKnownProvider}
+										onAddCustomProvider={() => setShowCustomProviderSheet(true)}
+									/>
+								</div>
+							) : null}
+						</div>
 					</div>
 				</TooltipProvider>
 			</div>

--- a/ui/app/workspace/webhooks/views/webhookSheet.tsx
+++ b/ui/app/workspace/webhooks/views/webhookSheet.tsx
@@ -52,25 +52,25 @@ const TUNING_FIELDS: {
 	label: string;
 	description: string;
 }[] = [
-	{ key: "max_retries", label: "Max retries", description: "Retries after the first delivery attempt." },
-	{
-		key: "retry_backoff_initial_seconds",
-		label: "Initial retry backoff (seconds)",
-		description: "Delay before the first retry; doubles per retry.",
-	},
-	{ key: "retry_backoff_max_seconds", label: "Max retry backoff (seconds)", description: "Cap on the per-retry delay." },
-	{ key: "attempt_timeout_seconds", label: "Attempt timeout (seconds)", description: "End-to-end bound for one delivery attempt." },
-	{
-		key: "max_response_payload_kbs",
-		label: "Max response payload (KB)",
-		description: "Responses above this size are omitted from the payload.",
-	},
-	{
-		key: "max_concurrent_deliveries",
-		label: "Max concurrent deliveries",
-		description: "Concurrent in-flight deliveries to this endpoint per node.",
-	},
-];
+		{ key: "max_retries", label: "Max retries", description: "Retries after the first delivery attempt." },
+		{
+			key: "retry_backoff_initial_seconds",
+			label: "Initial retry backoff (seconds)",
+			description: "Delay before the first retry; doubles per retry.",
+		},
+		{ key: "retry_backoff_max_seconds", label: "Max retry backoff (seconds)", description: "Cap on the per-retry delay." },
+		{ key: "attempt_timeout_seconds", label: "Attempt timeout (seconds)", description: "End-to-end bound for one delivery attempt." },
+		{
+			key: "max_response_payload_kbs",
+			label: "Max response payload (KB)",
+			description: "Responses above this size are omitted from the payload.",
+		},
+		{
+			key: "max_concurrent_deliveries",
+			label: "Max concurrent deliveries",
+			description: "Concurrent in-flight deliveries to this endpoint per node.",
+		},
+	];
 
 const formDefaults = (endpoint: WebhookEndpoint | null): WebhookFormData => ({
 	name: endpoint?.name ?? "",
@@ -194,7 +194,7 @@ export function WebhookSheet({ open, endpoint, onClose, onSecret }: WebhookSheet
 	return (
 		<Sheet open={open} onOpenChange={(sheetOpen) => !sheetOpen && onClose()}>
 			<SheetContent className="flex w-full flex-col overflow-x-hidden px-0" data-testid="webhook-sheet-content">
-				<SheetHeader className="flex flex-col items-start px-4 pt-8 md:px-7">
+				<SheetHeader className="flex flex-col items-start pt-8" headerClassName="px-4 md:px-6">
 					<SheetTitle>{isEditing ? endpoint.name : "Add Webhook Endpoint"}</SheetTitle>
 					<SheetDescription>
 						{isEditing


### PR DESCRIPTION
## Summary

Fixes several UI layout and z-index issues across the providers page, sheet headers, and the classifier status badge popover.

## Changes

- Added `z-0` to the `PopoverContent` in `classifierStatusBadge.tsx` to prevent it from incorrectly layering over other elements.
- Moved the "Add Provider" button inside the scrollable provider list container so it sticks to the bottom when the list overflows, rather than being pinned outside the scroll area. Also adjusted the provider lane height calculation and removed bottom padding to accommodate this.
- Standardized `SheetHeader` padding across `embeddingConfigSheet.tsx`, `mcpLibrarySettingsSheet.tsx`, and `webhookSheet.tsx` by moving horizontal padding to `headerClassName` (`px-4 md:px-6`) instead of applying it directly to the header element, aligning with a consistent responsive padding pattern.
- Removed the `text-xs` override from the `SheetDescription` in `embeddingConfigSheet.tsx` so it inherits the default description text size.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the Providers page and verify:
- The "Add Provider" button follows the provider list and sticks to the bottom when the list is long enough to scroll.
- No unexpected overflow or clipping occurs in the provider lane.

Open the Embedding Config, MCP Library Settings, and Webhook sheets and verify:
- Sheet headers have consistent horizontal padding at all breakpoints.
- The embedding sheet description renders at the default text size.

Open the classifier status badge popover and verify it does not incorrectly overlap other UI elements.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

<!-- Add before/after screenshots or clips if available -->

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

<!-- Link related issues here -->

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable