### PR TITLE
fix: preserve realtime auth across KV replication

### DIFF
--- a/transports/bifrost-http/handlers/realtime_client_secrets.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets.go
@@ -391,16 +391,12 @@ func cacheRealtimeEphemeralKeyMapping(kv schemas.KVStore, body []byte, keyID str
 		return
 	}
 
-	payload, err := json.Marshal(realtimeEphemeralKeyMapping{
+	mapping := realtimeEphemeralKeyMapping{
 		KeyID:      strings.TrimSpace(keyID),
 		VirtualKey: strings.TrimSpace(virtualKey),
-	})
-	if err != nil {
-		logger.Warn("failed to encode realtime ephemeral key mapping for key_id=%s: %v", keyID, err)
-		return
 	}
 
-	if err := kv.SetWithTTL(buildRealtimeEphemeralKeyMappingKey(token), payload, ttl); err != nil {
+	if err := kv.SetWithTTL(buildRealtimeEphemeralKeyMappingKey(token), mapping, ttl); err != nil {
 		logger.Warn("failed to cache realtime ephemeral key mapping for key_id=%s: %v", keyID, err)
 	}
 }

--- a/transports/bifrost-http/handlers/realtime_client_secrets_test.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets_test.go
@@ -407,13 +407,9 @@ func TestCacheRealtimeEphemeralKeyMappingStoresKeyID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("store.Get() error = %v", err)
 	}
-	value, ok := raw.([]byte)
+	mapping, ok := raw.(realtimeEphemeralKeyMapping)
 	if !ok {
-		t.Fatalf("cached value type = %T, want []byte", raw)
-	}
-	var mapping realtimeEphemeralKeyMapping
-	if err := json.Unmarshal(value, &mapping); err != nil {
-		t.Fatalf("json.Unmarshal() error = %v", err)
+		t.Fatalf("cached value type = %T, want realtimeEphemeralKeyMapping", raw)
 	}
 	if mapping.KeyID != "key_123" {
 		t.Fatalf("mapping.KeyID = %q, want %q", mapping.KeyID, "key_123")

--- a/transports/bifrost-http/handlers/webrtc_realtime.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime.go
@@ -400,6 +400,8 @@ func lookupRealtimeEphemeralKeyMapping(kv schemas.KVStore, token string) (realti
 	}
 
 	switch value := raw.(type) {
+	case realtimeEphemeralKeyMapping:
+		return value, true
 	case string:
 		return parseRealtimeEphemeralKeyMappingValue([]byte(value))
 	case []byte:

--- a/transports/bifrost-http/handlers/webrtc_realtime_test.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+type testKVSyncDelegate struct {
+	destination *kvstore.Store
+	err         error
+}
+
+func (d *testKVSyncDelegate) OnSet(key string, valueJSON []byte, writtenAt int64, expiresAt int64) {
+	d.err = d.destination.SetRemote(key, valueJSON, writtenAt, expiresAt)
+}
+
+func (d *testKVSyncDelegate) OnDelete(string, int64) {}
+
 type testHandlerStore struct {
 	kv *kvstore.Store
 }
@@ -236,6 +247,48 @@ func TestLookupRealtimeEphemeralKeyMappingKeepsEntryUntilTTLExpiry(t *testing.T)
 	}
 	if raw == nil {
 		t.Fatal("expected mapping to remain in KV store")
+	}
+}
+
+func TestCacheRealtimeEphemeralKeyMappingPreservesVirtualKeyAcrossKVReplication(t *testing.T) {
+	t.Parallel()
+
+	source, err := kvstore.New(kvstore.Config{})
+	if err != nil {
+		t.Fatalf("kvstore.New() source error = %v", err)
+	}
+	defer source.Close()
+
+	destination, err := kvstore.New(kvstore.Config{})
+	if err != nil {
+		t.Fatalf("kvstore.New() destination error = %v", err)
+	}
+	defer destination.Close()
+
+	delegate := &testKVSyncDelegate{destination: destination}
+	source.SetDelegate(delegate)
+
+	body, err := json.Marshal(map[string]any{
+		"value":      "ek_test_replicated",
+		"expires_at": time.Now().Add(time.Minute).Unix(),
+	})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	cacheRealtimeEphemeralKeyMapping(source, body, "key_123", "sk-bf-test")
+	if delegate.err != nil {
+		t.Fatalf("replicating mapping error = %v", delegate.err)
+	}
+
+	mapping, ok := lookupRealtimeEphemeralKeyMapping(destination, "ek_test_replicated")
+	if !ok {
+		t.Fatal("expected replicated mapping")
+	}
+	if mapping.KeyID != "key_123" {
+		t.Fatalf("mapping.KeyID = %q, want %q", mapping.KeyID, "key_123")
+	}
+	if mapping.VirtualKey != "sk-bf-test" {
+		t.Fatalf("mapping.VirtualKey = %q, want %q", mapping.VirtualKey, "sk-bf-test")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix WebRTC realtime authentication when client-secret creation and SDP setup
land on different Bifrost instances.

Bifrost stores a short-lived mapping from an OpenAI ephemeral token to the
selected provider key and the virtual key that minted it. The handler previously
encoded that mapping into `[]byte` before passing it to the KV store. Local
reads worked because the local store kept those bytes unchanged. Cluster
replication encoded the byte slice again, following normal JSON semantics for
`[]byte`, and produced a base64 string instead of a JSON object.

A different instance then interpreted that base64 string as a legacy provider
key ID. The selected provider key survived, but the virtual key did not. The
WebRTC connection could open against the provider, then governance rejected its
first inference turn because the relay had no Bifrost credential.

```text
POST /realtime/client_secrets                 POST /realtime/calls
          │                                             │
          ▼                                             ▼
     instance A                                    instance B
          │                                             │
          │ stores pre-encoded []byte                   │ reads replicated value
          │                                             │
          ├── local value:                              │
          │   {"key_id":"key_123",                      │
          │    "virtual_key":"sk-bf-..."}               │
          │                                             │
          └── replication JSON-encodes []byte ─────────►│
              "eyJrZXlfaWQiOi..."                       │
                                                        ▼
                                              parsed as legacy KeyID
                                              VirtualKey is empty
                                                        │
                                                        ▼
                                              governance rejects turn
```

## Changes

- Store `realtimeEphemeralKeyMapping` as a typed value instead of pre-encoded
  JSON bytes.
- Accept the typed mapping during same-instance lookup.
- Keep the existing `string` and `[]byte` readers for cached legacy entries and
  replicated JSON values.
- Add a regression test with two KV stores connected through the real `OnSet`
  and `SetRemote` path. The test verifies that both `KeyID` and `VirtualKey`
  survive replication.
- Update the local cache test to assert the typed representation.

With the typed value, serialization happens once at the KV replication boundary:

```text
same instance

realtimeEphemeralKeyMapping
          │
          ▼
local KV stores typed mapping
          │
          ▼
lookup reads typed mapping

cross instance

realtimeEphemeralKeyMapping
          │
          ▼
KV replication encodes one JSON object
          │
          ▼
{"key_id":"key_123","virtual_key":"sk-bf-..."}
          │
          ▼
remote KV stores JSON bytes
          │
          ▼
lookup decodes both fields
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the focused handler and KV tests:

```sh
go test ./transports/bifrost-http/handlers/... ./framework/kvstore/...
```

Expected result:

```text
ok  github.com/maximhq/bifrost/transports/bifrost-http/handlers
ok  github.com/maximhq/bifrost/framework/kvstore
```

The cross-instance regression test creates a mapping on one KV store, replicates
it to a second store, and checks that the destination returns:

```text
KeyID:      key_123
VirtualKey: sk-bf-test
```

For a manual cluster test:

1. Send `POST /openai/v1/realtime/client_secrets` through the load balancer
   using `x-bf-vk`.
2. Use the returned ephemeral token for `POST /openai/v1/realtime/calls`.
3. Route the two requests to different Bifrost instances.
4. Start a realtime response turn.
5. Confirm the turn succeeds instead of returning `authentication is required`.

No new configuration or environment variables are required.

## Screenshots/Recordings

Not applicable. This change has no UI impact.

## Breaking changes

- [ ] Yes
- [x] No

Existing scalar key-ID mappings remain readable through the compatibility paths.

## Related issues

None.

## Security considerations

The replicated mapping contains the virtual key that authenticated the
client-secret request. That value was already part of the intended mapping and
has the same TTL as the ephemeral token. This change preserves it across
instances instead of losing it during serialization. Tests use synthetic
credentials and no logs expose key values.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable
