### PR TITLE
feat(databricks): auto-prefix bare model names with `system.ai.` for the Unity AI Gateway

### DIFF
--- a/core/providers/databricks/databricks.go
+++ b/core/providers/databricks/databricks.go
@@ -8,7 +8,10 @@
 //     OpenAI Responses API at /serving-endpoints/responses.
 //   - Unity AI Gateway model APIs (model services), at /ai-gateway/mlflow/v1. The model name
 //     is a Unity Catalog name (e.g. "system.ai.claude-sonnet-4-5", or a user-created
-//     "<catalog>.<schema>.<service>").
+//     "<catalog>.<schema>.<service>"). A bare name sent to this surface is prefixed with
+//     "system.ai." so callers can address the built-in models by their short name; under the
+//     default auto surface selection, a bare name that is not a "databricks-*" endpoint
+//     lands here.
 //
 // Because both surfaces are OpenAI-compatible, every request is delegated to the shared
 // openai.HandleOpenAI* helpers; this package only resolves the workspace host, selects the
@@ -140,24 +143,72 @@ func normalizeHost(raw string) string {
 	return host
 }
 
+// modelServingEndpointPrefix is the naming convention for Databricks pay-per-token Foundation
+// Model endpoints ("databricks-claude-sonnet-4-5", "databricks-gte-large-en").
+const modelServingEndpointPrefix = "databricks-"
+
 // resolveAPIFormat decides which Databricks surface a request targets. An explicit
-// api_format on the key wins; otherwise the model name decides. A dotted name is a Unity
-// Catalog model service (system.ai.*, or <catalog>.<schema>.<service>) and goes to the Unity
-// AI Gateway; anything else is a Model Serving endpoint name.
+// api_format on the key wins; otherwise the model name decides:
 //
-// Model aliases need no special handling here: alias resolution rewrites the model to its
-// upstream model_id before the provider sees it, so auto-detection reads the wire name.
-func resolveAPIFormat(key schemas.Key, model string) schemas.DatabricksAPIFormat {
+//   - A catalog-qualified name (system.ai.*, or <catalog>.<schema>.<service>) is a Unity
+//     Catalog model service and goes to the Unity AI Gateway.
+//   - A "databricks-*" name is a pay-per-token Foundation Model endpoint on Model Serving.
+//   - A name resolved from a key alias is the exact upstream name the user configured. A bare
+//     one can only be a Model Serving endpoint, since the gateway requires catalog names.
+//   - Any other bare name ("gpt-5.5", "claude-opus-5") is a short name for a ready-to-use
+//     system.ai model and goes to the Unity AI Gateway, where wireModel adds the prefix.
+//
+// Provisioned-throughput endpoints with a custom name need api_format: model_serving or a key
+// alias, because their names carry no marker that separates them from a short gateway name.
+func resolveAPIFormat(ctx *schemas.BifrostContext, key schemas.Key, model string) schemas.DatabricksAPIFormat {
 	if key.DatabricksKeyConfig != nil {
 		switch key.DatabricksKeyConfig.APIFormat {
 		case schemas.DatabricksAPIFormatModelServing, schemas.DatabricksAPIFormatAIGateway:
 			return key.DatabricksKeyConfig.APIFormat
 		}
 	}
-	if strings.Contains(model, ".") {
+	if isCatalogQualified(model) {
 		return schemas.DatabricksAPIFormatAIGateway
 	}
-	return schemas.DatabricksAPIFormatModelServing
+	if strings.HasPrefix(strings.ToLower(model), modelServingEndpointPrefix) || schemas.GetResolvedAlias(ctx) != nil {
+		return schemas.DatabricksAPIFormatModelServing
+	}
+	return schemas.DatabricksAPIFormatAIGateway
+}
+
+// aiGatewayDefaultCatalogPrefix is the Unity Catalog prefix under which Databricks publishes
+// its ready-to-use AI Gateway models. Every account can query these with no setup.
+const aiGatewayDefaultCatalogPrefix = "system.ai."
+
+// wireModel returns the model name sent to Databricks for a request. The Unity AI Gateway
+// addresses models by their three-part Unity Catalog name, so a bare name such as
+// "gpt-5.5" is rewritten to "system.ai.gpt-5.5" when the request targets that surface.
+// This applies whether the surface was pinned with api_format: ai_gateway or picked by the
+// auto rule in resolveAPIFormat. Names that already carry a catalog and schema
+// ("system.ai.gpt-5.5", "main.default.my-service") pass through untouched, as do names
+// resolved from a key alias: the alias's model_id is the exact upstream name the user
+// configured, so it is never rewritten. Requests bound for Model Serving are unaffected
+// because endpoint names there are bare by design.
+//
+// A name counts as catalog-qualified when it has at least two dots. A single dot is a
+// version separator ("gpt-5.5", "claude-sonnet-4.5"), not a catalog boundary.
+func wireModel(ctx *schemas.BifrostContext, key schemas.Key, model string) string {
+	if model == "" || isCatalogQualified(model) {
+		return model
+	}
+	if resolveAPIFormat(ctx, key, model) != schemas.DatabricksAPIFormatAIGateway {
+		return model
+	}
+	if schemas.GetResolvedAlias(ctx) != nil {
+		return model
+	}
+	return aiGatewayDefaultCatalogPrefix + model
+}
+
+// isCatalogQualified reports whether a model name already spells out a Unity Catalog
+// <catalog>.<schema>.<name> path.
+func isCatalogQualified(model string) bool {
+	return strings.Count(model, ".") >= 2
 }
 
 // basePathFor returns the OpenAI-compatible base path under the workspace host for a surface.
@@ -180,7 +231,7 @@ func (provider *DatabricksProvider) buildURL(ctx *schemas.BifrostContext, key sc
 	if bErr != nil {
 		return "", bErr
 	}
-	return "https://" + host + basePathFor(resolveAPIFormat(key, model)) + path, nil
+	return "https://" + host + basePathFor(resolveAPIFormat(ctx, key, model)) + path, nil
 }
 
 // workspaceAPIURL composes a URL for a Databricks control-plane REST API (not an inference

--- a/core/providers/databricks/databricks_test.go
+++ b/core/providers/databricks/databricks_test.go
@@ -3,6 +3,7 @@ package databricks_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -111,6 +112,13 @@ const stubChatResponse = `{
 	"usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
 }`
 
+const stubEmbeddingResponse = `{
+	"object": "list",
+	"data": [{"object": "embedding", "index": 0, "embedding": [0.1, 0.2]}],
+	"model": "m",
+	"usage": {"prompt_tokens": 1, "total_tokens": 1}
+}`
+
 // TestDatabricksSurfaceRouting pins the base path each surface is addressed on, and the rule
 // that picks between them. A dotted model name is a Unity Catalog model service and must go
 // to the AI Gateway; a bare name is a Model Serving endpoint. Getting this wrong sends every
@@ -125,6 +133,8 @@ func TestDatabricksSurfaceRouting(t *testing.T) {
 		wantPath  string
 	}{
 		{"auto routes a serving endpoint name to model serving", "databricks-claude-sonnet-4-5", "", "/serving-endpoints/chat/completions"},
+		{"auto routes a short model name to the ai gateway", "claude-opus-5", "", "/ai-gateway/mlflow/v1/chat/completions"},
+		{"auto routes a versioned short name to the ai gateway", "gpt-5.5", "", "/ai-gateway/mlflow/v1/chat/completions"},
 		{"auto routes a system.ai name to the ai gateway", "system.ai.claude-sonnet-4-5", "", "/ai-gateway/mlflow/v1/chat/completions"},
 		{"auto routes a unity catalog fqn to the ai gateway", "main.default.my-service", "", "/ai-gateway/mlflow/v1/chat/completions"},
 		{"explicit model_serving overrides a dotted name", "system.ai.claude-sonnet-4-5", schemas.DatabricksAPIFormatModelServing, "/serving-endpoints/chat/completions"},
@@ -171,6 +181,137 @@ func TestDatabricksSurfaceRouting(t *testing.T) {
 			defer mu.Unlock()
 			if gotPath != tt.wantPath {
 				t.Errorf("path: got %q, want %q", gotPath, tt.wantPath)
+			}
+		})
+	}
+}
+
+// TestDatabricksAIGatewayModelPrefix covers the model name Databricks receives. A bare name
+// bound for the Unity AI Gateway gains the system.ai. catalog prefix; names that already
+// carry a catalog, names bound for Model Serving, and names resolved from a key alias are
+// sent exactly as given.
+func TestDatabricksAIGatewayModelPrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		model     string
+		apiFormat schemas.DatabricksAPIFormat
+		alias     *schemas.ResolvedAlias
+		wantModel string
+	}{
+		{"bare name on the ai gateway gains the system.ai prefix", "gpt-5.5", schemas.DatabricksAPIFormatAIGateway, nil, "system.ai.gpt-5.5"},
+		{"bare name without a version dot on the ai gateway gains the prefix", "claude-opus-5", schemas.DatabricksAPIFormatAIGateway, nil, "system.ai.claude-opus-5"},
+		{"version dot under auto routes to the ai gateway and gains the prefix", "gpt-5.5", "", nil, "system.ai.gpt-5.5"},
+		{"short name under auto routes to the ai gateway and gains the prefix", "claude-opus-5", "", nil, "system.ai.claude-opus-5"},
+		{
+			"bare alias model_id under auto stays on model serving unchanged",
+			"my-pt-endpoint",
+			"",
+			&schemas.ResolvedAlias{Key: "gpt-5.5", Config: &schemas.AliasConfig{ModelID: "my-pt-endpoint"}},
+			"my-pt-endpoint",
+		},
+		{"system.ai name on the ai gateway is unchanged", "system.ai.gpt-5.5", schemas.DatabricksAPIFormatAIGateway, nil, "system.ai.gpt-5.5"},
+		{"unity catalog fqn on the ai gateway is unchanged", "main.default.my-service", schemas.DatabricksAPIFormatAIGateway, nil, "main.default.my-service"},
+		{"bare name under auto is a serving endpoint and is unchanged", "databricks-claude-sonnet-4-5", "", nil, "databricks-claude-sonnet-4-5"},
+		{"bare name pinned to model serving is unchanged", "gpt-5.5", schemas.DatabricksAPIFormatModelServing, nil, "gpt-5.5"},
+		{
+			"alias model_id on the ai gateway is sent verbatim",
+			"my-gpt-deployment",
+			schemas.DatabricksAPIFormatAIGateway,
+			&schemas.ResolvedAlias{Key: "gpt-5.5", Config: &schemas.AliasConfig{ModelID: "my-gpt-deployment"}},
+			"my-gpt-deployment",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mu sync.Mutex
+			var gotModels []string
+
+			provider, server := newStubProvider(t, func(w http.ResponseWriter, r *http.Request) {
+				var body map[string]any
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Errorf("decode request body: %v", err)
+				}
+				mu.Lock()
+				gotModels = append(gotModels, fmt.Sprint(body["model"]))
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case strings.HasSuffix(r.URL.Path, "/embeddings"):
+					_, _ = w.Write([]byte(stubEmbeddingResponse))
+				case strings.HasSuffix(r.URL.Path, "/responses"):
+					_, _ = w.Write([]byte(stubResponsesResponse))
+				default:
+					_, _ = w.Write([]byte(stubChatResponse))
+				}
+			})
+
+			key := schemas.Key{
+				Models: []string{"*"},
+				Value:  *schemas.NewSecretVar("dapi-test"),
+				DatabricksKeyConfig: &schemas.DatabricksKeyConfig{
+					WorkspaceURL: *schemas.NewSecretVar(serverHost(t, server)),
+					APIFormat:    tt.apiFormat,
+				},
+			}
+
+			ctx, cancel := schemas.NewBifrostContextWithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if tt.alias != nil {
+				ctx.SetValue(schemas.BifrostContextKeyResolvedAlias, tt.alias)
+			}
+
+			chatRequest := &schemas.BifrostChatRequest{
+				Provider: schemas.Databricks,
+				Model:    tt.model,
+				Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+			}
+			if _, bErr := provider.ChatCompletion(ctx, key, chatRequest); bErr != nil {
+				t.Fatalf("ChatCompletion returned an error: %v", bErr)
+			}
+			if chatRequest.Model != tt.model {
+				t.Errorf("ChatCompletion mutated the caller's model: got %q, want %q", chatRequest.Model, tt.model)
+			}
+
+			embeddingRequest := &schemas.BifrostEmbeddingRequest{
+				Provider: schemas.Databricks,
+				Model:    tt.model,
+				Input:    &schemas.EmbeddingInput{Text: schemas.Ptr("hi")},
+			}
+			if _, bErr := provider.Embedding(ctx, key, embeddingRequest); bErr != nil {
+				t.Fatalf("Embedding returned an error: %v", bErr)
+			}
+			if embeddingRequest.Model != tt.model {
+				t.Errorf("Embedding mutated the caller's model: got %q, want %q", embeddingRequest.Model, tt.model)
+			}
+
+			// Responses is emulated through chat on the AI Gateway and served natively on
+			// Model Serving; the wire model must be rewritten on both routes.
+			responsesRequest := &schemas.BifrostResponsesRequest{
+				Provider: schemas.Databricks,
+				Model:    tt.model,
+				Input:    []schemas.ResponsesMessage{{Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser), Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")}}},
+			}
+			if _, bErr := provider.Responses(ctx, key, responsesRequest); bErr != nil {
+				t.Fatalf("Responses returned an error: %v", bErr)
+			}
+			if responsesRequest.Model != tt.model {
+				t.Errorf("Responses mutated the caller's model: got %q, want %q", responsesRequest.Model, tt.model)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(gotModels) != 3 {
+				t.Fatalf("expected 3 upstream calls, got %d", len(gotModels))
+			}
+			for i, got := range gotModels {
+				if got != tt.wantModel {
+					t.Errorf("call %d: wire model got %q, want %q", i, got, tt.wantModel)
+				}
 			}
 		})
 	}

--- a/core/providers/databricks/inference.go
+++ b/core/providers/databricks/inference.go
@@ -263,6 +263,50 @@ func stripUnsupportedResponsesFields(ctx *schemas.BifrostContext, request *schem
 	return &requestCopy
 }
 
+// withChatWireModel returns request with its model rewritten to the name Databricks expects
+// on the wire (see wireModel). The caller's request is never mutated: a shallow copy carries
+// the rewritten name, and the original keeps the user-facing model for logging and pricing.
+func withChatWireModel(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
+	if request == nil {
+		return nil
+	}
+	wire := wireModel(ctx, key, request.Model)
+	if wire == request.Model {
+		return request
+	}
+	requestCopy := *request
+	requestCopy.Model = wire
+	return &requestCopy
+}
+
+// withEmbeddingWireModel is withChatWireModel for embedding requests.
+func withEmbeddingWireModel(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) *schemas.BifrostEmbeddingRequest {
+	if request == nil {
+		return nil
+	}
+	wire := wireModel(ctx, key, request.Model)
+	if wire == request.Model {
+		return request
+	}
+	requestCopy := *request
+	requestCopy.Model = wire
+	return &requestCopy
+}
+
+// withResponsesWireModel is withChatWireModel for Responses requests.
+func withResponsesWireModel(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
+	if request == nil {
+		return nil
+	}
+	wire := wireModel(ctx, key, request.Model)
+	if wire == request.Model {
+		return request
+	}
+	requestCopy := *request
+	requestCopy.Model = wire
+	return &requestCopy
+}
+
 // ChatCompletion performs a chat completion request against the resolved Databricks surface.
 func (provider *DatabricksProvider) ChatCompletion(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostChatRequest) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	request = stripUnsupportedChatFields(ctx, request)
@@ -270,6 +314,7 @@ func (provider *DatabricksProvider) ChatCompletion(ctx *schemas.BifrostContext, 
 	if bErr != nil {
 		return nil, bErr
 	}
+	request = withChatWireModel(ctx, key, request)
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/chat/completions")
 	if bErr != nil {
 		return nil, bErr
@@ -299,6 +344,7 @@ func (provider *DatabricksProvider) ChatCompletionStream(ctx *schemas.BifrostCon
 	if bErr != nil {
 		return nil, bErr
 	}
+	request = withChatWireModel(ctx, key, request)
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/chat/completions")
 	if bErr != nil {
 		return nil, bErr
@@ -328,6 +374,7 @@ func (provider *DatabricksProvider) ChatCompletionStream(ctx *schemas.BifrostCon
 
 // Embedding performs an embedding request against the resolved Databricks surface.
 func (provider *DatabricksProvider) Embedding(ctx *schemas.BifrostContext, key schemas.Key, request *schemas.BifrostEmbeddingRequest) (*schemas.BifrostEmbeddingResponse, *schemas.BifrostError) {
+	request = withEmbeddingWireModel(ctx, key, request)
 	url, auth, bErr := provider.prepareRequest(ctx, key, request.Model, "/embeddings")
 	if bErr != nil {
 		return nil, bErr
@@ -361,7 +408,7 @@ func (provider *DatabricksProvider) Responses(ctx *schemas.BifrostContext, key s
 		}
 		return chatResponse.ToBifrostResponsesResponse(), nil
 	}
-	if provider.emulateResponses(key, request.Model) {
+	if provider.emulateResponses(ctx, key, request.Model) {
 		return emulate()
 	}
 
@@ -370,6 +417,7 @@ func (provider *DatabricksProvider) Responses(ctx *schemas.BifrostContext, key s
 	if bErr != nil {
 		return nil, bErr
 	}
+	wireRequest = withResponsesWireModel(ctx, key, wireRequest)
 	url, auth, bErr := provider.prepareRequest(ctx, key, wireRequest.Model, "/responses")
 	if bErr != nil {
 		return nil, bErr
@@ -404,7 +452,7 @@ func (provider *DatabricksProvider) ResponsesStream(ctx *schemas.BifrostContext,
 		ctx.SetValue(schemas.BifrostContextKeyIsResponsesToChatCompletionFallback, true)
 		return provider.ChatCompletionStream(ctx, postHookRunner, postHookSpanFinalizer, key, request.ToChatRequest())
 	}
-	if provider.emulateResponses(key, request.Model) {
+	if provider.emulateResponses(ctx, key, request.Model) {
 		return emulate()
 	}
 
@@ -413,6 +461,7 @@ func (provider *DatabricksProvider) ResponsesStream(ctx *schemas.BifrostContext,
 	if bErr != nil {
 		return nil, bErr
 	}
+	wireRequest = withResponsesWireModel(ctx, key, wireRequest)
 	url, auth, bErr := provider.prepareRequest(ctx, key, wireRequest.Model, "/responses")
 	if bErr != nil {
 		return nil, bErr
@@ -463,8 +512,8 @@ func isResponsesPassthroughUnsupported(bErr *schemas.BifrostError) bool {
 // emulateResponses decides whether a Responses request is served through chat completions
 // without trying the native route first: always on the AI Gateway, and on Model Serving once
 // the endpoint has declined the surface for this workspace and model.
-func (provider *DatabricksProvider) emulateResponses(key schemas.Key, model string) bool {
-	if resolveAPIFormat(key, model) == schemas.DatabricksAPIFormatAIGateway {
+func (provider *DatabricksProvider) emulateResponses(ctx *schemas.BifrostContext, key schemas.Key, model string) bool {
+	if resolveAPIFormat(ctx, key, model) == schemas.DatabricksAPIFormatAIGateway {
 		return true
 	}
 	_, unsupported := provider.responsesUnsupported.Load(provider.responsesCacheKey(key, model))

--- a/core/schemas/account.go
+++ b/core/schemas/account.go
@@ -830,9 +830,11 @@ type SGLKeyConfig struct {
 type DatabricksAPIFormat string
 
 const (
-	// DatabricksAPIFormatAuto picks the surface from the model name: a dotted name
+	// DatabricksAPIFormatAuto picks the surface from the model name: a catalog-qualified name
 	// (system.ai.*, or a <catalog>.<schema>.<service> Unity Catalog model service) goes to the
-	// Unity AI Gateway; anything else is treated as a Model Serving endpoint name.
+	// Unity AI Gateway; a databricks-* name or an alias model_id is a Model Serving endpoint;
+	// any other bare name is a short name for a system.ai model and goes to the Unity AI
+	// Gateway with the system.ai. prefix added.
 	DatabricksAPIFormatAuto DatabricksAPIFormat = "auto"
 	// DatabricksAPIFormatModelServing targets /serving-endpoints — the Foundation Model APIs,
 	// covering pay-per-token endpoints (databricks-*) and provisioned-throughput endpoints.

--- a/docs/providers/supported-providers/databricks.mdx
+++ b/docs/providers/supported-providers/databricks.mdx
@@ -153,12 +153,28 @@ A key needs either a `value` (personal access token) or both `client_id` and `cl
 
 With `api_format: "auto"` (the default) the model name decides:
 
-- A name containing a dot — `system.ai.claude-sonnet-4-5`, or a `<catalog>.<schema>.<service>` Unity Catalog model service — routes to the **Unity AI Gateway**.
-- Any other name — `databricks-claude-sonnet-4-5`, or your own serving endpoint name — routes to **Model Serving**.
+- A catalog-qualified name — `system.ai.claude-sonnet-4-5`, or a `<catalog>.<schema>.<service>` Unity Catalog model service — routes to the **Unity AI Gateway**.
+- A `databricks-*` name — `databricks-claude-sonnet-4-5` — is a pay-per-token endpoint and routes to **Model Serving**.
+- A model name that came from a key alias is sent exactly as configured; when it is bare it routes to **Model Serving**.
+- Any other bare name — `gpt-5.5`, `claude-opus-5` — is treated as a short name for a ready-to-use `system.ai` model and routes to the **Unity AI Gateway** with the `system.ai.` prefix added (see below).
 
-Set `api_format` explicitly to pin one surface. For production, an explicit setting is safer than relying on the naming convention.
+Set `api_format` explicitly to pin one surface. For production, an explicit setting is safer than relying on the naming convention. Provisioned-throughput endpoints with a custom name need `api_format: "model_serving"` or a key alias, since nothing in their name separates them from a short gateway name.
 
 Model aliases need no extra configuration: alias resolution rewrites the model to its upstream `model_id` before the provider sees it, so the surface is chosen from the upstream name.
+
+### Short names on the Unity AI Gateway
+
+The AI Gateway addresses models by their full Unity Catalog name, but you do not have to spell out the `system.ai` catalog yourself. When a request targets the AI Gateway and the model name is not already catalog-qualified, Bifrost prefixes it with `system.ai.` before sending it upstream:
+
+| You send | Databricks receives |
+|----------|---------------------|
+| `databricks/gpt-5.5` (under `auto` or `ai_gateway`) | `system.ai.gpt-5.5` |
+| `databricks/claude-opus-5` (under `auto` or `ai_gateway`) | `system.ai.claude-opus-5` |
+| `databricks/system.ai.gpt-5.5` | `system.ai.gpt-5.5` |
+| `databricks/main.default.my-service` | `main.default.my-service` |
+| `databricks/databricks-claude-sonnet-4-5` under `auto` | `databricks-claude-sonnet-4-5` (Model Serving, no prefix) |
+
+A name counts as catalog-qualified when it has at least two dots, so a version dot such as the one in `gpt-5.5` does not stop the prefix from being added. Names that come from a key alias are always sent exactly as the alias's `model_id`, so an alias is the way to point a short name at a model service in a different catalog.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Callers targeting the Databricks Unity AI Gateway had to spell out the full `system.ai.<model>` Unity Catalog path themselves. This PR adds automatic prefixing so that a bare model name like `gpt-5.5` is transparently rewritten to `system.ai.gpt-5.5` before the request is sent upstream, matching how Databricks publishes its built-in AI Gateway models. The auto-routing rule is also updated so that bare names not prefixed with `databricks-` and not resolved from a key alias are now directed to the AI Gateway rather than Model Serving.

## Changes

- Added `wireModel` to compute the upstream model name for a request. Bare names routed to the AI Gateway are prefixed with `system.ai.`; catalog-qualified names (two or more dots), `databricks-*` Model Serving names, and names resolved from a key alias pass through unchanged.
- Added `isCatalogQualified` to distinguish a Unity Catalog path from a version dot (`gpt-5.5` has one dot and is not catalog-qualified; `main.default.my-service` has two and is).
- Updated `resolveAPIFormat` to accept a `*schemas.BifrostContext` so it can inspect the resolved alias. Bare names that are not `databricks-*` and not alias-resolved now route to the AI Gateway instead of Model Serving.
- Added `withChatWireModel`, `withEmbeddingWireModel`, and `withResponsesWireModel` helpers that produce a shallow copy of the request with the rewritten model name, leaving the caller's original request untouched so logging and pricing see the user-facing name.
- Applied the wire-model rewrite in `ChatCompletion`, `ChatCompletionStream`, `Embedding`, `Responses`, and `ResponsesStream`.
- Added `refineDatabricksModel` to `modelcatalog` so that `RefineModelForProvider` mirrors the same wire-model rule for Databricks, prefixing bare names with `system.ai.` and leaving `databricks-*` and catalog-qualified names unchanged.
- Added `TestDatabricksAIGatewayModelPrefix` covering bare names, already-qualified names, Model Serving names, auto-routed names, and alias-resolved names across all three request types (chat, embedding, responses). Each case also asserts the caller's request struct is not mutated.
- Added routing test cases for short model names and versioned names (e.g. `gpt-5.5`, `claude-opus-5`) to `TestDatabricksSurfaceRouting`.
- Documented the short-name behaviour and updated the auto-routing rules in the Databricks provider docs with a mapping table.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/providers/databricks/... ./framework/modelcatalog/...
```

The new `TestDatabricksAIGatewayModelPrefix` test spins up a stub HTTP server and asserts the model name received by Databricks for each combination of surface, model format, and alias presence. All three request types (chat, embedding, responses) are exercised per case.

## Breaking changes

- [ ] Yes
- [x] No

Provisioned-throughput endpoints with a custom bare name that previously auto-routed to Model Serving will now route to the AI Gateway under `auto`. These endpoints need `api_format: "model_serving"` or a key alias to preserve the old behaviour.

## Related issues

## Security considerations

No auth, secrets, or PII are involved. The rewrite is purely a string transformation applied to the model name before the outbound HTTP request is constructed.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable