### PR TITLE
fix: replace <> fragments with <p> in access profile alert descriptions

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -1113,12 +1113,12 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 										<Lock className="h-4 w-4" />
 										<AlertDescription>
 											{isEditing ? (
-												<>
+												<p>
 													This virtual key belongs to an access profile. What it can reach, and what it can spend, are the profile&apos;s:
 													the key itself carries only a name and a description.
-												</>
+												</p>
 											) : (
-												<>
+												<p>
 													This virtual key will be managed by your access profile
 													{vkCreationPolicy?.profile_name ? (
 														<>
@@ -1128,7 +1128,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 													) : null}
 													. Set a name and description; providers, budgets, rate limits, and MCP access are applied from the profile on
 													creation.
-												</>
+												</p>
 											)}
 										</AlertDescription>
 									</Alert>


### PR DESCRIPTION
## Summary

Replaces fragment shorthand tags (`<>...</>`) with `<p>` elements inside the `AlertDescription` component of the virtual key sheet. This ensures the alert text is wrapped in proper paragraph elements for correct semantic HTML and consistent rendering.

## Changes

- Replaced React fragments with `<p>` tags in the access profile alert message for both the editing and creation states of the virtual key sheet

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

Navigate to the virtual keys section and open a virtual key that belongs to an access profile. Verify the alert description renders correctly in both edit and create modes.

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

## Screenshots/Recordings

Verify the alert text in the virtual key sheet displays without layout or styling regressions in both the editing and creation states.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable