### PR TITLE
feat(databricks): add model name refinement with Unity Catalog prefix and endpoint passthrough

### DIFF
--- a/framework/modelcatalog/models.go
+++ b/framework/modelcatalog/models.go
@@ -393,8 +393,34 @@ func (mc *ModelCatalog) RefineModelForProvider(provider schemas.ModelProvider, m
 	switch provider {
 	case schemas.Groq, schemas.Replicate, schemas.Perplexity, schemas.OpenRouter:
 		return mc.refineNestedProviderModel(provider, model)
+	case schemas.Databricks:
+		return refineDatabricksModel(model), nil
 	}
 	return model, nil
+}
+
+// Mirrors Databricks model refinement:
+// - Catalog-qualified names (2+ dots) and `databricks-*` endpoints pass through.
+// - Other names get the `system.ai.` prefix.
+// - A single dot is treated as a version separator (e.g. `gpt-5.5`).
+//
+// Aliases and explicit `api_format` are handled by the provider and are not visible here.
+func refineDatabricksModel(model string) string {
+	const (
+		// defaultCatalogPrefix is the Unity Catalog prefix under which Databricks publishes
+		// its ready-to-use AI Gateway models.
+		defaultCatalogPrefix = "system.ai."
+		// modelServingEndpointPrefix is the naming convention for Databricks pay-per-token
+		// Foundation Model endpoints, which live on Model Serving and take a bare name.
+		modelServingEndpointPrefix = "databricks-"
+	)
+	if model == "" || strings.Count(model, ".") >= 2 {
+		return model
+	}
+	if strings.HasPrefix(strings.ToLower(model), modelServingEndpointPrefix) {
+		return model
+	}
+	return defaultCatalogPrefix + model
 }
 
 // refineNestedProviderModel resolves provider-native model slugs such as

--- a/framework/modelcatalog/models_refine_test.go
+++ b/framework/modelcatalog/models_refine_test.go
@@ -39,6 +39,13 @@ func TestRefineModelForProvider(t *testing.T) {
 		{"own prefix on non-nested provider is stripped", schemas.OpenAI, "openai/gpt-oss-120b", "gpt-oss-120b"},
 		{"foreign prefix on non-nested provider unchanged", schemas.OpenAI, "anthropic/claude-opus-4-6", "anthropic/claude-opus-4-6"},
 		{"non-nested provider bare unchanged", schemas.Anthropic, "claude-opus-4-6", "claude-opus-4-6"},
+		{"databricks short name gains the system.ai prefix", schemas.Databricks, "claude-opus-5", "system.ai.claude-opus-5"},
+		{"databricks short name with a version dot gains the prefix", schemas.Databricks, "gpt-5.5", "system.ai.gpt-5.5"},
+		{"databricks system.ai name is unchanged", schemas.Databricks, "system.ai.gpt-5.5", "system.ai.gpt-5.5"},
+		{"databricks unity catalog fqn is unchanged", schemas.Databricks, "main.default.my-service", "main.default.my-service"},
+		{"databricks pay-per-token endpoint is unchanged", schemas.Databricks, "databricks-claude-sonnet-4-5", "databricks-claude-sonnet-4-5"},
+		{"databricks own-prefixed short name is stripped and refined", schemas.Databricks, "databricks/claude-opus-5", "system.ai.claude-opus-5"},
+		{"databricks refinement is idempotent", schemas.Databricks, "system.ai.claude-opus-5", "system.ai.claude-opus-5"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds Databricks-specific model name refinement so that short model names are automatically qualified with the `system.ai.` Unity Catalog prefix, while pay-per-token Foundation Model endpoints (`databricks-*`) and already fully-qualified catalog names (two or more dots) pass through unchanged.

## Changes

- Introduced `refineDatabricksModel` which applies the following rules:
  - Empty strings and catalog-qualified names (2+ dots) are returned as-is.
  - Names prefixed with `databricks-` (case-insensitive) are returned as-is, preserving pay-per-token Model Serving endpoint names.
  - All other names receive the `system.ai.` prefix, including names containing a single dot (treated as a version separator, e.g. `gpt-5.5`).
- Wired `schemas.Databricks` into `RefineModelForProvider` to invoke the new function.
- Added test cases covering: short names, versioned names, already-prefixed `system.ai.` names, fully-qualified Unity Catalog names, pay-per-token endpoints, provider-prefixed inputs, and idempotency.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./framework/modelcatalog/...
```

Expected: all existing and new test cases in `models_refine_test.go` pass, including the seven new Databricks-specific cases.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

No auth, secrets, or PII involved. Model name transformation is purely string-based and deterministic.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable