### PR TITLE
feat(databricks): add Claude reasoning translation, image inlining, and Responses API fallback

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -505,6 +505,10 @@ func (account *ComprehensiveTestAccount) GetKeysForProvider(ctx context.Context,
 				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
 					WorkspaceURL: *schemas.NewSecretVar("env.DATABRICKS_WORKSPACE_URL"),
 				},
+				// Databricks has no batch surface. The flag is still required so the
+				// router hands batch and file requests to the provider, whose
+				// unsupported_operation answer is what the harness asserts on.
+				UseForBatchAPI: bifrost.Ptr(true),
 			},
 		}, nil
 	case schemas.GithubCopilot:

--- a/core/providers/databricks/databricks.go
+++ b/core/providers/databricks/databricks.go
@@ -67,6 +67,11 @@ type DatabricksProvider struct {
 	networkConfig       schemas.NetworkConfig // Network configuration including extra headers
 	sendBackRawRequest  bool                  // Whether to include raw request in BifrostResponse
 	sendBackRawResponse bool                  // Whether to include raw response in BifrostResponse
+
+	// responsesUnsupported records "<workspace host>|<model>" pairs whose Model Serving
+	// endpoint has declined the native Responses API, so those requests go straight to
+	// chat-completion emulation. See inference.go.
+	responsesUnsupported sync.Map
 }
 
 // NewDatabricksProvider creates a new Databricks provider instance.

--- a/core/providers/databricks/databricks_test.go
+++ b/core/providers/databricks/databricks_test.go
@@ -57,8 +57,9 @@ func TestDatabricks(t *testing.T) {
 			ImageBase64:           true,
 			CompleteEnd2End:       true,
 			Embedding:             true,
-			ListModels:            true,
 			Reasoning:             true,
+			// listModelsByKey intentionally returns nothing; the datasheet is the catalog.
+			ListModels: false,
 			// Text completions are not exposed by either Databricks surface.
 			TextCompletion:       false,
 			TextCompletionStream: false,
@@ -524,7 +525,8 @@ func TestDatabricksReasoningEffortFollowsDatasheet(t *testing.T) {
 // TestDatabricksChatParamsFollowDatasheet covers the rest of the parameter wiring. Bifrost's
 // neutral parameter set is wider than any single Databricks endpoint accepts, so each
 // optional field is gated on the datasheet record for the model rather than on a
-// provider-wide rule. A model the datasheet does not describe keeps every field.
+// provider-wide rule. A model the datasheet does not describe keeps every field except
+// parallel_tool_calls, which both surfaces reject and so is only sent when a row opts in.
 func TestDatabricksChatParamsFollowDatasheet(t *testing.T) {
 	sent := []string{
 		"temperature", "top_p", "top_k", "tool_choice", "parallel_tool_calls",
@@ -538,8 +540,14 @@ func TestDatabricksChatParamsFollowDatasheet(t *testing.T) {
 		wantDropped []string
 	}{
 		{
-			name:  "no datasheet row keeps every field",
-			model: "databricks-unknown-endpoint",
+			name:        "no datasheet row keeps every field but parallel_tool_calls",
+			model:       "databricks-unknown-endpoint",
+			wantDropped: []string{"parallel_tool_calls"},
+		},
+		{
+			name:  "supports_parallel_function_calling true keeps parallel_tool_calls",
+			model: "databricks-parallel-tools-endpoint",
+			caps:  &schemas.ModelCapabilities{SupportsParallelFunctionCalling: schemas.Ptr(true)},
 		},
 		{
 			// The shape of the real databricks/databricks-claude-opus-5 row: adaptive-only
@@ -547,13 +555,13 @@ func TestDatabricksChatParamsFollowDatasheet(t *testing.T) {
 			name:        "supports_sampling_params false drops temperature, top_p and top_k",
 			model:       "databricks-adaptive-endpoint",
 			caps:        &schemas.ModelCapabilities{SupportsSamplingParams: schemas.Ptr(false)},
-			wantDropped: []string{"temperature", "top_p", "top_k"},
+			wantDropped: []string{"temperature", "top_p", "top_k", "parallel_tool_calls"},
 		},
 		{
 			name:        "supports_tool_choice false drops the tool_choice pin",
 			model:       "databricks-no-tool-choice-endpoint",
 			caps:        &schemas.ModelCapabilities{SupportsToolChoice: schemas.Ptr(false)},
-			wantDropped: []string{"tool_choice"},
+			wantDropped: []string{"tool_choice", "parallel_tool_calls"},
 		},
 		{
 			name:        "supports_parallel_function_calling false drops parallel_tool_calls",
@@ -565,7 +573,7 @@ func TestDatabricksChatParamsFollowDatasheet(t *testing.T) {
 			name:        "supports_response_schema false drops response_format",
 			model:       "databricks-no-schema-endpoint",
 			caps:        &schemas.ModelCapabilities{SupportsResponseSchema: schemas.Ptr(false)},
-			wantDropped: []string{"response_format"},
+			wantDropped: []string{"response_format", "parallel_tool_calls"},
 		},
 		{
 			name:  "unsupported_fields drops stop and the penalties",
@@ -575,13 +583,13 @@ func TestDatabricksChatParamsFollowDatasheet(t *testing.T) {
 				schemas.FieldPresencePenalty:  true,
 				schemas.FieldFrequencyPenalty: true,
 			}},
-			wantDropped: []string{"stop", "presence_penalty", "frequency_penalty"},
+			wantDropped: []string{"stop", "presence_penalty", "frequency_penalty", "parallel_tool_calls"},
 		},
 		{
 			name:        "unsupported_fields top_p drops the sampling knobs",
 			model:       "databricks-no-top-p-endpoint",
 			caps:        &schemas.ModelCapabilities{UnsupportedFields: map[string]bool{schemas.FieldTopP: true}},
-			wantDropped: []string{"temperature", "top_p", "top_k"},
+			wantDropped: []string{"temperature", "top_p", "top_k", "parallel_tool_calls"},
 		},
 	}
 

--- a/core/providers/databricks/imageinlining.go
+++ b/core/providers/databricks/imageinlining.go
@@ -1,0 +1,188 @@
+package databricks
+
+import (
+	"fmt"
+	"mime"
+	"net/url"
+	"path"
+	"strings"
+
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// fetchAndEncodeURL is the download seam for image inlining. It is a variable so stub tests
+// can stand in for the network: providerUtils.FetchAndEncodeURL dials through the SSRF-safe
+// dialer, which rejects loopback unconditionally, so an httptest server is unreachable by
+// design (the same constraint documented in core/providers/openai/chatfileurl_test.go).
+var fetchAndEncodeURL = providerUtils.FetchAndEncodeURL
+
+// inlineChatImageURLs replaces every http(s) image_url in a chat request with a data URL,
+// fetching the bytes over HTTP. Databricks forwards image parts to the serving model as-is,
+// and the Claude-backed endpoints reject remote URLs with "Http data URLs are not supported
+// by Claude" (INVALID_PARAMETER_VALUE), so remote images have to be inlined before they
+// leave Bifrost. Bedrock and Anthropic-on-Vertex already do this for the same reason.
+//
+// Work on a copy: the original request may be reused by fallbacks and post-hooks. A failed
+// fetch aborts the request; a silently dropped image would produce a confidently wrong answer
+// about a picture the model never saw. URLs Bifrost cannot fetch (data:, file IDs) are left
+// untouched and the endpoint answers for itself.
+func inlineChatImageURLs(ctx *schemas.BifrostContext, request *schemas.BifrostChatRequest) (*schemas.BifrostChatRequest, *schemas.BifrostError) {
+	if request == nil || !chatRequestHasRemoteImage(request) {
+		return request, nil
+	}
+
+	requestCopy := *request
+	requestCopy.Input = make([]schemas.ChatMessage, len(request.Input))
+	copy(requestCopy.Input, request.Input)
+
+	for i := range requestCopy.Input {
+		message := &requestCopy.Input[i]
+		if message.Content == nil || len(message.Content.ContentBlocks) == 0 {
+			continue
+		}
+		contentCopy := *message.Content
+		contentCopy.ContentBlocks = make([]schemas.ChatContentBlock, len(message.Content.ContentBlocks))
+		copy(contentCopy.ContentBlocks, message.Content.ContentBlocks)
+		for j := range contentCopy.ContentBlocks {
+			block := &contentCopy.ContentBlocks[j]
+			if block.Type != schemas.ChatContentBlockTypeImage || block.ImageURLStruct == nil || !isRemoteHTTPURL(block.ImageURLStruct.URL) {
+				continue
+			}
+			dataURL, err := fetchImageAsDataURL(ctx, block.ImageURLStruct.URL)
+			if err != nil {
+				return nil, imageInliningError(err)
+			}
+			imageCopy := *block.ImageURLStruct
+			imageCopy.URL = dataURL
+			block.ImageURLStruct = &imageCopy
+		}
+		message.Content = &contentCopy
+	}
+	return &requestCopy, nil
+}
+
+// inlineResponsesImageURLs is inlineChatImageURLs for the native Responses surface, where an
+// input_image block carries the URL directly.
+func inlineResponsesImageURLs(ctx *schemas.BifrostContext, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesRequest, *schemas.BifrostError) {
+	if request == nil || !responsesRequestHasRemoteImage(request) {
+		return request, nil
+	}
+
+	requestCopy := *request
+	requestCopy.Input = make([]schemas.ResponsesMessage, len(request.Input))
+	copy(requestCopy.Input, request.Input)
+
+	for i := range requestCopy.Input {
+		message := &requestCopy.Input[i]
+		if message.Content == nil || len(message.Content.ContentBlocks) == 0 {
+			continue
+		}
+		contentCopy := *message.Content
+		contentCopy.ContentBlocks = make([]schemas.ResponsesMessageContentBlock, len(message.Content.ContentBlocks))
+		copy(contentCopy.ContentBlocks, message.Content.ContentBlocks)
+		for j := range contentCopy.ContentBlocks {
+			block := &contentCopy.ContentBlocks[j]
+			if !responsesBlockHasRemoteImage(block) {
+				continue
+			}
+			dataURL, err := fetchImageAsDataURL(ctx, *block.ResponsesInputMessageContentBlockImage.ImageURL)
+			if err != nil {
+				return nil, imageInliningError(err)
+			}
+			imageCopy := *block.ResponsesInputMessageContentBlockImage
+			imageCopy.ImageURL = schemas.Ptr(dataURL)
+			block.ResponsesInputMessageContentBlockImage = &imageCopy
+		}
+		message.Content = &contentCopy
+	}
+	return &requestCopy, nil
+}
+
+func chatRequestHasRemoteImage(request *schemas.BifrostChatRequest) bool {
+	for _, message := range request.Input {
+		if message.Content == nil {
+			continue
+		}
+		for _, block := range message.Content.ContentBlocks {
+			if block.Type == schemas.ChatContentBlockTypeImage && block.ImageURLStruct != nil && isRemoteHTTPURL(block.ImageURLStruct.URL) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func responsesRequestHasRemoteImage(request *schemas.BifrostResponsesRequest) bool {
+	for _, message := range request.Input {
+		if message.Content == nil {
+			continue
+		}
+		for i := range message.Content.ContentBlocks {
+			if responsesBlockHasRemoteImage(&message.Content.ContentBlocks[i]) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func responsesBlockHasRemoteImage(block *schemas.ResponsesMessageContentBlock) bool {
+	return block.Type == schemas.ResponsesInputMessageContentBlockTypeImage &&
+		block.ResponsesInputMessageContentBlockImage != nil &&
+		block.ResponsesInputMessageContentBlockImage.ImageURL != nil &&
+		isRemoteHTTPURL(*block.ResponsesInputMessageContentBlockImage.ImageURL)
+}
+
+// isRemoteHTTPURL reports whether raw is something Bifrost can download. data: URLs are
+// already inline and anything else (a file ID, an unsupported scheme) is not ours to judge.
+func isRemoteHTTPURL(raw string) bool {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	return scheme == "http" || scheme == "https"
+}
+
+// fetchImageAsDataURL downloads resourceURL and returns it as a data URL. Content-Type wins
+// over the URL extension, but servers commonly answer with a generic octet-stream, so the
+// extension is the fallback; with neither the endpoint reports the media-type error itself.
+func fetchImageAsDataURL(ctx *schemas.BifrostContext, resourceURL string) (string, error) {
+	mediaType, encoded, err := fetchAndEncodeURL(ctx, resourceURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to inline image URL %q: %w", providerUtils.RedactURLForError(resourceURL), err)
+	}
+	if parsed, _, parseErr := mime.ParseMediaType(mediaType); parseErr == nil {
+		mediaType = strings.ToLower(parsed)
+	}
+	if mediaType == "" || mediaType == "application/octet-stream" {
+		mediaType = imageMediaTypeFromURL(resourceURL)
+	}
+	return "data:" + mediaType + ";base64," + encoded, nil
+}
+
+func imageMediaTypeFromURL(resourceURL string) string {
+	if parsed, err := url.Parse(resourceURL); err == nil {
+		if ext := path.Ext(parsed.Path); ext != "" {
+			if byExt, _, err := mime.ParseMediaType(mime.TypeByExtension(ext)); err == nil && byExt != "" {
+				return strings.ToLower(byExt)
+			}
+		}
+	}
+	return "application/octet-stream"
+}
+
+// imageInliningError surfaces a fetch failure as a client-visible 400: the request as written
+// cannot be served, and the caller can fix the URL. The message carries the redacted URL only.
+func imageInliningError(err error) *schemas.BifrostError {
+	return &schemas.BifrostError{
+		IsBifrostError: false,
+		StatusCode:     schemas.Ptr(400),
+		Error: &schemas.ErrorField{
+			Type:    schemas.Ptr("invalid_request_error"),
+			Message: err.Error(),
+			Error:   err,
+		},
+	}
+}

--- a/core/providers/databricks/imageinlining_test.go
+++ b/core/providers/databricks/imageinlining_test.go
@@ -1,0 +1,184 @@
+package databricks
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// stubFetcher replaces the network for the duration of a test. Tests that install it must
+// not run in parallel with each other: the seam is a package variable.
+func stubFetcher(t *testing.T, mediaType, encoded string, err error) *[]string {
+	t.Helper()
+	var fetched []string
+	previous := fetchAndEncodeURL
+	fetchAndEncodeURL = func(_ context.Context, resourceURL string) (string, string, error) {
+		fetched = append(fetched, resourceURL)
+		return mediaType, encoded, err
+	}
+	t.Cleanup(func() { fetchAndEncodeURL = previous })
+	return &fetched
+}
+
+func chatImageRequest(urls ...string) *schemas.BifrostChatRequest {
+	blocks := []schemas.ChatContentBlock{{Type: schemas.ChatContentBlockTypeText, Text: schemas.Ptr("what is this?")}}
+	for _, u := range urls {
+		blocks = append(blocks, schemas.ChatContentBlock{
+			Type:           schemas.ChatContentBlockTypeImage,
+			ImageURLStruct: &schemas.ChatInputImage{URL: u, Detail: schemas.Ptr("high")},
+		})
+	}
+	return &schemas.BifrostChatRequest{
+		Provider: schemas.Databricks,
+		Model:    "databricks-claude-sonnet-4-5",
+		Input: []schemas.ChatMessage{
+			{Role: schemas.ChatMessageRoleSystem, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("be brief")}},
+			{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentBlocks: blocks}},
+		},
+	}
+}
+
+func responsesImageRequest(urls ...string) *schemas.BifrostResponsesRequest {
+	blocks := []schemas.ResponsesMessageContentBlock{{Type: schemas.ResponsesInputMessageContentBlockTypeText, Text: schemas.Ptr("what is this?")}}
+	for _, u := range urls {
+		blocks = append(blocks, schemas.ResponsesMessageContentBlock{
+			Type:                                   schemas.ResponsesInputMessageContentBlockTypeImage,
+			ResponsesInputMessageContentBlockImage: &schemas.ResponsesInputMessageContentBlockImage{ImageURL: schemas.Ptr(u)},
+		})
+	}
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.Databricks,
+		Model:    "databricks-claude-sonnet-4-5",
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentBlocks: blocks},
+		}},
+	}
+}
+
+// TestInlineChatImageURLs reproduces the live rejection "Http data URLs are not supported by
+// Claude": a remote image must reach Databricks as a data URL, a data URL is left alone, and
+// the caller's request is not mutated.
+func TestInlineChatImageURLs(t *testing.T) {
+	fetched := stubFetcher(t, "image/png", "AAAA", nil)
+
+	const remote = "https://example.com/cat.png?sig=secret"
+	const inline = "data:image/jpeg;base64,BBBB"
+	original := chatImageRequest(remote, inline)
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 0)
+	defer cancel()
+	got, bErr := inlineChatImageURLs(ctx, original)
+	if bErr != nil {
+		t.Fatalf("inlineChatImageURLs returned an error: %v", bErr)
+	}
+
+	if len(*fetched) != 1 || (*fetched)[0] != remote {
+		t.Errorf("fetched URLs: got %v, want [%s]", *fetched, remote)
+	}
+	blocks := got.Input[1].Content.ContentBlocks
+	if want := "data:image/png;base64,AAAA"; blocks[1].ImageURLStruct.URL != want {
+		t.Errorf("remote image: got %q, want %q", blocks[1].ImageURLStruct.URL, want)
+	}
+	if blocks[1].ImageURLStruct.Detail == nil || *blocks[1].ImageURLStruct.Detail != "high" {
+		t.Error("inlining dropped the image detail hint")
+	}
+	if blocks[2].ImageURLStruct.URL != inline {
+		t.Errorf("data URL was rewritten: got %q", blocks[2].ImageURLStruct.URL)
+	}
+	if got.Input[0].Content.ContentStr == nil || *got.Input[0].Content.ContentStr != "be brief" {
+		t.Error("string-content message was not carried over")
+	}
+	if original.Input[1].Content.ContentBlocks[1].ImageURLStruct.URL != remote {
+		t.Error("inlining mutated the original request")
+	}
+}
+
+// TestInlineChatImageURLsNoRemoteImagesIsPassthrough pins that a request without a remote
+// image is returned as-is: no copy, no fetch.
+func TestInlineChatImageURLsNoRemoteImagesIsPassthrough(t *testing.T) {
+	fetched := stubFetcher(t, "", "", errors.New("must not be called"))
+
+	original := chatImageRequest("data:image/png;base64,AAAA")
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 0)
+	defer cancel()
+	got, bErr := inlineChatImageURLs(ctx, original)
+	if bErr != nil {
+		t.Fatalf("inlineChatImageURLs returned an error: %v", bErr)
+	}
+	if got != original {
+		t.Error("a request with nothing to inline must be returned unchanged")
+	}
+	if len(*fetched) != 0 {
+		t.Errorf("fetcher was called for %v", *fetched)
+	}
+}
+
+// TestInlineChatImageURLsFetchFailureIsClientError pins that a fetch failure aborts the
+// request with a 400 that names the URL by its redacted form only.
+func TestInlineChatImageURLsFetchFailureIsClientError(t *testing.T) {
+	stubFetcher(t, "", "", errors.New("dial tcp: i/o timeout"))
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 0)
+	defer cancel()
+	_, bErr := inlineChatImageURLs(ctx, chatImageRequest("https://example.com/cat.png?X-Amz-Signature=secret"))
+	if bErr == nil {
+		t.Fatal("inlineChatImageURLs succeeded, want an error")
+	}
+	if bErr.StatusCode == nil || *bErr.StatusCode != 400 {
+		t.Errorf("status: got %v, want 400", bErr.StatusCode)
+	}
+	if strings.Contains(bErr.Error.Message, "secret") {
+		t.Errorf("error leaks the URL query: %q", bErr.Error.Message)
+	}
+	if !strings.Contains(bErr.Error.Message, "i/o timeout") {
+		t.Errorf("error lost the cause: %q", bErr.Error.Message)
+	}
+}
+
+// TestInlineChatImageURLsFallsBackToExtension covers a server answering octet-stream for a
+// PNG: the extension decides the media type.
+func TestInlineChatImageURLsFallsBackToExtension(t *testing.T) {
+	stubFetcher(t, "application/octet-stream", "AAAA", nil)
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 0)
+	defer cancel()
+	got, bErr := inlineChatImageURLs(ctx, chatImageRequest("https://example.com/cat.PNG"))
+	if bErr != nil {
+		t.Fatalf("inlineChatImageURLs returned an error: %v", bErr)
+	}
+	if want := "data:image/png;base64,AAAA"; got.Input[1].Content.ContentBlocks[1].ImageURLStruct.URL != want {
+		t.Errorf("got %q, want %q", got.Input[1].Content.ContentBlocks[1].ImageURLStruct.URL, want)
+	}
+}
+
+// TestInlineResponsesImageURLs is the native Responses surface counterpart.
+func TestInlineResponsesImageURLs(t *testing.T) {
+	fetched := stubFetcher(t, "image/jpeg; charset=binary", "CCCC", nil)
+
+	const remote = "http://example.com/dog.jpg"
+	original := responsesImageRequest(remote, "data:image/png;base64,AAAA")
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 0)
+	defer cancel()
+	got, bErr := inlineResponsesImageURLs(ctx, original)
+	if bErr != nil {
+		t.Fatalf("inlineResponsesImageURLs returned an error: %v", bErr)
+	}
+	if len(*fetched) != 1 || (*fetched)[0] != remote {
+		t.Errorf("fetched URLs: got %v, want [%s]", *fetched, remote)
+	}
+	blocks := got.Input[0].Content.ContentBlocks
+	if want := "data:image/jpeg;base64,CCCC"; *blocks[1].ImageURL != want {
+		t.Errorf("remote image: got %q, want %q", *blocks[1].ImageURL, want)
+	}
+	if *blocks[2].ImageURL != "data:image/png;base64,AAAA" {
+		t.Errorf("data URL was rewritten: got %q", *blocks[2].ImageURL)
+	}
+	if *original.Input[0].Content.ContentBlocks[1].ImageURL != remote {
+		t.Error("inlining mutated the original request")
+	}
+}

--- a/core/providers/databricks/inference.go
+++ b/core/providers/databricks/inference.go
@@ -5,10 +5,13 @@ package databricks
 import (
 	"context"
 	"maps"
+	"strings"
 
+	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/openai"
 	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/valyala/fasthttp"
 )
 
 // paramSupport records which optional wire fields the resolved model accepts. Bifrost's
@@ -19,7 +22,7 @@ import (
 //
 // Every fallback is "keep the field": a workspace can serve a model the datasheet has never
 // heard of, and a silent drop is worse than an upstream error the caller can read.
-// reasoning_effort is the exception — see resolveParamSupport.
+// reasoning_effort and parallel_tool_calls are the exceptions — see resolveParamSupport.
 type paramSupport struct {
 	reasoningEffort   bool // reasoning_effort
 	samplingParams    bool // temperature, top_p, top_k
@@ -29,6 +32,12 @@ type paramSupport struct {
 	stop              bool // stop
 	presencePenalty   bool // presence_penalty
 	frequencyPenalty  bool // frequency_penalty
+
+	// anthropicThinking marks a Claude-backed endpoint, which takes reasoning as a "thinking"
+	// object instead of reasoning_effort (see reasoning.go). adaptiveOnlyThinking narrows that
+	// to the models that have dropped budget_tokens.
+	anthropicThinking    bool
+	adaptiveOnlyThinking bool
 }
 
 // resolveParamSupport reads the datasheet record for the model behind a Databricks endpoint
@@ -45,17 +54,23 @@ func resolveParamSupport(ctx *schemas.BifrostContext, model string) paramSupport
 	canonicalModel := schemas.ResolveCanonicalModel(ctx, model)
 	caps := schemas.ResolveModelCaps(schemas.Databricks, canonicalModel)
 
+	isAnthropic := schemas.IsAnthropicModelFamily(ctx, canonicalModel)
 	effortFallback := caps.PublishesParameter(schemas.FieldReasoningEffort) ||
-		(caps.SupportsReasoning(false) && !schemas.IsAnthropicModelFamily(ctx, canonicalModel))
+		(caps.SupportsReasoning(false) && !isAnthropic)
 
 	return paramSupport{
+		anthropicThinking:    isAnthropic,
+		adaptiveOnlyThinking: caps.AdaptiveOnlyThinking(anthropic.DefaultAdaptiveOnlyThinking(canonicalModel)),
 		reasoningEffort: !caps.FieldUnsupported(schemas.FieldReasoningEffort,
 			!caps.SupportsReasoningEffort(effortFallback)),
 		// supports_sampling_params is false on the adaptive-only Claude models
 		// (Opus 4.7+, Sonnet 5+, Fable), which 400 on temperature/top_p/top_k.
-		samplingParams:    caps.SupportsSamplingParams(!caps.FieldUnsupported(schemas.FieldTopP, false)),
-		toolChoice:        caps.SupportsToolChoice(true),
-		parallelToolCalls: caps.SupportsParallelFunctionCalling(true),
+		samplingParams: caps.SupportsSamplingParams(!caps.FieldUnsupported(schemas.FieldTopP, false)),
+		toolChoice:     caps.SupportsToolChoice(true),
+		// Both surfaces reject parallel_tool_calls outright ("Extra inputs are not
+		// permitted" on Model Serving, "unknown field" on the AI Gateway), so a model
+		// with no datasheet row must not send it. A row that says otherwise still wins.
+		parallelToolCalls: caps.SupportsParallelFunctionCalling(false),
 		responseSchema:    caps.SupportsResponseSchema(true),
 		stop:              !caps.FieldUnsupported(schemas.FieldStop, false),
 		presencePenalty:   !caps.FieldUnsupported(schemas.FieldPresencePenalty, false),
@@ -97,6 +112,14 @@ func stripUnsupportedChatFields(ctx *schemas.BifrostContext, request *schemas.Bi
 	dropPresencePenalty := !support.presencePenalty && params.PresencePenalty != nil
 	dropFrequencyPenalty := !support.frequencyPenalty && params.FrequencyPenalty != nil
 
+	// A Claude-backed endpoint does not lose the reasoning request when reasoning_effort is
+	// dropped: it is re-expressed as the "thinking" object the endpoint does accept.
+	var thinking map[string]any
+	var thinkingMaxTokens *int
+	if dropReasoningEffort {
+		thinking, thinkingMaxTokens = thinkingParam(support, params)
+	}
+
 	if !dropAnthropicFields && !dropReasoningEffort && !dropSamplingParams && !dropToolChoice &&
 		!dropParallelToolCalls && !dropResponseFormat && !dropStop && !dropPresencePenalty &&
 		!dropFrequencyPenalty {
@@ -105,6 +128,16 @@ func stripUnsupportedChatFields(ctx *schemas.BifrostContext, request *schemas.Bi
 
 	requestCopy := *request
 	paramsCopy := *params
+	if thinking != nil {
+		paramsCopy.ExtraParams = maps.Clone(paramsCopy.ExtraParams)
+		if paramsCopy.ExtraParams == nil {
+			paramsCopy.ExtraParams = map[string]any{}
+		}
+		paramsCopy.ExtraParams["thinking"] = thinking
+		if thinkingMaxTokens != nil {
+			paramsCopy.MaxCompletionTokens = thinkingMaxTokens
+		}
+	}
 	if dropAnthropicFields {
 		paramsCopy.ContextManagement = nil
 		paramsCopy.CacheControl = nil
@@ -233,6 +266,10 @@ func stripUnsupportedResponsesFields(ctx *schemas.BifrostContext, request *schem
 // ChatCompletion performs a chat completion request against the resolved Databricks surface.
 func (provider *DatabricksProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	request = stripUnsupportedChatFields(ctx, request)
+	request, bErr := inlineChatImageURLs(ctx, request)
+	if bErr != nil {
+		return nil, bErr
+	}
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/chat/completions")
 	if bErr != nil {
 		return nil, bErr
@@ -247,7 +284,7 @@ func (provider *DatabricksProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
 		providerUtils.ShouldSendBackRawResponse(ctx, provider.sendBackRawResponse),
 		provider.GetProviderKey(),
-		nil,
+		chatResponseHandler,
 		parseDatabricksError,
 		nil,
 		provider.logger,
@@ -258,6 +295,10 @@ func (provider *DatabricksProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 // Databricks surface. Both surfaces emit OpenAI-shaped Server-Sent Events.
 func (provider *DatabricksProvider) ChatCompletionStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostChatRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	request = stripUnsupportedChatFields(ctx, request)
+	request, bErr := inlineChatImageURLs(ctx, request)
+	if bErr != nil {
+		return nil, bErr
+	}
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/chat/completions")
 	if bErr != nil {
 		return nil, bErr
@@ -275,7 +316,7 @@ func (provider *DatabricksProvider) ChatCompletionStream(ctx *schemas.BifrostCon
 		provider.GetProviderKey(),
 		postHookRunner,
 		nil,
-		nil,
+		chatResponseHandler,
 		parseDatabricksError,
 		chatStreamOptionsFixup(request.Model),
 		nil,
@@ -307,28 +348,37 @@ func (provider *DatabricksProvider) Embedding(ctx *schemas.BifrostContext, key s
 	)
 }
 
-// Responses performs a responses request. Model Serving exposes the OpenAI Responses API
-// natively at /serving-endpoints/responses. The Unity AI Gateway MLflow surface is chat-only,
-// so there the request is emulated through chat completions.
+// Responses performs a responses request. Model Serving documents the OpenAI Responses API
+// at /serving-endpoints/responses, but pay-per-token foundation model endpoints answer it
+// with "Responses API passthrough is not supported" (HTTP 400). The Unity AI Gateway MLflow
+// surface has no Responses route at all. In both cases the request is emulated through chat
+// completions; see emulateResponses for the rule.
 func (provider *DatabricksProvider) Responses(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
-	if resolveAPIFormat(key, request.Model) == schemas.DatabricksAPIFormatAIGateway {
+	emulate := func() (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 		chatResponse, bErr := provider.ChatCompletion(ctx, key, request.ToChatRequest())
 		if bErr != nil {
 			return nil, bErr
 		}
 		return chatResponse.ToBifrostResponsesResponse(), nil
 	}
+	if provider.emulateResponses(key, request.Model) {
+		return emulate()
+	}
 
-	request = stripUnsupportedResponsesFields(ctx, request)
-	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/responses")
+	wireRequest := stripUnsupportedResponsesFields(ctx, request)
+	wireRequest, bErr := inlineResponsesImageURLs(ctx, wireRequest)
 	if bErr != nil {
 		return nil, bErr
 	}
-	return openai.HandleOpenAIResponsesRequest(
+	url, auth, bErr := provider.prepareRequest(ctx, key, wireRequest.Model, "/responses")
+	if bErr != nil {
+		return nil, bErr
+	}
+	response, bErr := openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.client,
 		url,
-		request,
+		wireRequest,
 		auth,
 		provider.networkConfig.ExtraHeaders,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -339,26 +389,39 @@ func (provider *DatabricksProvider) Responses(ctx *schemas.BifrostContext, key s
 		nil,
 		provider.logger,
 	)
+	if bErr != nil && isResponsesPassthroughUnsupported(bErr) {
+		provider.markResponsesUnsupported(key, request.Model)
+		return emulate()
+	}
+	return response, bErr
 }
 
 // ResponsesStream performs a streaming responses request. See Responses for how the two
-// surfaces differ.
+// surfaces differ. The native call fails before any chunk is produced when the endpoint
+// rejects the surface, so retrying through chat is safe: nothing has reached the caller.
 func (provider *DatabricksProvider) ResponsesStream(ctx *schemas.BifrostContext, postHookRunner schemas.PostHookRunner, postHookSpanFinalizer func(context.Context), key schemas.Key, request *schemas.BifrostResponsesRequest) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
-	if resolveAPIFormat(key, request.Model) == schemas.DatabricksAPIFormatAIGateway {
+	emulate := func() (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 		ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
 		return provider.ChatCompletionStream(ctx, postHookRunner, postHookSpanFinalizer, key, request.ToChatRequest())
 	}
+	if provider.emulateResponses(key, request.Model) {
+		return emulate()
+	}
 
-	request = stripUnsupportedResponsesFields(ctx, request)
-	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/responses")
+	wireRequest := stripUnsupportedResponsesFields(ctx, request)
+	wireRequest, bErr := inlineResponsesImageURLs(ctx, wireRequest)
 	if bErr != nil {
 		return nil, bErr
 	}
-	return openai.HandleOpenAIResponsesStreaming(
+	url, auth, bErr := provider.prepareRequest(ctx, key, wireRequest.Model, "/responses")
+	if bErr != nil {
+		return nil, bErr
+	}
+	stream, bErr := openai.HandleOpenAIResponsesStreaming(
 		ctx,
 		provider.streamingClient,
 		url,
-		request,
+		wireRequest,
 		auth,
 		provider.networkConfig.ExtraHeaders,
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
@@ -374,4 +437,54 @@ func (provider *DatabricksProvider) ResponsesStream(ctx *schemas.BifrostContext,
 		provider.logger,
 		postHookSpanFinalizer,
 	)
+	if bErr != nil && isResponsesPassthroughUnsupported(bErr) {
+		provider.markResponsesUnsupported(key, request.Model)
+		return emulate()
+	}
+	return stream, bErr
+}
+
+// responsesPassthroughUnsupportedMarker is the fragment of the 400 body a Model Serving
+// endpoint returns when it does not expose the Responses surface for the model.
+const responsesPassthroughUnsupportedMarker = "responses api passthrough is not supported"
+
+// isResponsesPassthroughUnsupported reports whether an upstream error is the endpoint
+// declining the Responses surface, as opposed to rejecting this particular request.
+func isResponsesPassthroughUnsupported(bErr *schemas.BifrostError) bool {
+	if bErr == nil || bErr.Error == nil {
+		return false
+	}
+	if bErr.StatusCode != nil && *bErr.StatusCode != fasthttp.StatusBadRequest {
+		return false
+	}
+	return strings.Contains(strings.ToLower(bErr.Error.Message), responsesPassthroughUnsupportedMarker)
+}
+
+// emulateResponses decides whether a Responses request is served through chat completions
+// without trying the native route first: always on the AI Gateway, and on Model Serving once
+// the endpoint has declined the surface for this workspace and model.
+func (provider *DatabricksProvider) emulateResponses(key schemas.Key, model string) bool {
+	if resolveAPIFormat(key, model) == schemas.DatabricksAPIFormatAIGateway {
+		return true
+	}
+	_, unsupported := provider.responsesUnsupported.Load(provider.responsesCacheKey(key, model))
+	return unsupported
+}
+
+// markResponsesUnsupported remembers that the native Responses route declined a model so
+// later requests skip the failing round trip. The decision is per workspace host and model
+// because the same endpoint name can be served differently on different workspaces.
+func (provider *DatabricksProvider) markResponsesUnsupported(key schemas.Key, model string) {
+	cacheKey := provider.responsesCacheKey(key, model)
+	if _, loaded := provider.responsesUnsupported.LoadOrStore(cacheKey, struct{}{}); !loaded {
+		provider.logger.Info("[databricks] native Responses API declined for %s; emulating through chat completions from now on", cacheKey)
+	}
+}
+
+func (provider *DatabricksProvider) responsesCacheKey(key schemas.Key, model string) string {
+	host, bErr := provider.resolveWorkspaceHost(key)
+	if bErr != nil {
+		host = ""
+	}
+	return host + "|" + model
 }

--- a/core/providers/databricks/reasoning.go
+++ b/core/providers/databricks/reasoning.go
@@ -1,0 +1,238 @@
+package databricks
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/maximhq/bifrost/core/providers/anthropic"
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
+	schemas "github.com/maximhq/bifrost/core/schemas"
+	"github.com/tidwall/gjson"
+	"github.com/tidwall/sjson"
+)
+
+// Claude-backed Databricks endpoints reason through Anthropic's own knob. They reject
+// reasoning_effort ("Extra inputs are not permitted") and instead accept a "thinking" object
+// on the OpenAI-shaped request, exactly as the native Anthropic API spells it:
+//
+//	{"thinking": {"type": "enabled", "budget_tokens": N}}   // budget models
+//	{"thinking": {"type": "adaptive"}}                       // adaptive-only models
+//
+// with the hard rule that max_tokens must exceed budget_tokens. Every model, Claude or not,
+// then answers with reasoning as a content block rather than a top-level field:
+//
+//	"content": [{"type": "reasoning", "summary": [{"type": "summary_text", "text": "...", "signature": "..."}]},
+//	            {"type": "text", "text": "..."}]
+//
+// Streaming deltas carry the same block shape for the thinking phase and a plain string for
+// the answer. Neither shape is something Bifrost's OpenAI-shaped parser models (delta.content
+// is a string there), so the request is translated on the way out and the response is
+// normalised on the way in.
+
+// thinkingParam builds the "thinking" extra param for a Claude-backed endpoint from the
+// neutral reasoning parameters. It returns nil when nothing should be sent. maxTokens is the
+// max_completion_tokens the request should carry to satisfy the budget rule, or nil to leave
+// the caller's value alone.
+func thinkingParam(support paramSupport, params *schemas.ChatParameters) (thinking map[string]any, maxTokens *int) {
+	if params == nil || !support.anthropicThinking {
+		return nil, nil
+	}
+	if _, callerSet := params.ExtraParams["thinking"]; callerSet {
+		// The caller spoke Databricks' dialect directly; it passes through untouched.
+		return nil, nil
+	}
+
+	var effort string
+	var budget *int
+	var enabled *bool
+	if params.Reasoning != nil {
+		if params.Reasoning.Effort != nil {
+			effort = *params.Reasoning.Effort
+		}
+		budget = params.Reasoning.MaxTokens
+		enabled = params.Reasoning.Enabled
+	}
+	if effort == "" {
+		if raw, ok := params.ExtraParams["reasoning_effort"].(string); ok {
+			effort = raw
+		}
+	}
+	// An explicit enabled flag wins over effort and budget: false sends nothing, true turns
+	// thinking on even when the other knobs say otherwise, at the model's default budget when
+	// none is given.
+	switch {
+	case enabled != nil && !*enabled:
+		return nil, nil
+	case enabled != nil && *enabled:
+		if effort == "none" {
+			effort = ""
+		}
+	case effort == "none" || (effort == "" && budget == nil):
+		return nil, nil
+	}
+
+	if support.adaptiveOnlyThinking {
+		thinking = map[string]any{"type": "adaptive"}
+		// thinking.display ("summarized" | "omitted") is an adaptive-thinking option; it
+		// controls whether the reasoning is returned, not whether it happens.
+		if params.Reasoning != nil && params.Reasoning.Display != nil && *params.Reasoning.Display != "" {
+			thinking["display"] = *params.Reasoning.Display
+		}
+		return thinking, nil
+	}
+
+	budgetTokens := 0
+	switch {
+	case budget != nil && *budget > 0:
+		budgetTokens = *budget
+	default:
+		// -1 asks for a dynamic budget, which Claude does not offer; an effort label is
+		// scaled against the output ceiling the same way the Anthropic provider does.
+		ceiling := anthropic.AnthropicDefaultMaxTokens
+		if params.MaxCompletionTokens != nil && *params.MaxCompletionTokens > 0 {
+			ceiling = *params.MaxCompletionTokens
+		}
+		if effort == "" {
+			budgetTokens = anthropic.MinimumReasoningMaxTokens
+		} else if computed, err := providerUtils.GetBudgetTokensFromReasoningEffort(effort, anthropic.MinimumReasoningMaxTokens, ceiling); err == nil {
+			budgetTokens = computed
+		} else {
+			budgetTokens = anthropic.MinimumReasoningMaxTokens
+		}
+	}
+	if budgetTokens < anthropic.MinimumReasoningMaxTokens {
+		budgetTokens = anthropic.MinimumReasoningMaxTokens
+	}
+
+	thinking = map[string]any{"type": "enabled", "budget_tokens": budgetTokens}
+
+	// max_tokens must be greater than budget_tokens. When the caller set no ceiling, give
+	// the answer the same room the Anthropic provider defaults to on top of the budget. An
+	// explicit ceiling below the budget is the caller's contradiction and is left for the
+	// endpoint to report, as the native Anthropic API would.
+	if params.MaxCompletionTokens == nil || *params.MaxCompletionTokens <= 0 {
+		maxTokens = schemas.Ptr(budgetTokens + anthropic.AnthropicDefaultMaxTokens)
+	} else if budget == nil && *params.MaxCompletionTokens <= budgetTokens {
+		// Effort was scaled against the caller's ceiling; "max" lands exactly on it. A
+		// ceiling too small to fit the minimum budget cannot carry thinking at all, and
+		// an effort label is a preference rather than a contract, so it is omitted.
+		fitted := *params.MaxCompletionTokens - 1
+		if fitted < anthropic.MinimumReasoningMaxTokens {
+			return nil, nil
+		}
+		thinking["budget_tokens"] = fitted
+	}
+	return thinking, maxTokens
+}
+
+// chatResponseHandler parses a Databricks chat completion (or stream event) after lifting
+// reasoning content blocks into Bifrost's reasoning fields. It stands in for the shared
+// handler's default parse; raw request/response capture is preserved with the upstream
+// bytes, not the normalised ones.
+func chatResponseHandler(responseBody []byte, response *schemas.BifrostChatResponse, requestBody []byte, sendBackRawRequest bool, sendBackRawResponse bool) (rawRequest interface{}, rawResponse interface{}, bErr *schemas.BifrostError) {
+	rawRequest, _, bErr = providerUtils.HandleProviderResponse(normalizeReasoningBlocks(responseBody), response, requestBody, sendBackRawRequest, false)
+	if bErr != nil {
+		return nil, nil, bErr
+	}
+	if sendBackRawResponse {
+		rawResponse = compactJSON(responseBody)
+	}
+	return rawRequest, rawResponse, nil
+}
+
+// normalizeReasoningBlocks rewrites the Databricks reasoning content-block shape into the
+// OpenAI-shaped fields Bifrost parses: reasoning text goes to "reasoning" (with a
+// reasoning_details entry carrying the signature), and the remaining blocks stay as content,
+// collapsed to a string when they are all text so that streaming deltas parse. A body
+// without array content is returned untouched.
+func normalizeReasoningBlocks(body []byte) []byte {
+	choices := gjson.GetBytes(body, "choices")
+	if !choices.IsArray() {
+		return body
+	}
+
+	out := body
+	choices.ForEach(func(idx, choice gjson.Result) bool {
+		for _, carrier := range []string{"message", "delta"} {
+			content := choice.Get(carrier + ".content")
+			if !content.IsArray() {
+				continue
+			}
+
+			var reasoning strings.Builder
+			var signature string
+			var texts []string
+			var kept []string
+			allText := true
+			content.ForEach(func(_, block gjson.Result) bool {
+				switch block.Get("type").String() {
+				case "reasoning":
+					block.Get("summary").ForEach(func(_, summary gjson.Result) bool {
+						reasoning.WriteString(summary.Get("text").String())
+						if sig := summary.Get("signature").String(); sig != "" {
+							signature = sig
+						}
+						return true
+					})
+					return true
+				case "text":
+					texts = append(texts, block.Get("text").String())
+				default:
+					allText = false
+				}
+				kept = append(kept, block.Raw)
+				return true
+			})
+
+			base := fmt.Sprintf("choices.%d.%s", idx.Int(), carrier)
+			var err error
+			switch {
+			case len(kept) == 0 && carrier == "delta":
+				out, err = sjson.DeleteBytes(out, base+".content")
+			case len(kept) == 0:
+				out, err = sjson.SetBytes(out, base+".content", "")
+			case allText:
+				out, err = sjson.SetBytes(out, base+".content", strings.Join(texts, ""))
+			default:
+				out, err = sjson.SetRawBytes(out, base+".content", []byte("["+strings.Join(kept, ",")+"]"))
+			}
+			if err != nil {
+				out = body
+				return false
+			}
+
+			if reasoning.Len() == 0 && signature == "" {
+				continue
+			}
+			detail := schemas.ChatReasoningDetails{
+				Index: 0,
+				Type:  schemas.BifrostReasoningDetailsTypeText,
+				Text:  schemas.Ptr(reasoning.String()),
+			}
+			if signature != "" {
+				detail.Signature = schemas.Ptr(signature)
+			}
+			if out, err = sjson.SetBytes(out, base+".reasoning", reasoning.String()); err != nil {
+				out = body
+				return false
+			}
+			if out, err = sjson.SetBytes(out, base+".reasoning_details", []schemas.ChatReasoningDetails{detail}); err != nil {
+				out = body
+				return false
+			}
+		}
+		return true
+	})
+	return out
+}
+
+// compactJSON strips insignificant whitespace so a raw response can ride inside an SSE frame.
+func compactJSON(body []byte) json.RawMessage {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, body); err != nil {
+		return json.RawMessage(bytes.TrimSpace(body))
+	}
+	return json.RawMessage(buf.Bytes())
+}

--- a/core/providers/databricks/reasoning_test.go
+++ b/core/providers/databricks/reasoning_test.go
@@ -1,0 +1,261 @@
+package databricks
+
+import (
+	"testing"
+
+	"github.com/tidwall/gjson"
+
+	schemas "github.com/maximhq/bifrost/core/schemas"
+)
+
+// Budgets the shared effort ladder yields against the default 4096 ceiling.
+var (
+	spread     = float64(4096 - 1024)
+	highBudget = 1024 + int(0.80*spread)
+	lowBudget  = 1024 + int(0.15*spread)
+)
+
+func TestThinkingParam(t *testing.T) {
+	t.Parallel()
+
+	claude := paramSupport{anthropicThinking: true}
+	adaptive := paramSupport{anthropicThinking: true, adaptiveOnlyThinking: true}
+
+	tests := []struct {
+		name          string
+		support       paramSupport
+		params        *schemas.ChatParameters
+		wantThinking  map[string]any
+		wantMaxTokens *int
+	}{
+		{
+			name:    "non-claude endpoint sends nothing",
+			support: paramSupport{},
+			params:  &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high")}},
+		},
+		{
+			name:    "no reasoning requested sends nothing",
+			support: claude,
+			params:  &schemas.ChatParameters{},
+		},
+		{
+			name:    "effort none sends nothing",
+			support: claude,
+			params:  &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("none")}},
+		},
+		{
+			name:    "caller-supplied thinking passes through untouched",
+			support: claude,
+			params: &schemas.ChatParameters{
+				Reasoning:   &schemas.ChatReasoning{Effort: schemas.Ptr("high")},
+				ExtraParams: map[string]any{"thinking": map[string]any{"type": "enabled", "budget_tokens": 2048}},
+			},
+		},
+		{
+			name:          "explicit budget is sent and the ceiling is raised above it",
+			support:       claude,
+			params:        &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high"), MaxTokens: schemas.Ptr(1500)}},
+			wantThinking:  map[string]any{"type": "enabled", "budget_tokens": 1500},
+			wantMaxTokens: schemas.Ptr(1500 + 4096),
+		},
+		{
+			name:         "explicit budget below the caller's ceiling leaves the ceiling alone",
+			support:      claude,
+			params:       &schemas.ChatParameters{MaxCompletionTokens: schemas.Ptr(8000), Reasoning: &schemas.ChatReasoning{MaxTokens: schemas.Ptr(1500)}},
+			wantThinking: map[string]any{"type": "enabled", "budget_tokens": 1500},
+		},
+		{
+			name:          "effort alone is scaled against the default ceiling",
+			support:       claude,
+			params:        &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high")}},
+			wantThinking:  map[string]any{"type": "enabled", "budget_tokens": highBudget},
+			wantMaxTokens: schemas.Ptr(highBudget + 4096),
+		},
+		{
+			name:         "effort max against the caller's ceiling stays one token below it",
+			support:      claude,
+			params:       &schemas.ChatParameters{MaxCompletionTokens: schemas.Ptr(2000), Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("max")}},
+			wantThinking: map[string]any{"type": "enabled", "budget_tokens": 1999},
+		},
+		{
+			name:    "enabled false omits thinking despite effort and budget",
+			support: claude,
+			params:  &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Enabled: schemas.Ptr(false), Effort: schemas.Ptr("high"), MaxTokens: schemas.Ptr(2048)}},
+		},
+		{
+			name:    "enabled false omits thinking on adaptive-only models too",
+			support: adaptive,
+			params:  &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Enabled: schemas.Ptr(false), Effort: schemas.Ptr("high")}},
+		},
+		{
+			name:          "enabled true alone turns thinking on at the default budget",
+			support:       claude,
+			params:        &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Enabled: schemas.Ptr(true)}},
+			wantThinking:  map[string]any{"type": "enabled", "budget_tokens": 1024},
+			wantMaxTokens: schemas.Ptr(1024 + 4096),
+		},
+		{
+			name:          "enabled true overrides effort none",
+			support:       claude,
+			params:        &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Enabled: schemas.Ptr(true), Effort: schemas.Ptr("none")}},
+			wantThinking:  map[string]any{"type": "enabled", "budget_tokens": 1024},
+			wantMaxTokens: schemas.Ptr(1024 + 4096),
+		},
+		{
+			name:          "enabled true keeps an explicit budget",
+			support:       claude,
+			params:        &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Enabled: schemas.Ptr(true), MaxTokens: schemas.Ptr(2048)}},
+			wantThinking:  map[string]any{"type": "enabled", "budget_tokens": 2048},
+			wantMaxTokens: schemas.Ptr(2048 + 4096),
+		},
+		{
+			name:         "enabled true on an adaptive-only model sends adaptive",
+			support:      adaptive,
+			params:       &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Enabled: schemas.Ptr(true)}},
+			wantThinking: map[string]any{"type": "adaptive"},
+		},
+		{
+			name:         "adaptive-only model forwards display omitted to suppress returned reasoning",
+			support:      adaptive,
+			params:       &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high"), Display: schemas.Ptr("omitted")}},
+			wantThinking: map[string]any{"type": "adaptive", "display": "omitted"},
+		},
+		{
+			name:         "budget model ignores display",
+			support:      claude,
+			params:       &schemas.ChatParameters{MaxCompletionTokens: schemas.Ptr(8000), Reasoning: &schemas.ChatReasoning{MaxTokens: schemas.Ptr(1500), Display: schemas.Ptr("omitted")}},
+			wantThinking: map[string]any{"type": "enabled", "budget_tokens": 1500},
+		},
+		{
+			name:    "effort against a ceiling too small for the minimum budget sends nothing",
+			support: claude,
+			params:  &schemas.ChatParameters{MaxCompletionTokens: schemas.Ptr(1024), Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high")}},
+		},
+		{
+			name:          "dynamic budget becomes the minimum",
+			support:       claude,
+			params:        &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{MaxTokens: schemas.Ptr(-1)}},
+			wantThinking:  map[string]any{"type": "enabled", "budget_tokens": 1024},
+			wantMaxTokens: schemas.Ptr(1024 + 4096),
+		},
+		{
+			name:          "extra-param reasoning_effort spelling is honoured",
+			support:       claude,
+			params:        &schemas.ChatParameters{ExtraParams: map[string]any{"reasoning_effort": "low"}},
+			wantThinking:  map[string]any{"type": "enabled", "budget_tokens": lowBudget},
+			wantMaxTokens: schemas.Ptr(lowBudget + 4096),
+		},
+		{
+			name:         "adaptive-only model gets adaptive thinking with no budget",
+			support:      adaptive,
+			params:       &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high"), MaxTokens: schemas.Ptr(1500)}},
+			wantThinking: map[string]any{"type": "adaptive"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotThinking, gotMaxTokens := thinkingParam(tt.support, tt.params)
+			if len(gotThinking) != len(tt.wantThinking) {
+				t.Fatalf("thinking: got %#v, want %#v", gotThinking, tt.wantThinking)
+			}
+			for k, want := range tt.wantThinking {
+				if gotThinking[k] != want {
+					t.Errorf("thinking[%s]: got %#v, want %#v", k, gotThinking[k], want)
+				}
+			}
+			switch {
+			case tt.wantMaxTokens == nil && gotMaxTokens != nil:
+				t.Errorf("max tokens: got %d, want unchanged", *gotMaxTokens)
+			case tt.wantMaxTokens != nil && gotMaxTokens == nil:
+				t.Errorf("max tokens: got unchanged, want %d", *tt.wantMaxTokens)
+			case tt.wantMaxTokens != nil && *gotMaxTokens != *tt.wantMaxTokens:
+				t.Errorf("max tokens: got %d, want %d", *gotMaxTokens, *tt.wantMaxTokens)
+			}
+		})
+	}
+}
+
+// TestNormalizeReasoningBlocks pins the rewrite from Databricks' reasoning content blocks to
+// the fields Bifrost's OpenAI-shaped parser reads, for both the unary message and the
+// streaming delta as observed on a live workspace.
+func TestNormalizeReasoningBlocks(t *testing.T) {
+	t.Parallel()
+
+	t.Run("message with reasoning and text collapses to string content", func(t *testing.T) {
+		t.Parallel()
+		body := `{"choices":[{"message":{"role":"assistant","content":[{"type":"reasoning","summary":[{"type":"summary_text","text":"17 * 23 = 391","signature":"sig-1"}]},{"type":"text","text":"391"}]},"index":0,"finish_reason":"stop"}]}`
+		got := normalizeReasoningBlocks([]byte(body))
+
+		if v := gjson.GetBytes(got, "choices.0.message.content"); v.Type != gjson.String || v.String() != "391" {
+			t.Errorf("content: got %s, want the text block as a string", v.Raw)
+		}
+		if v := gjson.GetBytes(got, "choices.0.message.reasoning").String(); v != "17 * 23 = 391" {
+			t.Errorf("reasoning: got %q", v)
+		}
+		if v := gjson.GetBytes(got, "choices.0.message.reasoning_details.0.signature").String(); v != "sig-1" {
+			t.Errorf("signature: got %q", v)
+		}
+		if v := gjson.GetBytes(got, "choices.0.message.reasoning_details.0.type").String(); v != string(schemas.BifrostReasoningDetailsTypeText) {
+			t.Errorf("details type: got %q", v)
+		}
+		if gjson.GetBytes(got, "choices.0.finish_reason").String() != "stop" {
+			t.Error("unrelated fields were disturbed")
+		}
+	})
+
+	t.Run("delta with only reasoning drops content", func(t *testing.T) {
+		t.Parallel()
+		body := `{"choices":[{"delta":{"role":"assistant","content":[{"type":"reasoning","summary":[{"type":"summary_text","text":"17","signature":""}]}]},"index":0,"finish_reason":null}]}`
+		got := normalizeReasoningBlocks([]byte(body))
+
+		if gjson.GetBytes(got, "choices.0.delta.content").Exists() {
+			t.Errorf("content survived: %s", gjson.GetBytes(got, "choices.0.delta.content").Raw)
+		}
+		if v := gjson.GetBytes(got, "choices.0.delta.reasoning").String(); v != "17" {
+			t.Errorf("reasoning: got %q", v)
+		}
+		if gjson.GetBytes(got, "choices.0.delta.reasoning_details.0.signature").Exists() {
+			t.Error("an empty signature must be omitted")
+		}
+	})
+
+	t.Run("signature-only delta still carries the signature", func(t *testing.T) {
+		t.Parallel()
+		body := `{"choices":[{"delta":{"role":"assistant","content":[{"type":"reasoning","summary":[{"type":"summary_text","text":"","signature":"sig-final"}]}]},"index":0}]}`
+		got := normalizeReasoningBlocks([]byte(body))
+		if v := gjson.GetBytes(got, "choices.0.delta.reasoning_details.0.signature").String(); v != "sig-final" {
+			t.Errorf("signature: got %q", v)
+		}
+	})
+
+	t.Run("string content is untouched", func(t *testing.T) {
+		t.Parallel()
+		body := `{"choices":[{"delta":{"role":"assistant","content":"Hi"},"index":0,"finish_reason":null}]}`
+		if got := normalizeReasoningBlocks([]byte(body)); string(got) != body {
+			t.Errorf("body was rewritten: %s", got)
+		}
+	})
+
+	t.Run("non-text blocks are kept as an array", func(t *testing.T) {
+		t.Parallel()
+		body := `{"choices":[{"message":{"role":"assistant","content":[{"type":"reasoning","summary":[{"type":"summary_text","text":"r"}]},{"type":"text","text":"see"},{"type":"image_url","image_url":{"url":"data:image/png;base64,AA"}}]},"index":0}]}`
+		got := normalizeReasoningBlocks([]byte(body))
+		content := gjson.GetBytes(got, "choices.0.message.content")
+		if !content.IsArray() || len(content.Array()) != 2 {
+			t.Fatalf("content: got %s, want the two non-reasoning blocks", content.Raw)
+		}
+		if content.Array()[1].Get("type").String() != "image_url" {
+			t.Errorf("block order changed: %s", content.Raw)
+		}
+	})
+
+	t.Run("no choices is a no-op", func(t *testing.T) {
+		t.Parallel()
+		body := `{"error":{"message":"nope"}}`
+		if got := normalizeReasoningBlocks([]byte(body)); string(got) != body {
+			t.Errorf("body was rewritten: %s", got)
+		}
+	})
+}

--- a/core/providers/databricks/reasoning_wire_test.go
+++ b/core/providers/databricks/reasoning_wire_test.go
@@ -1,0 +1,145 @@
+package databricks_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// Observed on a live workspace: the thinking phase streams as reasoning content blocks, the
+// answer as plain string deltas, and the signature arrives on a final empty reasoning block.
+const stubClaudeReasoningStream = `data: {"model":"m","choices":[{"delta":{"role":"assistant","content":[{"type":"reasoning","summary":[{"type":"summary_text","text":"17 * 23","signature":""}]}]},"index":0,"finish_reason":null}],"object":"chat.completion.chunk","id":"msg-1","created":1}` + "\n\n" +
+	`data: {"model":"m","choices":[{"delta":{"role":"assistant","content":[{"type":"reasoning","summary":[{"type":"summary_text","text":" = 391","signature":""}]}]},"index":0,"finish_reason":null}],"object":"chat.completion.chunk","id":"msg-1","created":1}` + "\n\n" +
+	`data: {"model":"m","choices":[{"delta":{"role":"assistant","content":[{"type":"reasoning","summary":[{"type":"summary_text","text":"","signature":"sig-1"}]}]},"index":0,"finish_reason":null}],"object":"chat.completion.chunk","id":"msg-1","created":1}` + "\n\n" +
+	`data: {"model":"m","choices":[{"delta":{"role":"assistant","content":"391"},"index":0,"finish_reason":null}],"object":"chat.completion.chunk","id":"msg-1","created":1}` + "\n\n" +
+	`data: {"model":"m","choices":[{"delta":{"role":"assistant","content":""},"index":0,"finish_reason":"stop"}],"usage":{"completion_tokens":9,"prompt_tokens":4,"total_tokens":13},"object":"chat.completion.chunk","id":"msg-1","created":1}` + "\n\n" +
+	"data: [DONE]\n\n"
+
+const stubClaudeReasoningResponse = `{"model":"m","choices":[{"message":{"role":"assistant","content":[{"type":"reasoning","summary":[{"type":"summary_text","text":"17 * 23 = 391","signature":"sig-1"}]},{"type":"text","text":"391"}]},"index":0,"finish_reason":"stop"}],"usage":{"completion_tokens":9,"prompt_tokens":4,"total_tokens":13},"object":"chat.completion","id":"msg-1","created":1}`
+
+// TestDatabricksClaudeReasoningOverTheWire reproduces the live gap: a reasoning request to a
+// Claude endpoint used to lose reasoning entirely (reasoning_effort dropped, nothing sent in
+// its place) and the endpoint's reasoning blocks were not readable. Now the request carries a
+// thinking budget with a ceiling above it, and the reasoning comes back on Bifrost's fields.
+func TestDatabricksClaudeReasoningOverTheWire(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	var gotBody map[string]any
+	provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		mu.Lock()
+		gotBody = body
+		mu.Unlock()
+		if stream, _ := body["stream"].(bool); stream {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(stubClaudeReasoningStream))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stubClaudeReasoningResponse))
+	})
+
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+	request := func() *schemas.BifrostChatRequest {
+		return &schemas.BifrostChatRequest{
+			Provider: schemas.Databricks,
+			Model:    "databricks-claude-sonnet-4-5",
+			Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("17*23?")}}},
+			Params: &schemas.ChatParameters{
+				Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high"), MaxTokens: schemas.Ptr(1500)},
+			},
+		}
+	}
+	assertWire := func(t *testing.T) {
+		t.Helper()
+		mu.Lock()
+		defer mu.Unlock()
+		if _, exists := gotBody["reasoning_effort"]; exists {
+			t.Errorf("reasoning_effort reached Databricks: %#v", gotBody["reasoning_effort"])
+		}
+		thinking, _ := gotBody["thinking"].(map[string]any)
+		if thinking["type"] != "enabled" || thinking["budget_tokens"] != float64(1500) {
+			t.Errorf("thinking: got %#v, want enabled with a 1500 budget", gotBody["thinking"])
+		}
+		if ceiling, _ := gotBody["max_completion_tokens"].(float64); ceiling <= 1500 {
+			t.Errorf("max_completion_tokens: got %v, want above the budget", gotBody["max_completion_tokens"])
+		}
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	t.Run("unary", func(t *testing.T) {
+		response, bErr := provider.ChatCompletion(ctx, key, request())
+		if bErr != nil {
+			t.Fatalf("ChatCompletion returned an error: %v", bErr)
+		}
+		assertWire(t)
+		message := response.Choices[0].Message
+		if message.Content == nil || message.Content.ContentStr == nil || *message.Content.ContentStr != "391" {
+			t.Errorf("content: got %#v, want \"391\"", message.Content)
+		}
+		if message.ChatAssistantMessage == nil || message.Reasoning == nil || *message.Reasoning != "17 * 23 = 391" {
+			t.Errorf("reasoning was not lifted out of the content blocks: %#v", message.ChatAssistantMessage)
+		}
+		if len(message.ReasoningDetails) != 1 || message.ReasoningDetails[0].Signature == nil || *message.ReasoningDetails[0].Signature != "sig-1" {
+			t.Errorf("reasoning details: got %#v, want one entry carrying the signature", message.ReasoningDetails)
+		}
+	})
+
+	t.Run("stream", func(t *testing.T) {
+		stream, bErr := provider.ChatCompletionStream(ctx, noopPostHook, nil, key, request())
+		if bErr != nil {
+			t.Fatalf("ChatCompletionStream returned an error: %v", bErr)
+		}
+		var reasoning, content strings.Builder
+		var signature string
+		for chunk := range stream {
+			if chunk.BifrostChatResponse == nil {
+				continue
+			}
+			for _, choice := range chunk.BifrostChatResponse.Choices {
+				if choice.ChatStreamResponseChoice == nil || choice.Delta == nil {
+					continue
+				}
+				if choice.Delta.Reasoning != nil {
+					reasoning.WriteString(*choice.Delta.Reasoning)
+				}
+				if choice.Delta.Content != nil {
+					content.WriteString(*choice.Delta.Content)
+				}
+				for _, detail := range choice.Delta.ReasoningDetails {
+					if detail.Signature != nil {
+						signature = *detail.Signature
+					}
+				}
+			}
+		}
+		assertWire(t)
+		if reasoning.String() != "17 * 23 = 391" {
+			t.Errorf("streamed reasoning: got %q", reasoning.String())
+		}
+		if content.String() != "391" {
+			t.Errorf("streamed content: got %q", content.String())
+		}
+		if signature != "sig-1" {
+			t.Errorf("streamed signature: got %q", signature)
+		}
+	})
+}

--- a/core/providers/databricks/responses_fallback_test.go
+++ b/core/providers/databricks/responses_fallback_test.go
@@ -1,0 +1,272 @@
+package databricks_test
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+const stubResponsesResponse = `{
+	"id": "resp-1",
+	"object": "response",
+	"created_at": 1700000000,
+	"model": "m",
+	"status": "completed",
+	"output": [{"type": "message", "id": "msg-1", "status": "completed", "role": "assistant", "content": [{"type": "output_text", "text": "ok", "annotations": []}]}],
+	"usage": {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2}
+}`
+
+const stubResponsesStream = "event: response.created\n" +
+	`data: {"type":"response.created","sequence_number":0,"response":{"id":"resp-1","object":"response","created_at":1,"model":"m","status":"in_progress"}}` + "\n\n" +
+	"event: response.completed\n" +
+	`data: {"type":"response.completed","sequence_number":1,"response":{"id":"resp-1","object":"response","created_at":1,"model":"m","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}}` + "\n\n"
+
+const stubChatStream = `data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{"role":"assistant","content":"ok"},"finish_reason":null}]}` + "\n\n" +
+	`data: {"id":"chatcmpl-1","object":"chat.completion.chunk","created":1,"model":"m","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}` + "\n\n" +
+	"data: [DONE]\n\n"
+
+const passthroughUnsupportedBody = `{"error":{"message":"Responses API passthrough is not supported for model databricks-claude-sonnet-4-5.","type":"invalid_request_error"}}`
+
+// pathRecorder is a stub workspace that answers /responses according to responsesStatus and
+// serves chat completions normally, remembering every path it was asked for.
+type pathRecorder struct {
+	mu              sync.Mutex
+	paths           []string
+	responsesStatus int
+	responsesBody   string
+}
+
+func (p *pathRecorder) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p.mu.Lock()
+		p.paths = append(p.paths, r.URL.Path)
+		p.mu.Unlock()
+
+		stream := r.URL.Query().Get("stream") == "true" || r.Header.Get("Accept") == "text/event-stream"
+		switch r.URL.Path {
+		case "/serving-endpoints/responses":
+			if p.responsesStatus != http.StatusOK {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(p.responsesStatus)
+				_, _ = w.Write([]byte(p.responsesBody))
+				return
+			}
+			if stream {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(stubResponsesStream))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(stubResponsesResponse))
+		case "/serving-endpoints/chat/completions":
+			if stream {
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte(stubChatStream))
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(stubChatResponse))
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}
+}
+
+func (p *pathRecorder) seen() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.paths...)
+}
+
+func responsesRequest(model string) *schemas.BifrostResponsesRequest {
+	return &schemas.BifrostResponsesRequest{
+		Provider: schemas.Databricks,
+		Model:    model,
+		Input: []schemas.ResponsesMessage{{
+			Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+		}},
+	}
+}
+
+func equalPaths(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestDatabricksResponsesFallsBackWhenPassthroughUnsupported reproduces the live failure:
+// pay-per-token endpoints answer /serving-endpoints/responses with a 400 saying the surface
+// is not supported. The request must then be served through chat completions, and once an
+// endpoint has declined, later requests for the same model skip the failing round trip.
+func TestDatabricksResponsesFallsBackWhenPassthroughUnsupported(t *testing.T) {
+	t.Parallel()
+
+	recorder := &pathRecorder{responsesStatus: http.StatusBadRequest, responsesBody: passthroughUnsupportedBody}
+	provider, server := newStubProvider(t, recorder.handler(t))
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	response, bErr := provider.Responses(ctx, key, responsesRequest("databricks-claude-sonnet-4-5"))
+	if bErr != nil {
+		t.Fatalf("Responses returned an error: %v", bErr)
+	}
+	if response == nil || len(response.Output) == 0 {
+		t.Fatalf("Responses returned no output through the chat fallback: %#v", response)
+	}
+	want := []string{"/serving-endpoints/responses", "/serving-endpoints/chat/completions"}
+	if got := recorder.seen(); !equalPaths(got, want) {
+		t.Fatalf("first request paths: got %v, want %v", got, want)
+	}
+
+	if _, bErr := provider.Responses(ctx, key, responsesRequest("databricks-claude-sonnet-4-5")); bErr != nil {
+		t.Fatalf("second Responses returned an error: %v", bErr)
+	}
+	want = append(want, "/serving-endpoints/chat/completions")
+	if got := recorder.seen(); !equalPaths(got, want) {
+		t.Errorf("second request must skip the native route: got %v, want %v", got, want)
+	}
+
+	// The decision is per model: another endpoint on the same workspace still gets a try.
+	if _, bErr := provider.Responses(ctx, key, responsesRequest("databricks-gpt-oss-120b")); bErr != nil {
+		t.Fatalf("Responses for a second model returned an error: %v", bErr)
+	}
+	want = append(want, "/serving-endpoints/responses", "/serving-endpoints/chat/completions")
+	if got := recorder.seen(); !equalPaths(got, want) {
+		t.Errorf("a different model must try the native route: got %v, want %v", got, want)
+	}
+}
+
+// TestDatabricksResponsesStreamFallsBackWhenPassthroughUnsupported covers the streaming
+// path, where the 400 arrives before any chunk so retrying through chat loses nothing.
+func TestDatabricksResponsesStreamFallsBackWhenPassthroughUnsupported(t *testing.T) {
+	t.Parallel()
+
+	recorder := &pathRecorder{responsesStatus: http.StatusBadRequest, responsesBody: passthroughUnsupportedBody}
+	provider, server := newStubProvider(t, recorder.handler(t))
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stream, bErr := provider.ResponsesStream(ctx, noopPostHook, nil, key, responsesRequest("databricks-claude-sonnet-4-5"))
+	if bErr != nil {
+		t.Fatalf("ResponsesStream returned an error: %v", bErr)
+	}
+	chunks := 0
+	for range stream {
+		chunks++
+	}
+	if chunks == 0 {
+		t.Fatal("ResponsesStream produced no chunks through the chat fallback")
+	}
+	want := []string{"/serving-endpoints/responses", "/serving-endpoints/chat/completions"}
+	if got := recorder.seen(); !equalPaths(got, want) {
+		t.Fatalf("paths: got %v, want %v", got, want)
+	}
+
+	stream, bErr = provider.ResponsesStream(ctx, noopPostHook, nil, key, responsesRequest("databricks-claude-sonnet-4-5"))
+	if bErr != nil {
+		t.Fatalf("second ResponsesStream returned an error: %v", bErr)
+	}
+	for range stream {
+	}
+	want = append(want, "/serving-endpoints/chat/completions")
+	if got := recorder.seen(); !equalPaths(got, want) {
+		t.Errorf("second stream must skip the native route: got %v, want %v", got, want)
+	}
+}
+
+// TestDatabricksResponsesStaysNativeWhenSupported pins that an endpoint which does serve the
+// Responses API is not needlessly emulated.
+func TestDatabricksResponsesStaysNativeWhenSupported(t *testing.T) {
+	t.Parallel()
+
+	recorder := &pathRecorder{responsesStatus: http.StatusOK}
+	provider, server := newStubProvider(t, recorder.handler(t))
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	if _, bErr := provider.Responses(ctx, key, responsesRequest("databricks-claude-sonnet-4-5")); bErr != nil {
+		t.Fatalf("Responses returned an error: %v", bErr)
+	}
+	if _, bErr := provider.Responses(ctx, key, responsesRequest("databricks-claude-sonnet-4-5")); bErr != nil {
+		t.Fatalf("second Responses returned an error: %v", bErr)
+	}
+	want := []string{"/serving-endpoints/responses", "/serving-endpoints/responses"}
+	if got := recorder.seen(); !equalPaths(got, want) {
+		t.Errorf("paths: got %v, want %v", got, want)
+	}
+}
+
+// TestDatabricksResponsesOtherErrorsAreNotRetried pins that only the "surface not
+// supported" rejection triggers emulation. Any other 400 is the caller's request being
+// wrong, and replaying it through chat would only hide the real message.
+func TestDatabricksResponsesOtherErrorsAreNotRetried(t *testing.T) {
+	t.Parallel()
+
+	recorder := &pathRecorder{
+		responsesStatus: http.StatusBadRequest,
+		responsesBody:   `{"error":{"message":"max_output_tokens must be positive","type":"invalid_request_error"}}`,
+	}
+	provider, server := newStubProvider(t, recorder.handler(t))
+	key := schemas.Key{
+		Models: []string{"*"},
+		Value:  *schemas.NewSecretVar("dapi-test"),
+		DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+			WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+		},
+	}
+
+	ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, bErr := provider.Responses(ctx, key, responsesRequest("databricks-claude-sonnet-4-5"))
+	if bErr == nil {
+		t.Fatal("Responses succeeded, want the upstream 400 surfaced")
+	}
+	if bErr.Error == nil || bErr.Error.Message != "max_output_tokens must be positive" {
+		t.Errorf("error message: got %#v, want the upstream message", bErr.Error)
+	}
+	want := []string{"/serving-endpoints/responses"}
+	if got := recorder.seen(); !equalPaths(got, want) {
+		t.Errorf("paths: got %v, want %v (no chat retry)", got, want)
+	}
+}
+
+func noopPostHook(_ *schemas.BifrostContext, result *schemas.BifrostResponse, err *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError) {
+	return result, err
+}

--- a/docs/providers/supported-providers/databricks.mdx
+++ b/docs/providers/supported-providers/databricks.mdx
@@ -10,14 +10,16 @@ Databricks serves foundation models through two surfaces, both reachable under y
 
 | Surface | Base path | Model name looks like | What it covers |
 |---------|-----------|-----------------------|----------------|
-| **Model Serving** (Foundation Model APIs) | `/serving-endpoints` | `databricks-claude-sonnet-4-5` | Every pay-per-token endpoint, provisioned-throughput endpoints, and the OpenAI Responses API |
+| **Model Serving** (Foundation Model APIs) | `/serving-endpoints` | `databricks-claude-sonnet-4-5` | Every pay-per-token endpoint and provisioned-throughput endpoint |
 | **Unity AI Gateway** (model services) | `/ai-gateway/mlflow/v1` | `system.ai.claude-sonnet-4-5` or `<catalog>.<schema>.<service>` | Ready-to-use `system.ai` models and user-created Unity Catalog model services, governed by Unity Catalog |
 
 Key characteristics:
 
 - **One provider, two surfaces** - the surface is chosen per request, by model name or by an explicit setting
 - **OpenAI-compatible** - Bifrost uses its shared OpenAI converters, so tool calling, structured outputs and streaming work unchanged
-- **Responses API** - served natively on Model Serving, so coding agents (Claude Code, Cursor, Codex CLI) work through Bifrost
+- **Responses API** - works on every endpoint, so coding agents (Claude Code, Cursor, Codex CLI) work through Bifrost; served natively where the endpoint supports it and emulated through Chat Completions elsewhere
+- **Reasoning on Claude** - a `reasoning_effort` or reasoning budget is translated to the `thinking` object Claude endpoints take, and the reasoning they return is surfaced on the standard reasoning fields
+- **Remote images** - `http(s)` image URLs are fetched and inlined, since Claude endpoints on Databricks accept only inline image data
 - **Two auth methods** - a personal access token, or OAuth machine-to-machine with a service principal (Databricks' production recommendation)
 - **Governance tags** - optionally forward Bifrost virtual key / team / customer names to Databricks usage tracking
 
@@ -26,7 +28,7 @@ Key characteristics:
 | Operation | Non-Streaming | Streaming | Endpoint |
 |-----------|---------------|-----------|----------|
 | Chat Completions | ✅ | ✅ | `<base>/chat/completions` |
-| Responses API | ✅ | ✅ | `/serving-endpoints/responses` (Model Serving); emulated via chat on AI Gateway |
+| Responses API | ✅ | ✅ | `/serving-endpoints/responses` where the endpoint supports it; emulated via chat everywhere else |
 | Embeddings | ✅ | - | `<base>/embeddings` |
 | List Models | ✅ | - | Served from Bifrost's model catalog; no workspace API is called |
 | Text Completions | ❌ | ❌ | - |
@@ -208,10 +210,32 @@ curl -X POST http://localhost:8080/v1/responses \
   }'
 ```
 
-The Responses API is native on Model Serving. On the Unity AI Gateway, which is chat-only, Bifrost emulates it by converting to Chat Completions.
+Bifrost first tries the native `/serving-endpoints/responses` route. Pay-per-token foundation model endpoints commonly decline it (`Responses API passthrough is not supported for model ...`), in which case the request is replayed through Chat Completions and converted back, and later requests for that endpoint skip straight to the emulated path. The Unity AI Gateway is chat-only and is always emulated.
 
 </Tab>
 </Tabs>
+
+### Reasoning on Claude endpoints
+
+Claude endpoints on Databricks reject `reasoning_effort` and take Anthropic's `thinking` object instead. Bifrost translates for you: a reasoning budget (`reasoning.max_tokens`) is sent as `budget_tokens`, an effort label is scaled to a budget the same way the Anthropic provider does, and models that only offer adaptive thinking get `{"type": "adaptive"}`. `max_completion_tokens` is raised above the budget when you have not set one, because the endpoint requires the ceiling to exceed the budget.
+
+```bash
+curl -X POST http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "databricks/databricks-claude-sonnet-4-5",
+    "messages": [{"role": "user", "content": "What is 17 * 23?"}],
+    "reasoning": {"effort": "high", "max_tokens": 2048}
+  }'
+```
+
+Every Databricks endpoint, Claude or not, returns reasoning as a content block (`{"type": "reasoning", "summary": [...]}`). Bifrost lifts it onto `reasoning` and `reasoning_details` (with the signature) on the message and on each streaming delta, so clients read it the same way as from any other provider.
+
+To speak the Databricks dialect directly, send `thinking` as a top-level field; Bifrost passes it through untouched and does not add its own.
+
+### Image inputs
+
+Claude endpoints on Databricks accept only inline image data (`Http data URLs are not supported by Claude`). Bifrost fetches any `http(s)` `image_url` and sends it as a base64 data URL. The fetch uses the same SSRF-safe downloader as the Bedrock and Anthropic providers: only `http`/`https`, no private or loopback addresses, 25 MiB cap. A URL that cannot be fetched fails the request with a 400 rather than sending the model a request with the image silently removed.
 
 ### Provider-specific parameters
 
@@ -240,9 +264,9 @@ Bifrost's parameter set is wider than any single Databricks endpoint accepts, an
 | `response_format` (`text.format` on Responses) | `supports_response_schema: false` |
 | `stop`, `presence_penalty`, `frequency_penalty` | the field is listed in `unsupported_fields` |
 
-A model the datasheet does not describe keeps every field except `reasoning_effort` — Databricks endpoint names are workspace-defined, so there is nothing to identify an unknown endpoint by, and a silent drop is worse than an upstream error you can read.
+A model the datasheet does not describe keeps every field except `reasoning_effort` and `parallel_tool_calls` — Databricks endpoint names are workspace-defined, so there is nothing to identify an unknown endpoint by, and a silent drop is worse than an upstream error you can read. `parallel_tool_calls` is the exception because both surfaces reject it outright; it is only sent when the datasheet row opts in.
 
-`reasoning_effort` resolves through `unsupported_fields` → `supports_reasoning_effort` (or a published effort ladder) → a `reasoning_effort` entry in the row's parameters → the model reasons and is not Claude-family. Claude endpoints on Databricks reason through a thinking budget and reject an effort label, so it is dropped there. A requested effort is clamped onto the levels the model publishes.
+`reasoning_effort` resolves through `unsupported_fields` → `supports_reasoning_effort` (or a published effort ladder) → a `reasoning_effort` entry in the row's parameters → the model reasons and is not Claude-family. Claude endpoints on Databricks reason through a thinking budget and reject an effort label, so it is translated to `thinking` there (see [Reasoning on Claude endpoints](#reasoning-on-claude-endpoints)). A requested effort is clamped onto the levels the model publishes.
 
 Anthropic-native fields — `context_management`, `cache_control`, `speed`, `inference_geo`, `task_budget`, `container`, `mcp_servers` — are always dropped, whatever the model. Both Databricks surfaces are OpenAI-shaped and reject them even on Claude endpoints.
 


### PR DESCRIPTION
### TL;DR

Fixes three gaps in the Databricks provider: Claude endpoints now receive reasoning as a `thinking` object instead of the rejected `reasoning_effort`, remote image URLs are fetched and inlined before reaching Claude endpoints that reject them, and the Responses API now falls back to Chat Completions emulation when a pay-per-token endpoint declines the native surface.

### What changed?

**Reasoning on Claude endpoints (`reasoning.go`)**
Claude-backed Databricks endpoints reject `reasoning_effort` and instead accept Anthropic's `thinking` object. A new `thinkingParam` function translates Bifrost's neutral reasoning parameters — effort labels, explicit budgets, or `reasoning.max_tokens` — into the correct `thinking` wire shape. Adaptive-only models receive `{"type": "adaptive"}` with no budget. `max_completion_tokens` is raised above the budget when the caller has not set one, satisfying the endpoint's requirement that the ceiling exceed the budget. A new `chatResponseHandler` and `normalizeReasoningBlocks` function lift the reasoning content blocks the endpoint returns onto Bifrost's standard `reasoning` and `reasoning_details` fields, for both unary responses and streaming deltas.

**Image inlining (`imageinlining.go`)**
Claude endpoints on Databricks reject remote image URLs with "Http data URLs are not supported by Claude". A new `inlineChatImageURLs` / `inlineResponsesImageURLs` pair fetches any `http(s)` image URL and replaces it with a base64 data URL before the request leaves Bifrost, using the same SSRF-safe downloader as the Bedrock and Anthropic providers. A failed fetch aborts the request with a 400 rather than silently dropping the image. Requests with no remote images are returned as-is with no copy.

**Responses API fallback (`inference.go`)**
Pay-per-token Model Serving endpoints commonly decline the native `/serving-endpoints/responses` route with "Responses API passthrough is not supported". The provider now catches that specific 400, replays the request through Chat Completions, and records the endpoint in a `sync.Map` so subsequent requests for the same workspace host and model skip the failing round trip. Other 400 errors are surfaced to the caller unchanged. The Unity AI Gateway continues to be emulated unconditionally.

**`parallel_tool_calls` default changed**
Both Databricks surfaces reject `parallel_tool_calls` outright. The default for models with no datasheet row is now `false` (was `true`); a datasheet row with `supports_parallel_function_calling: true` still opts in.

### How to test?

- Run the new unit tests: `go test ./core/providers/databricks/...`
- `TestThinkingParam` covers the budget/effort translation matrix.
- `TestNormalizeReasoningBlocks` covers the content-block rewrite for unary and streaming shapes.
- `TestDatabricksClaudeReasoningOverTheWire` drives a stub server end-to-end for both unary and streaming reasoning.
- `TestInlineChatImageURLs` / `TestInlineResponsesImageURLs` cover inlining, passthrough of data URLs, fetch failures, and extension-based media type fallback.
- `TestDatabricksResponsesFallsBackWhenPassthroughUnsupported` / `TestDatabricksResponsesStreamFallsBackWhenPassthroughUnsupported` verify the fallback path and the skip-on-second-request behaviour.
- `TestDatabricksResponsesOtherErrorsAreNotRetried` pins that only the surface-not-supported rejection triggers emulation.
- The existing `TestDatabricks` and `TestDatabricksChatParamsFollowDatasheet` suites are updated to reflect the new `parallel_tool_calls` default.

### Why make this change?

Claude endpoints on Databricks have three behaviours that differ from the OpenAI-shaped contract Bifrost assumes: they reject `reasoning_effort` in favour of `thinking`, they reject remote image URLs, and many of them do not expose the Responses API surface at all. Without these fixes, reasoning requests silently lost their reasoning, image requests failed with an opaque upstream error, and Responses requests failed entirely on pay-per-token endpoints. The changes bring Claude-on-Databricks to feature parity with the native Anthropic and Bedrock providers for these capabilities.