### PR TITLE
docs: remove redundant info callout about user-focused scope in access-profiles

### DIFF
--- a/docs/enterprise/access-profiles.mdx
+++ b/docs/enterprise/access-profiles.mdx
@@ -10,11 +10,6 @@ An **Access Profile** is a reusable policy template that describes what a user,t
 
 A user can hold **several access profiles at once**. Together they decide what the user can reach, and one of them pays for each request - see [Multiple profiles per user](#multiple-profiles-per-user).
 
-<Info>
-	For rest of the article we will focus on access profiles for users. But the same principles apply to access profiles for teams and
-	business units.
-</Info>
-
 **Key benefits:**
 
 - **Reusable policy** - Define a profile once (for example, "Engineering") and apply it to every user in a role.


### PR DESCRIPTION
## Summary

Removes a redundant informational callout from the Access Profiles documentation page that noted the article focuses on user access profiles but that the same principles apply to teams and business units.

## Changes

- Removed the `<Info>` callout block from `docs/enterprise/access-profiles.mdx` that clarified scope of the article, as it is no longer needed or was deemed unnecessary noise in the documentation flow.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation page for `access-profiles.mdx` to confirm the callout block no longer appears and the content flows correctly without it.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable