### PR TITLE
harness fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2052,6 +2052,7 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		printf '  %-18s %s\n' ""                "  Retry reports merge LAST, so a successful attempt supersedes its own failure in tmp/newman-report.json."; \
 		printf '  %-18s %s\n' "SHARD_LINES=0"  "Drop the per-shard completion lines (<shard> N total/pass/fail) and show only the provider table."; \
 		printf '  %-18s %s\n' "SKIP_STREAM_CANCEL=1" "Skip the post-Newman stream-abort probes that verify server-side cancellation on client disconnect."; \
+		printf '  %-18s %s\n' "HARNESS_SERVER_CWD" "Server working directory for relative logs_store SQLite paths (default: transports/bifrost-http, matching make dev). BIFROST_LOGS_DB_URL overrides config resolution."; \
 		printf '  %-18s %s\n' "DB_VERIFY=0"      "Disable the dbverify reporter (ON by default). When on, [Costing]/[Accounting] requests assert the logs DB cost matches the getbifrost.ai/datasheet-computed cost (resolves DB from APP_DIR/config.json or BIFROST_LOGS_DB_URL); skips gracefully if no logs DB is reachable."; \
 		printf '  %-18s %s\n' "USE_INFISICAL=1" "Source secrets from Infisical CLI ('infisical export --path /local --format dotenv') instead of .env."; \
 		printf '  %-18s %s\n' "VERTEX_GCS_BUCKET" "Env-sourced (.env/Infisical): GCS bucket for Vertex file ops (forwarded to Newman as vertexGcsBucket)."; \
@@ -2241,10 +2242,10 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 	if [ "$(DB_VERIFY)" != "0" ] && [ "$$E2E_DEPS_READY" = "1" ]; then \
 		DBVERIFY_READY=1; \
 		DBVERIFY_REPORTER=",dbverify"; \
-		LOGS_DB_VAL="$${BIFROST_LOGS_DB_URL:-sqlite://$(CURDIR)/$$APP_DIR_VAL/logs.db}"; \
+		LOGS_DB_VAL="$$(node tests/e2e/api/lib/logs-db-url.js "$$APP_DIR_VAL/config.json" "$(or $(HARNESS_SERVER_CWD),$(CURDIR)/transports/bifrost-http)")"; \
 		export BIFROST_LOGS_DB_URL="$$LOGS_DB_VAL"; \
 		DBVERIFY_ARGS="--reporter-dbverify-config $$APP_DIR_VAL/config.json"; \
-		say "$(CYAN)dbverify reporter enabled (logs DB: $$LOGS_DB_VAL). Set DB_VERIFY=0 to disable.$(NC)"; \
+		say "$(CYAN)dbverify reporter enabled (logs DB resolved from configuration or BIFROST_LOGS_DB_URL). Set DB_VERIFY=0 to disable.$(NC)"; \
 	fi; \
 	TOKEN_PARITY_REPORTER=""; \
 	CACHE_PARITY_REPORTER=""; \
@@ -2820,6 +2821,8 @@ run-provider-harness-test: $(if $(HELP),,install-newman) ## Run the Bifrost prov
 		say "$(CYAN)Running stream cancellation probes...$(NC)"; \
 		$(USE_NODE); node tests/e2e/api/runners/run-stream-cancellation.mjs \
 			--base-url "$$BASE_URL_VAL" \
+			--config "$$APP_DIR_VAL/config.json" \
+			--server-working-dir "$(or $(HARNESS_SERVER_CWD),$(CURDIR)/transports/bifrost-http)" \
 			$(if $(PROVIDER),--provider "$(PROVIDER)",) \
 			--out tmp/stream-cancel-report.json > tmp/stream-cancel-cli.log 2>&1; \
 		STREAM_CANCEL_EXIT=$$?; \

--- a/tests/e2e/api/lib/logs-db-url.js
+++ b/tests/e2e/api/lib/logs-db-url.js
@@ -1,0 +1,42 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+// SQLite opens config.path relative to the server process cwd, not config.json.
+function logsDbUrlFromConfig(config, serverWorkingDir, env = process.env) {
+  const ls = config.logs_store;
+  if (!ls || !ls.enabled) return '';
+  const resolve = value => {
+    const text = String((value && typeof value === 'object' ? value.value : value) ?? '');
+    return text.startsWith('env.') ? env[text.slice(4)] || '' : text;
+  };
+  const c = ls.config || {};
+  if (ls.type === 'sqlite') {
+    const filePath = resolve(c.path);
+    return filePath ? 'sqlite://' + path.resolve(serverWorkingDir, filePath) : '';
+  }
+  if (ls.type === 'postgres') {
+    const user = encodeURIComponent(resolve(c.user) || 'bifrost');
+    const password = encodeURIComponent(resolve(c.password));
+    const host = resolve(c.host) || 'localhost';
+    const port = resolve(c.port) || '5432';
+    const database = encodeURIComponent(resolve(c.db_name) || 'bifrost');
+    const ssl = encodeURIComponent(resolve(c.ssl_mode) || 'disable');
+    return `postgresql://${user}:${password}@${host}:${port}/${database}?sslmode=${ssl}`;
+  }
+  return '';
+}
+
+function readLogsDbUrl(configPath, serverWorkingDir, env = process.env) {
+  if (env.BIFROST_LOGS_DB_URL) return env.BIFROST_LOGS_DB_URL;
+  try {
+    return logsDbUrlFromConfig(JSON.parse(fs.readFileSync(configPath, 'utf8')), serverWorkingDir, env);
+  } catch {
+    return '';
+  }
+}
+
+module.exports = { logsDbUrlFromConfig, readLogsDbUrl };
+
+if (require.main === module) {
+  process.stdout.write(readLogsDbUrl(process.argv[2], process.argv[3] || process.cwd()));
+}

--- a/tests/e2e/api/runners/lib/crossprovider-cache-matrix.mjs
+++ b/tests/e2e/api/runners/lib/crossprovider-cache-matrix.mjs
@@ -58,12 +58,15 @@
 // indistinguishable from the bug this suite hunts. Segments are therefore sized against the
 // WORST floor in the matrix (4096), not the target model's, which is why {{cachePrefix}} (~5.9K
 // tokens) is used whole and never sliced. Four segments puts each cell near 24K tokens.
+// Opus 5 uses a shorter visitor-guide fixture above its 512-token floor; its four
+// distinct sections preserve the conversation and breakpoint coverage.
 //
 // COST/CONCURRENCY: run this folder with PARALLEL=0. The harness forks one newman per provider,
 // and these rows match six of them (openai/anthropic/gemini/vertex/bedrock/azure), so a default
 // parallel run would execute every request up to six times over.
 
 import { createHash } from "node:crypto";
+import { libraryReference } from "./fixtures/library-cache-reference.mjs";
 
 const J = (v) => JSON.stringify(v);
 
@@ -256,11 +259,14 @@ const ARMS = [
 // only family routed here.
 function anthropicBody(cell, arm, cellId) {
   const cc = { type: "ephemeral" };
+  const reference = cell.model === "anthropic/claude-opus-5" ? libraryReference : null;
+  const question = reference ? "Where does the Thursday book group meet?" : QUESTION;
+  const reminder = reference ? "This week, the Thursday book group has moved to the Cedar study room upstairs. The starting time is unchanged." : REMINDER;
   const messages = [
-    { role: "user", content: [{ type: "text", text: `${SEG}\n\nDocument A. Reply ${ACK}` }] },
-    { role: "assistant", content: [{ type: "text", text: ACK }] },
-    { role: "user", content: [{ type: "text", text: `${SEG}\n\nDocument B. Reply ${ACK}` }] },
-    { role: "assistant", content: [{ type: "text", text: ACK }] },
+    { role: "user", content: [{ type: "text", text: reference ? `${reference.rooms}\n\nHow long does a study room reservation last?` : `${SEG}\n\nDocument A. Reply ${ACK}` }] },
+    { role: "assistant", content: [{ type: "text", text: reference ? "A study room reservation lasts one hour." : ACK }] },
+    { role: "user", content: [{ type: "text", text: reference ? `${reference.events}\n\nWhen are the family story sessions?` : `${SEG}\n\nDocument B. Reply ${ACK}` }] },
+    { role: "assistant", content: [{ type: "text", text: reference ? "Family story sessions take place on Saturday mornings." : ACK }] },
   ];
 
   if (arm.midconv) {
@@ -275,12 +281,12 @@ function anthropicBody(cell, arm, cellId) {
     // get hoisted instead and never surface the error, which makes the failure look
     // model-specific when it is really placement-specific. Trailing the user turn satisfies
     // both clauses on every provider in this matrix.
-    messages.push({ role: "user", content: [{ type: "text", text: QUESTION }] });
-    messages.push({ role: "system", content: [{ type: "text", text: REMINDER, cache_control: cc }] });
+    messages.push({ role: "user", content: [{ type: "text", text: question }] });
+    messages.push({ role: "system", content: [{ type: "text", text: reminder, cache_control: cc }] });
   } else {
     messages.push({
       role: "user",
-      content: [{ type: "text", text: REMINDER, cache_control: cc }, { type: "text", text: QUESTION }],
+      content: [{ type: "text", text: reminder, cache_control: cc }, { type: "text", text: question }],
     });
   }
 
@@ -288,8 +294,8 @@ function anthropicBody(cell, arm, cellId) {
     model: cell.model,
     max_tokens: maxTokensFor(cell),
     system: [
-      { type: "text", text: salt(cellId), cache_control: cc },
-      { type: "text", text: SEG, cache_control: cc },
+      { type: "text", text: reference ? `Visitor guide edition {{pcNonce}}-${createHash("sha256").update(cellId).digest("hex").slice(0, 12)}.\n\n${reference.welcome}` : salt(cellId), cache_control: cc },
+      { type: "text", text: reference ? reference.borrowing : SEG, cache_control: cc },
     ],
     messages,
   };
@@ -385,7 +391,12 @@ function round1Script(cell, cellId) {
 ${EXTRACT[cell.shape]}
 ${HIT_RATE}
 pm.test(${J(`Cache matrix [${cellId}] round 1 (write) succeeds`)}, function () {
-  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);
+  if (pm.response.code !== 200) throw new Error('request failed: HTTP ' + pm.response.code + ': ' + pm.response.text());
+  if (j.stop_reason === 'refusal') {
+    throw new Error('provider refused the cache fixture: ' + JSON.stringify(j.stop_details || {}));
+  }
+${cell.model === "anthropic/claude-opus-5" ? `  var answer = (j.content || []).filter(function (block) { return block.type === 'text'; }).map(function (block) { return block.text || ''; }).join(' ');
+  if (!/cedar/i.test(answer)) throw new Error('expected the updated book-group location (Cedar study room), got: ' + answer);` : ""}
 });
 if (pm.response.code < 400) {
   console.log('[cache-matrix] ' + ${J(cellId)} + ' round1(write) ' + detail);
@@ -399,7 +410,12 @@ function round2Script(cell, arm, cellId) {
 ${EXTRACT[cell.shape]}
 ${HIT_RATE}
 pm.test(${J(`Cache matrix [${label}] round 2 (read) succeeds`)}, function () {
-  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);
+  if (pm.response.code !== 200) throw new Error('request failed: HTTP ' + pm.response.code + ': ' + pm.response.text());
+  if (j.stop_reason === 'refusal') {
+    throw new Error('provider refused the cache fixture: ' + JSON.stringify(j.stop_details || {}));
+  }
+${cell.model === "anthropic/claude-opus-5" ? `  var answer = (j.content || []).filter(function (block) { return block.type === 'text'; }).map(function (block) { return block.text || ''; }).join(' ');
+  if (!/cedar/i.test(answer)) throw new Error('expected the updated book-group location (Cedar study room), got: ' + answer);` : ""}
 });
 if (pm.response.code < 400) {
   console.log('CACHE_MATRIX_REPORT', JSON.stringify({
@@ -435,7 +451,12 @@ function implicitRoundScript(cell, arm, cellId, round, isLast) {
 ${EXTRACT[cell.shape]}
 ${HIT_RATE}
 pm.test(${J(`Cache matrix [${label}] round ${round} succeeds`)}, function () {
-  pm.expect(pm.response.code, 'request failed: ' + pm.response.text()).to.be.below(400);
+  if (pm.response.code !== 200) throw new Error('request failed: HTTP ' + pm.response.code + ': ' + pm.response.text());
+  if (j.stop_reason === 'refusal') {
+    throw new Error('provider refused the cache fixture: ' + JSON.stringify(j.stop_details || {}));
+  }
+${cell.model === "anthropic/claude-opus-5" ? `  var answer = (j.content || []).filter(function (block) { return block.type === 'text'; }).map(function (block) { return block.text || ''; }).join(' ');
+  if (!/cedar/i.test(answer)) throw new Error('expected the updated book-group location (Cedar study room), got: ' + answer);` : ""}
 });
 if (pm.response.code < 400) {
   var series = [];

--- a/tests/e2e/api/runners/lib/crossprovider-cache-matrix.test.mjs
+++ b/tests/e2e/api/runners/lib/crossprovider-cache-matrix.test.mjs
@@ -28,12 +28,12 @@ const itemNamed = (fragment) => {
 // the series it left in the collection variable, plus the CACHE_MATRIX_REPORT it logged. The
 // script is executed rather than string-matched because the property under test is arithmetic
 // across rounds, which a substring search cannot see.
-function runRound(item, usage, vars) {
+function runRound(item, usage, vars, responseFields = {}) {
   const script = scriptOf(item, "test");
   const logged = [];
   const failures = [];
   const pm = {
-    response: { code: 200, json: () => ({ usage }), text: () => JSON.stringify({ usage }) },
+    response: { code: 200, json: () => ({ usage, ...responseFields }), text: () => JSON.stringify({ usage, ...responseFields }) },
     collectionVariables: {
       get: (k) => (k in vars ? vars[k] : null),
       set: (k, v) => {
@@ -174,6 +174,44 @@ test("the verdict report carries writes summed across rounds, not just the best 
   // would call this cold run warm.
   assert.strictEqual(report.write, 0, "fixture no longer exercises the best-round-is-not-round-1 case");
   assert.ok(report.writeTotal > report.write, "writeTotal must outlive the best round's write");
+});
+
+
+
+
+test("a refused response fails request success even when cache writes are reported", () => {
+  const item = itemNamed("anthropic/claude-opus-5 / control round 1 (write)");
+  const result = runRound(item, {input_tokens: 73, cache_creation_input_tokens: 29672}, {}, {
+    content: [], stop_reason: "refusal", stop_details: {category: "reasoning_extraction"},
+  });
+  assert.ok(result.failures.some(([name, message]) => name.includes("succeeds") && message.includes("reasoning_extraction")),
+    "HTTP 200 and cache-write usage must not make a refused request succeed");
+});
+
+test("Opus 5 reference conversation preserves byte-identical rounds and cache placement", () => {
+  for (const arm of ["control", "midconv"]) {
+    const first = itemNamed(`anthropic/claude-opus-5 / ${arm} round 1 (write)`);
+    const second = itemNamed(`anthropic/claude-opus-5 / ${arm} round 2 (read)`);
+    assert.strictEqual(first.request.body.raw, second.request.body.raw);
+    const body = JSON.parse(first.request.body.raw);
+    assert.strictEqual(body.system.length, 2);
+    assert.ok(body.system.every(block => block.cache_control?.type === "ephemeral"));
+    assert.deepStrictEqual(body.messages.slice(0, 4).map(message => message.role), ["user", "assistant", "user", "assistant"]);
+    const last = body.messages.at(-1);
+    assert.strictEqual(last.role, arm === "midconv" ? "system" : "user");
+    assert.strictEqual(last.content[0].cache_control.type, "ephemeral");
+    assert.ok(body.messages.some(message => message.content.some(block => block.text.includes("Where does the Thursday book group meet?"))));
+    assert.ok(!first.request.body.raw.includes("{{cachePrefix}}"));
+  }
+});
+
+test("Opus 5 must answer the updated location as well as reporting usage", () => {
+  const item = itemNamed("anthropic/claude-opus-5 / midconv round 1 (write)");
+  const usage = {input_tokens: 2, cache_creation_input_tokens: 2900};
+  const accepted = runRound(item, usage, {}, {content: [{type: "text", text: "The group meets in the Cedar study room upstairs."}], stop_reason: "end_turn"});
+  assert.deepStrictEqual(accepted.failures, []);
+  const wrong = runRound(item, usage, {}, {content: [{type: "text", text: "The group meets in the ground-floor meeting room."}], stop_reason: "end_turn"});
+  assert.ok(wrong.failures.some(([, message]) => message.includes("Cedar study room")));
 });
 
 console.log(`\n${passed} passed`);

--- a/tests/e2e/api/runners/lib/fixtures/library-cache-reference.mjs
+++ b/tests/e2e/api/runners/lib/fixtures/library-cache-reference.mjs
@@ -1,0 +1,49 @@
+// Fictional reference material for a normal question-answering conversation.
+// Distinct prose sections avoid padding the request with repeated behavioral instructions.
+export const libraryReference = {
+  welcome: `You help visitors find information in the following guide to Willowbrook Library.
+
+Willowbrook Library occupies a former school beside the town square. The building has two floors, a small courtyard, and a covered entrance facing Market Street. The main doors open into a bright lobby with a welcome desk on the left and a display of recently returned books on the right. Visitors do not need a library card to enter, read, use the reference shelves, or ask staff for assistance. A card is needed only when borrowing material to take home. New visitors can collect a printed map at the welcome desk. The map shows the location of each collection, the stairs, the lift, the toilets, and the courtyard doors.
+
+The ground floor contains general fiction, travel writing, cookery, large-print books, and the children's collection. The first floor contains local history, art, music, science, and the quiet study rooms. Signs at the ends of the shelves list the subjects found in each aisle. Books are arranged alphabetically by author within the fiction collection and by subject in the other collections. A visitor who cannot find a title can ask at either service desk. Staff can check whether the book is on loan, waiting to be reshelved, or held at a neighboring branch. They can also suggest another book on the same subject.
+
+The courtyard is open during daylight hours when the weather is suitable. It has several benches, a raised flower bed, and a sheltered reading table. Food is permitted in the courtyard but not beside the indoor collections. Drinks with secure lids may be taken to the general reading areas. The quiet study rooms have a separate rule asking visitors to leave food and drinks outside. Water is available from the fountain beside the ground-floor cloakroom. Reusable cups and bottles can be filled there.
+
+The library's weekly noticeboard is updated on Monday mornings. It lists story sessions, reading groups, visiting speakers, and changes to room availability. Some events require a place to be reserved, while others welcome visitors without a reservation. Each notice states which arrangement applies. Visitors can ask the welcome desk for a large-print copy of the noticeboard or a verbal explanation of the week's activities. The staff aim to make a first visit straightforward: questions about finding a room, choosing a book, or understanding a notice are all welcome.`,
+
+  borrowing: `Borrowing from Willowbrook Library
+
+A standard library card allows a reader to borrow six books at a time. Books are normally issued for three weeks. The return date is printed on a paper slip, and readers can ask staff to write it inside a personal diary as well. Reference books marked with a small grey label stay in the building so that everyone can consult them. Magazines from the current month also stay in the library; older issues may be borrowed from the magazine shelves near the lobby.
+
+Readers can renew a book at the service desk if nobody else is waiting for it. Staff check the reservation list before agreeing to a renewal. When a reader reserves a book that is already on loan, the library holds it at the welcome desk after it is returned. Reserved books are kept there for seven days. The reader should bring their library card when collecting one. Someone collecting a book for another person should first ask staff what information is needed.
+
+Books may be returned at either indoor service desk. A book returned upstairs is recorded in exactly the same way as one returned downstairs. When the building is closed, ordinary books can be placed in the return box next to the Market Street entrance. Large illustrated volumes and items borrowed from another branch should be handed to a member of staff during opening hours. This helps protect their covers and ensures that any accompanying material is accounted for.
+
+A reader who finds a damaged page should show it to staff before borrowing the book. An existing tear can then be noted on the record. Readers should avoid folding page corners or leaving adhesive notes inside a borrowed volume. Paper bookmarks are available free of charge at both desks. These bookmarks also show the opening hours and the telephone number for general questions.
+
+The library runs a small collection exchange with nearby branches every Wednesday. A requested title may therefore take several days to arrive even when another branch has a copy on its shelves. Staff give an estimated arrival date and explain that the date can change. Visitors interested in a subject immediately can ask for an alternative title while waiting. The purpose of the exchange is to broaden the available collection without asking readers to travel between towns.`,
+
+  rooms: `Rooms and reading spaces at Willowbrook Library
+
+The first floor has three quiet study rooms, named Ash, Beech, and Cedar. Each contains a table, four chairs, a reading lamp, and a coat hook. The rooms are intended for reading, writing, and small study groups. Visitors reserve a room at the upstairs desk. A reservation lasts one hour and can be extended if nobody has booked the following hour. Staff ask visitors to arrive within ten minutes of the reserved time so that an unused room can be offered to someone else.
+
+The larger meeting room is on the ground floor, beyond the travel shelves. It contains movable chairs, two folding tables, and a whiteboard. Local reading groups and community associations use it for activities that fit the library's opening hours. A group organizer should speak to the welcome desk about the room before advertising an event. Staff explain the available times, the seating arrangements, and the amount of time needed to put the furniture back afterward.
+
+There is also an open reading area beside the tall courtyard windows. This area has comfortable chairs and small side tables. It cannot be reserved. Visitors are welcome to sit there with books from any part of the building, provided that reference material is returned to its own shelves when they finish. A low trolley near the windows is used for books that visitors are unsure how to reshelve. Leaving a book on the trolley helps staff return it to the right place.
+
+The children's room is separated from the general reading area by a glass partition. Its shelves are lower, and several have picture labels to help young readers choose a subject. During story sessions, the central rug is cleared for families to sit together. At other times, the room is available for ordinary browsing and reading. Children should remain with their accompanying adult throughout a visit.
+
+Visitors who prefer a less busy period often choose the first hour after opening on a weekday. Saturday mornings are usually livelier because the library hosts a family story session. The welcome desk can describe the usual pattern of activities but cannot guarantee that a particular area will be empty. Staff can help a visitor find another seat if an event makes their original choice unsuitable.`,
+
+  events: `Reading groups and events at Willowbrook Library
+
+The Thursday book group meets in the ground-floor meeting room at six in the evening. It discusses one novel each month, chosen at the previous meeting. Copies of the selected book are displayed on a dedicated shelf beside the welcome desk. New members are welcome to attend even if they have not finished the book. The group begins with brief reactions from anyone who wishes to speak, followed by a discussion of characters, setting, and writing style.
+
+A separate poetry circle meets on the first Tuesday of each month. Participants may bring a poem they enjoy, a poem they have written, or simply come to listen. The organizer provides printed copies of a few short poems for visitors who do not bring one. Reading aloud is optional. The circle uses the same meeting room as the book group, but it starts earlier, at five in the afternoon.
+
+The monthly local-history talk takes place on the last Saturday of the month. Speakers have discussed the old railway station, changes to the market square, traditional crafts, and the history of the river footbridge. The talk is followed by time for questions. Visitors with photographs or recollections relevant to a future subject can speak to the local-history librarian upstairs. Original photographs are handled carefully, and owners can choose to share a copy instead.
+
+Family story sessions take place on Saturday mornings in the children's room. The first session starts at ten and is intended for younger children. A second session starts at eleven and usually includes a longer story and a simple drawing activity. The library supplies paper and pencils. Families do not need to bring materials or prepare anything beforehand. The noticeboard announces any change to this schedule during school holidays.
+
+Most events are free, but space in the meeting room is limited. A notice that asks visitors to reserve a place will also explain how to do so at the welcome desk. When every place has been taken, staff keep a waiting list. Visitors who no longer need a reserved place are asked to let the desk know so it can be offered to someone else. Event details may change, so the weekly noticeboard is the final place to check before making a special journey.`,
+};

--- a/tests/e2e/api/runners/lib/logs-db-url.test.mjs
+++ b/tests/e2e/api/runners/lib/logs-db-url.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { logsDbUrlFromConfig, readLogsDbUrl } = require('../../lib/logs-db-url.js');
+
+test('relative SQLite paths resolve from the server working directory', () => {
+  assert.equal(logsDbUrlFromConfig({logs_store: {enabled: true, type: 'sqlite', config: {path: 'tests/integrations/python/logs.db'}}}, '/repo/transports/bifrost-http'),
+    'sqlite:///repo/transports/bifrost-http/tests/integrations/python/logs.db');
+});
+
+test('absolute SQLite paths and env paths are preserved', () => {
+  const config = path => ({logs_store: {enabled: true, type: 'sqlite', config: {path}}});
+  assert.equal(logsDbUrlFromConfig(config('/data/logs.db'), '/repo'), 'sqlite:///data/logs.db');
+  assert.equal(logsDbUrlFromConfig(config('env.LOG_PATH'), '/repo', {LOG_PATH: '/data/logs.db'}), 'sqlite:///data/logs.db');
+});
+
+test('Postgres configuration resolves env values and escapes credentials', () => {
+  assert.equal(logsDbUrlFromConfig({logs_store: {enabled: true, type: 'postgres', config: {host: 'db', user: 'tester', password: 'env.PASS', db_name: 'logs'}}}, '/repo', {PASS: 'a@b'}),
+    'postgresql://tester:a%40b@db:5432/logs?sslmode=disable');
+});
+
+test('disabled or absent log stores do not invent a SQLite database', () => {
+  assert.equal(logsDbUrlFromConfig({}, '/repo'), '');
+  assert.equal(logsDbUrlFromConfig({logs_store: {enabled: false}}, '/repo'), '');
+});
+
+
+test('explicit database URL takes priority even when config is unavailable', () => {
+  assert.equal(readLogsDbUrl('/missing/config.json', '/repo', {BIFROST_LOGS_DB_URL: 'sqlite:///override/logs.db'}), 'sqlite:///override/logs.db');
+});

--- a/tests/e2e/api/runners/run-stream-cancellation.mjs
+++ b/tests/e2e/api/runners/run-stream-cancellation.mjs
@@ -2,8 +2,7 @@
 // Exercises Bifrost's server-side stream cancellation path by opening a stream,
 // reading the first bytes, then aborting the downstream request.
 
-import { writeFileSync, readFileSync } from "node:fs";
-import path from "node:path";
+import { writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { evaluateProbeStream } from "./lib/stream-probe-verdict.mjs";
 import { resolveVariables } from "./lib/resolve-variables.mjs";
@@ -12,6 +11,7 @@ const require = createRequire(import.meta.url);
 
 // Shared with newman-reporter-dbverify so provider alias normalization stays in sync.
 const { resolvePricingEntry } = require("../lib/pricing");
+const { readLogsDbUrl } = require("../lib/logs-db-url");
 
 const args = Object.fromEntries(
   process.argv.slice(2).reduce((acc, cur, i, arr) => {
@@ -38,6 +38,7 @@ const nonStreamAbortMs = Number(args["nonstream-abort-ms"] || 300);
 const skipCostCheck = args["no-cost-check"] === "true";
 const logsDbUrlArg = args["logs-db-url"] || process.env.BIFROST_LOGS_DB_URL || "";
 const configPathArg = args["config"] || process.env.BIFROST_CONFIG_PATH || "config.json";
+const serverWorkingDir = args["server-working-dir"] || process.cwd();
 const pricingUrl =
   args["pricing-url"] || process.env.BIFROST_PRICING_URL || "https://getbifrost.ai/datasheet";
 // Providers that emit usage in the FIRST stream event → a cancel-after-first-byte
@@ -56,31 +57,7 @@ const EARLY_USAGE_PROVIDERS = new Set(["anthropic"]);
 
 // ─── logs DB + datasheet helpers (cost verification) ──────────────────────────
 function resolveLogsDbUrl() {
-  if (logsDbUrlArg) return logsDbUrlArg;
-  try {
-    const cfg = JSON.parse(readFileSync(configPathArg, "utf8"));
-    const ls = cfg.logs_store;
-    if (!ls || !ls.enabled) return "";
-    if (ls.type === "sqlite") {
-      const p = ls.config && ls.config.path;
-      if (!p || typeof p !== "string") return "";
-      const abs = path.isAbsolute(p) ? p : path.resolve(path.dirname(configPathArg), p);
-      return "sqlite://" + abs;
-    }
-    if (ls.type === "postgres") {
-      const c = ls.config || {};
-      const host = c.host || "localhost",
-        port = c.port || "5432",
-        user = c.user || "bifrost";
-      const pass = c.password || "",
-        db = c.db_name || "bifrost",
-        ssl = c.ssl_mode || "disable";
-      return `postgresql://${user}:${encodeURIComponent(pass)}@${host}:${port}/${db}?sslmode=${ssl}`;
-    }
-  } catch (_) {
-    /* no config / unreadable → skip */
-  }
-  return "";
+  return logsDbUrlArg || readLogsDbUrl(configPathArg, serverWorkingDir);
 }
 
 async function connectLogsDb(url) {

--- a/ui/components/ui/sheet.tsx
+++ b/ui/components/ui/sheet.tsx
@@ -111,14 +111,14 @@ function SheetContent({
 					className={cn(
 						"bg-card data-[state=open]:animate-in data-[state=closed]:animate-out custom-scrollbar fixed z-50 flex flex-col shadow-lg transition-all ease-in-out overscroll-none data-[state=closed]:duration-100 data-[state=open]:duration-100",
 						side === "right" &&
-							"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 right-2 bottom-2  h-auto w-full rounded-sm border-l sm:w-3/4",
+							"data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right top-2 right-2 bottom-2  h-auto w-full rounded-sm border sm:w-3/4",
 						side === "right" && (!expandable || !expanded) && "sm:max-w-2xl",
 						side === "right" && expandable && expanded && "sm:max-w-5xl",
 						side === "left" &&
-							"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-2 bottom-2 left-2 h-auto w-full rounded-sm border-r sm:w-3/4 sm:max-w-sm",
-						side === "top" && "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-2 h-auto border-b",
+							"data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left top-2 bottom-2 left-2 h-auto w-full rounded-sm border sm:w-3/4 sm:max-w-sm",
+						side === "top" && "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top inset-x-0 top-2 h-auto border",
 						side === "bottom" &&
-							"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-2 h-auto border-t",
+							"data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom inset-x-0 bottom-2 h-auto border",
 						className,
 					)}
 					{...props}


### PR DESCRIPTION
## Summary

Centralizes logs-DB URL resolution into a shared `logs-db-url.js` module so that both the Makefile harness and the stream-cancellation runner derive the database connection string the same way — reading `logs_store` from `config.json` and resolving SQLite paths relative to the server's working directory rather than the config file's location. Also adds a dedicated fixture and answer-verification logic for `anthropic/claude-opus-5` in the cross-provider cache matrix, and normalizes Sheet component borders in the UI.

## Changes

- **`tests/e2e/api/lib/logs-db-url.js`** (new): Shared module that resolves a logs-DB URL from `config.json`, handling SQLite relative-path resolution against the server's working directory, Postgres credential assembly with proper URL encoding, `env.*` value interpolation, and `BIFROST_LOGS_DB_URL` override precedence.
- **`tests/e2e/api/runners/lib/logs-db-url.test.mjs`** (new): Unit tests covering relative/absolute SQLite paths, env-variable interpolation, Postgres credential escaping, disabled stores, and explicit URL override.
- **`run-stream-cancellation.mjs`**: Replaced the inline `resolveLogsDbUrl` implementation with a call to `readLogsDbUrl` from the shared module. Accepts a new `--server-working-dir` flag so SQLite paths are resolved correctly.
- **`Makefile`**: Passes `--config` and `--server-working-dir` to the stream-cancellation runner. Replaces the hardcoded `sqlite://$(CURDIR)/$$APP_DIR_VAL/logs.db` fallback with a call to `logs-db-url.js`. Adds `HARNESS_SERVER_CWD` to the help text.
- **`tests/e2e/api/runners/lib/fixtures/library-cache-reference.mjs`** (new): Fictional library visitor-guide fixture with four distinct prose sections (`welcome`, `borrowing`, `rooms`, `events`) used as cache content for `claude-opus-5`, replacing the repeated `{{cachePrefix}}` segments that exceed its token floor.
- **`crossprovider-cache-matrix.mjs`**: For `anthropic/claude-opus-5`, substitutes the library-reference fixture into the system prompt and conversation turns. Adds answer-verification assertions (checking for "Cedar study room") in round-1, round-2, and implicit-round test scripts. Upgrades all round-success checks from `pm.expect(code).to.be.below(400)` to explicit HTTP-200 and `stop_reason !== 'refusal'` guards.
- **`crossprovider-cache-matrix.test.mjs`**: Adds tests for refusal detection, byte-identical round bodies and cache placement for Opus 5, and the Cedar-location answer check.
- **`ui/components/ui/sheet.tsx`**: Replaces directional border classes (`border-l`, `border-r`, `border-b`, `border-t`) with a uniform `border` class on all Sheet sides.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Verify the shared URL resolver unit tests pass
node --test tests/e2e/api/runners/lib/logs-db-url.test.mjs

# Verify the cache-matrix unit tests pass
node --test tests/e2e/api/runners/lib/crossprovider-cache-matrix.test.mjs

# Run the full provider harness (DB_VERIFY on by default)
make run-provider-harness-test PROVIDER=anthropic

# Override the server working directory explicitly
make run-provider-harness-test HARNESS_SERVER_CWD=/path/to/server PROVIDER=anthropic

# Disable DB verification
make run-provider-harness-test DB_VERIFY=0
```

`HARNESS_SERVER_CWD` sets the working directory used to resolve relative SQLite paths from `config.json`. `BIFROST_LOGS_DB_URL` overrides config resolution entirely.

## Screenshots/Recordings

Sheet panels now render with a uniform border on all four sides instead of a single directional border edge.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

`logs-db-url.js` reads `env.*` values from `process.env` to resolve database credentials. No credentials are logged; the resolved URL is passed directly to the DB client. No new secrets are introduced.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable