### PR TITLE
fix: responses error events

### DIFF
--- a/core/providers/openai/errors.go
+++ b/core/providers/openai/errors.go
@@ -79,7 +79,77 @@ func responsesStreamError(response *schemas.BifrostResponsesStreamResponse) *sch
 		bifrostErr.Error.Message = fmt.Sprintf("provider stream error (%s)", details)
 	}
 
+	// Keep the upstream event so the transport can replay it as the terminal frame.
+	terminalEvent := *response
+	bifrostErr.ResponsesTerminalEvent = &terminalEvent
+
 	return bifrostErr
+}
+
+// newResponsesTruncationEvent synthesizes the terminal response.failed event for a
+// stream that died before sending one, reusing the identity from the last event seen.
+// Returns nil when the stream failed before any response identity arrived; the
+// transport then falls back to the untyped-identity `error` event.
+func newResponsesTruncationEvent(lastSeen *schemas.BifrostResponsesResponse, sequenceNumber int) *schemas.BifrostResponsesStreamResponse {
+	if lastSeen == nil {
+		return nil
+	}
+
+	failed := *lastSeen
+	failed.Status = schemas.Ptr(schemas.ResponsesResponseStatusFailed)
+	failed.Output = []schemas.ResponsesMessage{}
+	failed.Error = &schemas.ResponsesResponseError{
+		Type:    string(schemas.ProviderConnectionFailed),
+		Code:    string(schemas.ProviderConnectionFailed),
+		Message: schemas.ErrProviderStreamTruncated,
+	}
+
+	return &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeFailed,
+		SequenceNumber: sequenceNumber,
+		Response:       &failed,
+	}
+}
+
+// ToOpenAIResponsesStreamError renders a mid-stream failure as a Responses SSE
+// event so the stream always ends on a frame clients can dispatch on, rather than
+// on Bifrost's internal error envelope. Mirrors ToAnthropicResponsesStreamError:
+// returning the framed string is what lets the transport emit an `event:` line.
+func ToOpenAIResponsesStreamError(bifrostErr *schemas.BifrostError) string {
+	event := ResponsesStreamErrorEvent(bifrostErr)
+	if event == nil {
+		return ""
+	}
+
+	payload, err := providerUtils.MarshalSorted(event)
+	if err != nil {
+		return ""
+	}
+
+	// The event name comes from the payload's own type, so the two cannot disagree.
+	return fmt.Sprintf("event: %s\ndata: %s\n\n", event.Type, payload)
+}
+
+// ResponsesStreamErrorEvent returns the Responses event a mid-stream failure renders
+// as: the preserved upstream terminal event when there is one, otherwise a top-level
+// `error` event, which needs no response identity. Callers that frame their own SSE
+// (the native route) use this directly; ToOpenAIResponsesStreamError frames it for
+// the integration routes.
+func ResponsesStreamErrorEvent(bifrostErr *schemas.BifrostError) *schemas.BifrostResponsesStreamResponse {
+	if bifrostErr == nil {
+		return nil
+	}
+
+	event := bifrostErr.ResponsesTerminalEvent
+	if event == nil {
+		event = &schemas.BifrostResponsesStreamResponse{Type: schemas.ResponsesStreamResponseTypeError}
+		if bifrostErr.Error != nil {
+			event.Message = schemas.Ptr(bifrostErr.Error.Message)
+			event.Code = bifrostErr.Error.Code
+		}
+	}
+
+	return event.WithDefaults()
 }
 
 // ParseOpenAIError parses OpenAI error responses.

--- a/core/providers/openai/errors_test.go
+++ b/core/providers/openai/errors_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/maximhq/bifrost/core/schemas"
@@ -99,5 +100,99 @@ func TestParseOpenAIError_DefaultStatusCodeFallsBackWithStatusNumber(t *testing.
 	}
 	if errResp.Error.Message != "provider API error (status 200)" {
 		t.Fatalf("expected fallback message with default status, got %q", errResp.Error.Message)
+	}
+}
+
+// A Responses stream must end on a frame the client can dispatch on. Before this,
+// an upstream response.failed was flattened into Bifrost's error envelope and its
+// nested response object — id, status, usage — was dropped (#6783).
+func TestResponsesStreamError_PreservesUpstreamTerminalEvent(t *testing.T) {
+	upstream := &schemas.BifrostResponsesStreamResponse{
+		Type:           schemas.ResponsesStreamResponseTypeFailed,
+		SequenceNumber: 1,
+		Response: &schemas.BifrostResponsesResponse{
+			ID:     schemas.Ptr("resp_repro"),
+			Object: "response",
+			Status: schemas.Ptr(schemas.ResponsesResponseStatusFailed),
+			Model:  "gpt-5.6-sol",
+			Error: &schemas.ResponsesResponseError{
+				Code:    "server_error",
+				Message: "simulated Azure failure",
+			},
+		},
+	}
+
+	bifrostErr := responsesStreamError(upstream)
+
+	if bifrostErr.ResponsesTerminalEvent == nil {
+		t.Fatal("upstream terminal event was dropped")
+	}
+	if got := bifrostErr.ResponsesTerminalEvent.Type; got != schemas.ResponsesStreamResponseTypeFailed {
+		t.Errorf("event type = %q, want response.failed", got)
+	}
+	if bifrostErr.ResponsesTerminalEvent.Response == nil {
+		t.Fatal("nested response object was dropped")
+	}
+	if got := bifrostErr.ResponsesTerminalEvent.Response.ID; got == nil || *got != "resp_repro" {
+		t.Errorf("response id = %v, want resp_repro", got)
+	}
+	// The flattened fields must still be populated for retries, logging and billing.
+	if bifrostErr.Error == nil || bifrostErr.Error.Message != "simulated Azure failure" {
+		t.Errorf("flattened error = %+v, want the upstream message", bifrostErr.Error)
+	}
+}
+
+// A stream that dies mid-flight has no upstream event to replay, so one is
+// synthesized from the identity of the last event seen.
+func TestNewResponsesTruncationEvent_SynthesizesFailedFromLastSeen(t *testing.T) {
+	event := newResponsesTruncationEvent(&schemas.BifrostResponsesResponse{
+		ID:     schemas.Ptr("resp_abc"),
+		Object: "response",
+		Model:  "gpt-5.6-sol",
+		Status: schemas.Ptr(schemas.ResponsesResponseStatusInProgress),
+	}, 7)
+
+	if event == nil {
+		t.Fatal("expected a synthesized event")
+	}
+	if event.Type != schemas.ResponsesStreamResponseTypeFailed {
+		t.Errorf("type = %q, want response.failed", event.Type)
+	}
+	if event.SequenceNumber != 7 {
+		t.Errorf("sequence_number = %d, want 7", event.SequenceNumber)
+	}
+	if event.Response == nil || event.Response.Status == nil || *event.Response.Status != schemas.ResponsesResponseStatusFailed {
+		t.Fatalf("status must be flipped to failed, got %+v", event.Response)
+	}
+	if got := event.Response.ID; got == nil || *got != "resp_abc" {
+		t.Errorf("id = %v, want the id carried by the stream", got)
+	}
+	if event.Response.Error == nil || event.Response.Error.Message != schemas.ErrProviderStreamTruncated {
+		t.Errorf("error = %+v, want the truncation reason", event.Response.Error)
+	}
+}
+
+// Without an identity there is nothing to build a response.failed around, so the
+// renderer must still produce a typed frame — the `error` event needs no identity.
+func TestToOpenAIResponsesStreamError_FallsBackToTypedErrorEvent(t *testing.T) {
+	if got := newResponsesTruncationEvent(nil, 1); got != nil {
+		t.Fatalf("expected no synthesized event without an identity, got %+v", got)
+	}
+
+	framed := ToOpenAIResponsesStreamError(&schemas.BifrostError{
+		Error: &schemas.ErrorField{
+			Code:    schemas.Ptr("provider_connection_failed"),
+			Message: schemas.ErrProviderStreamTruncated,
+		},
+	})
+
+	if !strings.HasPrefix(framed, "event: error\n") {
+		t.Errorf("frame must be named for its own type, got %q", framed)
+	}
+	if !strings.Contains(framed, `"type":"error"`) {
+		t.Errorf("frame must carry a dispatchable type, got %q", framed)
+	}
+	if !strings.Contains(framed, schemas.ErrProviderStreamTruncated) {
+		t.Errorf("frame must carry the failure reason, got %q", framed)
 	}
 }

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -2008,6 +2008,11 @@ func HandleOpenAIResponsesStreaming(
 
 		lastChunkTime := startTime
 
+		// Identity of the response being streamed, kept so a stream that dies without a
+		// terminal event can still be reported as a well-formed response.failed.
+		var lastResponseSeen *schemas.BifrostResponsesResponse
+		lastSequenceNumber := 0
+
 		for {
 			// If context was cancelled/timed out, let defer handle it
 			if ctx.Err() != nil {
@@ -2079,6 +2084,14 @@ func HandleOpenAIResponsesStreaming(
 				}
 			}
 
+			if response.SequenceNumber > lastSequenceNumber {
+				lastSequenceNumber = response.SequenceNumber
+			}
+			if response.Response != nil {
+				snapshot := *response.Response
+				lastResponseSeen = &snapshot
+			}
+
 			if response.Type == schemas.ResponsesStreamResponseTypeError {
 				bifrostErr := responsesStreamError(&response)
 
@@ -2120,7 +2133,8 @@ func HandleOpenAIResponsesStreaming(
 		// surface it rather than closing the channel silently — a silent close is
 		// indistinguishable to the client from a stream that just stopped emitting.
 		if !providerUtils.SSEStreamEndedOnMarker(sseReader) {
-			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody)
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, logger, postHookSpanFinalizer, jsonBody,
+				newResponsesTruncationEvent(lastResponseSeen, lastSequenceNumber+1))
 		}
 	}()
 

--- a/core/providers/openai/responseslifecycle.go
+++ b/core/providers/openai/responseslifecycle.go
@@ -285,6 +285,11 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 		sseReader := providerUtils.GetSSEDataReader(ctx, reader)
 		lastChunkTime := startTime
 
+		// Identity of the response being streamed, kept so a stream that dies without a
+		// terminal event can still be reported as a well-formed response.failed.
+		var lastResponseSeen *schemas.BifrostResponsesResponse
+		lastSequenceNumber := 0
+
 		for {
 			if ctx.Err() != nil {
 				return
@@ -320,6 +325,14 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 				response.ExtraFields.RawResponse = jsonData
 			}
 
+			if response.SequenceNumber > lastSequenceNumber {
+				lastSequenceNumber = response.SequenceNumber
+			}
+			if response.Response != nil {
+				snapshot := *response.Response
+				lastResponseSeen = &snapshot
+			}
+
 			if response.Type == schemas.ResponsesStreamResponseTypeError {
 				bifrostErr := responsesStreamError(&response)
 				ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
@@ -353,7 +366,8 @@ func (provider *OpenAIProvider) ResponsesRetrieveStream(ctx *schemas.BifrostCont
 		// A plain io.EOF cannot distinguish that from a healthy close, so surface it
 		// instead of closing the channel silently.
 		if !providerUtils.SSEStreamEndedOnMarker(sseReader) {
-			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, nil)
+			providerUtils.SendStreamTruncatedError(ctx, postHookRunner, responseChan, provider.logger, postHookSpanFinalizer, nil,
+				newResponsesTruncationEvent(lastResponseSeen, lastSequenceNumber+1))
 		}
 	}()
 

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -3608,12 +3608,19 @@ func SendStreamTruncatedError(
 	logger schemas.Logger,
 	postHookSpanFinalizer func(context.Context),
 	jsonBody []byte,
+	terminalEvent ...*schemas.BifrostResponsesStreamResponse,
 ) {
 	if logger != nil {
 		logger.Warn("Stream ended without a terminal marker; treating as truncated upstream stream")
 	}
 
 	truncatedErr := NewBifrostUpstreamConnectionError(schemas.ErrProviderStreamTruncated, io.ErrUnexpectedEOF)
+
+	// Responses streams must end on a typed event, so callers on that path pass the
+	// synthesized terminal frame for the transport to emit.
+	if len(terminalEvent) > 0 {
+		truncatedErr.ResponsesTerminalEvent = terminalEvent[0]
+	}
 
 	if ShouldSendBackRawRequest(ctx, false) && len(jsonBody) > 0 {
 		truncatedErr.ExtraFields.RawRequest = compactRawJSON(jsonBody)

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -1957,6 +1957,11 @@ type BifrostError struct {
 	AllowFallbacks *bool                   `json:"-"` // Optional: Controls fallback behavior (nil = true by default)
 	StreamControl  *StreamControl          `json:"-"` // Optional: Controls stream behavior
 	ExtraFields    BifrostErrorExtraFields `json:"extra_fields"`
+
+	// ResponsesTerminalEvent is the Responses SSE event this failure renders as, so a
+	// Responses stream always ends on a typed event. Internal only: the error envelope
+	// itself is unchanged on the wire.
+	ResponsesTerminalEvent *BifrostResponsesStreamResponse `json:"-"`
 }
 
 // PopulateExtraFields sets RequestType, Provider, OriginalModelRequested, and ResolvedModelUsed on the

--- a/transports/bifrost-http/handlers/inference.go
+++ b/transports/bifrost-http/handlers/inference.go
@@ -22,6 +22,7 @@ import (
 	"github.com/fasthttp/router"
 	bifrost "github.com/maximhq/bifrost/core"
 
+	"github.com/maximhq/bifrost/core/providers/openai"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
@@ -2188,6 +2189,19 @@ func (h *CompletionHandler) handleStreamingResponse(ctx *fasthttp.RequestCtx, bi
 					eventType = string(chunk.BifrostImageGenerationStreamResponse.Type)
 				} else if chunk.BifrostError != nil {
 					eventType = string(schemas.ResponsesStreamResponseTypeError)
+					// Responses failures go out as a typed Responses event, taking both
+					// the event name and the body from it so they always agree — the raw
+					// error envelope carries no `type` the client can dispatch on.
+					if rt := chunk.BifrostError.ExtraFields.RequestType; rt == schemas.ResponsesStreamRequest || rt == schemas.ResponsesRetrieveStreamRequest {
+						if event := openai.ResponsesStreamErrorEvent(chunk.BifrostError); event != nil {
+							if payload, marshalErr := sonic.Marshal(event); marshalErr == nil {
+								eventType = string(event.Type)
+								chunkJSON = payload
+							} else {
+								logger.Warn("Failed to marshal responses stream error event: %v", marshalErr)
+							}
+						}
+					}
 				}
 			}
 

--- a/transports/bifrost-http/handlers/responsesstreamerror_test.go
+++ b/transports/bifrost-http/handlers/responsesstreamerror_test.go
@@ -1,0 +1,105 @@
+package handlers
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// On native /v1/responses the SSE event name used to be hardcoded to "error"
+// regardless of the payload, so a response.failed body went out under an "error"
+// event name — a frame that contradicts itself (#6783).
+
+// streamNativeResponsesError runs one error chunk through the native streaming
+// handler and returns the event name and decoded payload of the final frame.
+func streamNativeResponsesError(t *testing.T, bifrostErr *schemas.BifrostError) (string, map[string]interface{}) {
+	t.Helper()
+
+	stream := make(chan *schemas.BifrostStreamChunk, 1)
+	stream <- &schemas.BifrostStreamChunk{BifrostError: bifrostErr}
+	close(stream)
+
+	handler := &CompletionHandler{config: &lib.Config{}}
+	ctx := &fasthttp.RequestCtx{}
+	bifrostCtx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	handler.handleStreamingResponse(ctx, bifrostCtx, schemas.ResponsesStreamRequest,
+		func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) { return stream, nil },
+		func() {})
+
+	body, err := io.ReadAll(ctx.Response.BodyStream())
+	require.NoError(t, err)
+
+	frame := strings.TrimSpace(string(body))
+	require.NotEmpty(t, frame, "handler emitted no terminal frame")
+	require.NotContains(t, frame, "[DONE]", "responses streams must not append the done marker")
+
+	eventName, data, found := strings.Cut(frame, "\n")
+	require.True(t, found, "frame must carry both an event line and a data line: %q", frame)
+	eventName = strings.TrimPrefix(eventName, "event: ")
+
+	var payload map[string]interface{}
+	require.NoError(t, sonic.UnmarshalString(strings.TrimPrefix(data, "data: "), &payload))
+	return eventName, payload
+}
+
+func Test_NativeResponsesStreamErrorEventNameMatchesPayload(t *testing.T) {
+	eventName, payload := streamNativeResponsesError(t, &schemas.BifrostError{
+		Type:           schemas.Ptr("response.failed"),
+		IsBifrostError: false,
+		Error: &schemas.ErrorField{
+			Code:    schemas.Ptr("server_error"),
+			Message: "simulated Azure failure",
+		},
+		ResponsesTerminalEvent: &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeFailed,
+			SequenceNumber: 1,
+			Response: &schemas.BifrostResponsesResponse{
+				ID:     schemas.Ptr("resp_repro"),
+				Object: "response",
+				Model:  "gpt-5.6-sol",
+				Status: schemas.Ptr(schemas.ResponsesResponseStatusFailed),
+				Error: &schemas.ResponsesResponseError{
+					Code:    "server_error",
+					Message: "simulated Azure failure",
+				},
+			},
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ResponsesStreamRequest,
+			Provider:    schemas.Azure,
+		},
+	})
+
+	require.Equal(t, "response.failed", eventName, "event name must follow the payload, not a hardcoded 'error'")
+	require.Equal(t, eventName, payload["type"], "event name and data.type must agree")
+
+	response, ok := payload["response"].(map[string]interface{})
+	require.True(t, ok, "response.failed must carry its response object: %v", payload)
+	require.Equal(t, "resp_repro", response["id"])
+	require.Equal(t, "failed", response["status"])
+}
+
+// A failure carrying no Responses event still needs a dispatchable frame, and its
+// name must match the `error` type it falls back to.
+func Test_NativeResponsesStreamFallsBackToTypedErrorEvent(t *testing.T) {
+	eventName, payload := streamNativeResponsesError(t, &schemas.BifrostError{
+		Error: &schemas.ErrorField{
+			Code:    schemas.Ptr("provider_connection_failed"),
+			Message: schemas.ErrProviderStreamTruncated,
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ResponsesStreamRequest,
+		},
+	})
+
+	require.Equal(t, "error", eventName)
+	require.Equal(t, "error", payload["type"])
+	require.Equal(t, schemas.ErrProviderStreamTruncated, payload["message"])
+}

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -746,8 +746,10 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					}
 					return string(resp.Type), openAIWireCostResponse(converted), nil
 				},
+				// Responses streams must end on a typed event; the raw error envelope
+				// carries no Responses `type` for the client to dispatch on.
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
-					return err
+					return openai.ToOpenAIResponsesStreamError(err)
 				},
 			},
 			PreCallback: func(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext, req interface{}) error {
@@ -840,8 +842,10 @@ func CreateOpenAIRouteConfigs(pathPrefix string, handlerStore lib.HandlerStore) 
 					}
 					return string(resp.Type), openAIWireCostResponse(converted), nil
 				},
+				// Responses streams must end on a typed event; the raw error envelope
+				// carries no Responses `type` for the client to dispatch on.
 				ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {
-					return err
+					return openai.ToOpenAIResponsesStreamError(err)
 				},
 			},
 			ErrorConverter: func(ctx *schemas.BifrostContext, err *schemas.BifrostError) interface{} {

--- a/transports/bifrost-http/integrations/responsesstreamerror_test.go
+++ b/transports/bifrost-http/integrations/responsesstreamerror_test.go
@@ -1,0 +1,162 @@
+package integrations
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/bytedance/sonic"
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+)
+
+// Responses streams must end on a typed Responses event. Before #6783 the route
+// wrote Bifrost's internal error envelope as a bare `data:` frame, which carries no
+// Responses `type`, so clients discarded it and reported a dropped stream.
+
+func responsesRouteConfig(t *testing.T) RouteConfig {
+	t.Helper()
+	for _, config := range CreateOpenAIRouteConfigs("", &mockHandlerStore{}) {
+		if strings.HasSuffix(config.Path, "/v1/responses") && config.StreamConfig != nil &&
+			config.StreamConfig.ResponsesStreamResponseConverter != nil {
+			return config
+		}
+	}
+	t.Fatal("no /v1/responses route found")
+	return RouteConfig{}
+}
+
+// streamResponsesError runs a single error chunk through the route and returns the
+// SSE event name and the decoded data payload of the final frame.
+func streamResponsesError(t *testing.T, bifrostErr *schemas.BifrostError) (string, map[string]interface{}) {
+	t.Helper()
+
+	stream := make(chan *schemas.BifrostStreamChunk, 1)
+	stream <- &schemas.BifrostStreamChunk{BifrostError: bifrostErr}
+	close(stream)
+
+	router := NewGenericRouter(nil, &mockHandlerStore{}, nil, nil, nil, bifrost.NewNoOpLogger())
+	ctx := &fasthttp.RequestCtx{}
+	router.handleStreaming(ctx, nil, responsesRouteConfig(t), stream, func() {})
+
+	body, err := io.ReadAll(ctx.Response.BodyStream())
+	require.NoError(t, err)
+
+	frame := strings.TrimSpace(string(body))
+	require.NotEmpty(t, frame, "route emitted no terminal frame")
+	require.NotContains(t, frame, "[DONE]", "responses streams must not append the done marker")
+
+	eventName, data, found := strings.Cut(frame, "\n")
+	require.True(t, found, "frame must carry both an event line and a data line: %q", frame)
+	eventName = strings.TrimPrefix(eventName, "event: ")
+
+	var payload map[string]interface{}
+	require.NoError(t, sonic.UnmarshalString(strings.TrimPrefix(data, "data: "), &payload))
+	return eventName, payload
+}
+
+// A connection that dies mid-stream is reported as a well-formed response.failed
+// built from the identity the stream already carried.
+func Test_ResponsesStreamTruncationEmitsTypedFailureEvent(t *testing.T) {
+	statusCode := 502
+	eventName, payload := streamResponsesError(t, &schemas.BifrostError{
+		IsBifrostError: false,
+		StatusCode:     &statusCode,
+		Error: &schemas.ErrorField{
+			Type:    schemas.Ptr(schemas.ProviderConnectionFailed),
+			Message: schemas.ErrProviderStreamTruncated,
+		},
+		ResponsesTerminalEvent: &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeFailed,
+			SequenceNumber: 7,
+			Response: &schemas.BifrostResponsesResponse{
+				ID:     schemas.Ptr("resp_abc"),
+				Object: "response",
+				Model:  "gpt-5.6-sol",
+				Status: schemas.Ptr(schemas.ResponsesResponseStatusFailed),
+				Error: &schemas.ResponsesResponseError{
+					Code:    string(schemas.ProviderConnectionFailed),
+					Message: schemas.ErrProviderStreamTruncated,
+				},
+			},
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ResponsesStreamRequest,
+			Provider:    schemas.Azure,
+		},
+	})
+
+	require.Equal(t, "response.failed", eventName)
+	require.Equal(t, "response.failed", payload["type"], "clients dispatch on data.type")
+	require.Equal(t, eventName, payload["type"], "event name and payload type must agree")
+
+	response, ok := payload["response"].(map[string]interface{})
+	require.True(t, ok, "response.failed must carry its response object: %v", payload)
+	require.Equal(t, "resp_abc", response["id"])
+	require.Equal(t, "failed", response["status"])
+}
+
+// An upstream response.failed is replayed with its own payload intact rather than
+// being flattened into Bifrost's envelope.
+func Test_ResponsesStreamUpstreamFailureIsReplayedIntact(t *testing.T) {
+	eventName, payload := streamResponsesError(t, &schemas.BifrostError{
+		Type:           schemas.Ptr("response.failed"),
+		IsBifrostError: false,
+		Error: &schemas.ErrorField{
+			Code:    schemas.Ptr("server_error"),
+			Message: "simulated Azure failure",
+		},
+		ResponsesTerminalEvent: &schemas.BifrostResponsesStreamResponse{
+			Type:           schemas.ResponsesStreamResponseTypeFailed,
+			SequenceNumber: 1,
+			Response: &schemas.BifrostResponsesResponse{
+				ID:     schemas.Ptr("resp_repro"),
+				Object: "response",
+				Model:  "gpt-5.6-sol",
+				Status: schemas.Ptr(schemas.ResponsesResponseStatusFailed),
+				Usage:  &schemas.ResponsesResponseUsage{InputTokens: 10, OutputTokens: 2, TotalTokens: 12},
+				Error: &schemas.ResponsesResponseError{
+					Code:    "server_error",
+					Message: "simulated Azure failure",
+				},
+			},
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ResponsesStreamRequest,
+			Provider:    schemas.Azure,
+		},
+	})
+
+	require.Equal(t, "response.failed", eventName)
+	response, ok := payload["response"].(map[string]interface{})
+	require.True(t, ok, "the upstream response object must survive: %v", payload)
+	require.Equal(t, "resp_repro", response["id"])
+
+	usage, ok := response["usage"].(map[string]interface{})
+	require.True(t, ok, "usage must survive the replay: %v", response)
+	require.EqualValues(t, 12, usage["total_tokens"])
+
+	failure, ok := response["error"].(map[string]interface{})
+	require.True(t, ok, "the provider's reason must survive: %v", response)
+	require.Equal(t, "simulated Azure failure", failure["message"])
+}
+
+// A failure with no response identity still has to produce a dispatchable frame;
+// the top-level `error` event needs none.
+func Test_ResponsesStreamWithoutIdentityEmitsTypedErrorEvent(t *testing.T) {
+	eventName, payload := streamResponsesError(t, &schemas.BifrostError{
+		Error: &schemas.ErrorField{
+			Code:    schemas.Ptr("provider_connection_failed"),
+			Message: schemas.ErrProviderStreamTruncated,
+		},
+		ExtraFields: schemas.BifrostErrorExtraFields{
+			RequestType: schemas.ResponsesStreamRequest,
+		},
+	})
+
+	require.Equal(t, "error", eventName)
+	require.Equal(t, "error", payload["type"])
+	require.Equal(t, schemas.ErrProviderStreamTruncated, payload["message"])
+}


### PR DESCRIPTION
## Summary

Responses API streams were ending on Bifrost's internal error envelope instead of a typed Responses SSE event. Clients dispatching on `event:` and `data.type` could not handle these frames — the event name was hardcoded to `"error"` even when the payload was a `response.failed` object, and the nested response identity (id, status, usage, error reason) was dropped entirely.

## Changes

- `responsesStreamError` now preserves the upstream terminal event on `BifrostError.ResponsesTerminalEvent` so the transport can replay it as the final SSE frame rather than discarding it.
- `newResponsesTruncationEvent` synthesizes a well-formed `response.failed` event from the last response identity seen when a stream dies without sending a terminal event, carrying the correct status, error reason, and sequence number.
- `ResponsesStreamErrorEvent` and `ToOpenAIResponsesStreamError` select the right terminal frame: the preserved upstream event when one exists, otherwise a top-level `error` event (which requires no response identity).
- `HandleOpenAIResponsesStreaming` and `ResponsesRetrieveStream` now track `lastResponseSeen` and `lastSequenceNumber` across the stream loop and pass the synthesized truncation event to `SendStreamTruncatedError`.
- `SendStreamTruncatedError` accepts an optional `terminalEvent` variadic so Responses callers can attach the synthesized frame without changing the signature for other callers.
- The `/v1/responses` and retrieve-stream integration routes replace their `ErrorConverter` (which returned the raw envelope) with `ToOpenAIResponsesStreamError`, which returns a framed SSE string the transport emits directly.
- The native HTTP handler's streaming path detects Responses request types on error chunks and re-renders them through `ResponsesStreamErrorEvent`, aligning the event name with the payload type.
- `BifrostError` gains a `ResponsesTerminalEvent` field (JSON-ignored) to carry the terminal frame through the error path without changing the wire format.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/openai/...
go test ./transports/bifrost-http/handlers/...
go test ./transports/bifrost-http/integrations/...
```

The new tests cover:
- `TestResponsesStreamError_PreservesUpstreamTerminalEvent` — upstream `response.failed` payload survives into `ResponsesTerminalEvent`.
- `TestNewResponsesTruncationEvent_SynthesizesFailedFromLastSeen` — truncation event carries the correct id, status, sequence number, and error reason.
- `TestToOpenAIResponsesStreamError_FallsBackToTypedErrorEvent` — no identity produces a dispatchable `error` event.
- `Test_NativeResponsesStreamErrorEventNameMatchesPayload` — native handler emits `event: response.failed` with a matching `data.type`.
- `Test_NativeResponsesStreamFallsBackToTypedErrorEvent` — native handler falls back to `event: error` when no terminal event is present.
- `Test_ResponsesStreamTruncationEmitsTypedFailureEvent` — integration route emits a well-formed `response.failed` for a truncated stream.
- `Test_ResponsesStreamUpstreamFailureIsReplayedIntact` — upstream failure including usage and error reason survives the replay.
- `Test_ResponsesStreamWithoutIdentityEmitsTypedErrorEvent` — integration route falls back to `event: error` without an identity.

## Breaking changes

- [x] No

## Related issues

Closes #6783

## Security considerations

None. No auth, secrets, or PII are involved; the change only affects how SSE error frames are serialised.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable