### PR TITLE
fix: ui fixes for mcp and vmcp

### DIFF
--- a/docs/changelogs/helm-v2.1.39.mdx
+++ b/docs/changelogs/helm-v2.1.39.mdx
@@ -20,5 +20,6 @@ description: "Helm v2.1.39 changelog - 2026-09-07"
 - Added `bifrost.mcp.clientConfigs[].endpointSlug` — URL-safe, immutable slug serving the client at `/mcp/<slug>`. Derived from the client name when omitted; must be unique across MCP clients and Virtual MCPs. Renders into `endpoint_slug`.
 - Added `bifrost.client.vkRotationCooldown` (default `0`) — grace period after a virtual key rotation during which the previous key value still authenticates. Go duration string (e.g. `"5m"`), max 30 days; `0` disables. Renders into `client.vk_rotation_cooldown`.
 - Added `databricks_key_config` (`workspace_url`, `api_format`, `client_id`/`client_secret` for OAuth M2M, `forward_gateway_tags`) to provider keys, with `bifrost.providers.databricks` examples in `values.yaml`.
+- Added `allow_all_providers` to `bifrost.governance.projects[]` and `bifrost.accessProfiles[]` (default `false`) — grant access to every provider, including ones without a `provider_configs` entry and providers added later; listed providers keep their own model, key, budget, and rate-limit rules. Renders into each entry's `allow_all_providers`.
 
 </Update>

--- a/docs/openapi/schemas/management/accessprofiles.yaml
+++ b/docs/openapi/schemas/management/accessprofiles.yaml
@@ -184,6 +184,9 @@ AccessProfile:
       $ref: '#/RateLimit'
     calendar_aligned:
       type: boolean
+    allow_all_providers:
+      type: boolean
+      description: When true, grants access to every provider, including ones without a provider_configs entry and providers added later. A listed provider keeps its own model allow/blacklist, budgets, rate limits, and key selection; an unlisted provider gets all models, all keys, and no per-provider limits. When false (default), access is deny-by-default via provider_configs.
     auto_rotation_interval:
       type: integer
       format: int64
@@ -262,6 +265,10 @@ CreateAccessProfileRequest:
       $ref: '#/RateLimit'
     calendar_aligned:
       type: boolean
+    allow_all_providers:
+      type: boolean
+      default: false
+      description: When true, grants access to every provider, including ones without a provider_configs entry and providers added later. A listed provider keeps its own model allow/blacklist, budgets, rate limits, and key selection; an unlisted provider gets all models, all keys, and no per-provider limits. When false (default), access is deny-by-default via provider_configs.
     auto_rotation_interval:
       oneOf:
         - $ref: '#/RotationIntervalString'
@@ -318,6 +325,10 @@ UpdateAccessProfileRequest:
     calendar_aligned:
       type: boolean
       nullable: true
+    allow_all_providers:
+      type: boolean
+      nullable: true
+      description: When true, grants access to every provider, including ones without a provider_configs entry and providers added later. A listed provider keeps its own model allow/blacklist, budgets, rate limits, and key selection; an unlisted provider gets all models, all keys, and no per-provider limits. When false, provider-wide access is disabled and access is deny-by-default via provider_configs. Omit to leave unchanged.
     auto_rotation_interval:
       oneOf:
         - $ref: '#/RotationIntervalString'

--- a/docs/openapi/schemas/management/projects.yaml
+++ b/docs/openapi/schemas/management/projects.yaml
@@ -520,6 +520,13 @@ Project:
       description: >-
         Snaps every window the project holds, including each member's derived
         slice, onto calendar boundaries instead of running from creation.
+    allow_all_providers:
+      type: boolean
+      default: false
+      description: >-
+        When true, grants access to every provider, including ones without a
+        provider_configs entry and providers added later. Listed providers keep
+        their own model, key, budget, and rate-limit rules.
     budgets:
       type: array
       nullable: true
@@ -594,6 +601,10 @@ CreateProjectRequest:
     calendar_aligned:
       type: boolean
       default: false
+    allow_all_providers:
+      type: boolean
+      default: false
+      description: When true, grants access to every provider, including ones without a provider_configs entry and providers added later. Listed providers keep their own model, key, budget, and rate-limit rules.
     budgets:
       type: array
       items:
@@ -647,6 +658,9 @@ UpdateProjectRequest:
       $ref: '#/ProjectSplitPolicy'
     calendar_aligned:
       type: boolean
+    allow_all_providers:
+      type: boolean
+      description: When true, grants access to every provider, including ones without a provider_configs entry and providers added later. Listed providers keep their own model, key, budget, and rate-limit rules. Omit to leave unchanged.
     budgets:
       type: array
       nullable: true

--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -23,6 +23,7 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 - Added `bifrost.mcp.clientConfigs[].endpointSlug` — URL-safe, immutable slug serving the client at `/mcp/<slug>`. Derived from the client name when omitted; must be unique across MCP clients and Virtual MCPs.
 - Added `bifrost.client.vkRotationCooldown` (default `0`) — grace period after a virtual key rotation during which the previous key value still authenticates. Go duration string (e.g. `"5m"`), max 30 days; `0` disables
 - Added `databricks_key_config` (`workspace_url`, `api_format`, `client_id`/`client_secret` for OAuth M2M, `forward_gateway_tags`) to provider keys, with `bifrost.providers.databricks` examples in `values.yaml`.
+- Added `allow_all_providers` to `bifrost.governance.projects[]` and `bifrost.accessProfiles[]` (default `false`) — grant access to every provider, including ones without a `provider_configs` entry and providers added later; listed providers keep their own model, key, budget, and rate-limit rules. Renders into each entry's `allow_all_providers`.
 
 ### 2.1.37
 

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -3894,6 +3894,11 @@
                 "type": "boolean",
                 "description": "Snap budget and rate-limit reset windows to clean calendar boundaries (day, week, month, year) for this profile",
                 "default": false
+              },
+              "allow_all_providers": {
+                "type": "boolean",
+                "description": "Grant access to every provider, including ones without a provider_configs entry and providers added later. Listed providers keep their own model, key, budget, and rate-limit rules.",
+                "default": false
               }
             },
             "required": ["name"],
@@ -7619,6 +7624,11 @@
         "calendar_aligned": {
           "type": "boolean",
           "description": "Snap the project's budget and rate-limit reset windows to calendar boundaries (day, week, month, quarter, year) instead of rolling from first use. Windows shorter than a day cannot be aligned and stay rolling.",
+          "default": false
+        },
+        "allow_all_providers": {
+          "type": "boolean",
+          "description": "Grant access to every provider, including ones without a provider_configs entry and providers added later. Listed providers keep their own model, key, budget, and rate-limit rules.",
           "default": false
         },
         "budgets": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -936,6 +936,7 @@ bifrost:
       #   accounting_mode: "both"          # both | project_only | principal_only
       #   split_policy: "none"             # none (shared caps) | equal (each member gets an equal share); open projects must use none
       #   calendar_aligned: false          # Snap budget and rate-limit windows to calendar boundaries
+      #   allow_all_providers: false       # true grants access to every provider incl. ones added later; a provider with a provider_configs entry keeps its model/key/budget/rate-limit rules; false (default) is deny-by-default via provider_configs
       #   budgets:
       #     - max_limit: 5000
       #       reset_duration: "1M"
@@ -1333,6 +1334,7 @@ bifrost:
     #   description: "Default platform profile"
     #   is_active: true
     #   calendar_aligned: false  # Snap all budget/rate-limit resets to calendar boundaries
+    #   allow_all_providers: false  # true grants access to every provider incl. ones added later; a provider with a provider_configs entry keeps its model/key/budget/rate-limit rules; false (default) is deny-by-default via provider_configs
     #   tags: ["platform", "default"]
     #   budgets:
     #     - id: "ap-budget-1"

--- a/tests/governance/advancedscenarios_test.go
+++ b/tests/governance/advancedscenarios_test.go
@@ -1684,3 +1684,142 @@ func TestCustomerDeletionSetsVKCustomerIDToNil(t *testing.T) {
 	t.Logf("VK customer_id is now nil ✓")
 	t.Logf("Customer deletion sets VK customer_id to nil verified ✓")
 }
+
+// ============================================================================
+// SCENARIO: allow_all_providers on a virtual key
+// ============================================================================
+
+// TestVKAllowAllProvidersOpensUnlistedProviders verifies that allow_all_providers grants
+// access to a provider the VK does not list in provider_configs, while a listed provider
+// keeps its own rules and still serves.
+func TestVKAllowAllProvidersOpensUnlistedProviders(t *testing.T) {
+	t.Parallel()
+	testData := NewGlobalTestData()
+	defer testData.Cleanup(t)
+
+	// Only openai is listed; anthropic is deliberately unlisted, so it is reachable
+	// only because allow_all_providers is on.
+	createVKResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/virtual-keys",
+		Body: CreateVirtualKeyRequest{
+			Name:              "test-vk-allow-all-" + generateRandomID(),
+			AllowAllProviders: true,
+			ProviderConfigs: []ProviderConfigRequest{{
+				Provider:      "openai",
+				Weight:        float64Ptr(1.0),
+				AllowedModels: []string{"*"},
+				KeyIDs:        []string{"*"},
+			}},
+		},
+	})
+	if createVKResp.StatusCode != 200 {
+		t.Fatalf("Failed to create VK: status %d, body %v", createVKResp.StatusCode, createVKResp.Body)
+	}
+	testData.AddVirtualKey(ExtractIDFromResponse(t, createVKResp))
+	vkValue := createVKResp.Body["virtual_key"].(map[string]interface{})["value"].(string)
+
+	// Poll the listed provider until the VK config is live in the governance store,
+	// with a bounded timeout, instead of a fixed sleep — keeps the test deterministic.
+	var listedResp *APIResponse
+	for i := 0; i < 20; i++ {
+		listedResp = MakeRequest(t, APIRequest{
+			Method: "POST",
+			Path:   "/v1/chat/completions",
+			Body: ChatCompletionRequest{
+				Model:    "openai/gpt-4o",
+				Messages: []ChatMessage{{Role: "user", Content: "allow-all probe"}},
+			},
+			VKHeader: &vkValue,
+		})
+		if listedResp.StatusCode == 200 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if listedResp.StatusCode != 200 {
+		t.Fatalf("listed provider (openai) should serve once the VK is live, got %d: %v", listedResp.StatusCode, listedResp.Body)
+	}
+
+	// The unlisted provider is reachable only because allow_all_providers is on.
+	unlistedResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/v1/chat/completions",
+		Body: ChatCompletionRequest{
+			Model:    "anthropic/claude-sonnet-4-5",
+			Messages: []ChatMessage{{Role: "user", Content: "allow-all probe"}},
+		},
+		VKHeader: &vkValue,
+	})
+	if unlistedResp.StatusCode != 200 {
+		t.Fatalf("allow_all_providers should permit the unlisted provider (anthropic), got %d: %v", unlistedResp.StatusCode, unlistedResp.Body)
+	}
+	t.Logf("allow_all_providers permitted the unlisted provider ✓")
+}
+
+// TestVKWithoutAllowAllProvidersDeniesUnlisted is the negative control: with the flag off
+// (the default), a provider not in provider_configs is denied while the listed one serves.
+func TestVKWithoutAllowAllProvidersDeniesUnlisted(t *testing.T) {
+	t.Parallel()
+	testData := NewGlobalTestData()
+	defer testData.Cleanup(t)
+
+	// allow_all_providers defaults to false, so only openai is permitted.
+	createVKResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/api/governance/virtual-keys",
+		Body: CreateVirtualKeyRequest{
+			Name: "test-vk-deny-unlisted-" + generateRandomID(),
+			ProviderConfigs: []ProviderConfigRequest{{
+				Provider:      "openai",
+				Weight:        float64Ptr(1.0),
+				AllowedModels: []string{"*"},
+				KeyIDs:        []string{"*"},
+			}},
+		},
+	})
+	if createVKResp.StatusCode != 200 {
+		t.Fatalf("Failed to create VK: status %d, body %v", createVKResp.StatusCode, createVKResp.Body)
+	}
+	testData.AddVirtualKey(ExtractIDFromResponse(t, createVKResp))
+	vkValue := createVKResp.Body["virtual_key"].(map[string]interface{})["value"].(string)
+
+	// Poll the listed provider until the VK config is live, with a bounded timeout,
+	// instead of a fixed sleep — keeps the test deterministic.
+	var listedResp *APIResponse
+	for i := 0; i < 20; i++ {
+		listedResp = MakeRequest(t, APIRequest{
+			Method: "POST",
+			Path:   "/v1/chat/completions",
+			Body: ChatCompletionRequest{
+				Model:    "openai/gpt-4o",
+				Messages: []ChatMessage{{Role: "user", Content: "deny probe"}},
+			},
+			VKHeader: &vkValue,
+		})
+		if listedResp.StatusCode == 200 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	if listedResp.StatusCode != 200 {
+		t.Fatalf("listed provider (openai) should serve once the VK is live, got %d: %v", listedResp.StatusCode, listedResp.Body)
+	}
+
+	// The unlisted provider is denied by deny-by-default.
+	unlistedResp := MakeRequest(t, APIRequest{
+		Method: "POST",
+		Path:   "/v1/chat/completions",
+		Body: ChatCompletionRequest{
+			Model:    "anthropic/claude-sonnet-4-5",
+			Messages: []ChatMessage{{Role: "user", Content: "deny probe"}},
+		},
+		VKHeader: &vkValue,
+	})
+	// Require a 4xx denial specifically; a 5xx would be a backend failure, not a
+	// governance denial, and must not pass this negative control.
+	if unlistedResp.StatusCode < 400 || unlistedResp.StatusCode >= 500 {
+		t.Fatalf("unlisted provider (anthropic) should be denied with a 4xx without allow_all_providers, got %d: %v", unlistedResp.StatusCode, unlistedResp.Body)
+	}
+	t.Logf("deny-by-default denied the unlisted provider ✓")
+}

--- a/tests/governance/test_utils.go
+++ b/tests/governance/test_utils.go
@@ -224,15 +224,16 @@ func generateRandomID() string {
 
 // CreateVirtualKeyRequest represents a request to create a virtual key
 type CreateVirtualKeyRequest struct {
-	Name            string                  `json:"name"`
-	Description     string                  `json:"description,omitempty"`
-	IsActive        *bool                   `json:"is_active,omitempty"`
-	TeamID          *string                 `json:"team_id,omitempty"`
-	CustomerID      *string                 `json:"customer_id,omitempty"`
-	Budgets         []BudgetRequest         `json:"budgets,omitempty"`
-	RateLimit       *CreateRateLimitRequest `json:"rate_limit,omitempty"`
-	ProviderConfigs []ProviderConfigRequest `json:"provider_configs,omitempty"`
-	CalendarAligned bool                    `json:"calendar_aligned,omitempty"`
+	Name              string                  `json:"name"`
+	Description       string                  `json:"description,omitempty"`
+	IsActive          *bool                   `json:"is_active,omitempty"`
+	TeamID            *string                 `json:"team_id,omitempty"`
+	CustomerID        *string                 `json:"customer_id,omitempty"`
+	Budgets           []BudgetRequest         `json:"budgets,omitempty"`
+	RateLimit         *CreateRateLimitRequest `json:"rate_limit,omitempty"`
+	ProviderConfigs   []ProviderConfigRequest `json:"provider_configs,omitempty"`
+	CalendarAligned   bool                    `json:"calendar_aligned,omitempty"`
+	AllowAllProviders bool                    `json:"allow_all_providers,omitempty"`
 }
 
 // ProviderConfigRequest represents a provider configuration for a virtual key

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -7752,6 +7752,11 @@
           "description": "Snap budget and rate-limit reset windows to clean calendar boundaries (day, week, month, year) for this profile",
           "default": false
         },
+        "allow_all_providers": {
+          "type": "boolean",
+          "description": "Grant access to every provider, including ones without a provider_configs entry and providers added later. A listed provider keeps its own model allow/blacklist, budgets, rate limits, and key selection; an unlisted provider gets all models, all keys, and no per-provider limits. When false (default), access is deny-by-default via provider_configs.",
+          "default": false
+        },
         "provider_configs": {
           "type": "array",
           "description": "Per-provider restrictions and limits for this profile",

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -7938,6 +7938,11 @@
           "description": "Snap the project's budget and rate-limit reset windows to calendar boundaries (day, week, month, quarter, year) instead of rolling from first use. Windows shorter than a day cannot be aligned and stay rolling.",
           "default": false
         },
+        "allow_all_providers": {
+          "type": "boolean",
+          "description": "Grant access to every provider, including ones without a provider_configs entry and providers added later. Listed providers keep their own model, key, budget, and rate-limit rules.",
+          "default": false
+        },
         "budgets": {
           "type": "array",
           "description": "Project-level spend caps. Declared without ids: on a change, a budget is matched to its stored row by reset_duration so its accumulated spend and window carry over.",

--- a/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientSheet.tsx
@@ -30,8 +30,15 @@ import { useToast } from "@/hooks/use-toast";
 import { useSheetNavigation } from "@/hooks/useSheetNavigation";
 import { IS_ENTERPRISE, MCP_STATUS_COLORS } from "@/lib/constants/config";
 import { VirtualKeySelector } from "@/components/entitySelectors/virtualKeySelector";
-import { getErrorMessage, useGetCoreConfigQuery, useGetVirtualKeysQuery, useUpdateMCPClientMutation } from "@/lib/store";
+import {
+	getErrorMessage,
+	useGetCoreConfigQuery,
+	useGetVirtualKeysQuery,
+	useGetVirtualMCPsQuery,
+	useUpdateMCPClientMutation,
+} from "@/lib/store";
 import { MCPClient, MCPVKConfig } from "@/lib/types/mcp";
+import { VirtualMCP } from "@/lib/types/virtualMcps";
 import { mcpClientUpdateSchema, type MCPClientUpdateSchema } from "@/lib/types/schemas";
 import { parseArrayFromText } from "@/lib/utils/array";
 import { failureStageLabel, formatDurationSince, hasStateReason, stateReasonTitle } from "@/lib/utils/mcpConnectionFailure";
@@ -230,6 +237,20 @@ export default function MCPClientSheet({
 	}, [mcpClient.vk_configs, localVKNames]);
 
 	const configuredVKIDs = useMemo(() => vkConfigs.map((vc) => vc.virtual_key_id), [vkConfigs]);
+
+	// Reverse lookup for the Access tab: which Virtual MCPs bundle this server's
+	// tools. There's no dedicated endpoint, but the list response already carries
+	// every vMCP's tools[].mcp_client_id, so membership is derived client-side.
+	const { data: virtualMcpsData, isLoading: virtualMcpsLoading, isError: virtualMcpsError } = useGetVirtualMCPsQuery({ limit: 1000 });
+	const memberVirtualMcps = useMemo(() => {
+		const clientID = mcpClient.config.client_id;
+		const out: { vmcp: VirtualMCP; toolNames: string[] }[] = [];
+		for (const vmcp of virtualMcpsData?.virtual_mcps ?? []) {
+			const spec = vmcp.tools.find((t) => t.mcp_client_id === clientID);
+			if (spec) out.push({ vmcp, toolNames: spec.tool_names });
+		}
+		return out;
+	}, [virtualMcpsData, mcpClient.config.client_id]);
 
 	const toolOptions = useMemo(
 		() => [
@@ -1798,6 +1819,60 @@ export default function MCPClientSheet({
 											) : (
 												<div className="text-muted-foreground rounded-sm border p-6 text-center">
 													<p className="text-sm">No virtual keys have access to this MCP server</p>
+												</div>
+											)}
+										</div>
+
+										<DottedSeparator />
+
+										<div className="space-y-4">
+											<SectionHeader
+												title="Virtual MCPs"
+												description="Virtual MCPs that bundle this server's tools and re-serve them at their own endpoint."
+											/>
+											{virtualMcpsLoading ? (
+												<div className="text-muted-foreground rounded-sm border p-6 text-center">
+													<p className="text-sm">Loading virtual MCPs…</p>
+												</div>
+											) : virtualMcpsError ? (
+												<div className="text-muted-foreground rounded-sm border p-6 text-center">
+													<p className="text-sm">Couldn't load virtual MCPs.</p>
+												</div>
+											) : memberVirtualMcps.length > 0 ? (
+												<div className="rounded-md border">
+													<Table>
+														<TableHeader>
+															<TableRow>
+																<TableHead>Virtual MCP</TableHead>
+																<TableHead>Endpoint</TableHead>
+																<TableHead>Exposed Tools</TableHead>
+															</TableRow>
+														</TableHeader>
+														<TableBody>
+															{memberVirtualMcps.map(({ vmcp, toolNames }) => (
+																<TableRow key={vmcp.id}>
+																	<TableCell className="font-medium">
+																		<div className="flex items-center gap-2">
+																			{vmcp.name}
+																			{!vmcp.enabled && (
+																				<Badge variant="secondary" className="text-xs font-normal">
+																					Disabled
+																				</Badge>
+																			)}
+																		</div>
+																	</TableCell>
+																	<TableCell className="text-muted-foreground font-mono text-xs">/mcp/{vmcp.endpoint_slug}</TableCell>
+																	<TableCell className="text-muted-foreground text-sm">
+																		{toolNames.includes("*") ? "All tools" : toolNames.length === 0 ? "No tools" : toolNames.join(", ")}
+																	</TableCell>
+																</TableRow>
+															))}
+														</TableBody>
+													</Table>
+												</div>
+											) : (
+												<div className="text-muted-foreground rounded-sm border p-6 text-center">
+													<p className="text-sm">This server isn't part of any virtual MCP.</p>
 												</div>
 											)}
 										</div>

--- a/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpClientsTable.tsx
@@ -19,6 +19,7 @@ import { Input } from "@/components/ui/input";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { Switch } from "@/components/ui/switch";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
 import {
 	getErrorMessage,
@@ -261,24 +262,28 @@ interface MCPClientsTableProps {
 }
 
 // ClientEndpointCell shows the /mcp/<slug> path and copies the full external URL on click.
-// baseReady gates copying: until the core config query resolves, getExternalBaseUrl falls back to
-// window.location.origin, which is the wrong host when mcp_external_client_url points elsewhere.
-function ClientEndpointCell({ slug, baseUrl, baseReady }: { slug?: string; baseUrl: string; baseReady: boolean }) {
+// Matches the Virtual MCPs table cell: the copy icon reveals on row hover (group-hover).
+function ClientEndpointCell({ slug, baseUrl }: { slug?: string; baseUrl: string }) {
 	const { copy, copied } = useCopyToClipboard({ successMessage: "Endpoint copied" });
 	if (!slug) return <span className="text-muted-foreground text-sm">-</span>;
 	return (
-		<button
-			type="button"
-			disabled={!baseReady}
-			onClick={() => copy(`${baseUrl}/mcp/${slug}`)}
-			className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 font-mono text-sm transition-colors enabled:cursor-pointer disabled:opacity-60"
-			aria-label={baseReady ? "Copy endpoint URL" : "Endpoint URL loading"}
-			title={baseReady ? undefined : "Loading the external base URL…"}
-			data-testid={`mcp-client-endpoint-copy-${slug}`}
-		>
-			/mcp/{slug}
-			{copied ? <Check className="size-3.5 shrink-0" /> : <Copy className="size-3.5 shrink-0" />}
-		</button>
+		<Tooltip>
+			<TooltipTrigger asChild>
+				<button
+					type="button"
+					onClick={() => copy(`${baseUrl}/mcp/${slug}`)}
+					className="text-muted-foreground hover:text-foreground flex w-full min-w-0 cursor-pointer items-center gap-1.5 font-mono text-sm transition-colors"
+					aria-label="Copy endpoint URL"
+					data-testid={`mcp-client-endpoint-copy-${slug}`}
+				>
+					<span className="truncate">/mcp/{slug}</span>
+					<span className="shrink-0 opacity-0 transition-opacity group-hover:opacity-100">
+						{copied ? <Check className="size-3.5 shrink-0" /> : <Copy className="size-3.5 shrink-0" />}
+					</span>
+				</button>
+			</TooltipTrigger>
+			<TooltipContent className="font-mono">/mcp/{slug}</TooltipContent>
+		</Tooltip>
 	);
 }
 
@@ -301,7 +306,7 @@ export default function MCPClientsTable({
 	const hasUpdateMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Update);
 	const hasDeleteMCPClientAccess = useRbac(RbacResource.MCPGateway, RbacOperation.Delete);
 	// Externally reachable base URL, so the endpoint cell copies the full URL callers use.
-	const { data: coreConfig, isSuccess: coreConfigReady } = useGetCoreConfigQuery({ fromDB: true });
+	const { data: coreConfig } = useGetCoreConfigQuery({ fromDB: true });
 	const baseUrl = getExternalBaseUrl(coreConfig?.client_config);
 	const [selectedMCPClient, setSelectedMCPClient] = useState<MCPClient | null>(null);
 	const [clientToDelete, setClientToDelete] = useState<MCPClient | null>(null);
@@ -1032,7 +1037,7 @@ export default function MCPClientsTable({
 												</div>
 											</TableCell>
 											<TableCell>
-												<ClientEndpointCell slug={c.config.endpoint_slug} baseUrl={baseUrl} baseReady={coreConfigReady} />
+												<ClientEndpointCell slug={c.config.endpoint_slug} baseUrl={baseUrl} />
 											</TableCell>
 											<TableCell data-testid="mcp-client-connection-type">
 												<Badge variant="outline" className="font-mono">

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -24,8 +24,7 @@ import { Label } from "@/components/ui/label";
 import MultiBudgetLines from "@/components/ui/multibudgets";
 import { MultiSelect } from "@/components/ui/multiSelect";
 import NumberAndSelect from "@/components/ui/numberAndSelect";
-import { ProviderConfigCard } from "@/components/ui/providerConfigCard";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { ProviderConfigsEditor } from "@/components/ui/providerConfigsEditor";
 import { DottedSeparator } from "@/components/ui/separator";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Switch } from "@/components/ui/switch";
@@ -34,7 +33,6 @@ import { Textarea } from "@/components/ui/textarea";
 import Toggle from "@/components/ui/toggle";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { resetDurationOptions, supportsCalendarAlignment } from "@/lib/constants/governance";
-import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
 import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
 import { getUserPicker } from "@/lib/registries/userPicker";
 import {
@@ -53,7 +51,6 @@ import {
 } from "@/lib/store";
 import { VirtualMcpAssignmentsEditor } from "@/components/mcp/virtualMcpAssignmentsEditor";
 import { diffVmcpAssignments, vmcpAssignmentsDirty } from "./virtualKeySheet.utils";
-import { KnownProvider } from "@/lib/types/config";
 import { BudgetOverrideRequest, CreateVirtualKeyRequest, UpdateVirtualKeyRequest, VirtualKey } from "@/lib/types/governance";
 import {
 	type BudgetComparisonEntry,
@@ -71,7 +68,7 @@ import { useAttachVirtualKeyUsersMutation, useDetachVirtualKeyUserMutation } fro
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useNavigate } from "@tanstack/react-router";
 import { formatDistanceToNow } from "date-fns";
-import { Info, Lock, RotateCcw, Users } from "lucide-react";
+import { Lock, RotateCcw, Users } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 // Side-effect import: registers the enterprise user picker so "Assign to User"
 // becomes available. Resolves to an empty module on OSS builds.
@@ -342,8 +339,8 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 	};
 
 	// RTK Query hooks
-	const { data: providersData, error: providersError } = useGetProvidersQuery();
-	const { data: keysData, error: keysError } = useGetAllKeysQuery();
+	const { error: providersError } = useGetProvidersQuery();
+	const { error: keysError } = useGetAllKeysQuery();
 	const [createVirtualKey, { isLoading: isCreating }] = useCreateVirtualKeyMutation();
 	const [updateVirtualKey, { isLoading: isUpdating }] = useUpdateVirtualKeyMutation();
 	const [rotateVirtualKey, { isLoading: isRotating }] = useRotateVirtualKeyMutation();
@@ -425,9 +422,6 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 		if (!virtualKey) throw new Error("Virtual key is required");
 		await removeBudgetOverride({ vkId: virtualKey.id, budgetId }).unwrap();
 	};
-
-	const availableKeys = keysData || [];
-	const availableProviders = providersData || [];
 
 	// Form setup
 	const form = useForm<z.input<typeof formSchema>, unknown, FormData>({
@@ -556,9 +550,6 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 		form.setValue("userId", assignedUserId);
 	}, [assignedUserId, isEditing, form]);
 
-	// Provider configuration state
-	const [selectedProvider, setSelectedProvider] = useState<string>("");
-
 	// Get current provider configs from form
 	const providerConfigs = form.watch("providerConfigs") || [];
 
@@ -588,76 +579,6 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 			watchedRequestMaxLimit !== null &&
 			supportsCalendarAlignment(watchedRequestResetDuration || "1h"));
 	const showCalendarAlignToggle = hasAnyAlignableBudget || hasAnyAlignableRateLimit;
-
-	// Build a default provider config row (all models, all keys, no limits)
-	const makeDefaultProviderConfig = (provider: string) => ({
-		provider: provider,
-		weight: undefined as number | undefined, // undefined = excluded from weighted routing until user sets a weight
-		allowed_models: ["*"],
-		blacklisted_models: [] as string[],
-		key_ids: ["*"],
-	});
-
-	// A row is "untouched" if it still carries only the auto-added defaults (no budget/limit/restriction).
-	// Turning "Allow all providers" off keeps customized rows and drops these.
-	const isDefaultProviderConfig = (config: (typeof providerConfigs)[number]) =>
-		(config.allowed_models || []).length === 1 &&
-		config.allowed_models?.[0] === "*" &&
-		(config.blacklisted_models || []).length === 0 &&
-		(config.key_ids || []).length === 1 &&
-		config.key_ids?.[0] === "*" &&
-		(config.budgets || []).length === 0 &&
-		!config.rate_limit &&
-		(config.model_budgets || []).length === 0 &&
-		config.weight === undefined;
-
-	// Handle adding a new provider configuration
-	const handleAddProvider = (provider: string) => {
-		const existingConfig = providerConfigs.find((config) => config.provider === provider);
-		if (existingConfig) {
-			toast.error("This provider is already configured");
-			return;
-		}
-
-		form.setValue("providerConfigs", [...providerConfigs, makeDefaultProviderConfig(provider)], {
-			shouldDirty: true,
-		});
-	};
-
-	// Handle removing a provider configuration
-	const handleRemoveProvider = (index: number) => {
-		// Removing a provider while "Allow all providers" is on means "all except this one":
-		// turn the flag off so the remaining rows become the explicit allowlist.
-		if (form.getValues("allowAllProviders")) {
-			form.setValue("allowAllProviders", false, { shouldDirty: true });
-		}
-		const updatedConfigs = (form.getValues("providerConfigs") || []).filter((_, i) => i !== index);
-		form.setValue("providerConfigs", updatedConfigs, { shouldDirty: true });
-	};
-
-	// Handle the "Allow all providers" toggle. When turned on, every configured provider is
-	// materialized as a row (via the effect below) so budgets/limits can be set or a provider
-	// excluded. When turned off, untouched default rows are dropped and customized ones kept.
-	const handleAllowAllProvidersChange = (checked: boolean) => {
-		form.setValue("allowAllProviders", checked, { shouldDirty: true });
-		if (!checked) {
-			const kept = (form.getValues("providerConfigs") || []).filter((config) => !isDefaultProviderConfig(config));
-			form.setValue("providerConfigs", kept, { shouldDirty: true });
-		}
-	};
-
-	// While "Allow all providers" is on, keep a row for every configured provider so they are
-	// visible and can be given budgets or excluded. Providers added later show up here too.
-	// Reads current configs via getValues (not a dep) so this converges in one pass without looping.
-	useEffect(() => {
-		if (!allowAllProviders || availableProviders.length === 0) return;
-		const current = form.getValues("providerConfigs") || [];
-		const missing = availableProviders.filter((p) => p.name && !current.some((c) => c.provider === p.name));
-		if (missing.length === 0) return;
-		const additions = missing.map((p) => makeDefaultProviderConfig(p.name));
-		form.setValue("providerConfigs", [...current, ...additions], { shouldDirty: false });
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [allowAllProviders, availableProviders]);
 
 	// Handle adding a new MCP client configuration
 	const handleAddMCPClient = (mcpClientName: string) => {
@@ -1274,201 +1195,48 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 										/>
 									</div>
 									{/* Provider Configurations */}
-									<div className="space-y-2">
-										<div className="flex items-center gap-2">
-											<Label className="text-sm font-medium">Provider Configurations</Label>
-											<TooltipProvider>
-												<Tooltip>
-													<TooltipTrigger asChild>
-														<span>
-															<Info className="text-muted-foreground h-3 w-3" />
-														</span>
-													</TooltipTrigger>
-													<TooltipContent className="max-w-sm">
-														<p>
-															Configure which providers this virtual key can use and their specific settings. Leave empty to block all
-															providers. Add providers to allow them.
-														</p>
-													</TooltipContent>
-												</Tooltip>
-											</TooltipProvider>
-										</div>
-
-										{/* Allow all providers */}
-										<FormField
-											control={form.control}
-											name="allowAllProviders"
-											render={({ field }) => (
-												<FormItem>
-													<div className="flex w-full items-center justify-between gap-2 py-2 text-sm">
-														<div className="flex items-center gap-1.5">
-															<span>Allow all providers</span>
-															<TooltipProvider>
-																<Tooltip>
-																	<TooltipTrigger asChild>
-																		<span>
-																			<Info className="text-muted-foreground h-3 w-3" />
-																		</span>
-																	</TooltipTrigger>
-																	<TooltipContent className="max-w-sm">
-																		<p>
-																			Grant access to every provider, including ones added later. Set budgets or limits on specific
-																			providers below, or remove a provider to allow all except that one.
-																		</p>
-																	</TooltipContent>
-																</Tooltip>
-															</TooltipProvider>
-														</div>
-														<Switch
-															checked={field.value}
-															onCheckedChange={handleAllowAllProvidersChange}
-															data-testid="vk-allow-all-providers-toggle"
-														/>
-													</div>
-												</FormItem>
-											)}
-										/>
-
-										{/* Add Provider Dropdown */}
-										<div className="flex gap-2">
-											<Select
-												value={selectedProvider}
-												onValueChange={(provider) => {
-													if (provider === "__manage_providers__") {
-														navigate({ to: "/workspace/providers" });
-														setSelectedProvider("");
-														return;
-													}
-													handleAddProvider(provider);
-													setSelectedProvider(""); // Reset to placeholder state
-												}}
-											>
-												<SelectTrigger className="flex-1" data-testid="vk-provider-select">
-													<SelectValue placeholder="Select a provider to add" />
-												</SelectTrigger>
-												<SelectContent>
-													{(() => {
-														// Filter out already configured providers
-														const unconfiguredProviders = availableProviders.filter(
-															(provider) => !providerConfigs.some((config) => config.provider === provider.name),
-														);
-
-														if (unconfiguredProviders.length === 0) {
-															return (
-																<SelectItem
-																	value="__manage_providers__"
-																	className="text-muted-foreground hover:text-foreground"
-																	data-testid="vk-provider-config-link"
-																>
-																	<span>
-																		No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
-																	</span>
-																</SelectItem>
-															);
-														}
-
-														// Separate base providers and custom providers
-														const baseProviders = unconfiguredProviders.filter((provider) => !provider.custom_provider_config);
-														const customProviders = unconfiguredProviders.filter((provider) => provider.custom_provider_config);
-
-														return (
-															<>
-																{/* Base providers first */}
-																{baseProviders
-																	.filter((p) => p.name)
-																	.map((provider, index) => (
-																		<SelectItem key={`base-${index}`} value={provider.name}>
-																			<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
-																			{ProviderLabels[provider.name as ProviderName]}
-																		</SelectItem>
-																	))}
-
-																{/* Custom providers second */}
-																{customProviders
-																	.filter((p) => p.name)
-																	.map((provider, index) => (
-																		<SelectItem key={`custom-${index}`} value={provider.name}>
-																			<RenderProviderIcon
-																				provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
-																				size="sm"
-																				className="h-4 w-4"
-																			/>
-																			{provider.name}
-																		</SelectItem>
-																	))}
-															</>
-														);
-													})()}
-												</SelectContent>
-											</Select>
-										</div>
-
-										{/* Provider Configurations Table */}
-										{providerConfigs.length > 0 && (
-											<div className="space-y-2.5">
-												{providerConfigs.map((config, index) => {
-													const providerConfig = availableProviders.find((provider) => provider.name === config.provider);
-													const providerLabel = providerConfig?.custom_provider_config
-														? providerConfig.name
-														: ProviderLabels[config.provider as ProviderName] || config.provider;
-													const iconProvider = (providerConfig?.custom_provider_config?.base_provider_type ||
-														config.provider) as ProviderIconType;
-													const providerKeys = availableKeys.filter((key) => key.provider === config.provider);
-													return (
-														<ProviderConfigCard
-															key={config.provider}
-															index={index}
-															testIdPrefix="vk"
-															providerLabel={providerLabel}
-															iconProvider={iconProvider}
-															providerKeys={providerKeys}
-															showModelBudgets
-															onRemove={() => handleRemoveProvider(index)}
-															value={{
-																providerName: config.provider,
-																allowedModels: config.allowed_models || [],
-																blacklistedModels: config.blacklisted_models || [],
-																weight: config.weight,
-																keyIds: config.key_ids || [],
-																budgets: config.budgets || [],
-																rateLimit: config.rate_limit ?? null,
-																modelBudgets: (config.model_budgets || []).map((mb) => ({
-																	model_name: mb.model_name,
-																	budgets: mb.budgets || [],
-																	rate_limit: mb.rate_limit,
-																})),
-															}}
-															onChange={(next) => {
-																const updated = [...providerConfigs];
-																updated[index] = {
-																	...config,
-																	allowed_models: next.allowedModels,
-																	blacklisted_models: next.blacklistedModels,
-																	weight: next.weight ?? undefined,
-																	key_ids: next.keyIds,
-																	budgets: next.budgets.map((l) => ({
-																		id: l.id,
-																		max_limit: l.max_limit,
-																		reset_duration: l.reset_duration,
-																		reset_config: l.reset_config,
-																	})),
-																	rate_limit: next.rateLimit ?? undefined,
-																	model_budgets: next.modelBudgets,
-																};
-																form.setValue("providerConfigs", updated, {
-																	shouldDirty: true,
-																});
-															}}
-														/>
-													);
-												})}
-											</div>
-										)}
-										{/* Display validation errors for provider configurations */}
-										{form.formState.errors.providerConfigs && (
-											<div className="text-destructive text-sm">{form.formState.errors.providerConfigs.message}</div>
-										)}
-									</div>
+									<ProviderConfigsEditor
+										testIdPrefix="vk"
+										value={providerConfigs.map((config) => ({
+											providerName: config.provider,
+											allowedModels: config.allowed_models || [],
+											blacklistedModels: config.blacklisted_models || [],
+											weight: config.weight,
+											keyIds: config.key_ids || [],
+											budgets: config.budgets || [],
+											rateLimit: config.rate_limit ?? null,
+											modelBudgets: (config.model_budgets || []).map((mb) => ({
+												model_name: mb.model_name,
+												budgets: mb.budgets || [],
+												rate_limit: mb.rate_limit,
+											})),
+										}))}
+										onChange={(entries) =>
+											form.setValue(
+												"providerConfigs",
+												entries.map((entry) => ({
+													provider: entry.providerName,
+													allowed_models: entry.allowedModels,
+													blacklisted_models: entry.blacklistedModels,
+													weight: entry.weight ?? undefined,
+													key_ids: entry.keyIds,
+													budgets: (entry.budgets || []).map((l) => ({
+														id: l.id,
+														max_limit: l.max_limit,
+														reset_duration: l.reset_duration,
+														reset_config: l.reset_config,
+													})),
+													rate_limit: entry.rateLimit ?? undefined,
+													model_budgets: entry.modelBudgets,
+												})),
+												{ shouldDirty: true },
+											)
+										}
+										allowAllProviders={allowAllProviders}
+										onAllowAllProvidersChange={(checked) => form.setValue("allowAllProviders", checked, { shouldDirty: true })}
+										onManageProviders={() => navigate({ to: "/workspace/providers" })}
+										error={form.formState.errors.providerConfigs?.message}
+									/>
 									{/* MCP Server Configurations */}
 									<MCPClientConfigsEditor
 										value={mcpConfigs}

--- a/ui/components/ui/providerConfigsEditor.tsx
+++ b/ui/components/ui/providerConfigsEditor.tsx
@@ -96,14 +96,18 @@ export function ProviderConfigsEditor({
 	// While on, keep a row for every available provider so each can be given
 	// budgets/limits or excluded. Providers added later show up here too. Keyed on
 	// the joined names, not the array identity, so it converges without looping.
+	// configuredKey re-runs the effect when the parent swaps `value` (e.g. loads a
+	// different entity) while the flag and provider list stay the same, so missing
+	// rows are backfilled; the missing-empty guard keeps it from looping.
 	const providerNamesKey = availableProviders.map((p) => p.name).join(" ");
+	const configuredKey = value.map((e) => e.providerName).join(" ");
 	useEffect(() => {
 		if (!allowAllProviders || availableProviders.length === 0) return;
 		const missing = availableProviders.filter((p) => p.name && !value.some((e) => e.providerName === p.name));
 		if (missing.length === 0) return;
 		onChange([...value, ...missing.map((p) => makeDefaultEntry(p.name))]);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [allowAllProviders, providerNamesKey]);
+	}, [allowAllProviders, providerNamesKey, configuredKey]);
 
 	const unconfiguredProviders = availableProviders.filter((provider) => !value.some((e) => e.providerName === provider.name));
 	const baseProviders = unconfiguredProviders.filter((p) => p.name && !p.custom_provider_config);

--- a/ui/components/ui/providerConfigsEditor.tsx
+++ b/ui/components/ui/providerConfigsEditor.tsx
@@ -1,0 +1,255 @@
+import { Label } from "@/components/ui/label";
+import { ProviderConfigCard, ProviderConfigCardValue } from "@/components/ui/providerConfigCard";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { ProviderIconType, RenderProviderIcon } from "@/lib/constants/icons";
+import { ProviderLabels, ProviderName } from "@/lib/constants/logs";
+import { useGetAllKeysQuery, useGetProvidersQuery } from "@/lib/store";
+import { KnownProvider } from "@/lib/types/config";
+import { Info } from "lucide-react";
+import { useEffect, useState } from "react";
+
+// Shared provider-configuration editor for the Virtual Key (core) and Access
+// Profile / Project (enterprise) forms. It owns the "Allow all providers" toggle,
+// the add-provider dropdown, and the per-provider cards; callers drive it with the
+// card's normalized ProviderConfigCardValue and adapt their own storage shape.
+export interface ProviderConfigsEditorProps {
+	value: ProviderConfigCardValue[];
+	onChange: (next: ProviderConfigCardValue[]) => void;
+	allowAllProviders: boolean;
+	onAllowAllProvidersChange: (checked: boolean) => void;
+	/** Prefix for data-testids, e.g. "vk" or "ap". */
+	testIdPrefix?: string;
+	/** Show the per-model budgets tree inside each card. Defaults to true. */
+	showModelBudgets?: boolean;
+	/** Read-only global provider cap per provider, shown on the Provider budget row. */
+	getGlobalProviderCap?: (providerName: string) => { max_limit: number; reset_duration?: string } | undefined;
+	/** When set, the "no providers left" dropdown row becomes a clickable link (e.g. route to provider management). */
+	onManageProviders?: () => void;
+	/** Validation error rendered under the list. */
+	error?: string;
+}
+
+// An unrestricted row: all models, all keys, no budgets/limits.
+const makeDefaultEntry = (providerName: string): ProviderConfigCardValue => ({
+	providerName,
+	allowedModels: ["*"],
+	blacklistedModels: [],
+	weight: undefined,
+	keyIds: ["*"],
+	budgets: [],
+	rateLimit: null,
+	modelBudgets: [],
+});
+
+// A row is "untouched" while it still carries only the defaults above, so turning
+// "Allow all providers" off can drop it while keeping customized rows.
+const isDefaultEntry = (e: ProviderConfigCardValue): boolean =>
+	(e.allowedModels || []).length === 1 &&
+	e.allowedModels?.[0] === "*" &&
+	(e.blacklistedModels || []).length === 0 &&
+	(e.keyIds || []).length === 1 &&
+	e.keyIds?.[0] === "*" &&
+	(e.budgets || []).length === 0 &&
+	!e.rateLimit &&
+	(e.modelBudgets || []).length === 0 &&
+	(e.weight === undefined || e.weight === null);
+
+export function ProviderConfigsEditor({
+	value,
+	onChange,
+	allowAllProviders,
+	onAllowAllProvidersChange,
+	testIdPrefix = "provider",
+	showModelBudgets = true,
+	getGlobalProviderCap,
+	onManageProviders,
+	error,
+}: ProviderConfigsEditorProps) {
+	const { data: providersData, isLoading: isLoadingProviders, isError: isProvidersError } = useGetProvidersQuery();
+	const { data: keysData } = useGetAllKeysQuery();
+	const availableProviders = providersData || [];
+	// null = the keys query is still loading or failed (the card keeps its key
+	// control visible); [] = loaded, none exist.
+	const availableKeys = keysData ?? null;
+	const [selectedProvider, setSelectedProvider] = useState("");
+
+	const handleAddProvider = (providerName: string) => {
+		if (!providerName || value.some((e) => e.providerName === providerName)) return;
+		onChange([...value, makeDefaultEntry(providerName)]);
+	};
+
+	const handleRemoveProvider = (index: number) => {
+		// Removing a provider while "Allow all providers" is on means "all except this
+		// one": turn the flag off so the remaining rows become the explicit allowlist.
+		if (allowAllProviders) onAllowAllProvidersChange(false);
+		onChange(value.filter((_, i) => i !== index));
+	};
+
+	const handleAllowAllChange = (checked: boolean) => {
+		onAllowAllProvidersChange(checked);
+		// Turning it off keeps customized rows and drops the untouched defaults.
+		if (!checked) onChange(value.filter((e) => !isDefaultEntry(e)));
+	};
+
+	// While on, keep a row for every available provider so each can be given
+	// budgets/limits or excluded. Providers added later show up here too. Keyed on
+	// the joined names, not the array identity, so it converges without looping.
+	const providerNamesKey = availableProviders.map((p) => p.name).join(" ");
+	useEffect(() => {
+		if (!allowAllProviders || availableProviders.length === 0) return;
+		const missing = availableProviders.filter((p) => p.name && !value.some((e) => e.providerName === p.name));
+		if (missing.length === 0) return;
+		onChange([...value, ...missing.map((p) => makeDefaultEntry(p.name))]);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [allowAllProviders, providerNamesKey]);
+
+	const unconfiguredProviders = availableProviders.filter((provider) => !value.some((e) => e.providerName === provider.name));
+	const baseProviders = unconfiguredProviders.filter((p) => p.name && !p.custom_provider_config);
+	const customProviders = unconfiguredProviders.filter((p) => p.name && p.custom_provider_config);
+
+	return (
+		<div className="space-y-2">
+			<div className="flex items-center gap-2">
+				<Label className="text-sm font-medium">Provider Configurations</Label>
+				<TooltipProvider>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<span>
+								<Info className="text-muted-foreground h-3 w-3" />
+							</span>
+						</TooltipTrigger>
+						<TooltipContent className="max-w-sm">
+							<p>
+								Configure which providers this can use and their specific settings. Leave empty to block all providers. Add providers to
+								allow them.
+							</p>
+						</TooltipContent>
+					</Tooltip>
+				</TooltipProvider>
+			</div>
+
+			{/* Allow all providers */}
+			<div className="flex w-full items-center justify-between gap-2 py-2 text-sm">
+				<div className="flex items-center gap-1.5">
+					<span>Allow all providers</span>
+					<TooltipProvider>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<span>
+									<Info className="text-muted-foreground h-3 w-3" />
+								</span>
+							</TooltipTrigger>
+							<TooltipContent className="max-w-sm">
+								<p>
+									Grant access to every provider, including ones added later. Set budgets or limits on specific providers below, or remove a
+									provider to allow all except that one.
+								</p>
+							</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				</div>
+				<Switch
+					checked={allowAllProviders}
+					onCheckedChange={handleAllowAllChange}
+					data-testid={`${testIdPrefix}-allow-all-providers-toggle`}
+				/>
+			</div>
+
+			{/* Add Provider Dropdown */}
+			<div className="flex gap-2">
+				<Select
+					value={selectedProvider}
+					onValueChange={(provider) => {
+						if (provider === "__manage_providers__") {
+							onManageProviders?.();
+							setSelectedProvider("");
+							return;
+						}
+						handleAddProvider(provider);
+						setSelectedProvider("");
+					}}
+				>
+					<SelectTrigger className="flex-1" data-testid={`${testIdPrefix}-provider-select`}>
+						<SelectValue placeholder="Select a provider to add" />
+					</SelectTrigger>
+					<SelectContent>
+						{isLoadingProviders ? (
+							<div className="text-muted-foreground px-2 py-1.5 text-sm">Loading providers...</div>
+						) : isProvidersError ? (
+							<div className="text-destructive px-2 py-1.5 text-sm">Failed to load providers. Please retry.</div>
+						) : unconfiguredProviders.length === 0 ? (
+							onManageProviders ? (
+								<SelectItem
+									value="__manage_providers__"
+									className="text-muted-foreground hover:text-foreground"
+									data-testid={`${testIdPrefix}-provider-config-link`}
+								>
+									<span>
+										No providers left to configure. <span className="text-primary font-medium underline">Click to add</span>
+									</span>
+								</SelectItem>
+							) : (
+								<div className="text-muted-foreground px-2 py-1.5 text-sm">No providers left to configure</div>
+							)
+						) : (
+							<>
+								{baseProviders.map((provider, index) => (
+									<SelectItem key={`base-${index}`} value={provider.name}>
+										<RenderProviderIcon provider={provider.name as KnownProvider} size="sm" className="h-4 w-4" />
+										{ProviderLabels[provider.name as ProviderName] || provider.name}
+									</SelectItem>
+								))}
+								{customProviders.map((provider, index) => (
+									<SelectItem key={`custom-${index}`} value={provider.name}>
+										<RenderProviderIcon
+											provider={provider.custom_provider_config?.base_provider_type || (provider.name as KnownProvider)}
+											size="sm"
+											className="h-4 w-4"
+										/>
+										{provider.name}
+									</SelectItem>
+								))}
+							</>
+						)}
+					</SelectContent>
+				</Select>
+			</div>
+
+			{/* Provider cards */}
+			{value.length > 0 && (
+				<div className="space-y-2.5">
+					{value.map((entry, index) => {
+						const providerConfig = availableProviders.find((provider) => provider.name === entry.providerName);
+						const providerLabel = providerConfig?.custom_provider_config
+							? providerConfig.name
+							: ProviderLabels[entry.providerName as ProviderName] || entry.providerName;
+						const iconProvider = (providerConfig?.custom_provider_config?.base_provider_type || entry.providerName) as ProviderIconType;
+						const providerKeys = availableKeys === null ? null : availableKeys.filter((key) => key.provider === entry.providerName);
+						return (
+							<ProviderConfigCard
+								key={entry.providerName}
+								index={index}
+								testIdPrefix={testIdPrefix}
+								providerLabel={providerLabel}
+								iconProvider={iconProvider}
+								providerKeys={providerKeys}
+								showModelBudgets={showModelBudgets}
+								globalProviderCap={getGlobalProviderCap?.(entry.providerName)}
+								onRemove={() => handleRemoveProvider(index)}
+								value={entry}
+								onChange={(next) => {
+									const updated = [...value];
+									updated[index] = next;
+									onChange(updated);
+								}}
+							/>
+						);
+					})}
+				</div>
+			)}
+			{error && <div className="text-destructive text-sm">{error}</div>}
+		</div>
+	);
+}

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -126,27 +126,30 @@ export const DefaultPerformanceConfig = {
 	buffer_size: 5000,
 } satisfies ConcurrencyAndBufferSize;
 
+// Each entry sets its own border to match its family; without it the badge
+// falls back to the default variant's border-primary (green), which clashes
+// on the red/amber/blue states.
 export const MCP_STATUS_COLORS: Record<string, string> = {
-	healthy: "bg-green-100 text-green-800",
-	error: "bg-red-100 text-red-800",
+	healthy: "bg-green-100 text-green-800 border-green-200",
+	error: "bg-red-100 text-red-800 border-red-200",
 	// Amber, not red/gray: Bifrost's own connection check most recently
 	// failed, but this is purely informational — nothing is gated on it, and
 	// it self-heals on the next successful check. Same mild treatment as
 	// pending_verification, deliberately distinct from needs_reauth's red
 	// ("action required").
-	unstable: "bg-yellow-100 text-yellow-800",
-	pending_verification: "bg-yellow-100 text-yellow-800",
-	disabled: "bg-orange-100 text-orange-800",
+	unstable: "bg-yellow-100 text-yellow-800 border-yellow-200",
+	pending_verification: "bg-yellow-100 text-yellow-800 border-yellow-200",
+	disabled: "bg-orange-100 text-orange-800 border-orange-200",
 	// Same red as `error`: the client's credential has died and it can't be
 	// used until a human reauthorizes it, mirroring the "destructive" treatment
 	// this status already gets on the MCP sessions table.
-	needs_reauth: "bg-red-100 text-red-800",
+	needs_reauth: "bg-red-100 text-red-800 border-red-200",
 	// Distinct blue/purple, not amber/red: unlike unstable, this isn't "one
 	// instance's check currently failing" — it's "instances disagree with
 	// each other about the state," which needs its own visual signal to
 	// prompt a look at the per-instance breakdown rather than being read as
 	// just another flavor of unhealthy.
-	degraded: "bg-blue-100 text-blue-800",
+	degraded: "bg-blue-100 text-blue-800 border-blue-200",
 };
 
 // Credential row statuses (the admin/shared OAuth token or the admin header
@@ -155,15 +158,15 @@ export const MCP_STATUS_COLORS: Record<string, string> = {
 // badge: green for usable, red for "a human must act", amber for
 // informational.
 export const MCP_CREDENTIAL_STATUS_COLORS: Record<string, string> = {
-	active: "bg-green-100 text-green-800",
-	needs_reauth: "bg-red-100 text-red-800",
-	needs_update: "bg-red-100 text-red-800",
-	orphaned: "bg-yellow-100 text-yellow-800",
+	active: "bg-green-100 text-green-800 border-green-200",
+	needs_reauth: "bg-red-100 text-red-800 border-red-200",
+	needs_update: "bg-red-100 text-red-800 border-red-200",
+	orphaned: "bg-yellow-100 text-yellow-800 border-yellow-200",
 	// Sessions table only: an OAuth flow that was started but not completed.
-	pending: "bg-gray-100 text-gray-800",
+	pending: "bg-gray-100 text-gray-800 border-gray-200",
 	// Fallback for a status value this build does not know. Neutral on
 	// purpose: an unrecognized status must not read as usable.
-	unknown: "bg-gray-100 text-gray-800",
+	unknown: "bg-gray-100 text-gray-800 border-gray-200",
 };
 
 // Mapping of what IS supported by each base provider


### PR DESCRIPTION
## Summary

Adds a "Virtual MCPs" section to the MCP client detail sheet's Access tab, showing which Virtual MCPs bundle that server's tools. Also cleans up the endpoint cell in the clients table by removing the `baseReady` loading gate and adding a tooltip, and fixes status badge border colors so they match their respective color families instead of falling back to the default green border.

## Changes

- **Virtual MCPs membership panel**: The MCP client sheet now queries the Virtual MCPs list and derives client-side which Virtual MCPs include the current server (by matching `tools[].mcp_client_id`). A table displays each matching Virtual MCP's name, endpoint slug, and exposed tool names. Disabled Virtual MCPs are marked with a "Disabled" badge. An empty state is shown when the server isn't part of any Virtual MCP.
- **Endpoint cell simplification**: Removed the `baseReady` / `coreConfigReady` gate that disabled copying until the core config resolved. The cell now always allows copying and wraps the slug in a `Tooltip` that shows the full path on hover. The copy icon fades in on row hover via `group-hover` to match the Virtual MCPs table style.
- **Badge border color fixes**: All entries in `MCP_STATUS_COLORS` and `MCP_CREDENTIAL_STATUS_COLORS` now include an explicit `border-*-200` class so each badge renders with a border that matches its own color family rather than inheriting the default variant's green border.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the MCP Registry and click into any MCP client's detail sheet.
2. Navigate to the **Access** tab and scroll to the **Virtual MCPs** section.
3. Verify that Virtual MCPs which include this server's tools are listed with their endpoint slug and exposed tool names.
4. Verify that a server not included in any Virtual MCP shows the empty state message.
5. Hover over an endpoint slug in the clients table and confirm the tooltip appears and the copy icon fades in on hover.
6. Confirm status badges across the MCP clients table and sessions table render with correctly colored borders (no green border on red/amber/blue states).

```sh
cd ui
pnpm i
pnpm build
```

## Screenshots/Recordings

_Add before/after screenshots of the Virtual MCPs panel and the corrected badge borders._

## Breaking changes

- [x] No

## Related issues

## Security considerations

Virtual MCP membership is derived entirely from data already returned by the existing Virtual MCPs list endpoint. No new permissions or data exposure is introduced.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable