### PR TITLE
fix: rename assistant reasoning_content to alias for groq and cerebras instead of stripping

### DIFF
--- a/core/providers/openai/chat.go
+++ b/core/providers/openai/chat.go
@@ -95,17 +95,17 @@ func ToOpenAIChatRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifros
 		// can fail, and this function has no way to report a failure. Callers invoke
 		// ResolveChatFileURLs after conversion, where the error can propagate; see its doc comment.
 		return openaiReq
-	case schemas.Cerebras, schemas.Wafer:
-		openaiReq.filterOpenAISpecificParameters(caps)
-		openaiReq.stripReasoningDetails()
-		return openaiReq
 	case schemas.DeepSeek:
 		openaiReq.filterOpenAISpecificParameters(caps)
 		// DeepSeek is asymmetric: it rejects reasoning_content on ordinary assistant
 		// turns, but *requires* it to be replayed on assistant tool_call turns and 400s
-		// without it. Stripping both (as Cerebras/Wafer do) forced thinking off for every
-		// tool-calling conversation — see issue #5887.
+		// without it. Stripping both forced thinking off for every tool-calling conversation
+		// — see issue #5887.
 		openaiReq.stripReasoningDetailsExceptToolCalls()
+		return openaiReq
+	case schemas.Groq, schemas.Cerebras:
+		openaiReq.filterOpenAISpecificParameters(caps)
+		openaiReq.renameAssistantReasoningToAlias()
 		return openaiReq
 	case schemas.XAI:
 		openaiReq.filterOpenAISpecificParameters(caps)
@@ -289,18 +289,6 @@ func (req *OpenAIChatRequest) applyMistralCompatibility() {
 	}
 }
 
-// stripReasoningDetails for providers that throw error for reasoning_details in assistant messages
-// e.g. Cerebras, DeepSeek
-func (req *OpenAIChatRequest) stripReasoningDetails() {
-	for i := range req.Messages {
-		assistantMessage := req.Messages[i].OpenAIChatAssistantMessage
-		if assistantMessage == nil {
-			continue
-		}
-		assistantMessage.Reasoning = nil
-	}
-}
-
 // stripReasoningDetailsExceptToolCalls strips reasoning_content from assistant messages that
 // carry no tool calls, and preserves it on assistant tool_call turns. This is DeepSeek's
 // contract: reasoning_content "must be passed back to the API in all subsequent user
@@ -314,6 +302,21 @@ func (req *OpenAIChatRequest) stripReasoningDetailsExceptToolCalls() {
 		assistantMessage := req.Messages[i].OpenAIChatAssistantMessage
 		if assistantMessage == nil || len(assistantMessage.ToolCalls) > 0 {
 			continue
+		}
+		assistantMessage.Reasoning = nil
+	}
+}
+
+// renameAssistantReasoningToAlias moves replayed assistant reasoning from
+// reasoning_content to the "reasoning" key, for providers that only accept the latter.
+func (req *OpenAIChatRequest) renameAssistantReasoningToAlias() {
+	for i := range req.Messages {
+		assistantMessage := req.Messages[i].OpenAIChatAssistantMessage
+		if assistantMessage == nil || assistantMessage.Reasoning == nil {
+			continue
+		}
+		if assistantMessage.ReasoningAlias == nil {
+			assistantMessage.ReasoningAlias = assistantMessage.Reasoning
 		}
 		assistantMessage.Reasoning = nil
 	}

--- a/core/providers/openai/chat_test.go
+++ b/core/providers/openai/chat_test.go
@@ -897,7 +897,6 @@ func TestToOpenAIChatRequest_StripsAssistantReasoningContentForCompatibleProvide
 		provider schemas.ModelProvider
 		model    string
 	}{
-		{name: "cerebras", provider: schemas.Cerebras, model: "gpt-oss-120b"},
 		{name: "deepseek", provider: schemas.DeepSeek, model: "deepseek-v4-pro"},
 	}
 
@@ -968,6 +967,96 @@ func TestToOpenAIChatRequest_StripsAssistantReasoningContentForCompatibleProvide
 				t.Fatalf("expected reasoning_content to be absent from %s assistant payload, got %#v", tt.provider, assistantMessage["reasoning_content"])
 			}
 		})
+	}
+}
+
+// Groq rejects reasoning_content on assistant messages ("property 'reasoning_content'
+// is unsupported") but accepts the OpenRouter-style "reasoning" spelling, so replayed
+// reasoning has to move to that key rather than be dropped.
+func TestToOpenAIChatRequest_MovesAssistantReasoningToAliasForGroq(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		provider schemas.ModelProvider
+		model    string
+	}{
+		{name: "groq", provider: schemas.Groq, model: "qwen/qwen3.8-27b"},
+		{name: "cerebras", provider: schemas.Cerebras, model: "gpt-oss-120b"},
+	} {
+		t.Run(tt.name, func(t *testing.T) { assertMovesAssistantReasoningToAlias(t, tt.provider, tt.model) })
+	}
+}
+
+func assertMovesAssistantReasoningToAlias(t *testing.T, provider schemas.ModelProvider, model string) {
+	t.Helper()
+	ctx, cancel := schemas.NewBifrostContextWithCancel(nil)
+	defer cancel()
+
+	reasoning := "step by step"
+	assistantContent := "The weather in Paris is mild today."
+	userContent := "What is the weather in Paris?"
+
+	bifrostReq := &schemas.BifrostChatRequest{
+		Provider: provider,
+		Model:    model,
+		Input: []schemas.ChatMessage{
+			{
+				Role:    schemas.ChatMessageRoleUser,
+				Content: &schemas.ChatMessageContent{ContentStr: &userContent},
+			},
+			{
+				Role:    schemas.ChatMessageRoleAssistant,
+				Content: &schemas.ChatMessageContent{ContentStr: &assistantContent},
+				ChatAssistantMessage: &schemas.ChatAssistantMessage{
+					Reasoning: &reasoning,
+				},
+			},
+		},
+	}
+
+	result := ToOpenAIChatRequest(ctx, bifrostReq)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if len(result.Messages) != 2 || result.Messages[1].OpenAIChatAssistantMessage == nil {
+		t.Fatalf("expected assistant message with OpenAI assistant payload, got %#v", result.Messages)
+	}
+	assistant := result.Messages[1].OpenAIChatAssistantMessage
+	if assistant.Reasoning != nil {
+		t.Fatalf("expected reasoning_content to be cleared, got %#v", assistant.Reasoning)
+	}
+	if assistant.ReasoningAlias == nil || *assistant.ReasoningAlias != reasoning {
+		t.Fatalf("expected reasoning alias %q, got %#v", reasoning, assistant.ReasoningAlias)
+	}
+
+	ctx.SetValue(schemas.BifrostContextKeyPassthroughExtraParams, true)
+	wireBody, bifrostErr := providerUtils.CheckContextAndGetRequestBody(
+		ctx,
+		bifrostReq,
+		func() (providerUtils.RequestBodyWithExtraParams, error) {
+			return ToOpenAIChatRequest(ctx, bifrostReq), nil
+		},
+	)
+	if bifrostErr != nil {
+		t.Fatalf("failed to build request body: %v", bifrostErr.Error.Message)
+	}
+
+	var jsonMap map[string]any
+	if err := sonic.Unmarshal(wireBody, &jsonMap); err != nil {
+		t.Fatalf("failed to parse marshaled request body: %v", err)
+	}
+	messages, ok := jsonMap["messages"].([]any)
+	if !ok || len(messages) != 2 {
+		t.Fatalf("expected 2 messages in wire payload, got %#v", jsonMap["messages"])
+	}
+	assistantMessage, ok := messages[1].(map[string]any)
+	if !ok {
+		t.Fatalf("expected assistant message object, got %#v", messages[1])
+	}
+	if _, ok := assistantMessage["reasoning_content"]; ok {
+		t.Fatalf("expected reasoning_content to be absent from %s assistant payload, got %#v", provider, assistantMessage["reasoning_content"])
+	}
+	if got, ok := assistantMessage["reasoning"].(string); !ok || got != reasoning {
+		t.Fatalf("expected reasoning %q in %s assistant payload, got %#v", reasoning, provider, assistantMessage["reasoning"])
 	}
 }
 


### PR DESCRIPTION
## Summary

Groq rejects `reasoning_content` on assistant messages but accepts the OpenRouter-style `reasoning` key. When replaying assistant messages with reasoning to Groq, the content was being dropped entirely. This PR moves replayed assistant reasoning from `reasoning_content` to the `reasoning` alias key so that multi-turn conversations with reasoning models work correctly on Groq.

Cerebras is also moved to this same path — previously it stripped reasoning entirely, but it too accepts the `reasoning` alias, so it now benefits from the same fix.

## Changes

- Added a `case schemas.Groq, schemas.Cerebras` branch in `ToOpenAIChatRequest` that calls `filterOpenAISpecificParameters` and the new `renameAssistantReasoningToAlias` method, replacing the old `stripReasoningDetails` call for Cerebras.
- Added `renameAssistantReasoningToAlias`, which iterates over assistant messages and moves the value from `Reasoning` (serialized as `reasoning_content`) to `ReasoningAlias` (serialized as `reasoning`), clearing the original field.
- Removed `stripReasoningDetails`, which previously dropped reasoning entirely for Cerebras.
- Updated the comment in the `DeepSeek` case to remove the now-stale reference to Cerebras/Wafer.
- Added `TestToOpenAIChatRequest_MovesAssistantReasoningToAliasForGroq` covering both Groq and Cerebras, verifying both the in-memory struct transformation and the final wire JSON — confirming `reasoning_content` is absent and `reasoning` carries the correct value.
- Removed Cerebras from `TestToOpenAIChatRequest_StripsAssistantReasoningContentForCompatibleProviders` since it no longer strips reasoning.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestToOpenAIChatRequest_MovesAssistantReasoningToAliasForGroq -v
go test ./...
```

Send a multi-turn chat request to Groq using a reasoning-capable model (e.g. `qwen/qwen3.8-27b`) where the conversation history includes an assistant message with a `reasoning` field. Confirm the request is accepted by Groq without a `property 'reasoning_content' is unsupported` error and that the response is returned successfully.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5887

## Security considerations

No security implications. This change only affects request serialization for the Groq and Cerebras providers.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable