### PR TITLE
feat: Refactor provider configs editor to shared component

### DIFF
--- a/docs/openapi/schemas/management/accessprofiles.yaml
+++ b/docs/openapi/schemas/management/accessprofiles.yaml
@@ -184,6 +184,9 @@ AccessProfile:
       $ref: '#/RateLimit'
     calendar_aligned:
       type: boolean
+    allow_all_providers:
+      type: boolean
+      description: When true, grants access to every provider, including ones without a provider_configs entry and providers added later. A listed provider keeps its own model allow/blacklist, budgets, rate limits, and key selection; an unlisted provider gets all models, all keys, and no per-provider limits. When false (default), access is deny-by-default via provider_configs.
     auto_rotation_interval:
       type: integer
       format: int64
@@ -262,6 +265,10 @@ CreateAccessProfileRequest:
       $ref: '#/RateLimit'
     calendar_aligned:
       type: boolean
+    allow_all_providers:
+      type: boolean
+      default: false
+      description: When true, grants access to every provider, including ones without a provider_configs entry and providers added later. A listed provider keeps its own model allow/blacklist, budgets, rate limits, and key selection; an unlisted provider gets all models, all keys, and no per-provider limits. When false (default), access is deny-by-default via provider_configs.
     auto_rotation_interval:
       oneOf:
         - $ref: '#/RotationIntervalString'
@@ -318,6 +325,10 @@ UpdateAccessProfileRequest:
     calendar_aligned:
       type: boolean
       nullable: true
+    allow_all_providers:
+      type: boolean
+      nullable: true
+      description: When true, grants access to every provider, including ones without a provider_configs entry and providers added later. A listed provider keeps its own model allow/blacklist, budgets, rate limits, and key selection; an unlisted provider gets all models, all keys, and no per-provider limits. When false, provider-wide access is disabled and access is deny-by-default via provider_configs. Omit to leave unchanged.
     auto_rotation_interval:
       oneOf:
         - $ref: '#/RotationIntervalString'

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -7752,6 +7752,11 @@
           "description": "Snap budget and rate-limit reset windows to clean calendar boundaries (day, week, month, year) for this profile",
           "default": false
         },
+        "allow_all_providers": {
+          "type": "boolean",
+          "description": "Grant access to every provider, including ones without a provider_configs entry and providers added later. A listed provider keeps its own model allow/blacklist, budgets, rate limits, and key selection; an unlisted provider gets all models, all keys, and no per-provider limits. When false (default), access is deny-by-default via provider_configs.",
+          "default": false
+        },
         "provider_configs": {
           "type": "array",
           "description": "Per-provider restrictions and limits for this profile",

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -24,8 +24,7 @@ import { Label } from "@/components/ui/label";
 import MultiBudgetLines from "@/components/ui/multibudgets";
 import { MultiSelect } from "@/components/ui/multiSelect";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
-import { ProviderConfigCard } from "@/components/ui/providerConfigCard";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { ProviderConfigsEditor } from "@/components/ui/providerConfigsEditor";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
@@ -34,7 +33,6 @@ import { Textarea } from "@/components/ui/textarea";
 import Toggle from "@/components/ui/toggle";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
-import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { getUserPicker } from "@/lib/registries/userPicker";
 import {
@@ -53,7 +51,6 @@ import {
 } from "@/lib/store";
 import { VirtualMcpAssignmentsEditor } from "@/components/mcp/virtualMcpAssignmentsEditor";
 import { diffVmcpAssignments, vmcpAssignmentsDirty } from "./virtualKeySheet.utils";
-import { KnownProvider } from "@/lib/types/config";
 import { BudgetOverrideRequest, CreateVirtualKeyRequest, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
 import {
 	type BudgetComparisonEntry,
@@ -71,7 +68,7 @@ import { useAttachVirtualKeyUsersMutation, useDetachVirtualKeyUserMutation } fro
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
 import { formatDistanceToNow } from "date-fns";
-import { Info, Lock, RotateCcw, Users } from "lucide-react";
+import { Lock, RotateCcw, Users } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 // Side-effect import: registers the enterprise user picker so "Assign to User"
 // becomes available. Resolves to an empty module on OSS builds.
@@ -342,8 +339,8 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 	};
 
 	// RTK Query hooks
-	const { data: providersData, error: providersError } = useGetProvidersQuery();
-	const { data: keysData, error: keysError } = useGetAllKeysQuery();
+	const { error: providersError } = useGetProvidersQuery();
+	const { error: keysError } = useGetAllKeysQuery();
 	const [createVirtualKey, { isLoading: isCreating }] = useCreateVirtualKeyMutation();
 	const [updateVirtualKey, { isLoading: isUpdating }] = useUpdateVirtualKeyMutation();
 	const [rotateVirtualKey, { isLoading: isRotating }] = useRotateVirtualKeyMutation();
@@ -425,9 +422,6 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 		if (!virtualKey) throw new Error("Virtual key is required");
 		await removeBudgetOverride({ vkId: virtualKey.id, budgetId }).unwrap();
 	};
-
-	const availableKeys = keysData || [];
-	const availableProviders = providersData || [];
 
 	// Form setup
 	const form = useForm<z.input<typeof formSchema>, unknown, FormData>({
@@ -556,9 +550,6 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 		form.setValue("userId", assignedUserId);
 	}, [assignedUserId, isEditing, form]);
 
-	// Provider configuration state
-	const [selectedProvider, setSelectedProvider] = useState<string>("");
-
 	// Get current provider configs from form
 	const providerConfigs = form.watch("providerConfigs") || [];
 
@@ -588,76 +579,6 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 			watchedRequestMaxLimit !== null &&
 			supportsCalendarAlignment(watchedRequestResetDuration || "1h"));
 	const showCalendarAlignToggle = hasAnyAlignableBudget || hasAnyAlignableRateLimit;
-
-	// Build a default provider config row (all models, all keys, no limits)
-	const makeDefaultProviderConfig = (provider: string) => ({
-		provider: provider,
-		weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
-		allowed_models: ["*"],
-		blacklisted_models: [] as string[],
-		key_ids: ["*"],
-	});
-
-	// A row is "untouched" if it still carries only the auto-added defaults (no budget/limit/restriction).
-	// Turning "Allow all providers" off keeps customized rows and drops these.
-	const isDefaultProviderConfig = (config: (typeof providerConfigs)[number]) =>
-		(config.allowed_models || []).length === 1 &&
-		config.allowed_models?.[0] === "*" &&
-		(config.blacklisted_models || []).length === 0 &&
-		(config.key_ids || []).length === 1 &&
-		config.key_ids?.[0] === "*" &&
-		(config.budgets || []).length === 0 &&
-		!config.rate_limit &&
-		(config.model_budgets || []).length === 0 &&
-		config.weight === undefined;
-
-	// Handle adding a new provider configuration
-	const handleAddProvider = (provider: string) => {
-		const existingConfig = providerConfigs.find((config) => config.provider === provider);
-		if (existingConfig) {
-			toast.error("This provider is already configured");
-			return;
-		}
-
-		form.setValue("providerConfigs", [...providerConfigs, makeDefaultProviderConfig(provider)], {
-			shouldDirty: true,
-		});
-	};
-
-	// Handle removing a provider configuration
-	const handleRemoveProvider = (index: number) => {
-		// Removing a provider while "Allow all providers" is on means "all except this one":
-		// turn the flag off so the remaining rows become the explicit allowlist.
-		if (form.getValues("allowAllProviders")) {
-			form.setValue("allowAllProviders", false, { shouldDirty: true });
-		}
-		const updatedConfigs = (form.getValues("providerConfigs") || []).filter((_, i) => i !== index);
-		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
-	};
-
-	// Handle the "Allow all providers" toggle. When turned on, every configured provider is
-	// materialized as a row (via the effect below) so budgets/limits can be set or a provider
-	// excluded. When turned off, untouched default rows are dropped and customized ones kept.
-	const handleAllowAllProvidersChange = (checked: boolean) => {
-		form.setValue("allowAllProviders", checked, { shouldDirty: true });
-		if (!checked) {
-			const kept = (form.getValues("providerConfigs") || []).filter((config) => !isDefaultProviderConfig(config));
-			form.setValue("providerConfigs", kept, { shouldDirty: true });
-		}
-	};
-
-	// While "Allow all providers" is on, keep a row for every configured provider so they are
-	// visible and can be given budgets or excluded. Providers added later show up here too.
-	// Reads current configs via getValues (not a dep) so this converges in one pass without looping.
-	useEffect(() => {
-		if (!allowAllProviders || availableProviders.length === 0) return;
-		const current = form.getValues("providerConfigs") || [];
-		const missing = availableProviders.filter((p) => p.name && !current.some((c) => c.provider === p.name));
-		if (missing.length === 0) return;
-		const additions = missing.map((p) => makeDefaultProviderConfig(p.name));
-		form.setValue("providerConfigs", [...current, ...additions], { shouldDirty: false });
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [allowAllProviders, availableProviders]);
 
 	// Handle adding a new MCP client configuration
 	const handleAddMCPClient = (mcpClientName: string) => {
@@ -1274,201 +1195,48 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 										/>
 									</div>
 									{/* Provider Configurations */}
-									<div className="space-y-2">
-										<div className="flex items-center gap-2">
-											<Label className="text-sm font-medium">Provider Configurations</Label>
-											<TooltipProvider>
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<span>
-															<Info className="text-muted-foreground h-3 w-3" />
-														</span>
-													</TooltipTrigger>
-													<TooltipContent className="max-w-sm">
-														<p>
-															Configure which providers this virtual key can use and their specific settings. Leave empty to block all
-															providers. Add providers to allow them.
-														</p>
-													</TooltipContent>
-												</Tooltip>
-											</TooltipProvider>
-										</div>
-
-										{/* Allow all providers */}
-										<FormField
-											control={form.control}
-											name="allowAllProviders"
-											render={({ field }) => (
-												<FormItem>
-													<div className="flex w-full items-center justify-between gap-2 py-2 text-sm">
-														<div className="flex items-center gap-1.5">
-															<span>Allow all providers</span>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<span>
-																			<Info className="text-muted-foreground h-3 w-3" />
-																		</span>
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-sm">
-																		<p>
-																			Grant access to every provider, including ones added later. Set budgets or limits on specific
-																			providers below, or remove a provider to allow all except that one.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<Switch
-															checked={field.value}
-															onCheckedChange={handleAllowAllProvidersChange}
-															data-testid="vk-allow-all-providers-toggle"
-														/>
-													</div>
-												</FormItem>
-											)}
-										/>
-
-										{/* Add Provider Dropdown */}
-										<div className="flex gap-2">
-											<Select
-												value={selectedProvider}
-												onValueChange={(provider) => {
-													if (provider === "__manage_providers__") {
-														navigate({ to: "/workspace/providers" });
-														setSelectedProvider("");
-														return;
-													}
-													handleAddProvider(provider);
-													setSelectedProvider(""); // Reset to placeholder state
-												}}
-											>
-												<SelectTrigger className="flex-1" data-testid="vk-provider-select">
-													<SelectValue placeholder="Select a provider to add" />
-												</SelectTrigger>
-												<SelectContent>
-													{(() => {
-														// Filter out already configured providers
-														const unconfiguredProviders = availableProviders.filter(
-															(provider) => !providerConfigs.some((config) => config.provider === provider.name),
-														);
-
-														if (unconfiguredProviders.length === 0) {
-															return (
-																<SelectItem
-																	value="__manage_providers__"
-																	className="text-muted-foreground hover:text-foreground"
-																	data-testid="vk-provider-config-link"
-																>
-																	<span>
-																		No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
-																	</span>
-																</SelectItem>
-															);
-														}
-
-														// Separate base providers and custom providers
-														const baseProviders = unconfiguredProviders.filter((provider) => !provider.custom_provider_config);
-														const customProviders = unconfiguredProviders.filter((provider) => provider.custom_provider_config);
-
-														return (
-															<>
-																{/* Base providers first */}
-																{baseProviders
-																	.filter((p) => p.name)
-																	.map((provider, index) => (
-																		<SelectItem key={`base-${index}`} value={provider.name}>
-																			<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
-																			{ProviderLabels[provider.name as ProviderName]}
-																		</SelectItem>
-																	))}
-
-																{/* Custom providers second */}
-																{customProviders
-																	.filter((p) => p.name)
-																	.map((provider, index) => (
-																		<SelectItem key={`custom-${index}`} value={provider.name}>
-																			<RenderProviderIcon
-																				provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
-																				size="sm"
-																				className="h-4 w-4"
-																			/>
-																			{provider.name}
-																		</SelectItem>
-																	))}
-															</>
-														);
-													})()}
-												</SelectContent>
-											</Select>
-										</div>
-
-										{/* Provider Configurations Table */}
-										{providerConfigs.length > 0 && (
-											<div className="space-y-2.5">
-												{providerConfigs.map((config, index) => {
-													const providerConfig = availableProviders.find((provider) => provider.name === config.provider);
-													const providerLabel = providerConfig?.custom_provider_config
-														? providerConfig.name
-														: ProviderLabels[config.provider as ProviderName] || config.provider;
-													const iconProvider = (providerConfig?.custom_provider_config?.base_provider_type ||
-														config.provider) as ProviderIconType;
-													const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-													return (
-														<ProviderConfigCard
-															key={config.provider}
-															index={index}
-															testIdPrefix="vk"
-															providerLabel={providerLabel}
-															iconProvider={iconProvider}
-															providerKeys={providerKeys}
-															showModelBudgets
-															onRemove={() => handleRemoveProvider(index)}
-															value={{
-																providerName: config.provider,
-																allowedModels: config.allowed_models || [],
-																blacklistedModels: config.blacklisted_models || [],
-																weight: config.weight,
-																keyIds: config.key_ids || [],
-																budgets: config.budgets || [],
-																rateLimit: config.rate_limit ?? null,
-																modelBudgets: (config.model_budgets || []).map((mb) => ({
-																	model_name: mb.model_name,
-																	budgets: mb.budgets || [],
-																	rate_limit: mb.rate_limit,
-																})),
-															}}
-															onChange={(next) => {
-																const updated = [...providerConfigs];
-																updated[index] = {
-																	...config,
-																	allowed_models: next.allowedModels,
-																	blacklisted_models: next.blacklistedModels,
-																	weight: next.weight ?? undefined,
-																	key_ids: next.keyIds,
-																	budgets: next.budgets.map((l) => ({
-																		id: l.id,
-																		max_limit: l.max_limit,
-																		reset_duration: l.reset_duration,
-																		reset_config: l.reset_config,
-																	})),
-																	rate_limit: next.rateLimit ?? undefined,
-																	model_budgets: next.modelBudgets,
-																};
-																form.setValue("providerConfigs", updated, {
-																	shouldDirty: true,
-																});
-															}}
-														/>
-													);
-												})}
-											</div>
-										)}
-										{/* Display validation errors for provider configurations */}
-										{form.formState.errors.providerConfigs && (
-											<div className="text-destructive text-sm">{form.formState.errors.providerConfigs.message}</div>
-										)}
-									</div>
+									<ProviderConfigsEditor
+										testIdPrefix="vk"
+										value={providerConfigs.map((config) => ({
+											providerName: config.provider,
+											allowedModels: config.allowed_models || [],
+											blacklistedModels: config.blacklisted_models || [],
+											weight: config.weight,
+											keyIds: config.key_ids || [],
+											budgets: config.budgets || [],
+											rateLimit: config.rate_limit ?? null,
+											modelBudgets: (config.model_budgets || []).map((mb) => ({
+												model_name: mb.model_name,
+												budgets: mb.budgets || [],
+												rate_limit: mb.rate_limit,
+											})),
+										}))}
+										onChange={(entries) =>
+											form.setValue(
+												"providerConfigs",
+												entries.map((entry) => ({
+													provider: entry.providerName,
+													allowed_models: entry.allowedModels,
+													blacklisted_models: entry.blacklistedModels,
+													weight: entry.weight ?? undefined,
+													key_ids: entry.keyIds,
+													budgets: (entry.budgets || []).map((l) => ({
+														id: l.id,
+														max_limit: l.max_limit,
+														reset_duration: l.reset_duration,
+														reset_config: l.reset_config,
+													})),
+													rate_limit: entry.rateLimit ?? undefined,
+													model_budgets: entry.modelBudgets,
+												})),
+												{ shouldDirty: true },
+											)
+										}
+										allowAllProviders={allowAllProviders}
+										onAllowAllProvidersChange={(checked) => form.setValue("allowAllProviders", checked, { shouldDirty: true })}
+										onManageProviders={() => navigate({ to: "/workspace/providers" })}
+										error={form.formState.errors.providerConfigs?.message}
+									/>
 									{/* MCP Server Configurations */}
 									<MCPClientConfigsEditor
 										value={mcpConfigs}

--- a/ui/components/ui/providerConfigsEditor.tsx
+++ b/ui/components/ui/providerConfigsEditor.tsx
@@ -1,0 +1,255 @@
+import { Label } from "@/components/ui/label";
+import { ProviderConfigCard, ProviderConfigCardValue } from "@/components/ui/providerConfigCard";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store";
+import { KnownProvider } from "@/lib/types/config";
+import { Info } from "lucide-react";
+import { useEffect, useState } from "react";
+
+// Shared provider-configuration editor for the Virtual Key (core) and Access
+// Profile / Project (enterprise) forms. It owns the "Allow all providers" toggle,
+// the add-provider dropdown, and the per-provider cards; callers drive it with the
+// card's normalized ProviderConfigCardValue and adapt their own storage shape.
+export interface ProviderConfigsEditorProps {
+	value: ProviderConfigCardValue[];
+	onChange: (next: ProviderConfigCardValue[]) => void;
+	allowAllProviders: boolean;
+	onAllowAllProvidersChange: (checked: boolean) => void;
+	/** Prefix for data-testids, e.g. "vk" or "ap". */
+	testIdPrefix?: string;
+	/** Show the per-model budgets tree inside each card. Defaults to true. */
+	showModelBudgets?: boolean;
+	/** Read-only global provider cap per provider, shown on the Provider budget row. */
+	getGlobalProviderCap?: (providerName: string) => { max_limit: number; reset_duration?: string } | undefined;
+	/** When set, the "no providers left" dropdown row becomes a clickable link (e.g. route to provider management). */
+	onManageProviders?: () => void;
+	/** Validation error rendered under the list. */
+	error?: string;
+}
+
+// An unrestricted row: all models, all keys, no budgets/limits.
+const makeDefaultEntry = (providerName: string): ProviderConfigCardValue => ({
+	providerName,
+	allowedModels: ["*"],
+	blacklistedModels: [],
+	weight: undefined,
+	keyIds: ["*"],
+	budgets: [],
+	rateLimit: null,
+	modelBudgets: [],
+});
+
+// A row is "untouched" while it still carries only the defaults above, so turning
+// "Allow all providers" off can drop it while keeping customized rows.
+const isDefaultEntry = (e: ProviderConfigCardValue): boolean =>
+	(e.allowedModels || []).length === 1 &&
+	e.allowedModels?.[0] === "*" &&
+	(e.blacklistedModels || []).length === 0 &&
+	(e.keyIds || []).length === 1 &&
+	e.keyIds?.[0] === "*" &&
+	(e.budgets || []).length === 0 &&
+	!e.rateLimit &&
+	(e.modelBudgets || []).length === 0 &&
+	(e.weight === undefined || e.weight === null);
+
+export function ProviderConfigsEditor({
+	value,
+	onChange,
+	allowAllProviders,
+	onAllowAllProvidersChange,
+	testIdPrefix = "provider",
+	showModelBudgets = true,
+	getGlobalProviderCap,
+	onManageProviders,
+	error,
+}: ProviderConfigsEditorProps) {
+	const { data: providersData, isLoading: isLoadingProviders, isError: isProvidersError } = useGetProvidersQuery();
+	const { data: keysData } = useGetAllKeysQuery();
+	const availableProviders = providersData || [];
+	// null = the keys query is still loading or failed (the card keeps its key
+	// control visible); [] = loaded, none exist.
+	const availableKeys = keysData ?? null;
+	const [selectedProvider, setSelectedProvider] = useState("");
+
+	const handleAddProvider = (providerName: string) => {
+		if (!providerName || value.some((e) => e.providerName === providerName)) return;
+		onChange([...value, makeDefaultEntry(providerName)]);
+	};
+
+	const handleRemoveProvider = (index: number) => {
+		// Removing a provider while "Allow all providers" is on means "all except this
+		// one": turn the flag off so the remaining rows become the explicit allowlist.
+		if (allowAllProviders) onAllowAllProvidersChange(false);
+		onChange(value.filter((_, i) => i !== index));
+	};
+
+	const handleAllowAllChange = (checked: boolean) => {
+		onAllowAllProvidersChange(checked);
+		// Turning it off keeps customized rows and drops the untouched defaults.
+		if (!checked) onChange(value.filter((e) => !isDefaultEntry(e)));
+	};
+
+	// While on, keep a row for every available provider so each can be given
+	// budgets/limits or excluded. Providers added later show up here too. Keyed on
+	// the joined names, not the array identity, so it converges without looping.
+	const providerNamesKey = availableProviders.map((p) => p.name).join(" ");
+	useEffect(() => {
+		if (!allowAllProviders || availableProviders.length === 0) return;
+		const missing = availableProviders.filter((p) => p.name && !value.some((e) => e.providerName === p.name));
+		if (missing.length === 0) return;
+		onChange([...value, ...missing.map((p) => makeDefaultEntry(p.name))]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [allowAllProviders, providerNamesKey]);
+
+	const unconfiguredProviders = availableProviders.filter((provider) => !value.some((e) => e.providerName === provider.name));
+	const baseProviders = unconfiguredProviders.filter((p) => p.name && !p.custom_provider_config);
+	const customProviders = unconfiguredProviders.filter((p) => p.name && p.custom_provider_config);
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center gap-2">
+				<Label className="text-sm font-medium">Provider Configurations</Label>
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span>
+								<Info className="text-muted-foreground h-3 w-3" />
+							</span>
+						</TooltipTrigger>
+						<TooltipContent className="max-w-sm">
+							<p>
+								Configure which providers this can use and their specific settings. Leave empty to block all providers. Add providers to
+								allow them.
+							</p>
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			</div>
+
+			{/* Allow all providers */}
+			<div className="flex w-full items-center justify-between gap-2 py-2 text-sm">
+				<div className="flex items-center gap-1.5">
+					<span>Allow all providers</span>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span>
+									<Info className="text-muted-foreground h-3 w-3" />
+								</span>
+							</TooltipTrigger>
+							<TooltipContent className="max-w-sm">
+								<p>
+									Grant access to every provider, including ones added later. Set budgets or limits on specific providers below, or remove a
+									provider to allow all except that one.
+								</p>
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</div>
+				<Switch
+					checked={allowAllProviders}
+					onCheckedChange={handleAllowAllChange}
+					data-testid={`${testIdPrefix}-allow-all-providers-toggle`}
+				/>
+			</div>
+
+			{/* Add Provider Dropdown */}
+			<div className="flex gap-2">
+				<Select
+					value={selectedProvider}
+					onValueChange={(provider) => {
+						if (provider === "__manage_providers__") {
+							onManageProviders?.();
+							setSelectedProvider("");
+							return;
+						}
+						handleAddProvider(provider);
+						setSelectedProvider("");
+					}}
+				>
+					<SelectTrigger className="flex-1" data-testid={`${testIdPrefix}-provider-select`}>
+						<SelectValue placeholder="Select a provider to add" />
+					</SelectTrigger>
+					<SelectContent>
+						{isLoadingProviders ? (
+							<div className="text-muted-foreground px-2 py-1.5 text-sm">Loading providers...</div>
+						) : isProvidersError ? (
+							<div className="text-destructive px-2 py-1.5 text-sm">Failed to load providers. Please retry.</div>
+						) : unconfiguredProviders.length === 0 ? (
+							onManageProviders ? (
+								<SelectItem
+									value="__manage_providers__"
+									className="text-muted-foreground hover:text-foreground"
+									data-testid={`${testIdPrefix}-provider-config-link`}
+								>
+									<span>
+										No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
+									</span>
+								</SelectItem>
+							) : (
+								<div className="text-muted-foreground px-2 py-1.5 text-sm">No providers left to configure</div>
+							)
+						) : (
+							<>
+								{baseProviders.map((provider, index) => (
+									<SelectItem key={`base-${index}`} value={provider.name}>
+										<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
+										{ProviderLabels[provider.name as ProviderName] || provider.name}
+									</SelectItem>
+								))}
+								{customProviders.map((provider, index) => (
+									<SelectItem key={`custom-${index}`} value={provider.name}>
+										<RenderProviderIcon
+											provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
+											size="sm"
+											className="h-4 w-4"
+										/>
+										{provider.name}
+									</SelectItem>
+								))}
+							</>
+						)}
+					</SelectContent>
+				</Select>
+			</div>
+
+			{/* Provider cards */}
+			{value.length > 0 && (
+				<div className="space-y-2.5">
+					{value.map((entry, index) => {
+						const providerConfig = availableProviders.find((provider) => provider.name === entry.providerName);
+						const providerLabel = providerConfig?.custom_provider_config
+							? providerConfig.name
+							: ProviderLabels[entry.providerName as ProviderName] || entry.providerName;
+						const iconProvider = (providerConfig?.custom_provider_config?.base_provider_type || entry.providerName) as ProviderIconType;
+						const providerKeys = availableKeys === null ? null : availableKeys.filter((key) => key.provider === entry.providerName);
+						return (
+							<ProviderConfigCard
+								key={entry.providerName}
+								index={index}
+								testIdPrefix={testIdPrefix}
+								providerLabel={providerLabel}
+								iconProvider={iconProvider}
+								providerKeys={providerKeys}
+								showModelBudgets={showModelBudgets}
+								globalProviderCap={getGlobalProviderCap?.(entry.providerName)}
+								onRemove={() => handleRemoveProvider(index)}
+								value={entry}
+								onChange={(next) => {
+									const updated = [...value];
+									updated[index] = next;
+									onChange(updated);
+								}}
+							/>
+						);
+					})}
+				</div>
+			)}
+			{error && <div className="text-destructive text-sm">{error}</div>}
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Introduces an `allow_all_providers` flag on Access Profiles that grants access to every configured provider (including ones added later) without requiring an explicit `provider_configs` entry for each. Additionally, the provider configuration UI logic is extracted from the Virtual Key sheet into a standalone, reusable `ProviderConfigsEditor` component.

## Changes

- Added `allow_all_providers` boolean field to `AccessProfile`, `CreateAccessProfileRequest`, and `UpdateAccessProfileRequest` OpenAPI schemas, with appropriate nullability and default values.
- Added `allow_all_providers` to `config.schema.json` with a default of `false`.
- Extracted the "Allow all providers" toggle, add-provider dropdown, and per-provider card list from `virtualKeySheet.tsx` into a new `ProviderConfigsEditor` component (`ui/components/ui/providerConfigsEditor.tsx`).
- `ProviderConfigsEditor` owns the `allowAllProviders` effect (materializing a row per available provider when the flag is on), the add/remove logic, and the default-entry detection used when turning the flag off. Callers pass normalized `ProviderConfigCardValue` entries and adapt their own storage shape via `onChange`.
- `virtualKeySheet.tsx` now delegates entirely to `ProviderConfigsEditor`, removing ~200 lines of inline provider config management code.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [x] Docs

## How to test

1. Open the Virtual Key sheet and verify the Provider Configurations section behaves identically to before (add/remove providers, toggle "Allow all providers", set budgets and rate limits).
2. Enable "Allow all providers" and confirm a row appears for every configured provider automatically, including any added afterward.
3. Disable "Allow all providers" and confirm only customized (non-default) rows are retained.
4. Create or update an Access Profile via the API with `allow_all_providers: true` and confirm the field is accepted and persisted.

```sh
# UI
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Screenshots/Recordings

_Add before/after screenshots of the Provider Configurations section if available._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

The `allow_all_providers` flag broadens provider access for a key or profile. Operators should be aware that enabling it grants access to providers added in the future without requiring an explicit configuration update. Existing per-provider model, key, budget, and rate-limit rules are still enforced for listed providers.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable