### PR TITLE
tests: add e2e tests for allow all providers on vk

### DIFF
--- a/tests/governance/advancedscenarios_test.go
+++ b/tests/governance/advancedscenarios_test.go
@@ -1684,3 +1684,142 @@ func TestCustomerDeletionSetsVKCustomerIDToNil(t *testing.T) {
 	t.Logf("VK customer_id is now nil ✓")
 	t.Logf("Customer deletion sets VK customer_id to nil verified ✓")
 }
+
+// ============================================================================
+// SCENARIO: allow_all_providers on a virtual key
+// ============================================================================
+
+// TestVKAllowAllProvidersOpensUnlistedProviders verifies that allow_all_providers grants
+// access to a provider the VK does not list in provider_configs, while a listed provider
+// keeps its own rules and still serves.
+func TestVKAllowAllProvidersOpensUnlistedProviders(t *testing.T) {
+	t.Parallel()
+	testData := NewGlobalTestData()
+	defer testData.Cleanup(t)
+
+	// Only openai is listed; anthropic is deliberately unlisted, so it is reachable
+	// only because allow_all_providers is on.
+	createVKResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/virtual-keys",
+		Body: CreateVirtualKeyRequest{
+			Name:              "test-vk-allow-all-" + generateRandomID(),
+			AllowAllProviders: true,
+			ProviderConfigs: []ProviderConfigRequest{{
+				Provider:      "openai",
+				Weight:        float64Ptr(1.0),
+				AllowedModels: []string{"*"},
+				KeyIDs:        []string{"*"},
+			}},
+		},
+	})
+	if createVKResp.StatusCode != 200 {
+		t.Fatalf("Failed to create VK: status %d, body %v", createVKResp.StatusCode, createVKResp.Body)
+	}
+	testData.AddVirtualKey(ExtractIDFromResponse(t, createVKResp))
+	vkValue := createVKResp.Body["virtual_key"].(map[string]interface{})["value"].(string)
+
+	// Poll the listed provider until the VK config is live in the governance store,
+	// with a bounded timeout, instead of a fixed sleep — keeps the test deterministic.
+	var listedResp *APIResponse
+	for i := 0; i < 20; i++ {
+		listedResp = MakeRequest(t, APIRequest{
+			Method: "POST",
+			Path:   "/v1/chat/completions",
+			Body: ChatCompletionRequest{
+				Model:    "openai/gpt-4o",
+				Messages: []ChatMessage{{Role: "user", Content: "allow-all probe"}},
+			},
+			VKHeader: &vkValue,
+		})
+		if listedResp.StatusCode == 200 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if listedResp.StatusCode != 200 {
+		t.Fatalf("listed provider (openai) should serve once the VK is live, got %d: %v", listedResp.StatusCode, listedResp.Body)
+	}
+
+	// The unlisted provider is reachable only because allow_all_providers is on.
+	unlistedResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/v1/chat/completions",
+		Body: ChatCompletionRequest{
+			Model:    "anthropic/claude-sonnet-4-5",
+			Messages: []ChatMessage{{Role: "user", Content: "allow-all probe"}},
+		},
+		VKHeader: &vkValue,
+	})
+	if unlistedResp.StatusCode != 200 {
+		t.Fatalf("allow_all_providers should permit the unlisted provider (anthropic), got %d: %v", unlistedResp.StatusCode, unlistedResp.Body)
+	}
+	t.Logf("allow_all_providers permitted the unlisted provider ✓")
+}
+
+// TestVKWithoutAllowAllProvidersDeniesUnlisted is the negative control: with the flag off
+// (the default), a provider not in provider_configs is denied while the listed one serves.
+func TestVKWithoutAllowAllProvidersDeniesUnlisted(t *testing.T) {
+	t.Parallel()
+	testData := NewGlobalTestData()
+	defer testData.Cleanup(t)
+
+	// allow_all_providers defaults to false, so only openai is permitted.
+	createVKResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/virtual-keys",
+		Body: CreateVirtualKeyRequest{
+			Name: "test-vk-deny-unlisted-" + generateRandomID(),
+			ProviderConfigs: []ProviderConfigRequest{{
+				Provider:      "openai",
+				Weight:        float64Ptr(1.0),
+				AllowedModels: []string{"*"},
+				KeyIDs:        []string{"*"},
+			}},
+		},
+	})
+	if createVKResp.StatusCode != 200 {
+		t.Fatalf("Failed to create VK: status %d, body %v", createVKResp.StatusCode, createVKResp.Body)
+	}
+	testData.AddVirtualKey(ExtractIDFromResponse(t, createVKResp))
+	vkValue := createVKResp.Body["virtual_key"].(map[string]interface{})["value"].(string)
+
+	// Poll the listed provider until the VK config is live, with a bounded timeout,
+	// instead of a fixed sleep — keeps the test deterministic.
+	var listedResp *APIResponse
+	for i := 0; i < 20; i++ {
+		listedResp = MakeRequest(t, APIRequest{
+			Method: "POST",
+			Path:   "/v1/chat/completions",
+			Body: ChatCompletionRequest{
+				Model:    "openai/gpt-4o",
+				Messages: []ChatMessage{{Role: "user", Content: "deny probe"}},
+			},
+			VKHeader: &vkValue,
+		})
+		if listedResp.StatusCode == 200 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if listedResp.StatusCode != 200 {
+		t.Fatalf("listed provider (openai) should serve once the VK is live, got %d: %v", listedResp.StatusCode, listedResp.Body)
+	}
+
+	// The unlisted provider is denied by deny-by-default.
+	unlistedResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/v1/chat/completions",
+		Body: ChatCompletionRequest{
+			Model:    "anthropic/claude-sonnet-4-5",
+			Messages: []ChatMessage{{Role: "user", Content: "deny probe"}},
+		},
+		VKHeader: &vkValue,
+	})
+	// Require a 4xx denial specifically; a 5xx would be a backend failure, not a
+	// governance denial, and must not pass this negative control.
+	if unlistedResp.StatusCode < 400 || unlistedResp.StatusCode >= 500 {
+		t.Fatalf("unlisted provider (anthropic) should be denied with a 4xx without allow_all_providers, got %d: %v", unlistedResp.StatusCode, unlistedResp.Body)
+	}
+	t.Logf("deny-by-default denied the unlisted provider ✓")
+}

--- a/tests/governance/test_utils.go
+++ b/tests/governance/test_utils.go
@@ -224,15 +224,16 @@ func generateRandomID() string {
 
 // CreateVirtualKeyRequest represents a request to create a virtual key
 type CreateVirtualKeyRequest struct {
-	Name            string                  `json:"name"`
-	Description     string                  `json:"description,omitempty"`
-	IsActive        *bool                   `json:"is_active,omitempty"`
-	TeamID          *string                 `json:"team_id,omitempty"`
-	CustomerID      *string                 `json:"customer_id,omitempty"`
-	Budgets         []BudgetRequest         `json:"budgets,omitempty"`
-	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
-	ProviderConfigs []ProviderConfigRequest `json:"provider_configs,omitempty"`
-	CalendarAligned bool                    `json:"calendar_aligned,omitempty"`
+	Name              string                  `json:"name"`
+	Description       string                  `json:"description,omitempty"`
+	IsActive          *bool                   `json:"is_active,omitempty"`
+	TeamID            *string                 `json:"team_id,omitempty"`
+	CustomerID        *string                 `json:"customer_id,omitempty"`
+	Budgets           []BudgetRequest         `json:"budgets,omitempty"`
+	RateLimit         *CreateRateLimitRequest `json:"rate_limit,omitempty"`
+	ProviderConfigs   []ProviderConfigRequest `json:"provider_configs,omitempty"`
+	CalendarAligned   bool                    `json:"calendar_aligned,omitempty"`
+	AllowAllProviders bool                    `json:"allow_all_providers,omitempty"`
 }
 
 // ProviderConfigRequest represents a provider configuration for a virtual key

--- a/ui/components/ui/providerConfigsEditor.tsx
+++ b/ui/components/ui/providerConfigsEditor.tsx
@@ -96,14 +96,18 @@ export function ProviderConfigsEditor({
 	// While on, keep a row for every available provider so each can be given
 	// budgets/limits or excluded. Providers added later show up here too. Keyed on
 	// the joined names, not the array identity, so it converges without looping.
+	// configuredKey re-runs the effect when the parent swaps `value` (e.g. loads a
+	// different entity) while the flag and provider list stay the same, so missing
+	// rows are backfilled; the missing-empty guard keeps it from looping.
 	const providerNamesKey = availableProviders.map((p) => p.name).join(" ");
+	const configuredKey = value.map((e) => e.providerName).join(" ");
 	useEffect(() => {
 		if (!allowAllProviders || availableProviders.length === 0) return;
 		const missing = availableProviders.filter((p) => p.name && !value.some((e) => e.providerName === p.name));
 		if (missing.length === 0) return;
 		onChange([...value, ...missing.map((p) => makeDefaultEntry(p.name))]);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [allowAllProviders, providerNamesKey]);
+	}, [allowAllProviders, providerNamesKey, configuredKey]);
 
 	const unconfiguredProviders = availableProviders.filter((provider) => !value.some((e) => e.providerName === provider.name));
 	const baseProviders = unconfiguredProviders.filter((p) => p.name && !p.custom_provider_config);


### PR DESCRIPTION
## Summary

Adds integration tests for the `allow_all_providers` flag on virtual keys, verifying that when the flag is enabled, providers not explicitly listed in `provider_configs` are still accessible, and when the flag is disabled (the default), unlisted providers are denied.

## Changes

- Added `TestVKAllowAllProvidersOpensUnlistedProviders`: creates a virtual key with `allow_all_providers: true` and only `openai` in `provider_configs`, then asserts that both the listed provider (`openai`) and an unlisted provider (`anthropic`) return HTTP 200.
- Added `TestVKWithoutAllowAllProvidersDeniesUnlisted`: the negative control — creates a virtual key without `allow_all_providers`, then asserts that the listed provider (`openai`) serves while the unlisted provider (`anthropic`) is denied with a 4xx response.
- Added `AllowAllProviders bool` to `CreateVirtualKeyRequest` so the flag can be set in test request bodies.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./tests/governance/... -run TestVKAllowAllProvidersOpensUnlistedProviders
go test ./tests/governance/... -run TestVKWithoutAllowAllProvidersDeniesUnlisted
```

Both tests require a running governance service with valid API keys for `openai` and `anthropic` configured. The first test expects HTTP 200 for both providers; the second expects HTTP 200 for `openai` and a 4xx for `anthropic`.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None. These are test-only changes that exercise existing access-control logic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable