### PR TITLE
fix: terminate stream for upstream providers who sends heart beats after usage

### DIFF
--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -622,8 +622,18 @@ func HandleOpenAITextCompletionStreaming(
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
 					return
 				}
-				// The body is fully consumed, so the deferred release must not drain it again.
-				ctx.SetValue(schemas.BifrostContextKeyStreamBodyExhausted, true)
+				if providerUtils.SSEEndedOnComment(sseReader) {
+					// Stopped on a heartbeat: the body is still open, so cleanup must abandon it.
+					ctx.SetValue(schemas.BifrostContextKeyStreamParkedAfterFinish, true)
+					// Bifrost defaults stream_options.include_usage, so no usage by now means the
+					// upstream parked before sending it and this request cannot be costed.
+					if usage.TotalTokens == 0 {
+						logger.Warn("provider %s ended the stream on heartbeats after finish_reason without sending usage; token counts and cost are unavailable for this request", providerName)
+					}
+				} else {
+					// The body is fully consumed, so the deferred release must not drain it again.
+					ctx.SetValue(schemas.BifrostContextKeyStreamBodyExhausted, true)
+				}
 				break
 			}
 			jsonData := string(data)
@@ -727,6 +737,8 @@ func HandleOpenAITextCompletionStreaming(
 				// Collect finish reason and send at the end of the stream
 				finishReason = choice.FinishReason
 				response.Choices[0].FinishReason = nil
+				// An upstream that parks instead of sending [DONE] can only heartbeat now.
+				providerUtils.SSEEndOnCommentAfterFinish(sseReader)
 			}
 
 			if response.ID != "" && messageID == "" {
@@ -1297,8 +1309,18 @@ func HandleOpenAIChatCompletionStreaming(
 					providerUtils.ProcessAndSendError(ctx, postHookRunner, readErr, responseChan, logger, postHookSpanFinalizer)
 					return
 				}
-				// The body is fully consumed, so the deferred release must not drain it again.
-				ctx.SetValue(schemas.BifrostContextKeyStreamBodyExhausted, true)
+				if providerUtils.SSEEndedOnComment(sseReader) {
+					// Stopped on a heartbeat: the body is still open, so cleanup must abandon it.
+					ctx.SetValue(schemas.BifrostContextKeyStreamParkedAfterFinish, true)
+					// Bifrost defaults stream_options.include_usage, so no usage by now means the
+					// upstream parked before sending it and this request cannot be costed.
+					if usage.TotalTokens == 0 {
+						logger.Warn("provider %s ended the stream on heartbeats after finish_reason without sending usage; token counts and cost are unavailable for this request", providerName)
+					}
+				} else {
+					// The body is fully consumed, so the deferred release must not drain it again.
+					ctx.SetValue(schemas.BifrostContextKeyStreamBodyExhausted, true)
+				}
 				break
 			}
 			jsonData := string(data)
@@ -1499,6 +1521,8 @@ func HandleOpenAIChatCompletionStreaming(
 				if choice.FinishReason != nil && *choice.FinishReason != "" {
 					// Collect finish reason and send at the end of the stream
 					finishReason = choice.FinishReason
+					// An upstream that parks instead of sending [DONE] can only heartbeat now.
+					providerUtils.SSEEndOnCommentAfterFinish(sseReader)
 				}
 
 				if response.ID != "" && messageID == "" {

--- a/core/providers/openai/streamtruncation_test.go
+++ b/core/providers/openai/streamtruncation_test.go
@@ -342,40 +342,67 @@ func TestChatStreamHeartbeatAfterFinishReasonEndsOnOptIn(t *testing.T) {
 	}
 }
 
-// The counterpart: without the opt-in the loop keeps waiting for [DONE], which is
-// what providers emitting a usage-only chunk after finish_reason depend on. Asserted
-// with a bounded wait so a regression here cannot wedge the suite.
-func TestChatStreamHeartbeatAfterFinishReasonWaitsWithoutOptIn(t *testing.T) {
+// The opt-in only reaches providers an operator has already diagnosed. The reported
+// shape - a built-in or unconfigured custom provider that omits [DONE] and parks -
+// has to terminate on its own, so the first heartbeat after finish_reason ends the
+// read loop with no configuration at all.
+func TestChatStreamHeartbeatAfterFinishReasonEndsWithoutOptIn(t *testing.T) {
 	toolCalls := "tool_calls"
 	server := heartbeatSSEServer(t, chatChunk("hello", nil)+chatChunk("", &toolCalls))
 	defer server.Close()
 
-	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
-	defer cancel()
-
 	provider := newStreamTestProvider(server.URL)
-	stream, bifrostErr := provider.ChatCompletionStream(ctx, passthroughPostHook, nil, testKey(), basicChatRequest())
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
 	if bifrostErr != nil {
 		t.Fatalf("stream setup failed: %v", bifrostErr)
 	}
 
-	// The content chunk is forwarded as it arrives; the finish_reason chunk is not.
-	select {
-	case chunk, ok := <-stream:
-		if !ok {
-			t.Fatal("stream closed before delivering the content chunk")
-		}
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a stream that reached finish_reason")
+	}
+	for i, chunk := range chunks {
 		if chunk.BifrostError != nil {
-			t.Fatalf("content chunk carried an error: %+v", chunk.BifrostError)
+			t.Fatalf("chunk %d unexpectedly carried an error: %+v", i, chunk.BifrostError)
 		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("timed out waiting for the content chunk")
+	}
+	final := chunks[len(chunks)-1]
+	if final.BifrostChatResponse == nil {
+		t.Fatalf("expected a synthesized final chat chunk, got %+v", final)
+	}
+	if len(final.BifrostChatResponse.Choices) == 0 ||
+		final.BifrostChatResponse.Choices[0].FinishReason == nil ||
+		*final.BifrostChatResponse.Choices[0].FinishReason != toolCalls {
+		t.Errorf("expected the final chunk to carry finish_reason %q, got %+v", toolCalls, final.BifrostChatResponse.Choices)
+	}
+}
+
+// The reported upstream sends its usage-only chunk between finish_reason and the
+// heartbeats. Ending on the heartbeat rather than on finish_reason is what keeps
+// that chunk - and the cost derived from it - on a stream nobody configured.
+func TestChatStreamHeartbeatAfterFinishReasonKeepsTrailingUsage(t *testing.T) {
+	toolCalls := "tool_calls"
+	usageChunk := `data: {"id":"chatcmpl-repro","object":"chat.completion.chunk","created":1,"model":"repro-model",` +
+		`"choices":[],"usage":{"prompt_tokens":1000,"completion_tokens":100,"total_tokens":1100}}` + "\n\n"
+	server := heartbeatSSEServer(t, chatChunk("hello", nil)+chatChunk("", &toolCalls)+usageChunk)
+	defer server.Close()
+
+	provider := newStreamTestProvider(server.URL)
+	stream, bifrostErr := provider.ChatCompletionStream(newStreamTestContext(), passthroughPostHook, nil, testKey(), basicChatRequest())
+	if bifrostErr != nil {
+		t.Fatalf("stream setup failed: %v", bifrostErr)
 	}
 
-	select {
-	case chunk, ok := <-stream:
-		t.Fatalf("expected the stream to stay open waiting for [DONE], got chunk=%+v open=%v", chunk, ok)
-	case <-time.After(300 * time.Millisecond):
+	chunks := collectChunks(t, stream)
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from a stream that reached finish_reason")
+	}
+	final := chunks[len(chunks)-1]
+	if final.BifrostChatResponse == nil || final.BifrostChatResponse.Usage == nil {
+		t.Fatalf("expected the final chunk to carry the trailing usage, got %+v", final)
+	}
+	if final.BifrostChatResponse.Usage.TotalTokens != 1100 {
+		t.Errorf("expected total_tokens 1100 from the chunk after finish_reason, got %d", final.BifrostChatResponse.Usage.TotalTokens)
 	}
 }
 

--- a/core/providers/utils/sse.go
+++ b/core/providers/utils/sse.go
@@ -50,6 +50,35 @@ func SSEStreamEndedOnMarker(r SSEDataReader) bool {
 	return true
 }
 
+// SSEPostFinishTerminator is optionally implemented by SSE readers that can end
+// the stream on consecutive comments received after the caller has seen a
+// finish_reason. An upstream still producing sends its trailing usage chunk and
+// "data: [DONE]" back to back, so comments arriving after semantic completion
+// mean it has nothing left to send and is only holding the connection open.
+type SSEPostFinishTerminator interface {
+	EndOnCommentAfterFinish()
+	EndedOnComment() bool
+}
+
+// SSEEndOnCommentAfterFinish arms r to end the stream on the next SSE comment.
+// No-op for readers that do not implement SSEPostFinishTerminator (e.g. an
+// enterprise-injected SSEReaderFactory), which keep waiting for [DONE] or EOF.
+func SSEEndOnCommentAfterFinish(r SSEDataReader) {
+	if t, ok := r.(SSEPostFinishTerminator); ok {
+		t.EndOnCommentAfterFinish()
+	}
+}
+
+// SSEEndedOnComment reports whether r stopped on a post-finish comment rather
+// than at the end of the body. The connection is still open in that case, so
+// cleanup must abandon it instead of draining or releasing it.
+func SSEEndedOnComment(r SSEDataReader) bool {
+	if t, ok := r.(SSEPostFinishTerminator); ok {
+		return t.EndedOnComment()
+	}
+	return false
+}
+
 // SSEReaderFactory creates SSE readers for streaming response processing.
 // Enterprise injects this via BifrostContextKeySSEReaderFactory to replace
 // the default bufio.Scanner-based implementations with streaming readers.
@@ -97,6 +126,11 @@ type defaultSSEDataReader struct {
 	scanner *bufio.Scanner
 	pending []byte // line carried over from an aborted multi-line JSON accumulation
 	sawDone bool   // stream ended on "data: [DONE]" rather than a bare body EOF
+	// endOnComment is armed once the caller has seen a finish_reason; sawComment
+	// records that a comment then ended the stream with the body still open.
+	endOnComment bool
+	sawComment   bool
+	commentsSeen int
 	// ctx carries the request context so the per-event copy out of the scanner buffer
 	// can be attributed to the "response-parse" stream phase centrally, for every
 	// provider that uses the shared reader — rather than each provider timing its own
@@ -106,6 +140,12 @@ type defaultSSEDataReader struct {
 
 // SawDoneMarker implements SSEStreamTerminator.
 func (r *defaultSSEDataReader) SawDoneMarker() bool { return r.sawDone }
+
+// EndOnCommentAfterFinish implements SSEPostFinishTerminator.
+func (r *defaultSSEDataReader) EndOnCommentAfterFinish() { r.endOnComment = true }
+
+// EndedOnComment implements SSEPostFinishTerminator.
+func (r *defaultSSEDataReader) EndedOnComment() bool { return r.sawComment }
 
 func newDefaultSSEDataReader(ctx *schemas.BifrostContext, reader io.Reader) *defaultSSEDataReader {
 	scanner := bufio.NewScanner(reader)
@@ -134,9 +174,24 @@ func (r *defaultSSEDataReader) ReadDataLine() ([]byte, error) {
 			break
 		}
 		// Skip empty lines and comments
-		if len(line) == 0 || line[0] == ':' {
+		if len(line) == 0 {
 			continue
 		}
+		if line[0] == ':' {
+			// Heartbeats after finish_reason mean nothing further is coming. Two are
+			// required so a keepalive that merely straddles the trailing usage chunk
+			// cannot end the stream early; that chunk resets the count below.
+			if r.endOnComment {
+				r.commentsSeen++
+				if r.commentsSeen >= 2 {
+					r.sawComment = true
+					return nil, io.EOF
+				}
+			}
+			continue
+		}
+		// Any real SSE line means the upstream is still making progress.
+		r.commentsSeen = 0
 
 		// Parse "data:" lines
 		if bytes.HasPrefix(line, sseDataPrefix) {

--- a/core/providers/utils/sse_test.go
+++ b/core/providers/utils/sse_test.go
@@ -85,6 +85,134 @@ func TestSSEStreamEndedOnMarker_UnknownReaderDefaultsTrue(t *testing.T) {
 	}
 }
 
+// https://github.com/maximhq/bifrost/issues/6784: an upstream that omits [DONE] and
+// parks the connection can only heartbeat. Once the caller has seen a finish_reason,
+// the next comment is proof nothing further is coming, so it ends the stream.
+func TestSSEDataReader_ArmedReaderEndsOnComment(t *testing.T) {
+	reader := newDefaultSSEDataReader(nil, strings.NewReader("data: {\"a\":1}\n\n: ping\n\n: ping\n\n"))
+	if _, err := reader.ReadDataLine(); err != nil {
+		t.Fatalf("unexpected error on the first data line: %v", err)
+	}
+	reader.EndOnCommentAfterFinish()
+	if _, err := reader.ReadDataLine(); err != io.EOF {
+		t.Fatalf("expected io.EOF on the heartbeat, got %v", err)
+	}
+	if !reader.EndedOnComment() {
+		t.Error("expected EndedOnComment to be true after stopping on a heartbeat")
+	}
+	if reader.SawDoneMarker() {
+		t.Error("expected SawDoneMarker to stay false: the stream never sent [DONE]")
+	}
+}
+
+// The trailing usage chunk is sent back to back with finish_reason, before any
+// heartbeat exists to stop on, so arming must not cost the caller its usage. The
+// blank lines separating SSE frames must not be mistaken for comments either.
+func TestSSEDataReader_ArmedReaderKeepsTrailingUsageChunk(t *testing.T) {
+	stream := "data: {\"choices\":[{\"finish_reason\":\"tool_calls\"}]}\n" +
+		"\n" +
+		"data: {\"choices\":[],\"usage\":{\"total_tokens\":1100}}\n" +
+		"\n" +
+		": ping\n" +
+		"\n" +
+		": ping\n" +
+		"\n"
+	reader := newDefaultSSEDataReader(nil, strings.NewReader(stream))
+	if _, err := reader.ReadDataLine(); err != nil {
+		t.Fatalf("unexpected error on the finish_reason line: %v", err)
+	}
+	reader.EndOnCommentAfterFinish()
+	usage, err := reader.ReadDataLine()
+	if err != nil {
+		t.Fatalf("expected the trailing usage chunk, got error %v", err)
+	}
+	if !strings.Contains(string(usage), "total_tokens") {
+		t.Errorf("expected the usage chunk to survive arming, got %q", usage)
+	}
+	if _, err := reader.ReadDataLine(); err != io.EOF {
+		t.Fatalf("expected io.EOF on the heartbeat after usage, got %v", err)
+	}
+	if !reader.EndedOnComment() {
+		t.Error("expected EndedOnComment to be true after stopping on a heartbeat")
+	}
+}
+
+// A compliant provider sends [DONE] before any heartbeat, so arming must leave the
+// normal termination path — and its truncation reporting — exactly as it was.
+func TestSSEDataReader_ArmedReaderStillEndsOnDoneMarker(t *testing.T) {
+	reader := newDefaultSSEDataReader(nil, strings.NewReader("data: {\"a\":1}\n\ndata: [DONE]\n\n"))
+	if _, err := reader.ReadDataLine(); err != nil {
+		t.Fatalf("unexpected error on the first data line: %v", err)
+	}
+	reader.EndOnCommentAfterFinish()
+	if _, err := reader.ReadDataLine(); err != io.EOF {
+		t.Fatalf("expected io.EOF on [DONE], got %v", err)
+	}
+	if !reader.SawDoneMarker() {
+		t.Error("expected SawDoneMarker to be true: the stream ended on [DONE]")
+	}
+	if reader.EndedOnComment() {
+		t.Error("expected EndedOnComment to be false: the stream ended on [DONE], not a heartbeat")
+	}
+}
+
+// An unarmed reader must keep skipping comments, so a provider that heartbeats
+// mid-generation is unaffected.
+func TestSSEDataReader_UnarmedReaderSkipsComments(t *testing.T) {
+	reader := newDefaultSSEDataReader(nil, strings.NewReader("data: {\"a\":1}\n\n: ping\n\ndata: {\"b\":2}\n\n"))
+	payloads := drainSSEDataReader(t, reader)
+	if len(payloads) != 2 {
+		t.Fatalf("expected both data lines across the heartbeat, got %v", payloads)
+	}
+	if reader.EndedOnComment() {
+		t.Error("expected EndedOnComment to be false for a reader that was never armed")
+	}
+}
+
+// A proxy injecting keepalives on a timer can land one between finish_reason and
+// the trailing usage chunk. One comment must therefore never end the stream: the
+// usage chunk resets the count, and the provider's [DONE] still terminates.
+func TestSSEDataReader_ArmedReaderIgnoresSingleStraddlingComment(t *testing.T) {
+	stream := "data: {\"choices\":[{\"finish_reason\":\"stop\"}]}\n" +
+		"\n" +
+		": OPENROUTER PROCESSING\n" +
+		"\n" +
+		"data: {\"choices\":[],\"usage\":{\"total_tokens\":1100}}\n" +
+		"\n" +
+		"data: [DONE]\n" +
+		"\n"
+	reader := newDefaultSSEDataReader(nil, strings.NewReader(stream))
+	if _, err := reader.ReadDataLine(); err != nil {
+		t.Fatalf("unexpected error on the finish_reason line: %v", err)
+	}
+	reader.EndOnCommentAfterFinish()
+	usage, err := reader.ReadDataLine()
+	if err != nil {
+		t.Fatalf("expected the usage chunk to survive a straddling keepalive, got error %v", err)
+	}
+	if !strings.Contains(string(usage), "total_tokens") {
+		t.Errorf("expected the usage chunk after the keepalive, got %q", usage)
+	}
+	if _, err := reader.ReadDataLine(); err != io.EOF {
+		t.Fatalf("expected io.EOF on [DONE], got %v", err)
+	}
+	if !reader.SawDoneMarker() {
+		t.Error("expected SawDoneMarker to be true: the stream ended on [DONE]")
+	}
+	if reader.EndedOnComment() {
+		t.Error("expected EndedOnComment to be false: a single keepalive must not end the stream")
+	}
+}
+
+// Arming a reader that cannot honour it must be a no-op, and such a reader must
+// never be reported as having parked: cleanup would abandon a healthy connection.
+func TestSSEEndedOnComment_UnknownReaderDefaultsFalse(t *testing.T) {
+	SSEEndOnCommentAfterFinish(stubSSEDataReader{})
+	if SSEEndedOnComment(stubSSEDataReader{}) {
+		t.Error("expected SSEEndedOnComment to default to false for readers without SSEPostFinishTerminator")
+	}
+}
+
 func TestSSEDataReader_SingleLineRawJSONFallback(t *testing.T) {
 	stream := `{"error": {"code": 429, "status": "RESOURCE_EXHAUSTED"}}` + "\n"
 	payloads := drainSSEDataReader(t, newDefaultSSEDataReader(nil, strings.NewReader(stream)))

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -3796,7 +3796,10 @@ func ReleaseStreamingResponse(ctx *schemas.BifrostContext, resp *fasthttp.Respon
 		// Draining that blocks here forever, so abandon the connection: closing with a
 		// non-nil error takes fasthttp's CloseConn path and keeps the half-read stream
 		// out of the idle pool. The response is left to GC as in the branches above.
-		if doesNotSendDoneMarker, _ := ctx.Value(schemas.BifrostContextKeyDoesNotSendDoneMarker).(bool); doesNotSendDoneMarker {
+		// The same applies when the read loop itself stopped on a post-finish heartbeat.
+		parked, _ := ctx.Value(schemas.BifrostContextKeyStreamParkedAfterFinish).(bool)
+		doesNotSendDoneMarker, _ := ctx.Value(schemas.BifrostContextKeyDoesNotSendDoneMarker).(bool)
+		if parked || doesNotSendDoneMarker {
 			closeBodyStream(bodyStream, errStreamParkedAfterFinish)
 			return
 		}

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -426,6 +426,7 @@ const (
 	BifrostContextKeyPassthroughOverridesPresent         BifrostContextKey = "passthrough_overrides_present" // bool (set by HTTP transport) - passthrough raw request requested
 	BifrostContextKeyConnectionClosed                    BifrostContextKey = "connection_closed"
 	BifrostContextKeyStreamBodyExhausted                 BifrostContextKey = "stream_body_exhausted"          // bool (set by bifrost - DO NOT SET THIS MANUALLY) - upstream body was read to EOF, so cleanup must not drain it again
+	BifrostContextKeyStreamParkedAfterFinish             BifrostContextKey = "stream_parked_after_finish"     // bool (set by bifrost - DO NOT SET THIS MANUALLY) - reader stopped on a heartbeat after finish_reason with the body still open, so cleanup must abandon the connection instead of draining it
 	BifrostContextKeyTempTokenScope                      BifrostContextKey = "bifrost-temp-token-scope"       // string (set by auth middleware when a temp token authorized the request - names the scope from the temptoken registry)
 	BifrostContextKeyTempTokenResourceID                 BifrostContextKey = "bifrost-temp-token-resource-id" // string (set by auth middleware alongside the scope - the resource_id the token is bound to, e.g. an OAuth flow ID for mcp_auth)
 	BifrostContextKeyAsyncWebhookEndpoint                BifrostContextKey = "bifrost-async-webhook-endpoint" // string (webhook endpoint name to notify when an async job finishes - carried as-is from the x-bf-async-webhook header; the submit path resolves and validates it before the job is created)


### PR DESCRIPTION
## Summary

Some upstream providers omit `data: [DONE]` after streaming is complete and instead park the connection, sending only SSE heartbeat comments. Previously, the read loop would wait indefinitely for `[DONE]`, blocking cleanup and preventing the connection from being properly released. This change makes the SSE reader detect when a stream has semantically finished (after `finish_reason`) and is only producing heartbeats, then terminates the loop automatically without requiring any operator configuration.

## Changes

- Added `SSEPostFinishTerminator` interface to `sse.go` with `EndOnCommentAfterFinish()` and `EndedOnComment()` methods, implemented by `defaultSSEDataReader`.
- After the reader sees a `finish_reason`, `SSEEndOnCommentAfterFinish` is called to arm the reader. Once two consecutive SSE comments arrive with no intervening data lines, the reader returns `io.EOF` and sets `sawComment = true`. Two comments are required so a single keepalive straddling a trailing usage chunk (e.g. OpenRouter's `OPENROUTER PROCESSING` comment) does not prematurely end the stream before that usage data is delivered.
- Added `BifrostContextKeyStreamParkedAfterFinish` context key to signal that the read loop stopped on a heartbeat with the body still open. Cleanup in `ReleaseStreamingResponse` now checks this key alongside the existing `BifrostContextKeyDoesNotSendDoneMarker` and abandons the connection via `closeBodyStream` rather than draining it.
- Replaced `TestChatStreamHeartbeatAfterFinishReasonWaitsWithoutOptIn` with `TestChatStreamHeartbeatAfterFinishReasonEndsWithoutOptIn` and added `TestChatStreamHeartbeatAfterFinishReasonKeepsTrailingUsage` to assert that the stream terminates correctly and that trailing usage chunks are preserved even without any operator opt-in.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/openai/... ./core/providers/utils/...
```

The new and updated tests cover:
- A stream that parks after `finish_reason` terminates on the second heartbeat with no configuration.
- A trailing usage chunk sent between `finish_reason` and the heartbeats is preserved.
- A single straddling keepalive comment does not end the stream early; the provider's `[DONE]` still terminates normally.
- An unarmed reader continues skipping comments mid-generation.
- Readers that do not implement `SSEPostFinishTerminator` are unaffected and never reported as parked.

## Breaking changes

- [x] No

## Related issues

Closes #6784

## Security considerations

None. The change only affects how the SSE read loop and connection cleanup handle streams from providers that omit `[DONE]`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable