### PR TITLE
feat: add toggle for overhead spans filter in plugins

### DIFF
--- a/core/schemas/span_filter.go
+++ b/core/schemas/span_filter.go
@@ -96,18 +96,46 @@ func (f *PluginSpanFilter) BuildReparentMap(spans []*Span) map[string]string {
 	if f == nil {
 		return nil
 	}
-	// First pass: record direct parent ID for every filtered span.
+	return reparentMap(spans, f.ShouldExportSpan)
+}
+
+// IsOverheadLatencySpan reports whether a span is an internal overhead/latency phase span.
+// A parentless span (the trace root) is excluded so it is never stripped.
+func IsOverheadLatencySpan(span *Span) bool {
+	return span != nil && span.Kind == SpanKindInternal && span.ParentID != ""
+}
+
+// ShouldExportSpanWithOverhead is ShouldExportSpan, additionally dropping overhead spans when
+// exportOverheadSpans is false. Nil-safe.
+func (f *PluginSpanFilter) ShouldExportSpanWithOverhead(span *Span, exportOverheadSpans bool) bool {
+	if !exportOverheadSpans && IsOverheadLatencySpan(span) {
+		return false
+	}
+	return f.ShouldExportSpan(span)
+}
+
+// BuildReparentMapWithOverhead is BuildReparentMap honoring the overhead toggle. Not nil-gated:
+// overhead spans can drop with no plugin filter set.
+func (f *PluginSpanFilter) BuildReparentMapWithOverhead(spans []*Span, exportOverheadSpans bool) map[string]string {
+	return reparentMap(spans, func(span *Span) bool {
+		return f.ShouldExportSpanWithOverhead(span, exportOverheadSpans)
+	})
+}
+
+// reparentMap maps each dropped span to its nearest exported ancestor, resolving chains of
+// consecutive drops. Nil when nothing drops.
+func reparentMap(spans []*Span, shouldExport func(*Span) bool) map[string]string {
 	filtered := make(map[string]string) // spanID -> parentID
 	for _, span := range spans {
-		if !f.ShouldExportSpan(span) {
+		if span != nil && !shouldExport(span) {
 			filtered[span.SpanID] = span.ParentID
 		}
 	}
 	if len(filtered) == 0 {
 		return nil
 	}
-	// Second pass: resolve chains so each filtered span maps to its first exported ancestor.
-	// Cap the walk at len(filtered) to break out of any cycle caused by malformed span data.
+	// Resolve chains so each dropped span maps to its first exported ancestor.
+	// Cap the walk at len(filtered) to break out of any cycle from malformed span data.
 	maxHops := len(filtered)
 	for spanID := range filtered {
 		parentID := filtered[spanID]

--- a/core/schemas/span_filter_test.go
+++ b/core/schemas/span_filter_test.go
@@ -177,3 +177,47 @@ func TestPluginSpanFilter_BuildReparentMap(t *testing.T) {
 		_ = f.BuildReparentMap(spans) // must terminate
 	})
 }
+
+func TestShouldExportSpanWithOverhead(t *testing.T) {
+	llm := &Span{SpanID: "llm", ParentID: "root", Name: "chat", Kind: SpanKindLLMCall}
+	internalChild := &Span{SpanID: "ov", ParentID: "root", Name: "key.selection", Kind: SpanKindInternal}
+	internalRoot := &Span{SpanID: "root", ParentID: "", Name: "request", Kind: SpanKindInternal}
+	pluginKept := pluginSpan("pk", "root", "plugin.governance.prehook")
+
+	cases := []struct {
+		name           string
+		span           *Span
+		exportOverhead bool
+		want           bool
+	}{
+		{"internal child dropped by default", internalChild, false, false},
+		{"internal child kept when enabled", internalChild, true, true},
+		{"parentless internal (root) always kept", internalRoot, false, true},
+		{"llm span unaffected", llm, false, true},
+		{"plugin span unaffected by overhead toggle", pluginKept, false, true},
+	}
+	var f *PluginSpanFilter // nil filter: overhead toggle still applies
+	for _, tc := range cases {
+		if got := f.ShouldExportSpanWithOverhead(tc.span, tc.exportOverhead); got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestBuildReparentMapWithOverhead_ReparentsInternalChildren(t *testing.T) {
+	// root(http) -> phase(internal, dropped) -> llm(kept). llm must reparent to root.
+	spans := []*Span{
+		{SpanID: "root", ParentID: "", Name: "request", Kind: SpanKindHTTPRequest},
+		{SpanID: "phase", ParentID: "root", Name: "key.selection", Kind: SpanKindInternal},
+		{SpanID: "llm", ParentID: "phase", Name: "chat", Kind: SpanKindLLMCall},
+	}
+	var f *PluginSpanFilter
+	reparent := f.BuildReparentMapWithOverhead(spans, false)
+	if reparent["phase"] != "root" {
+		t.Fatalf("dropped internal span should map to root, got %q", reparent["phase"])
+	}
+	// With overhead export enabled, nothing is dropped.
+	if m := f.BuildReparentMapWithOverhead(spans, true); m != nil {
+		t.Fatalf("exportOverhead=true should drop nothing, got %v", m)
+	}
+}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1188,6 +1188,10 @@
                     },
                     "plugin_span_filter": {
                       "$ref": "#/$defs/pluginSpanFilter"
+                    },
+                    "export_overhead_spans": {
+                      "type": "boolean",
+                      "description": "Export internal overhead/latency spans (setup, key selection, pipeline phases). Default false."
                     }
                   }
                 }
@@ -1486,6 +1490,10 @@
                     },
                     "plugin_span_filter": {
                       "$ref": "#/$defs/pluginSpanFilter"
+                    },
+                    "export_overhead_spans": {
+                      "type": "boolean",
+                      "description": "Export internal overhead/latency spans (setup, key selection, pipeline phases). Default false."
                     }
                   }
                 }
@@ -1559,6 +1567,10 @@
                     },
                     "plugin_span_filter": {
                       "$ref": "#/$defs/pluginSpanFilter"
+                    },
+                    "export_overhead_spans": {
+                      "type": "boolean",
+                      "description": "Export internal overhead/latency spans (setup, key selection, pipeline phases). Default false."
                     }
                   }
                 }
@@ -5657,6 +5669,10 @@
         },
         "plugin_span_filter": {
           "$ref": "#/$defs/pluginSpanFilter"
+        },
+        "export_overhead_spans": {
+          "type": "boolean",
+          "description": "Export internal overhead/latency spans (setup, key selection, pipeline phases). Default false."
         }
       },
       "allOf": [
@@ -5733,6 +5749,10 @@
         },
         "plugin_span_filter": {
           "$ref": "#/$defs/pluginSpanFilter"
+        },
+        "export_overhead_spans": {
+          "type": "boolean",
+          "description": "Export internal overhead/latency spans (setup, key selection, pipeline phases). Default false."
         },
         "enabled": {
           "type": "boolean",

--- a/plugins/otel/converter.go
+++ b/plugins/otel/converter.go
@@ -97,7 +97,7 @@ func hexToBytes(hexStr string, length int) []byte {
 // profile service name. Span filtering and instance attributes are shared across profiles;
 // only the resource service name differs per profile.
 func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schemas.Trace, requestHeaders []string, disableContentLogging bool, groupTracesBySession bool, disableRootSpanContent bool) *ResourceSpan {
-	reparent := p.pluginSpanFilter.BuildReparentMap(trace.Spans)
+	reparent := p.pluginSpanFilter.BuildReparentMapWithOverhead(trace.Spans, p.exportOverheadSpans)
 	filteredHeaders := schemas.FilterHeaders(trace.RequestHeaders, requestHeaders)
 
 	// The x-bf-session-id header is a trace-level attribute, so it is not emitted as a span
@@ -120,7 +120,7 @@ func (p *OtelPlugin) convertTraceToResourceSpan(serviceName string, trace *schem
 
 	otelSpans := make([]*Span, 0, len(trace.Spans))
 	for _, span := range trace.Spans {
-		if !p.pluginSpanFilter.ShouldExportSpan(span) {
+		if !p.pluginSpanFilter.ShouldExportSpanWithOverhead(span, p.exportOverheadSpans) {
 			continue
 		}
 		// disableRootSpanContent drops content from the root span only (the framework duplicates

--- a/plugins/otel/converter_test.go
+++ b/plugins/otel/converter_test.go
@@ -174,7 +174,8 @@ func findRoot(spans []*Span) *Span {
 // makeSessionTrace builds a single-request trace (root + one LLM child) optionally carrying an
 // x-bf-session-id attribute and an inbound traceparent parent on the root span.
 func makeSessionTrace(traceID, sessionID, rootParentID string) *schemas.Trace {
-	root := makeSpan("aaaa", rootParentID, "request", schemas.SpanKindInternal)
+	// The HTTP request span is the trace root in production (never an internal span).
+	root := makeSpan("aaaa", rootParentID, "request", schemas.SpanKindHTTPRequest)
 	child := makeSpan("bbbb", "aaaa", "chat", schemas.SpanKindLLMCall)
 	tr := &schemas.Trace{
 		TraceID:  traceID,

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -184,6 +184,9 @@ type Config struct {
 	// single-object config it is read from the object; in a profiles wrapper it is read
 	// from the top-level field (or hoisted from the first profile that carries one).
 	PluginSpanFilter *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
+
+	// ExportOverheadSpans exports internal overhead/latency spans; nil/false drops them.
+	ExportOverheadSpans *bool `json:"export_overhead_spans,omitempty"`
 }
 
 // UnmarshalJSON normalizes both supported config shapes into Profiles. A wrapper object
@@ -198,10 +201,13 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 			return err
 		}
 		*c = Config(w)
-		// Allow plugin_span_filter to live on the first profile too; hoist it if the
-		// top-level field was omitted.
+		// Allow plugin_span_filter / export_overhead_spans to live on the first profile
+		// too; hoist them if the top-level field was omitted.
 		if c.PluginSpanFilter == nil {
 			c.PluginSpanFilter = hoistSpanFilter(data)
+		}
+		if c.ExportOverheadSpans == nil {
+			c.ExportOverheadSpans = hoistExportOverhead(data)
 		}
 		return nil
 	}
@@ -212,39 +218,54 @@ func (c *Config) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	c.Profiles = []*Profile{&prof}
-	c.PluginSpanFilter = spanFilterFrom(data)
+	carrier := spanFilterFrom(data)
+	c.PluginSpanFilter = carrier.PluginSpanFilter
+	c.ExportOverheadSpans = carrier.ExportOverheadSpans
 	return nil
 }
 
-// spanFilterCarrier captures only the plugin_span_filter field from a config or profile object.
+// spanFilterCarrier captures only the span-filter fields from a config or profile object.
 type spanFilterCarrier struct {
-	PluginSpanFilter *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
+	PluginSpanFilter    *PluginSpanFilter `json:"plugin_span_filter,omitempty"`
+	ExportOverheadSpans *bool             `json:"export_overhead_spans,omitempty"`
 }
 
-// spanFilterFrom extracts a top-level plugin_span_filter from a JSON object, or nil.
-func spanFilterFrom(data []byte) *PluginSpanFilter {
+// spanFilterFrom extracts the top-level span-filter fields from a JSON object.
+func spanFilterFrom(data []byte) spanFilterCarrier {
 	var c spanFilterCarrier
-	if err := sonic.Unmarshal(data, &c); err != nil {
-		return nil
-	}
-	return c.PluginSpanFilter
+	_ = sonic.Unmarshal(data, &c)
+	return c
 }
 
-// hoistSpanFilter returns the first plugin_span_filter found among the profiles of a
-// wrapper-shaped config, used as a fallback when the top-level field is absent.
+// hoistSpanFilter falls back to the first profile's plugin_span_filter.
 func hoistSpanFilter(data []byte) *PluginSpanFilter {
+	for _, p := range profileCarriers(data) {
+		if p.PluginSpanFilter != nil {
+			return p.PluginSpanFilter
+		}
+	}
+	return nil
+}
+
+// hoistExportOverhead falls back to the first profile's export_overhead_spans.
+func hoistExportOverhead(data []byte) *bool {
+	for _, p := range profileCarriers(data) {
+		if p.ExportOverheadSpans != nil {
+			return p.ExportOverheadSpans
+		}
+	}
+	return nil
+}
+
+// profileCarriers reads the span-filter fields off each profile of a wrapper-shaped config.
+func profileCarriers(data []byte) []spanFilterCarrier {
 	var w struct {
 		Profiles []spanFilterCarrier `json:"profiles"`
 	}
 	if err := sonic.Unmarshal(data, &w); err != nil {
 		return nil
 	}
-	for _, p := range w.Profiles {
-		if p.PluginSpanFilter != nil {
-			return p.PluginSpanFilter
-		}
-	}
-	return nil
+	return w.Profiles
 }
 
 // profileForStorage is the persisted form of a single profile: *SecretVar fields are
@@ -274,8 +295,9 @@ type profileForStorage struct {
 
 // configForStorage is the persisted wrapper shape.
 type configForStorage struct {
-	Profiles         []profileForStorage `json:"profiles"`
-	PluginSpanFilter *PluginSpanFilter   `json:"plugin_span_filter,omitempty"`
+	Profiles            []profileForStorage `json:"profiles"`
+	PluginSpanFilter    *PluginSpanFilter   `json:"plugin_span_filter,omitempty"`
+	ExportOverheadSpans *bool               `json:"export_overhead_spans,omitempty"`
 }
 
 // MarshalForStorage serializes Config to JSON with *SecretVar fields as plain strings
@@ -284,8 +306,9 @@ type configForStorage struct {
 // For HTTP API responses use json.Marshal directly so clients receive full SecretVar objects.
 func (c *Config) MarshalForStorage() ([]byte, error) {
 	out := configForStorage{
-		Profiles:         make([]profileForStorage, 0, len(c.Profiles)),
-		PluginSpanFilter: c.PluginSpanFilter,
+		Profiles:            make([]profileForStorage, 0, len(c.Profiles)),
+		PluginSpanFilter:    c.PluginSpanFilter,
+		ExportOverheadSpans: c.ExportOverheadSpans,
 	}
 	for _, p := range c.Profiles {
 		if p == nil {
@@ -326,7 +349,7 @@ func (c *Config) Redacted() *Config {
 	if c == nil {
 		return nil
 	}
-	redacted := &Config{PluginSpanFilter: c.PluginSpanFilter}
+	redacted := &Config{PluginSpanFilter: c.PluginSpanFilter, ExportOverheadSpans: c.ExportOverheadSpans}
 	if c.Profiles != nil {
 		redacted.Profiles = make([]*Profile, 0, len(c.Profiles))
 		for _, p := range c.Profiles {
@@ -460,7 +483,8 @@ type OtelPlugin struct {
 
 	pricingManager *modelcatalog.ModelCatalog
 
-	pluginSpanFilter *PluginSpanFilter
+	pluginSpanFilter    *PluginSpanFilter
+	exportOverheadSpans bool
 }
 
 // Init function for the OTEL plugin
@@ -511,6 +535,7 @@ func Init(ctx context.Context, config *Config, _logger schemas.Logger, pricingMa
 		attributesFromEnvironment: attributesFromEnvironment,
 		instanceAttrs:             instanceAttrs,
 		pluginSpanFilter:          config.PluginSpanFilter,
+		exportOverheadSpans:       config.ExportOverheadSpans != nil && *config.ExportOverheadSpans,
 	}
 	p.ctx, p.cancel = context.WithCancel(ctx)
 

--- a/ui/app/workspace/observability/sheets/pluginTracingSheet.tsx
+++ b/ui/app/workspace/observability/sheets/pluginTracingSheet.tsx
@@ -19,6 +19,8 @@ interface PluginTracingSheetProps {
 	pluginName: string;
 	/** Human-readable destination used in the copy, e.g. "the OTEL collector", "Datadog". */
 	destination: string;
+	/** Show the overhead-spans toggle. Connectors that don't honor it (BigQuery) pass false. */
+	showOverheadToggle?: boolean;
 }
 
 function resolveToggleState(filter: PluginSpanFilter | null | undefined, allPlugins: string[]): Record<string, boolean> {
@@ -59,7 +61,7 @@ function PluginRow({ name, checked, onChange }: { name: string; checked: boolean
 	);
 }
 
-export default function PluginTracingSheet({ open, onClose, pluginName, destination }: PluginTracingSheetProps) {
+export default function PluginTracingSheet({ open, onClose, pluginName, destination, showOverheadToggle = true }: PluginTracingSheetProps) {
 	// All currently loaded plugins (built-in, enterprise, custom, and auto-loaded) that can
 	// emit spans, named to match the connector's span filter. One flat list — the backend
 	// already returns the complete set, so there's no built-in/custom split to maintain.
@@ -67,6 +69,7 @@ export default function PluginTracingSheet({ open, onClose, pluginName, destinat
 	const { data: targetPlugin } = useGetPluginQuery(pluginName);
 	const [updatePlugin, { isLoading }] = useUpdatePluginMutation();
 	const [toggles, setToggles] = useState<Record<string, boolean>>({});
+	const [exportOverheadSpans, setExportOverheadSpans] = useState(false);
 	const wasOpenRef = useRef(false);
 
 	useEffect(() => {
@@ -75,6 +78,7 @@ export default function PluginTracingSheet({ open, onClose, pluginName, destinat
 			const filter = (targetPlugin.config?.plugin_span_filter as PluginSpanFilter | undefined) ?? null;
 			if (isLoadingLoadedPlugins || allPlugins.length === 0) return;
 			setToggles(resolveToggleState(filter, allPlugins));
+			setExportOverheadSpans(Boolean(targetPlugin.config?.export_overhead_spans));
 			wasOpenRef.current = true;
 		}
 		if (!open) wasOpenRef.current = false;
@@ -97,29 +101,32 @@ export default function PluginTracingSheet({ open, onClose, pluginName, destinat
 			return;
 		}
 		const filter = buildFilter(toggles);
+		const config: Record<string, unknown> = { plugin_span_filter: filter };
+		if (showOverheadToggle) {
+			config.export_overhead_spans = exportOverheadSpans;
+		}
 		try {
 			await updatePlugin({
 				name: pluginName,
 				data: {
 					enabled: targetPlugin.enabled,
-					config: { plugin_span_filter: filter },
+					config,
 				},
 			}).unwrap();
-			toast.success("Plugin tracing configuration saved");
+			toast.success("Tracing configuration saved");
 			onClose();
 		} catch (error) {
 			toast.error(getErrorMessage(error));
 		}
-	}, [toggles, targetPlugin, updatePlugin, onClose, pluginName, destination]);
+	}, [toggles, exportOverheadSpans, showOverheadToggle, targetPlugin, updatePlugin, onClose, pluginName, destination]);
 
 	return (
 		<Sheet open={open} onOpenChange={onClose}>
 			<SheetContent className="flex w-full flex-col overflow-hidden p-4 md:p-8">
 				<SheetHeader className="flex flex-col items-start p-0">
-					<SheetTitle>Configure Plugin Tracing</SheetTitle>
+					<SheetTitle>Configure Tracing</SheetTitle>
 					<SheetDescription>
-						Choose which plugin hook spans are exported to {destination}. Disabling a plugin removes its spans from traces without affecting
-						execution.
+						Choose which spans are exported to {destination}. Disabling a plugin removes its spans from traces without affecting execution.
 					</SheetDescription>
 				</SheetHeader>
 
@@ -149,6 +156,28 @@ export default function PluginTracingSheet({ open, onClose, pluginName, destinat
 								))}
 							</div>
 						</div>
+
+						{showOverheadToggle && (
+							<>
+								<div className="border-t" />
+								<div>
+									<p className="text-muted-foreground mb-2 text-xs font-medium tracking-wide uppercase">Overhead</p>
+									<div className="flex items-center justify-between rounded-md border px-3 py-2.5">
+										<div className="flex flex-col">
+											<span className="text-sm">Overhead latency spans</span>
+											<span className="text-muted-foreground text-xs">
+												Internal timing spans (setup, key selection, pipeline phases). Off by default.
+											</span>
+										</div>
+										<Switch
+											checked={exportOverheadSpans}
+											onCheckedChange={setExportOverheadSpans}
+											data-testid="tracing-overhead-toggle"
+										/>
+									</div>
+								</div>
+							</>
+						)}
 					</div>
 				</div>
 

--- a/ui/app/workspace/observability/views/plugins/otelView.tsx
+++ b/ui/app/workspace/observability/views/plugins/otelView.tsx
@@ -63,7 +63,7 @@ export default function OtelView({ onDelete, isDeleting }: OtelViewProps) {
 						data-testid="otel-configure-tracing-button"
 					>
 						<Activity className="h-4 w-4" />
-						Configure Plugin Tracing
+						Configure Tracing
 					</Button>
 				</div>
 				<OtelFormFragment onSave={handleOtelConfigSave} currentConfig={currentConfig} onDelete={onDelete} isDeleting={isDeleting} />


### PR DESCRIPTION
## Summary

Adds an `export_overhead_spans` toggle that controls whether internal overhead/latency spans (setup, key selection, pipeline phases) are included in exported traces. These spans are dropped by default to reduce noise, but can be re-enabled per connector when detailed timing breakdowns are needed.

## Changes

- Introduced `IsOverheadLatencySpan`, `ShouldExportSpanWithOverhead`, and `BuildReparentMapWithOverhead` in `span_filter.go`. Overhead spans are defined as `SpanKindInternal` spans with a non-empty `ParentID` (the trace root is never stripped). The existing `BuildReparentMap` logic was extracted into a shared `reparentMap` helper to avoid duplication.
- The OTEL converter now calls `BuildReparentMapWithOverhead` and `ShouldExportSpanWithOverhead` instead of their non-overhead counterparts, gated by the new `exportOverheadSpans` field on `OtelPlugin`.
- `Config` and `configForStorage` gained an `ExportOverheadSpans *bool` field. `UnmarshalJSON` hoists the value from the first profile when the top-level field is absent, matching the existing `plugin_span_filter` hoisting behavior. `spanFilterCarrier` and `profileCarriers` were refactored to serve both fields.
- Helm schema (`values.schema.json`) updated to document `export_overhead_spans` at all relevant config levels.
- `PluginTracingSheet` gained an `exportOverheadSpans` state variable and an optional "Overhead latency spans" toggle row, controlled by a new `showOverheadToggle` prop (defaults `true`; BigQuery and other connectors that don't honor the field can pass `false`).
- Sheet and button copy simplified from "Configure Plugin Tracing" to "Configure Tracing" to reflect that the sheet now covers more than plugin spans.
- A test helper in `converter_test.go` was corrected to use `SpanKindHTTPRequest` for the trace root span, matching production behavior and preventing the root from being incorrectly classified as an overhead span.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go test ./core/schemas/... ./plugins/otel/...
```

1. Configure the OTEL plugin with `export_overhead_spans: false` (default). Verify that `SpanKindInternal` child spans are absent from exported traces and that their children are reparented to the nearest exported ancestor.
2. Set `export_overhead_spans: true`. Verify that internal overhead spans appear in the exported trace.
3. In the UI, open **Configure Tracing** for the OTEL connector. Confirm the "Overhead latency spans" toggle is visible, persists across saves, and is absent for connectors that pass `showOverheadToggle={false}`.

**New config field:**

| Field | Type | Default | Description |
|---|---|---|---|
| `export_overhead_spans` | `bool` | `false` | When `true`, internal overhead/latency spans are included in exported traces. |

## Screenshots/Recordings

_Before:_ Sheet titled "Configure Plugin Tracing" with only plugin hook toggles.
_After:_ Sheet titled "Configure Tracing" with plugin hook toggles and an "Overhead" section containing the "Overhead latency spans" switch.

## Breaking changes

- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII implications. The toggle only affects which spans are forwarded to the configured tracing backend.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable