### PR TITLE
Authorize inspected MCP tools through trusted scoped context

### DIFF
--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -1322,7 +1322,7 @@ func (p *GovernancePlugin) PreMCPHook(ctx *schemas.BifrostContext, req *schemas.
 	// disagree. What is left is a question about the tool, which the access answers whatever granted it.
 	// A request carrying no access is unrestricted and may execute any tool, as it always could.
 	access := ctx.Grant().Access()
-	if access != nil && !access.IsMCPToolAllowed(toolName) {
+	if access != nil && !access.IsMCPToolAllowed(toolName) && !hasMCPExecutionAuthorization(ctx, req) {
 		ctx.SetValue(governanceRejectedContextKey, true)
 		return req, &schemas.MCPPluginShortCircuit{Error: &schemas.BifrostError{
 			Type:       bifrost.Ptr(string(DecisionMCPToolBlocked)),

--- a/plugins/governance/mcpauthorization.go
+++ b/plugins/governance/mcpauthorization.go
@@ -1,0 +1,21 @@
+package governance
+
+import "github.com/maximhq/bifrost/core/schemas"
+
+const mcpAuthorizationContextKey schemas.BifrostContextKey = "bf-governance-mcp-authorization"
+
+// mcpAuthorization binds trusted transport approval to one exact execution target.
+type mcpAuthorization struct{ clientName, toolName string }
+
+// SetMCPExecutionAuthorization records a transport-verified approval for one MCP call.
+// Only trusted handlers may call this after checking their own authorization policy;
+// it replaces the MCP tool permit check, never identity, headers or usage limits.
+func SetMCPExecutionAuthorization(ctx *schemas.BifrostContext, clientName, toolName string) {
+	ctx.SetValue(mcpAuthorizationContextKey, mcpAuthorization{clientName, toolName})
+}
+
+// hasMCPExecutionAuthorization prevents approval from following a retargeted request.
+func hasMCPExecutionAuthorization(ctx *schemas.BifrostContext, req *schemas.BifrostMCPRequest) bool {
+	approval, ok := ctx.Value(mcpAuthorizationContextKey).(mcpAuthorization)
+	return ok && approval.clientName != "" && approval.toolName != "" && req.ClientName == approval.clientName && req.GetToolName() == approval.toolName
+}

--- a/plugins/governance/mcpauthorization_test.go
+++ b/plugins/governance/mcpauthorization_test.go
@@ -1,0 +1,53 @@
+package governance
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMCPExecutionAuthorization preserves governance while replacing only the exact tool permit.
+func TestMCPExecutionAuthorization(t *testing.T) {
+	p := newPluginForMCPStamping(t, buildVKForMCPStamping(nil), false)
+	for _, tc := range []struct {
+		name, client, tool, key string
+		approved, allowed       bool
+	}{
+		{"gateway", "local", "local-read", mcpTestVKValue, false, false},
+		{"approved", "local", "local-read", mcpTestVKValue, true, true},
+		{"other tool", "local", "local-write", mcpTestVKValue, true, false},
+		{"other client", "other", "local-read", mcpTestVKValue, true, false},
+		{"invalid identity", "local", "local-read", "invalid", true, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := presentCtx(tc.key)
+			if tc.approved {
+				SetMCPExecutionAuthorization(ctx, "local", "local-read")
+			}
+			req := &schemas.BifrostMCPRequest{RequestType: schemas.MCPRequestTypeChatToolCall, ClientName: tc.client, ChatAssistantMessageToolCall: &schemas.ChatAssistantMessageToolCall{Function: schemas.ChatAssistantMessageToolCallFunction{Name: &tc.tool, Arguments: "{}"}}}
+			_, short, err := p.PreMCPHook(ctx, req)
+			require.NoError(t, err)
+			if tc.allowed {
+				require.Nil(t, short)
+			} else {
+				require.NotNil(t, short)
+				require.NotNil(t, short.Error)
+			}
+		})
+	}
+}
+
+// TestMCPExecutionAuthorizationRequiresHeaders keeps transport requirements ahead of tool approval.
+func TestMCPExecutionAuthorizationRequiresHeaders(t *testing.T) {
+	p := newPluginForMCPStamping(t, buildVKForMCPStamping(nil), false)
+	p.requiredHeaders = &[]string{"x-required"}
+	ctx := presentCtx(mcpTestVKValue)
+	SetMCPExecutionAuthorization(ctx, "local", "local-read")
+	name := "local-read"
+	req := &schemas.BifrostMCPRequest{RequestType: schemas.MCPRequestTypeChatToolCall, ClientName: "local", ChatAssistantMessageToolCall: &schemas.ChatAssistantMessageToolCall{Function: schemas.ChatAssistantMessageToolCallFunction{Name: &name, Arguments: "{}"}}}
+	_, short, err := p.PreMCPHook(ctx, req)
+	require.NoError(t, err)
+	require.NotNil(t, short)
+	require.Equal(t, "missing_required_headers", *short.Error.Type)
+}


### PR DESCRIPTION
## Summary

Introduces a transport-level MCP execution authorization mechanism that allows trusted handlers to bypass the MCP tool permit check for a specific, pinned `(clientName, toolName)` pair, without relaxing identity verification, required headers, or usage limits.

## Changes

- Added `SetMCPExecutionAuthorization` to let trusted transport handlers record a verified approval for one exact MCP tool call, stored in the `BifrostContext` under a dedicated key.
- Added `hasMCPExecutionAuthorization` to validate that a stored approval matches the current request's `clientName` and `toolName` exactly, preventing approval from being reused on a retargeted request.
- Updated `PreMCPHook` to consult `hasMCPExecutionAuthorization` as an additional condition before blocking a tool call that would otherwise fail the access-level tool permit check.
- Added tests covering: no approval (blocked), matching approval (allowed), mismatched tool name (blocked), mismatched client name (blocked), invalid identity (blocked), and approval present but required headers missing (blocked at the header check, not the tool permit check).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
```

Expected: all tests pass, including `TestMCPExecutionAuthorization` and `TestMCPExecutionAuthorizationRequiresHeaders`.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The authorization is intentionally scoped to a single `(clientName, toolName)` pair per request context. It cannot be reused across different tools or clients, and it does not bypass identity verification, required header checks, or usage limits — only the MCP tool permit check. Only trusted transport handlers should call `SetMCPExecutionAuthorization`, as it is the caller's responsibility to enforce their own authorization policy before invoking it.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable