### PR TITLE
fix: add custom provider toggle to differentiate in providers who send done marker

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6872,6 +6872,12 @@ func (bifrost *Bifrost) requestWorker(provider schemas.Provider, config *schemas
 		req.Context.SetValue(schemas.BifrostContextKeyIsCustomProvider, !IsStandardProvider(baseProvider))
 		// Lets downstream converters resolve a custom provider key back to the built-in provider it wraps.
 		req.Context.SetValue(schemas.BifrostContextKeyBaseProviderType, baseProvider)
+		// Re-stamped per attempt so a fallback cannot inherit the previous provider's opt-in.
+		if config.CustomProviderConfig != nil && config.CustomProviderConfig.DoesNotSendDoneMarker {
+			req.Context.SetValue(schemas.BifrostContextKeyDoesNotSendDoneMarker, true)
+		} else {
+			req.Context.ClearValue(schemas.BifrostContextKeyDoesNotSendDoneMarker)
+		}
 
 		bifrost.endCoreSpan(workerSetupSpan)
 

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -620,6 +620,96 @@ func TestHandleProviderRequest_OCROperationNotAllowed(t *testing.T) {
 	}
 }
 
+// https://github.com/maximhq/bifrost/issues/6784: an OpenAI-compatible upstream that ends
+// generation on finish_reason, never sends [DONE] and then parks the connection behind SSE
+// heartbeats holds the stream open indefinitely — heartbeat bytes reset the idle timer without
+// making semantic progress. custom_provider_config.does_not_send_done_marker is the operator's
+// declaration that finish_reason is terminal for this upstream; this pins the whole path, from
+// the account config through the per-attempt context stamp to the provider's read loop.
+func TestCustomProviderDoesNotSendDoneMarkerEndsParkedStream(t *testing.T) {
+	const chunk = `data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}` + "\n\n" +
+		`data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}` + "\n\n"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		fl, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		if _, err := w.Write([]byte(chunk)); err != nil {
+			return
+		}
+		fl.Flush()
+
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+					return
+				}
+				fl.Flush()
+			}
+		}
+	}))
+	defer server.Close()
+
+	const customProvider = schemas.ModelProvider("custom-openai")
+	account := NewMockAccount()
+	account.AddProviderWithBaseURL(customProvider, 1, 1, server.URL)
+	account.configs[customProvider].NetworkConfig.MaxRetries = 0
+	account.SetCustomProviderConfig(customProvider, &schemas.CustomProviderConfig{
+		BaseProviderType:      schemas.OpenAI,
+		DoesNotSendDoneMarker: true,
+	})
+	account.SetKeysForProvider(customProvider, []schemas.Key{
+		{ID: "custom-key", Value: *schemas.NewSecretVar("sk-custom"), Models: schemas.WhiteList{"*"}, Weight: 100},
+	})
+
+	client := newStreamTestClient(t, account)
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	stream, bifrostErr := client.ChatCompletionStreamRequest(ctx, &schemas.BifrostChatRequest{
+		Provider: customProvider,
+		Model:    "repro-model",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: Ptr("hi")},
+		}},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("stream request failed: %v", bifrostErr)
+	}
+
+	type drained struct {
+		content string
+		errs    []string
+	}
+	done := make(chan drained, 1)
+	go func() {
+		content, errs := drainChatStream(stream)
+		done <- drained{content: content, errs: errs}
+	}()
+
+	select {
+	case result := <-done:
+		if len(result.errs) > 0 {
+			t.Fatalf("stream carried errors: %v", result.errs)
+		}
+		if result.content != "hello" {
+			t.Errorf("expected the streamed content to survive the early break, got %q", result.content)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("stream never terminated: does_not_send_done_marker did not reach the provider read loop")
+	}
+}
+
 // Test that transientServerStatusCodes are properly defined.
 // These are upstream-side failures unrelated to the credential — the same key is retried.
 func TestTransientServerStatusCodes(t *testing.T) {

--- a/core/providers/huggingface/chat_test.go
+++ b/core/providers/huggingface/chat_test.go
@@ -205,6 +205,6 @@ func TestToHuggingFaceChatCompletionStreamRequest_StreamOptions(t *testing.T) {
 // (`choices: []` plus top-level `usage`), which several inference providers
 // emit after the finish chunk — the stream then completes with zero tokens.
 func TestHuggingFaceSendsDoneMarker(t *testing.T) {
-	assert.True(t, providerUtils.ProviderSendsDoneMarker(schemas.HuggingFace),
+	assert.True(t, providerUtils.ProviderSendsDoneMarker(nil, schemas.HuggingFace),
 		"HuggingFace sends [DONE]; breaking on finish_reason drops the trailing usage chunk")
 }

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -752,7 +752,7 @@ func HandleOpenAITextCompletionStreaming(
 			}
 
 			// For providers that don't send [DONE] marker break on finish_reason
-			if !providerUtils.ProviderSendsDoneMarker(providerName) && finishReason != nil {
+			if !providerUtils.ProviderSendsDoneMarker(ctx, providerName) && finishReason != nil {
 				break
 			}
 		}
@@ -1533,7 +1533,7 @@ func HandleOpenAIChatCompletionStreaming(
 				}
 
 				// For providers that don't send [DONE] marker break on finish_reason
-				if !providerUtils.ProviderSendsDoneMarker(providerName) && finishReason != nil {
+				if !providerUtils.ProviderSendsDoneMarker(ctx, providerName) && finishReason != nil {
 					break
 				}
 			}

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -267,6 +267,153 @@ func TestChatStreamFinishReasonWithoutDoneIsNotTruncated(t *testing.T) {
 	}
 }
 
+// heartbeatSSEServer writes body and then keeps the connection alive with SSE
+// comment frames until the client goes away. It never sends [DONE] and never
+// closes: the shape an upstream has when it ends generation but leaves the
+// connection parked. Write errors are swallowed rather than reported through t,
+// since the handler outlives the test body once the client disconnects.
+func heartbeatSSEServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			return
+		}
+		if _, err := w.Write([]byte(body)); err != nil {
+			return
+		}
+		flusher.Flush()
+
+		ticker := time.NewTicker(20 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.Context().Done():
+				return
+			case <-ticker.C:
+				if _, err := w.Write([]byte(": ping\n\n")); err != nil {
+					return
+				}
+				flusher.Flush()
+			}
+		}
+	}))
+}
+
+// https://github.com/maximhq/bifrost/issues/6784: heartbeat comments reset the raw-read
+// idle timer before SSE framing is interpreted, so an upstream that finishes generating
+// and then parks the connection holds the read loop open forever — the client waits on a
+// finish_reason chunk that was already received. custom_provider_config.does_not_send_done_marker
+// is the operator's declaration that this upstream ends on finish_reason, and core stamps it
+// on the context per attempt.
+func TestChatStreamHeartbeatAfterFinishReasonEndsOnOptIn(t *testing.T) {
+	toolCalls := "tool_calls"
+	server := heartbeatSSEServer(t, chatChunk("hello", nil)+chatChunk("", &toolCalls))
+	defer server.Close()
+
+	ctx := newStreamTestContext()
+	ctx.SetValue(schemas.BifrostContextKeyDoesNotSendDoneMarker, true)
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a stream that reached finish_reason")
+	}
+	for i, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+	final := chunks[len(chunks)-1]
+	if final.BifrostChatResponse == nil {
+		t.Fatalf("expected a synthesized final chat chunk, got %+v", final)
+	}
+	if len(final.BifrostChatResponse.Choices) == 0 ||
+		final.BifrostChatResponse.Choices[0].FinishReason == nil ||
+		*final.BifrostChatResponse.Choices[0].FinishReason != toolCalls {
+		t.Errorf("expected the final chunk to carry finish_reason %q, got %+v", toolCalls, final.BifrostChatResponse.Choices)
+	}
+}
+
+// The counterpart: without the opt-in the loop keeps waiting for [DONE], which is
+// what providers emitting a usage-only chunk after finish_reason depend on. Asserted
+// with a bounded wait so a regression here cannot wedge the suite.
+func TestChatStreamHeartbeatAfterFinishReasonWaitsWithoutOptIn(t *testing.T) {
+	toolCalls := "tool_calls"
+	server := heartbeatSSEServer(t, chatChunk("hello", nil)+chatChunk("", &toolCalls))
+	defer server.Close()
+
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(ctx, passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	// The content chunk is forwarded as it arrives; the finish_reason chunk is not.
+	select {
+	case chunk, ok := <-stream:
+		if !ok {
+			t.Fatal("stream closed before delivering the content chunk")
+		}
+		if chunk.BifrostError != nil {
+			t.Fatalf("content chunk carried an error: %+v", chunk.BifrostError)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the content chunk")
+	}
+
+	select {
+	case chunk, ok := <-stream:
+		t.Fatalf("expected the stream to stay open waiting for [DONE], got chunk=%+v open=%v", chunk, ok)
+	case <-time.After(300 * time.Millisecond):
+	}
+}
+
+// The text-completion loop terminates on the same switch, so the opt-in has to
+// reach it too.
+func TestTextCompletionStreamHeartbeatAfterFinishReasonEndsOnOptIn(t *testing.T) {
+	server := heartbeatSSEServer(t, `data: {"id":"cmpl-repro","object":"text_completion","created":1,"model":"repro-model","choices":[{"index":0,"text":"hello","finish_reason":null}]}`+"\n\n"+
+		`data: {"id":"cmpl-repro","object":"text_completion","created":1,"model":"repro-model","choices":[{"index":0,"text":"","finish_reason":"stop"}]}`+"\n\n")
+	defer server.Close()
+
+	ctx := newStreamTestContext()
+	ctx.SetValue(schemas.BifrostContextKeyDoesNotSendDoneMarker, true)
+
+	provider := newStreamTestProvider(server.URL)
+	request := &schemas.BifrostTextCompletionRequest{
+		Provider: schemas.OpenAI,
+		Model:    "repro-model",
+		Input:    &schemas.TextCompletionInput{PromptStr: schemas.Ptr("hi")},
+	}
+	stream, bifrostErr := provider.TextCompletionStream(ctx, passthroughPostHook, nil, testKey(), request)
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
+	}
+
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a stream that reached finish_reason")
+	}
+	for i, chunk := range chunks {
+		if chunk.BifrostError != nil {
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
+		}
+	}
+	if chunks[len(chunks)-1].BifrostTextCompletionResponse == nil {
+		t.Fatalf("expected a synthesized final text completion chunk, got %+v", chunks[len(chunks)-1])
+	}
+}
+
 func TestTextCompletionStreamTruncated(t *testing.T) {
 	server := truncatingSSEServer(t, `data: {"id":"cmpl-repro","object":"text_completion","created":1,"model":"repro-model","choices":[{"index":0,"text":"partial"}]}`+"\n\n")
 	defer server.Close()

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -3380,6 +3380,10 @@ func (r *idleTimeoutReader) Read(p []byte) (n int, err error) {
 // stream_idle_timeout_in_seconds window.
 var ErrStreamIdleTimeout = errors.New("stream idle timeout: no data received within configured window")
 
+// errStreamParkedAfterFinish closes a body stream that ended on finish_reason while the
+// upstream kept the connection open. Internal to ReleaseStreamingResponse; never surfaced.
+var errStreamParkedAfterFinish = errors.New("stream ended on finish_reason with the connection still open")
+
 // ErrStreamClosed is returned when a stream has already been closed by
 // cancellation or cleanup before the next read starts.
 var ErrStreamClosed = errors.New("stream closed")
@@ -3714,7 +3718,14 @@ func GetProviderName(defaultProvider schemas.ModelProvider, customConfig *schema
 // ProviderSendsDoneMarker returns true if the provider sends the [DONE] marker in streaming responses.
 // Some OpenAI-compatible providers (like Cerebras) don't send [DONE] and instead end the stream
 // after sending the finish_reason. This function helps determine the correct stream termination logic.
-func ProviderSendsDoneMarker(providerName schemas.ModelProvider) bool {
+// A custom provider can opt into the same treatment via custom_provider_config.does_not_send_done_marker,
+// which only ever ends the read loop earlier - it cannot make a provider wait for a marker it never sends.
+func ProviderSendsDoneMarker(ctx *schemas.BifrostContext, providerName schemas.ModelProvider) bool {
+	if ctx != nil {
+		if doesNotSendDoneMarker, ok := ctx.Value(schemas.BifrostContextKeyDoesNotSendDoneMarker).(bool); ok && doesNotSendDoneMarker {
+			return false
+		}
+	}
 	switch providerName {
 	case schemas.Cerebras, schemas.Perplexity, schemas.Bedrock, schemas.BedrockMantle:
 		// Cerebras, Perplexity, Bedrock and Bedrock mantle don't send [DONE] marker, ends stream after finish_reason
@@ -3780,6 +3791,15 @@ func ReleaseStreamingResponse(ctx *schemas.BifrostContext, resp *fasthttp.Respon
 	// parseChunkSize waiting for a chunk the upstream will never send, which
 	// deadlocks this deferred cleanup and stops the stream channel from closing.
 	if exhausted, _ := ctx.Value(schemas.BifrostContextKeyStreamBodyExhausted).(bool); !exhausted {
+		// An upstream declared via custom_provider_config.does_not_send_done_marker ends on
+		// finish_reason and may then park the connection, heartbeating instead of closing.
+		// Draining that blocks here forever, so abandon the connection: closing with a
+		// non-nil error takes fasthttp's CloseConn path and keeps the half-read stream
+		// out of the idle pool. The response is left to GC as in the branches above.
+		if doesNotSendDoneMarker, _ := ctx.Value(schemas.BifrostContextKeyDoesNotSendDoneMarker).(bool); doesNotSendDoneMarker {
+			closeBodyStream(bodyStream, errStreamParkedAfterFinish)
+			return
+		}
 		if _, err := io.Copy(io.Discard, bodyStream); err != nil {
 			getLogger().Warn("failed to drain streaming response body before release (may cause stale connection reuse): %v", err)
 		}

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -2306,9 +2306,37 @@ func TestProviderSendsDoneMarker(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(string(tt.provider), func(t *testing.T) {
-			if got := ProviderSendsDoneMarker(tt.provider); got != tt.want {
+			if got := ProviderSendsDoneMarker(nil, tt.provider); got != tt.want {
 				t.Errorf("ProviderSendsDoneMarker(%s) = %v, want %v", tt.provider, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestProviderSendsDoneMarkerCustomProviderOptIn covers custom_provider_config.does_not_send_done_marker,
+// which core stamps on the context per attempt. An OpenAI-compatible upstream that ends its stream on
+// finish_reason without [DONE] otherwise keeps the read loop open for as long as it sends SSE heartbeats,
+// since heartbeat bytes reset the idle timeout without making semantic progress.
+func TestProviderSendsDoneMarkerCustomProviderOptIn(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	if !ProviderSendsDoneMarker(ctx, schemas.OpenAI) {
+		t.Fatal("without the opt-in, an OpenAI-based custom provider must still wait for [DONE]")
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyDoesNotSendDoneMarker, true)
+	if ProviderSendsDoneMarker(ctx, schemas.OpenAI) {
+		t.Error("opt-in must end the stream on finish_reason instead of waiting for [DONE]")
+	}
+	// The opt-in only ever ends the loop earlier; it can never make a provider that
+	// already terminates on finish_reason start waiting for a marker it never sends.
+	if ProviderSendsDoneMarker(ctx, schemas.Cerebras) {
+		t.Error("opt-in must not flip a provider that never sends [DONE] back to waiting for one")
+	}
+
+	// A fallback attempt onto a provider without the opt-in clears the key.
+	ctx.ClearValue(schemas.BifrostContextKeyDoesNotSendDoneMarker)
+	if !ProviderSendsDoneMarker(ctx, schemas.OpenAI) {
+		t.Error("cleared opt-in must fall back to the built-in provider default")
 	}
 }

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -341,6 +341,7 @@ const (
 	BifrostContextKeyRetryDBFetch                        BifrostContextKey = "bifrost-retry-db-fetch"                           // bool (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyIsCustomProvider                    BifrostContextKey = "bifrost-is-custom-provider"                       // bool (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyBaseProviderType                    BifrostContextKey = "bifrost-base-provider-type"                       // ModelProvider (set by bifrost - DO NOT SET THIS MANUALLY) — built-in provider backing this attempt (custom providers resolve to their BaseProviderType)
+	BifrostContextKeyDoesNotSendDoneMarker               BifrostContextKey = "bifrost-does-not-send-done-marker"                // bool (set by bifrost from custom_provider_config.does_not_send_done_marker - DO NOT SET THIS MANUALLY) — ends the SSE read loop on finish_reason instead of waiting for [DONE]
 	BifrostContextKeyHTTPRequestType                     BifrostContextKey = "bifrost-http-request-type"                        // RequestType (set by bifrost - DO NOT SET THIS MANUALLY)
 	BifrostContextKeyHTTPRoute                           BifrostContextKey = "bifrost-http-route"                               // string (set by bifrost - DO NOT SET THIS MANUALLY — matched route template, set by HTTP transport; used as the low-cardinality metrics `path` label)
 	BifrostContextKeyPassthroughExtraParams              BifrostContextKey = "bifrost-passthrough-extra-params"                 // bool

--- a/core/schemas/provider.go
+++ b/core/schemas/provider.go
@@ -532,11 +532,12 @@ func (ar *AllowedRequests) IsOperationAllowed(operation RequestType) bool {
 }
 
 type CustomProviderConfig struct {
-	CustomProviderKey    string                 `json:"-"`                                // Custom provider key, internally set by Bifrost
-	IsKeyLess            bool                   `json:"is_key_less"`                      // Whether the custom provider requires a key (not allowed for Bedrock)
-	BaseProviderType     ModelProvider          `json:"base_provider_type"`               // Base provider type
-	AllowedRequests      *AllowedRequests       `json:"allowed_requests,omitempty"`       // Allowed requests for the custom provider
-	RequestPathOverrides map[RequestType]string `json:"request_path_overrides,omitempty"` // Mapping of request type to its custom path which will override the default path of the provider (not allowed for Bedrock)
+	CustomProviderKey     string                 `json:"-"`                                // Custom provider key, internally set by Bifrost
+	IsKeyLess             bool                   `json:"is_key_less"`                      // Whether the custom provider requires a key (not allowed for Bedrock)
+	BaseProviderType      ModelProvider          `json:"base_provider_type"`               // Base provider type
+	AllowedRequests       *AllowedRequests       `json:"allowed_requests,omitempty"`       // Allowed requests for the custom provider
+	RequestPathOverrides  map[RequestType]string `json:"request_path_overrides,omitempty"` // Mapping of request type to its custom path which will override the default path of the provider (not allowed for Bedrock)
+	DoesNotSendDoneMarker bool                   `json:"does_not_send_done_marker"`        // Upstream ends its SSE stream after finish_reason without sending data: [DONE]
 }
 
 // IsOperationAllowed checks if a specific operation is allowed for this custom provider

--- a/docs/openapi/schemas/management/providers.yaml
+++ b/docs/openapi/schemas/management/providers.yaml
@@ -304,6 +304,12 @@ CustomProviderConfig:
   properties:
     is_key_less:
       type: boolean
+    does_not_send_done_marker:
+      type: boolean
+      description: >-
+        Provider ends streams on finish_reason without sending a data: [DONE] marker.
+        Without this, a provider that also keeps the connection open leaves the stream
+        waiting for a marker it never sends.
     base_provider_type:
       $ref: '../../schemas/inference/common.yaml#/ModelProvider'
     allowed_requests:

--- a/docs/providers/custom-providers.mdx
+++ b/docs/providers/custom-providers.mdx
@@ -257,6 +257,22 @@ Custom providers can be built on these supported providers:
 - `gemini` - Gemini
 - `replicate` - Replicate
 
+### Streaming Termination
+
+Most OpenAI-compatible providers end a stream with a `data: [DONE]` marker, and Bifrost reads until it arrives so that a trailing usage-only chunk — which many providers send after `finish_reason` — is not lost.
+
+Set `does_not_send_done_marker` to `true` when your upstream instead ends streams on `finish_reason` and never sends `[DONE]`:
+
+```json
+{
+    "custom_provider_config": {
+        "base_provider_type": "openai",
+        "does_not_send_done_marker": true
+    }
+}
+```
+
+
 ### Request Path Overrides
 
 The `request_path_overrides` field allows you to override the default API endpoint paths for specific request types. This is useful when:

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -5903,6 +5903,10 @@
             "is_key_less": {
               "type": "boolean"
             },
+            "does_not_send_done_marker": {
+              "type": "boolean",
+              "description": "Whether the provider ends streams on finish_reason without sending a data: [DONE] marker"
+            },
             "base_provider_type": {
               "type": "string"
             },

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -8544,6 +8544,10 @@
           "type": "boolean",
           "description": "Whether the custom provider requires a key"
         },
+        "does_not_send_done_marker": {
+          "type": "boolean",
+          "description": "Whether the provider ends streams on finish_reason without sending a data: [DONE] marker"
+        },
         "base_provider_type": {
           "type": "string",
           "enum": [

--- a/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
+++ b/ui/app/workspace/providers/dialogs/addNewCustomProviderSheet.tsx
@@ -24,6 +24,7 @@ const formSchema = z.object({
 	allowed_requests: allowedRequestsSchema,
 	request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
 	is_key_less: z.boolean().optional(),
+	does_not_send_done_marker: z.boolean().optional(),
 	allow_private_network: z.boolean().optional(),
 });
 
@@ -86,6 +87,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 			},
 			request_path_overrides: undefined,
 			is_key_less: false,
+			does_not_send_done_marker: false,
 			allow_private_network: false,
 		},
 	});
@@ -104,6 +106,7 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 				allowed_requests: data.allowed_requests,
 				request_path_overrides: cleanPathOverrides(data.request_path_overrides),
 				is_key_less: data.is_key_less ?? false,
+				does_not_send_done_marker: data.does_not_send_done_marker ?? false,
 			},
 			network_config: {
 				base_url: data.base_url,
@@ -130,6 +133,14 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 
 	const baseFormat = form.watch("baseFormat") as BaseProvider;
 	const isKeyLessDisabled = baseFormat === "bedrock";
+	// Only the OpenAI stream loops read this flag; every other base format ignores it.
+	const isDoneMarkerToggleDisabled = baseFormat !== "openai";
+
+	useEffect(() => {
+		if (isDoneMarkerToggleDisabled) {
+			form.setValue("does_not_send_done_marker", false);
+		}
+	}, [isDoneMarkerToggleDisabled, form]);
 
 	return (
 		<>
@@ -249,6 +260,34 @@ export function AddCustomProviderSheetContent({ show = true, onClose, onSave }: 
 												onCheckedChange={field.onChange}
 												disabled={!hasProviderCreateAccess}
 												data-testid="custom-provider-keyless-switch"
+											/>
+										</div>
+									</FormItem>
+								)}
+							/>
+						)}
+						{!isDoneMarkerToggleDisabled && (
+							<FormField
+								control={form.control}
+								name="does_not_send_done_marker"
+								render={({ field }) => (
+									<FormItem>
+										<div className="flex items-center justify-between space-x-2 rounded-lg border p-3">
+											<div className="space-y-0.5">
+												<label htmlFor="does-not-send-done-marker" className="text-sm font-medium">
+													Does Not Send [DONE] Marker?
+												</label>
+												<p className="text-muted-foreground text-sm">
+													Whether the provider ends streams on finish_reason without sending a [DONE] marker
+												</p>
+											</div>
+											<Switch
+												id="does-not-send-done-marker"
+												size="md"
+												checked={field.value}
+												onCheckedChange={field.onChange}
+												disabled={!hasProviderCreateAccess}
+												data-testid="custom-provider-does-not-send-done-marker-switch"
 											/>
 										</div>
 									</FormItem>

--- a/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
+++ b/ui/app/workspace/providers/fragments/apiStructureFormFragment.tsx
@@ -36,6 +36,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 		defaultValues: {
 			base_provider_type: provider.custom_provider_config?.base_provider_type ?? "openai",
 			is_key_less: provider.custom_provider_config?.is_key_less ?? false,
+			does_not_send_done_marker: provider.custom_provider_config?.does_not_send_done_marker ?? false,
 			allowed_requests: {
 				text_completion: provider.custom_provider_config?.allowed_requests?.text_completion ?? true,
 				text_completion_stream: provider.custom_provider_config?.allowed_requests?.text_completion_stream ?? true,
@@ -76,6 +77,7 @@ export function ApiStructureFormFragment({ provider }: Props) {
 				custom_provider_config: {
 					base_provider_type: data.base_provider_type as unknown as BaseProvider,
 					is_key_less: data.is_key_less ?? false,
+					does_not_send_done_marker: data.does_not_send_done_marker ?? false,
 					allowed_requests: data.allowed_requests,
 					request_path_overrides: cleanPathOverrides(data.request_path_overrides),
 				},
@@ -95,6 +97,12 @@ export function ApiStructureFormFragment({ provider }: Props) {
 
 	const isKeyLessDisabled = useMemo(
 		() => provider.custom_provider_config?.base_provider_type === "bedrock",
+		[provider.custom_provider_config?.base_provider_type],
+	);
+
+	// Only the OpenAI stream loops read this flag; every other base format ignores it.
+	const isDoneMarkerToggleDisabled = useMemo(
+		() => provider.custom_provider_config?.base_provider_type !== "openai",
 		[provider.custom_provider_config?.base_provider_type],
 	);
 
@@ -143,6 +151,33 @@ export function ApiStructureFormFragment({ provider }: Props) {
 										</div>
 										<Switch
 											id="drop-excess-requests"
+											size="md"
+											checked={field.value}
+											onCheckedChange={field.onChange}
+											disabled={!hasUpdateProviderAccess}
+										/>
+									</div>
+								</FormItem>
+							)}
+						/>
+					)}
+					{!isDoneMarkerToggleDisabled && (
+						<FormField
+							control={form.control}
+							name="does_not_send_done_marker"
+							render={({ field }) => (
+								<FormItem>
+									<div className="flex items-center justify-between space-x-2 rounded-lg border p-3">
+										<div className="space-y-0.5">
+											<label htmlFor="does-not-send-done-marker" className="text-sm font-medium">
+												Does Not Send [DONE] Marker?
+											</label>
+											<p className="text-muted-foreground text-sm">
+												Whether the provider ends streams on finish_reason without sending a [DONE] marker
+											</p>
+										</div>
+										<Switch
+											id="does-not-send-done-marker"
 											size="md"
 											checked={field.value}
 											onCheckedChange={field.onChange}

--- a/ui/lib/types/config.ts
+++ b/ui/lib/types/config.ts
@@ -440,6 +440,7 @@ export interface AllowedRequests {
 export interface CustomProviderConfig {
 	base_provider_type: KnownProvider;
 	is_key_less?: boolean;
+	does_not_send_done_marker?: boolean;
 	allowed_requests?: AllowedRequests;
 	request_path_overrides?: Record<string, string>;
 }

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -820,6 +820,7 @@ export const customProviderConfigSchema = z
 	.object({
 		base_provider_type: knownProviderSchema,
 		is_key_less: z.boolean().optional(),
+		does_not_send_done_marker: z.boolean().optional(),
 		allowed_requests: allowedRequestsSchema.optional(),
 		request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
 	})
@@ -841,6 +842,7 @@ export const formCustomProviderConfigSchema = z
 	.object({
 		base_provider_type: z.string().min(1, "Base provider type is required"),
 		is_key_less: z.boolean().optional(),
+		does_not_send_done_marker: z.boolean().optional(),
 		allowed_requests: allowedRequestsSchema.optional(),
 		request_path_overrides: z.record(z.string(), z.string().optional()).optional(),
 	})


### PR DESCRIPTION
## Summary

Fixes a stream hang ([#6784](https://github.com/maximhq/bifrost/issues/6784)) where an OpenAI-compatible upstream that ends generation on `finish_reason` — without ever sending `data: [DONE]` — then parks the connection open with SSE heartbeat comments. Because heartbeat bytes reset the raw-read idle timer before SSE framing is interpreted, the read loop waits indefinitely for a marker that never arrives. A new `does_not_send_done_marker` field on `custom_provider_config` lets operators declare this upstream behaviour; Bifrost then terminates the stream as soon as a non-empty `finish_reason` is received.

## Changes

- Added `DoesNotSendDoneMarker bool` to `CustomProviderConfig` (schema, JSON, OpenAPI, config JSON schema).
- Added `BifrostContextKeyDoesNotSendDoneMarker` context key; stamped per attempt in `requestWorker` and cleared on each retry so a fallback cannot inherit the previous provider's opt-in.
- `ProviderSendsDoneMarker` now accepts a `*BifrostContext` and returns `false` when the key is set, taking priority over the built-in provider list. The opt-in can only end the loop earlier — it cannot make a provider that already terminates on `finish_reason` start waiting for `[DONE]`.
- Both the chat-completion and text-completion OpenAI streaming loops pass `ctx` through to `ProviderSendsDoneMarker`.
- `ReleaseStreamingResponse` short-circuits body draining when the opt-in is active: instead of blocking on a connection that will heartbeat forever, it closes the body stream with a sentinel error (`errStreamParkedAfterFinish`) that takes fasthttp's `CloseConn` path and keeps the half-read stream out of the idle pool.
- UI: added a "Does Not Send [DONE] Marker?" toggle to the custom provider API structure form, wired through the Zod schemas and TypeScript types.
- Docs: added a "Streaming Termination" section to the custom providers page with a warning that trailing usage chunks are dropped when the opt-in is active.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./core/... ./core/providers/openai/... ./core/providers/utils/... ./core/providers/huggingface/...

# UI
cd ui
pnpm i
pnpm build
```

To reproduce the original hang manually: configure a custom provider backed by `openai` pointing at an upstream that sends `finish_reason` and then streams SSE heartbeats without `[DONE]`. Without the fix the stream never closes. With `does_not_send_done_marker: true` the stream closes immediately after the `finish_reason` chunk.

## Breaking changes

- [x] No

`ProviderSendsDoneMarker` signature changed from `(providerName)` to `(ctx, providerName)`. All internal call sites are updated; this function is not part of the public API surface.

## Related issues

Closes #6784

## Security considerations

None. The new field is operator-configured and does not affect authentication or secret handling.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable