### PR TITLE
feat: add overhead exports functionality to telemetry and otel metric exporters

### DIFF
--- a/docs/features/observability/latency-breakdown.mdx
+++ b/docs/features/observability/latency-breakdown.mdx
@@ -23,6 +23,10 @@ The breakdown is populated automatically whenever logging is enabled. There is n
 
 ![Overhead breakdown in the log detail view](../../media/ui-log-detail-overhead-breakdown.png)
 
+<Note>
+This same per-component overhead can also be exported as a metric. Enable the opt-in `overhead_breakdown_enabled` toggle to emit `bifrost_overhead_component_microseconds`, a histogram that splits Bifrost's overhead by an `overhead_component` label. That label takes one of the same ten categories described below (`serialization`, `conversion`, `plugins`, `middleware`, `routing` for Key selection, `processing`, `networking`, `streaming` for Client delivery, `miscellaneous`, and `other`), so the metric and this UI breakdown agree, and summing the components for a given label set reconstructs the scalar `bifrost_overhead_latency_microseconds` total. See [Prometheus](/features/observability/prometheus#overhead-breakdown) and [OpenTelemetry](/features/observability/otel#overhead-breakdown). The metric is derived from completed trace spans, so like the breakdown here it only populates when tracing is active for the request.
+</Note>
+
 ---
 
 ## How it's measured
@@ -114,7 +118,6 @@ The internal request pipeline: the glue that moves a request through the core, a
 | Worker handoff | The goroutine-hop latency from the worker back to the caller |
 | Queue wait | Time the request waits in the provider queue before a worker picks it up |
 | Attribute population | Writing prompt and message attributes onto the LLM call span |
-| Miscellaneous | Pre-dispatch glue that sits on no other span: field re-reads, validation, MCP tool merge, channel-message setup |
 
 ### Networking
 
@@ -137,11 +140,12 @@ Streaming egress: sending chunks back to the client over the response socket.
 |------|------------------|
 | Client write | Writing streamed chunks back to the client |
 
-### Scheduling
+### Miscellaneous
 
 | Name | What it measures |
 |------|------------------|
-| Scheduling | Overhead not attributed to any single phase, mostly time spent passing the request between pipeline stages (a residual, see below) |
+| Miscellaneous | Small glue work that sits on no dedicated span: field re-reads, validation, MCP tool merge, channel-message setup |
+| Residual | Overhead not attributed to any single phase, mostly time spent passing the request between pipeline stages (a residual, see below) |
 
 ---
 
@@ -155,9 +159,9 @@ The **Provider processing** row is the provider's own server-side handling of th
 
 It varies by provider, and a larger value simply means more of that provider's handling is not itemized into finer rows. It is normally small.
 
-### Scheduling
+### Miscellaneous
 
-The **Scheduling** row is overhead that does not belong to any single measured phase, mostly the time the request spends being passed between the stages of the pipeline. It is normally small.
+The **Miscellaneous** category combines small glue work that sits on no dedicated span with the residual overhead that does not belong to any single measured phase, mostly the time the request spends being passed between the stages of the pipeline. It is normally small.
 
 <Note>
 Both residuals appear on **unary** (non-streaming) requests only. See below for why streaming excludes them.
@@ -169,7 +173,7 @@ Both residuals appear on **unary** (non-streaming) requests only. See below for 
 
 A streamed response is accounted for differently, because most of its time is spent waiting between chunks rather than doing Bifrost work. Two consequences:
 
-- **Provider processing and Scheduling are not shown.** For a stream, the time between chunks is off-CPU waiting, not Bifrost work, so these two residuals are left out to avoid mislabeling it.
+- **Provider processing and the Miscellaneous residual are not shown.** For a stream, the time between chunks is off-CPU waiting, not Bifrost work, so these two residuals are left out to avoid mislabeling it.
 - **Per-chunk work still appears in the usual rows.** Decoding each chunk shows up in **Response parse** (Serialization), converting chunks in **Stream convert (inbound)** and **Stream convert (outbound)** (Conversion), and writing chunks back to the client in **Client write** (Client delivery). A stream's numbers therefore read like a unary request's.
 
 ---
@@ -179,7 +183,7 @@ A streamed response is accounted for differently, because most of its time is sp
 - **Compare overhead against upstream first.** If a request feels slow but overhead is a thin sliver next to upstream, the time is the provider's, not Bifrost's.
 - **Look at the largest category.** It tells you where Bifrost spent most of its own time on the request, whether that is serialization, plugins, key selection, or networking.
 - **Drill into a category** with **View details** to see its member rows.
-- **Other** is a fallback for a row that has no assigned category, which is different from **Scheduling**: Scheduling is measured overhead that belonged to no single phase, whereas Other is a row that exists but has not been filed under a category. Every row Bifrost emits today maps to one of the nine categories, so Other is normally empty.
+- **Other** is a fallback for a row that has no assigned category, which is different from the **Miscellaneous** residual: that residual is measured overhead that belonged to no single phase, whereas Other is a row that exists but has not been filed under a category. Every row Bifrost emits today maps to one of the nine categories, so Other is normally empty.
 
 ---
 

--- a/docs/features/observability/otel.mdx
+++ b/docs/features/observability/otel.mdx
@@ -949,6 +949,7 @@ MCP client operations are exported as `mcp.client.operation.duration` (histogram
 | `metrics_endpoint` | `string \| EnvVar` | ✅ Yes (if enabled) | OTLP metrics endpoint URL — supports `env.VAR_NAME` |
 | `metrics_push_interval` | `integer` | ❌ No | Push interval in seconds (default: `15`, range: 1-300) |
 | `metrics_headers` | `object` | ❌ No | Extra headers sent only to the metrics endpoint, overlaid on `headers`. See [Per-signal headers](#per-signal-headers) |
+| `overhead_breakdown_enabled` | `boolean` | ❌ No | Export the per-component overhead histogram `bifrost_overhead_component_microseconds`. Requires `metrics_enabled: true` (no metric is exported otherwise). Default `false`. See [Overhead breakdown](#overhead-breakdown) |
 
 <Note>
 The collector is dialed lazily, so an unreachable metrics endpoint never blocks Bifrost startup or request handling. Metrics that fail to push are dropped and retried on the next interval.
@@ -1107,6 +1108,8 @@ These are the same **Prometheus-style metrics** from the telemetry plugin, pushe
 | `bifrost_cache_write_input_tokens_1h_total` | Counter | Cache-write input tokens with a 1-hour TTL (Anthropic only). Subset of `bifrost_cache_write_input_tokens_total` — do not sum with it |
 | `bifrost_cost_total` | Counter | Total cost in USD |
 | `bifrost_upstream_latency_seconds` | Histogram | Upstream request latency |
+| `bifrost_overhead_latency_microseconds` | Histogram | Total Bifrost overhead per request in microseconds (excludes upstream provider time) |
+| `bifrost_overhead_component_microseconds` | Histogram | That overhead split by internal component via the `overhead_component` attribute. Opt-in per profile via `overhead_breakdown_enabled`, and populated only when tracing is active — see [Overhead breakdown](#overhead-breakdown) |
 | `bifrost_stream_first_token_latency_seconds` | Histogram | Time to first token |
 | `bifrost_stream_inter_token_latency_seconds` | Histogram | Inter-token latency |
 | `bifrost_request_retries` | Histogram | Retries used per request (observed once per request) |
@@ -1117,6 +1120,55 @@ These are the same **Prometheus-style metrics** from the telemetry plugin, pushe
 | `http_response_size_bytes` | Histogram | HTTP response body size |
 
 > **Note:** Size metrics are only recorded when the `Content-Length` header is present. Requests or responses without it (e.g., chunked transfer encoding, streaming responses) do not produce data points in these histograms.
+
+### Overhead breakdown
+
+`bifrost_overhead_component_microseconds` decomposes the same overhead measured by `bifrost_overhead_latency_microseconds` into per-component histograms, sharing its bucket boundaries. It carries the same base attributes plus an `overhead_component` attribute naming the internal component, so summing every component for a given attribute set reconstructs the scalar total.
+
+`overhead_component` takes one of a fixed set of ten values, each rolling the individual pipeline spans up into a category. These match the categories the Bifrost UI's [log-detail overhead breakdown](/features/observability/latency-breakdown) groups into, so the metric and the UI agree:
+
+| Value | UI label | Component |
+|-------|----------|-----------|
+| `serialization` | Serialization | JSON parsing and encoding at the request edges (request/response unmarshal and marshal) |
+| `conversion` | Conversion | Translating between Bifrost's unified schema and the provider's native shape, including per-chunk stream conversion |
+| `plugins` | Plugins | All plugin hook spans combined, across every configured plugin |
+| `middleware` | Middleware | HTTP transport auth and access-control middleware |
+| `routing` | Key selection | Selecting which provider API key to use (key-pool lookup and key selection) |
+| `processing` | Processing | Internal pipeline glue: request setup, pre/post-hook loops, worker setup and handoff, queue wait, and attribute population |
+| `networking` | Networking | Handling between client, gateway, and provider: provider-side processing, request context, response headers, response finalize, request signing, and credential fetch |
+| `streaming` | Client delivery | Streaming egress: backpressure and writing chunks back to the client |
+| `miscellaneous` | Miscellaneous | Small glue work not worth its own span, plus the residual overhead not attributed to any phase span |
+| `other` | Other | Any unmapped bucket (its presence signals a new bucket needs a category) |
+
+The set is bounded, so the list above is exhaustive.
+
+The metric is **off by default**. Enable it per profile with `overhead_breakdown_enabled` (a sibling of `metrics_enabled`, under the profile's Metrics section), or toggle **Enable Overhead Breakdown** on the Metrics tab of the **Observability → OpenTelemetry** page in the UI.
+
+```json
+{
+  "plugins": [
+    {
+      "enabled": true,
+      "name": "otel",
+      "config": {
+        "profiles": [
+          {
+            "service_name": "bifrost",
+            "protocol": "http",
+            "metrics_enabled": true,
+            "metrics_endpoint": "http://otel-collector:4318/v1/metrics",
+            "overhead_breakdown_enabled": true
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+<Note>
+The breakdown is computed from completed trace spans, so it only populates when tracing/observability is active for the request. With tracing off, `bifrost_overhead_component_microseconds` stays empty even when `overhead_breakdown_enabled` is on.
+</Note>
 
 ### OTEL Collector Configuration
 

--- a/docs/features/observability/prometheus.mdx
+++ b/docs/features/observability/prometheus.mdx
@@ -231,6 +231,8 @@ The `path` label contains the matched route template (e.g. `/genai/v1beta/models
 |--------|------|-------------|
 | `bifrost_upstream_requests_total` | Counter | Total requests to LLM providers |
 | `bifrost_upstream_latency_seconds` | Histogram | Provider request latency |
+| `bifrost_overhead_latency_microseconds` | Histogram | Total Bifrost overhead per request in microseconds (Bifrost's own work, excluding upstream provider time) |
+| `bifrost_overhead_component_microseconds` | Histogram | That same overhead broken down by internal component via the `overhead_component` label. Opt-in, and populated only when tracing is active — see [Overhead Breakdown](#overhead-breakdown) |
 | `bifrost_success_requests_total` | Counter | Successful provider requests |
 | `bifrost_error_requests_total` | Counter | Failed provider requests |
 | `bifrost_input_tokens_total` | Counter | Total input tokens processed |
@@ -245,6 +247,47 @@ The `path` label contains the matched route template (e.g. `/genai/v1beta/models
 | `bifrost_request_retries` | Histogram | Number of retries used per request (observed once per request; buckets `0,1,2,3,5,10`). |
 | `bifrost_routing_embedding_requests_total` | Counter | Embedding calls made by semantic complexity routing. Labels: `provider`, `model` (the embedding provider/model, not the request's), `phase` (`request` classification vs `warmup` exemplar embedding). |
 | `bifrost_routing_embedding_cost_total` | Counter | Cost in USD of semantic routing embeddings (same labels as above). Recorded regardless of whether embedding usage counts toward budgets. |
+
+### Overhead Breakdown
+
+`bifrost_overhead_component_microseconds` decomposes the same overhead measured by `bifrost_overhead_latency_microseconds` into per-component histograms. It carries the same base labels as `bifrost_overhead_latency_microseconds` (see [Default Labels](#default-labels)) plus an `overhead_component` label naming the internal component, and shares the same bucket boundaries. Summing every component for a given label set reconstructs the scalar total.
+
+`overhead_component` takes one of a fixed set of ten values. Each rolls the individual pipeline spans up into a category, matching the categories the Bifrost UI's [log-detail overhead breakdown](/features/observability/latency-breakdown) groups into, so the metric and the UI agree:
+
+| Value | UI label | Component |
+|-------|----------|-----------|
+| `serialization` | Serialization | JSON parsing and encoding at the request edges (request/response unmarshal and marshal) |
+| `conversion` | Conversion | Translating between Bifrost's unified schema and the provider's native shape, including per-chunk stream conversion |
+| `plugins` | Plugins | All plugin hook spans combined, across every configured plugin |
+| `middleware` | Middleware | HTTP transport auth and access-control middleware |
+| `routing` | Key selection | Selecting which provider API key to use (key-pool lookup and key selection) |
+| `processing` | Processing | Internal pipeline glue: request setup, pre/post-hook loops, worker setup and handoff, queue wait, and attribute population |
+| `networking` | Networking | Handling between client, gateway, and provider: provider-side processing, request context, response headers, response finalize, request signing, and credential fetch |
+| `streaming` | Client delivery | Streaming egress: backpressure and writing chunks back to the client |
+| `miscellaneous` | Miscellaneous | Small glue work not worth its own span, plus the residual overhead not attributed to any phase span |
+| `other` | Other | Any unmapped bucket (its presence signals a new bucket needs a category) |
+
+The set is bounded, so the list above is exhaustive.
+
+This metric is **off by default**. Enable it with the telemetry plugin's `overhead_breakdown_enabled` config field (a sibling of `metrics_enabled`), or toggle **Enable Overhead Breakdown** on the pull-based tab of the **Observability → Prometheus** page in the UI.
+
+```json
+{
+  "plugins": [
+    {
+      "name": "telemetry",
+      "enabled": true,
+      "config": {
+        "overhead_breakdown_enabled": true
+      }
+    }
+  ]
+}
+```
+
+<Note>
+The breakdown is computed from completed trace spans, so it only populates when tracing/observability is active for the request. With tracing off, `bifrost_overhead_component_microseconds` stays empty even when `overhead_breakdown_enabled` is on.
+</Note>
 
 ### Bifrost MCP Metrics
 

--- a/docs/features/telemetry.mdx
+++ b/docs/features/telemetry.mdx
@@ -53,6 +53,8 @@ These metrics track requests forwarded to AI providers:
 | `bifrost_success_requests_total`   | Counter   | Total successful requests to upstream providers                   | Base Labels, custom labels                            |
 | `bifrost_error_requests_total`     | Counter   | Total failed requests to upstream providers                       | Base Labels, `status_code`, custom labels             |
 | `bifrost_upstream_latency_seconds` | Histogram | Latency of upstream provider requests                             | Base Labels, `is_success`, custom labels              |
+| `bifrost_overhead_latency_microseconds`   | Histogram | Total Bifrost overhead per request in microseconds (Bifrost's own work, excluding upstream provider time) | Base Labels, custom labels                            |
+| `bifrost_overhead_component_microseconds` | Histogram | Same overhead broken down by internal component. Opt-in via `overhead_breakdown_enabled`; populated only when tracing is active | Base Labels, `overhead_component`, custom labels      |
 | `bifrost_input_tokens_total`       | Counter   | Total input tokens sent to upstream providers                     | Base Labels, custom labels                            |
 | `bifrost_output_tokens_total`      | Counter   | Total output tokens received from upstream providers              | Base Labels, custom labels                            |
 | `bifrost_cache_hits_total`         | Counter   | Total cache hits by type (direct/semantic)                        | Base Labels, `cache_type`, custom labels              |
@@ -83,6 +85,10 @@ Base Labels:
 - `team_id` / `team_name`: Team identifiers (empty when governance is not used)
 - `customer_id` / `customer_name`: Customer identifiers (empty when governance is not used)
 - custom labels: Custom labels configured in the Bifrost configuration
+
+<Note>
+`bifrost_overhead_component_microseconds` is off by default. Enable it with the telemetry plugin's `overhead_breakdown_enabled` config field (a sibling of `metrics_enabled`). It carries the Base Labels above plus an `overhead_component` label whose value is one of ten fixed categories (`serialization`, `conversion`, `plugins`, `middleware`, `routing`, `processing`, `networking`, `streaming`, `miscellaneous`, `other`), the same categories the Bifrost UI's log-detail overhead breakdown groups into; summing the components for a given label set reconstructs `bifrost_overhead_latency_microseconds`. Because the breakdown is derived from completed trace spans, it only populates when tracing is active for the request. See [Prometheus → Overhead Breakdown](/features/observability/prometheus#overhead-breakdown).
+</Note>
 
 ### Streaming Metrics
 

--- a/framework/overhead/breakdown.go
+++ b/framework/overhead/breakdown.go
@@ -1,0 +1,409 @@
+// Package overhead splits per-request overhead latency into per-phase buckets from a
+// completed trace's spans. Shared by logging (stores the full breakdown per log row) and
+// the metrics plugins (export a folded per-component histogram) so all three agree.
+package overhead
+
+import (
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/logstore"
+)
+
+// spanWall is a span's wall-clock duration, guarding against unfinished spans
+// (zero or non-monotonic EndTime) which would otherwise read as huge negatives.
+func spanWall(s *schemas.Span) time.Duration {
+	if s.EndTime.IsZero() || !s.EndTime.After(s.StartTime) {
+		return 0
+	}
+	return s.EndTime.Sub(s.StartTime)
+}
+
+// spanOverlap is the duration of child that falls inside parent's time window. For a
+// genuinely nested child this equals the child's wall duration, so self-time is
+// unchanged; for a child re-parented by ID but running outside the parent (a
+// sequential sibling in wall-clock terms) it is zero. Guards unfinished spans.
+func spanOverlap(parent, child *schemas.Span) time.Duration {
+	if parent.EndTime.IsZero() || !parent.EndTime.After(parent.StartTime) {
+		return 0
+	}
+	if child.EndTime.IsZero() || !child.EndTime.After(child.StartTime) {
+		return 0
+	}
+	start := child.StartTime
+	if parent.StartTime.After(start) {
+		start = parent.StartTime
+	}
+	end := child.EndTime
+	if parent.EndTime.Before(end) {
+		end = parent.EndTime
+	}
+	if !end.After(start) {
+		return 0
+	}
+	return end.Sub(start)
+}
+
+// isOverheadSpanKind reports whether a span's self-time counts as attributable
+// Bifrost overhead. Only spans that tightly bracket Bifrost's own code qualify:
+// plugin hooks and internal operations (key.selection, etc). Deliberately excluded:
+//   - llm.call/retry/fallback and the media provider kinds: the upstream side.
+//   - the root http.request span: its self-time is the glue between child spans,
+//     which for streaming also contains response-body socket reads that happen
+//     outside any child span. That time is real upstream (and is already in the
+//     upstream accumulator), so counting it here would double-report it as overhead.
+//
+// Excluded spans still subtract from their parent's self-time via childDur, so their
+// time is removed from any bucket rather than mislabeled. The gap between the summed
+// buckets and the stamped overhead number is surfaced as the reconciliation line.
+func isOverheadSpanKind(kind schemas.SpanKind) bool {
+	switch kind {
+	case schemas.SpanKindPlugin, schemas.SpanKindInternal:
+		return true
+	default:
+		return false
+	}
+}
+
+// overheadBucketName maps an overhead-side span to its breakdown bucket.
+func overheadBucketName(s *schemas.Span) string {
+	if s.Kind == schemas.SpanKindPlugin {
+		// plugin.<name>.<phase> -> plugin.<name>, collapsing the hook phases.
+		n := strings.TrimPrefix(s.Name, "plugin.")
+		if i := strings.LastIndex(n, "."); i > 0 {
+			n = n[:i]
+		}
+		return "plugin." + n
+	}
+	return s.Name // key.selection and other internal spans keep their name
+}
+
+// Compute decomposes Bifrost overhead across spans by self-time:
+// each span's own wall duration minus the wall duration of its direct children.
+// Self-times across the tree are non-overlapping and sum to the root duration, so
+// summing the overhead-side buckets is an independent measure of overhead that does
+// not depend on the upstream socket accumulator. Only overhead-side spans produce a
+// bucket; provider/upstream spans still subtract from their parent's self-time.
+//
+// The remaining overhead (the stamped total, minus the measured plugin/internal
+// self-time) is attributed to a residual "scheduling" bucket: the goroutine-scheduling
+// latency between phases plus any glue no phase span has captured yet. Now that
+// request/response conversion, marshal, and parse each have their own phase span, this
+// residual is small. It is derived from overheadMs (which already excludes upstream),
+// not from the root span's self-time, so it never picks up streaming socket reads.
+// Buckets are returned with microsecond values, measured spans first (chronological)
+// then the scheduling residual.
+//
+// Compute returns the per-phase buckets, the measured Bifrost-CPU total in ms (the sum
+// of those buckets), and whether this was a streaming request. For streams the caller
+// uses measuredMs as the overhead (see the logging plugin's Inject): total-upstream
+// over-counts stream overhead because it includes off-CPU relay/scheduler wait between
+// chunks, which is not Bifrost work.
+func Compute(trace *schemas.Trace, overheadMs float64, overheadOK bool, upstreamMs float64, upstreamOK bool) ([]logstore.OverheadBucket, float64, bool) {
+	if trace == nil || len(trace.Spans) == 0 {
+		return nil, 0, false
+	}
+	// Sum direct-children time per parent, over ALL spans (upstream ones too), so
+	// excluded child spans are still removed from their parent's self-time. Only the
+	// portion of a child that temporally OVERLAPS its parent counts: a child
+	// re-parented for trace-hierarchy reasons but running outside the parent's window
+	// (e.g. llm.call is linked under key.selection but starts after it ends) then
+	// correctly subtracts nothing, instead of driving the parent's self-time negative.
+	spanByID := make(map[string]*schemas.Span, len(trace.Spans))
+	for _, s := range trace.Spans {
+		if s != nil && s.SpanID != "" {
+			spanByID[s.SpanID] = s
+		}
+	}
+	childDur := make(map[string]time.Duration, len(trace.Spans))
+	for _, s := range trace.Spans {
+		if s == nil || s.ParentID == "" {
+			continue
+		}
+		parent := spanByID[s.ParentID]
+		if parent == nil {
+			continue
+		}
+		childDur[s.ParentID] += spanOverlap(parent, s)
+	}
+
+	type agg struct {
+		dur   time.Duration
+		kind  schemas.SpanKind
+		first time.Time
+	}
+	buckets := make(map[string]*agg)
+	for _, s := range trace.Spans {
+		if s == nil || !isOverheadSpanKind(s.Kind) {
+			continue
+		}
+		self := spanWall(s) - childDur[s.SpanID]
+		if self <= 0 {
+			continue
+		}
+		name := overheadBucketName(s)
+		b := buckets[name]
+		if b == nil {
+			b = &agg{kind: s.Kind, first: s.StartTime}
+			buckets[name] = b
+		}
+		b.dur += self
+		if s.StartTime.Before(b.first) {
+			b.first = s.StartTime
+		}
+	}
+
+	// Streaming runs no per-chunk spans: the relay loop's JSON decode, struct->unified
+	// mapping, and downstream-backpressure stall are stamped as root-span attributes at
+	// stream end. Fold them into the same buckets as their unary equivalents (decode ->
+	// response-parse/Serialization, mapping -> convertor/Convertor) so a stream's numbers
+	// read like a unary request's. Backpressure has no unary twin and is not Bifrost CPU,
+	// so it gets its own bucket. Seeding the map here means measuredNs and core pick them
+	// up on the existing path, with no separate bookkeeping.
+	if trace.RootSpan != nil {
+		attrs := trace.RootSpan.Attributes
+		addStreamBucketMs := func(name string, ms float64) {
+			if ms <= 0 {
+				return
+			}
+			b := buckets[name]
+			if b == nil {
+				b = &agg{kind: schemas.SpanKindInternal, first: trace.RootSpan.StartTime}
+				buckets[name] = b
+			}
+			b.dur += time.Duration(ms * float64(time.Millisecond))
+		}
+		if ms, ok := TraceAttrFloatMs(attrs, schemas.AttrBifrostStreamParseMs); ok {
+			addStreamBucketMs("response-parse", ms)
+		}
+		// Inbound per-chunk mapping (provider->Bifrost) is conversion work: it belongs
+		// in the Convertor category, as its own member so the stream split is visible.
+		if ms, ok := TraceAttrFloatMs(attrs, schemas.AttrBifrostStreamConvertMs); ok {
+			addStreamBucketMs("convertor.stream-in", ms)
+		}
+		// Backpressure is the provider-side downstream wait that IS in the overhead
+		// total. Split it into (A) client-write vs (B) transport CPU using the transport
+		// goroutine's concurrent measurements as weights (those run in parallel and are
+		// not themselves in the total, so they weight rather than add). The (B) share is
+		// the outbound per-chunk mapping (Bifrost->client) -- also conversion work, so it
+		// joins the Convertor category as the outbound member. The (A) share is the client
+		// socket write and stays its own bucket. No transport timing (raw passthrough, or a
+		// client that disconnected) falls back to a single undifferentiated bucket.
+		if bp, ok := TraceAttrFloatMs(attrs, schemas.AttrBifrostStreamBackpressureMs); ok && bp > 0 {
+			cpuMs, _ := TraceAttrFloatMs(attrs, schemas.AttrBifrostStreamTransportCPUMs)
+			writeMs, _ := TraceAttrFloatMs(attrs, schemas.AttrBifrostStreamClientWriteMs)
+			if total := cpuMs + writeMs; total > 0 {
+				addStreamBucketMs("stream-client-write", bp*writeMs/total)
+				addStreamBucketMs("convertor.stream-out", bp*cpuMs/total)
+			}
+		}
+		// Worker->caller goroutine-hop latency (unary path): scheduling wall-time
+		// inside the overhead window that sits on no span. Carve it into its own
+		// "worker-handoff" bucket. The reverse hop is the queue-wait span.
+		if ms, ok := TraceAttrFloatMs(attrs, schemas.AttrBifrostWorkerHandoffMs); ok {
+			addStreamBucketMs("worker-handoff", ms)
+		}
+	}
+
+	// Provider-agnostic catch-all. Every provider call runs inside an llm.call span
+	// (SpanKindLLMCall), which is not itself a bucket but envelops the upstream network
+	// call plus ALL provider-side glue. The hot pieces (request conversion/marshal/signing,
+	// response read/decompress/parse) now have their own phase spans; its self-time (wall
+	// minus the child phase spans) is therefore upstream plus whatever provider work no
+	// phase span captured. Subtracting the measured upstream leaves that uncaptured
+	// remainder, surfaced as "provider-internal" so a brand-new provider (or an unspanned
+	// step in an existing one) lands here, and its size tells us a provider needs finer
+	// spans. Summed across attempts: retries create
+	// one llm.call span each, and upstream latency likewise accumulates across them.
+	//
+	// STREAMING IS EXCLUDED. For a streamed response the llm.call span is DEFERRED — it
+	// covers the entire stream (ended on the final chunk), not just setup — while upstream
+	// is only time-to-first-byte. So llm.call self - upstream would capture the whole
+	// per-chunk relay, which is instead decomposed by the stream phases above
+	// (response-parse / convertor / backpressure via the stream accumulator). Computing
+	// provider-internal there would double-count that work and mislabel it. Detect
+	// streaming by the presence of any stream-overhead attribute on the root span.
+	isStreaming := false
+	if trace.RootSpan != nil && trace.RootSpan.Attributes != nil {
+		a := trace.RootSpan.Attributes
+		for _, k := range []string{schemas.AttrBifrostStreamParseMs, schemas.AttrBifrostStreamConvertMs, schemas.AttrBifrostStreamBackpressureMs} {
+			if _, ok := a[k]; ok {
+				isStreaming = true
+				break
+			}
+		}
+	}
+	if upstreamOK && !isStreaming {
+		var llmSelfNs int64
+		var firstLLM time.Time
+		for _, s := range trace.Spans {
+			if s == nil || s.Kind != schemas.SpanKindLLMCall {
+				continue
+			}
+			if self := spanWall(s) - childDur[s.SpanID]; self > 0 {
+				llmSelfNs += self.Nanoseconds()
+			}
+			if firstLLM.IsZero() || s.StartTime.Before(firstLLM) {
+				firstLLM = s.StartTime
+			}
+		}
+		// llmSelfNs and upstream are both provider-side wall time; the difference is the
+		// uninstrumented glue. Guard on a small floor so measurement skew (upstream
+		// stamped slightly larger than the enveloping span) never emits a noise bucket.
+		providerInternalUs := float64(llmSelfNs)/1000.0 - upstreamMs*1000.0
+		if providerInternalUs > 0.5 {
+			b := buckets["provider-internal"]
+			if b == nil {
+				b = &agg{kind: schemas.SpanKindInternal, first: firstLLM}
+				buckets["provider-internal"] = b
+			}
+			b.dur += time.Duration(providerInternalUs * float64(time.Microsecond))
+		}
+	}
+
+	out := make([]logstore.OverheadBucket, 0, len(buckets)+1)
+	var measuredNs int64
+	for name, b := range buckets {
+		measuredNs += b.dur.Nanoseconds()
+		out = append(out, logstore.OverheadBucket{
+			Name:       name,
+			Kind:       string(b.kind),
+			DurationUs: float64(b.dur.Nanoseconds()) / 1000.0,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return buckets[out[i].Name].first.Before(buckets[out[j].Name].first)
+	})
+
+	measuredMs := float64(measuredNs) / float64(time.Millisecond)
+
+	// Unary requests: whatever overhead is left over after every instrumented phase is
+	// the residual between phases — goroutine-scheduling latency (the request hops across
+	// the HTTP, core-pipeline and provider-worker goroutines) plus any not-yet-spanned
+	// transport edge.
+	//
+	// STREAMING IS EXCLUDED. For a stream, total-upstream is NOT Bifrost overhead: it
+	// includes the off-CPU relay/scheduler wait the request goroutine spends parked
+	// between provider chunks (confirmed ~2% CPU under load). All actual Bifrost CPU is
+	// already measured in the buckets above (parse/convert accumulators, aggregated
+	// per-chunk plugin timing, transport marshal/write).
+	if overheadOK && !isStreaming {
+		schedulingUs := overheadMs*1000.0 - float64(measuredNs)/1000.0
+		if schedulingUs > 0.5 {
+			out = append(out, logstore.OverheadBucket{Name: "scheduling", Kind: "scheduling", DurationUs: schedulingUs})
+		}
+	}
+	if len(out) == 0 {
+		return nil, measuredMs, isStreaming
+	}
+	return out, measuredMs, isStreaming
+}
+
+// TraceAttrFloatMs reads a millisecond span attribute, tolerating int/int64/float64.
+func TraceAttrFloatMs(attrs map[string]any, key string) (float64, bool) {
+	switch v := attrs[key].(type) {
+	case float64:
+		return v, true
+	case int64:
+		return float64(v), true
+	case int:
+		return float64(v), true
+	default:
+		return 0, false
+	}
+}
+
+// overhead_component values emitted by ComputeForMetrics: the UI's top-level overhead
+// categories, so the metric and the log-detail view share one vocabulary. Keep in sync
+// with overheadCategoryKey / OVERHEAD_BUCKET_CATEGORY in
+// ui/app/workspace/logs/sheets/logDetailView.tsx (paired Go/TS definitions).
+const (
+	CategorySerialization = "serialization"
+	CategoryConversion    = "conversion"
+	CategoryPlugins       = "plugins"
+	CategoryMiddleware    = "middleware"
+	CategoryRouting       = "routing"
+	CategoryProcessing    = "processing"
+	CategoryNetworking    = "networking"
+	CategoryStreaming     = "streaming"
+	// CategoryMiscellaneous: overhead not worth its own span. Folds the core "miscellaneous"
+	// glue span and the "scheduling" residual (overhead minus the measured phases).
+	CategoryMiscellaneous = "miscellaneous"
+	CategoryOther         = "other"
+)
+
+// bucketCategory maps internal phase-span names to their category. Anything unmapped and
+// not matched by a prefix rule falls to "other" (the signal to add a home here and in the UI).
+var bucketCategory = map[string]string{
+	"key-pool":                   CategoryRouting,
+	"key.selection":              CategoryRouting,
+	"handle-setup":               CategoryProcessing,
+	"pipeline-pre":               CategoryProcessing,
+	"pipeline-post":              CategoryProcessing,
+	"worker-setup":               CategoryProcessing,
+	"worker-handoff":             CategoryProcessing,
+	"queue-wait":                 CategoryProcessing,
+	"attribute-population":       CategoryProcessing,
+	"miscellaneous":              CategoryMiscellaneous,
+	"provider-internal":          CategoryNetworking,
+	"transport-context":          CategoryNetworking,
+	"transport-response-headers": CategoryNetworking,
+	"response-finalize":          CategoryNetworking,
+	"request-sign":               CategoryNetworking,
+	"credentials-fetch":          CategoryNetworking,
+	"stream-backpressure":        CategoryStreaming,
+	"stream-client-write":        CategoryStreaming,
+	"scheduling":                 CategoryMiscellaneous,
+}
+
+// MetricComponent maps one bucket to its category, mirroring the UI's overheadCategoryKey:
+// serialization phases, middleware.*, convertor(.*) and plugin.* by rule, else bucketCategory,
+// else "other" (or "plugins" for an unmatched plugin-kind span).
+func MetricComponent(b logstore.OverheadBucket) string {
+	switch b.Name {
+	case "request-unmarshal", "request-marshal", "response-parse", "response-marshal":
+		return CategorySerialization
+	}
+	if strings.HasPrefix(b.Name, "middleware.") {
+		return CategoryMiddleware
+	}
+	if b.Name == "convertor" || strings.HasPrefix(b.Name, "convertor.") {
+		return CategoryConversion
+	}
+	if strings.HasPrefix(b.Name, "plugin.") {
+		return CategoryPlugins
+	}
+	if c, ok := bucketCategory[b.Name]; ok {
+		return c
+	}
+	if b.Kind == string(schemas.SpanKindPlugin) {
+		return CategoryPlugins
+	}
+	return CategoryOther
+}
+
+// ComputeForMetrics rolls the breakdown up for metric export: overhead_component -> microseconds.
+// Reads overhead/upstream durations off the root span, so callers pass only the trace.
+// Returns nil when there's nothing to record, so callers can skip observation.
+func ComputeForMetrics(trace *schemas.Trace) map[string]float64 {
+	if trace == nil {
+		return nil
+	}
+	var upstreamMs, overheadMs float64
+	var upOK, ovOK bool
+	if trace.RootSpan != nil && trace.RootSpan.Attributes != nil {
+		upstreamMs, upOK = TraceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostUpstreamDurationMs)
+		overheadMs, ovOK = TraceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
+	}
+	buckets, _, _ := Compute(trace, overheadMs, ovOK, upstreamMs, upOK)
+	if len(buckets) == 0 {
+		return nil
+	}
+	out := make(map[string]float64, len(buckets))
+	for _, b := range buckets {
+		out[MetricComponent(b)] += b.DurationUs
+	}
+	return out
+}

--- a/framework/overhead/breakdown_test.go
+++ b/framework/overhead/breakdown_test.go
@@ -1,4 +1,4 @@
-package logging
+package overhead
 
 import (
 	"testing"
@@ -22,7 +22,7 @@ func span(base time.Time, id, parent, name string, kind schemas.SpanKind, startM
 func bucketMap(t *testing.T, trace *schemas.Trace, overheadMs float64, ovOK bool) map[string]float64 {
 	t.Helper()
 	out := map[string]float64{}
-	buckets, _, _ := computeOverheadBreakdown(trace, overheadMs, ovOK, 0, false)
+	buckets, _, _ := Compute(trace, overheadMs, ovOK, 0, false)
 	for _, b := range buckets {
 		out[b.Name] = b.DurationUs
 	}
@@ -254,16 +254,16 @@ func TestComputeOverheadBreakdown_NegligibleOverhead(t *testing.T) {
 		span(base, "llm", "root", "chat gpt-4o", schemas.SpanKindLLMCall, 0, 100),
 	}}
 
-	if got, _, _ := computeOverheadBreakdown(trace, 0, false, 0, false); len(got) != 0 {
+	if got, _, _ := Compute(trace, 0, false, 0, false); len(got) != 0 {
 		t.Errorf("expected no overhead buckets when overhead is negligible, got %v", got)
 	}
 }
 
 func TestComputeOverheadBreakdown_Empty(t *testing.T) {
-	if got, _, _ := computeOverheadBreakdown(nil, 0, false, 0, false); got != nil {
+	if got, _, _ := Compute(nil, 0, false, 0, false); got != nil {
 		t.Error("nil trace must yield nil")
 	}
-	if got, _, _ := computeOverheadBreakdown(&schemas.Trace{}, 5, true, 0, false); got != nil {
+	if got, _, _ := Compute(&schemas.Trace{}, 5, true, 0, false); got != nil {
 		t.Error("trace with no spans must yield nil")
 	}
 }
@@ -289,7 +289,7 @@ func TestComputeOverheadBreakdown_StreamingNoSchedulingResidual(t *testing.T) {
 
 	// total-upstream overhead is a huge 40ms (dominated by off-CPU relay wait), but the
 	// measured Bifrost CPU is only key.selection (2ms) + stream-parse (1ms) = 3ms.
-	buckets, measuredMs, isStreaming := computeOverheadBreakdown(trace, 40, true, 5, true)
+	buckets, measuredMs, isStreaming := Compute(trace, 40, true, 5, true)
 	if !isStreaming {
 		t.Fatal("expected isStreaming=true when a stream attr is present on the root span")
 	}
@@ -309,4 +309,59 @@ func TestComputeOverheadBreakdown_StreamingNoSchedulingResidual(t *testing.T) {
 	if measuredMs < 2.99 || measuredMs > 3.01 {
 		t.Errorf("measuredMs = %v, want ~3 (2ms key.selection + 1ms stream-parse), not the 40ms total-upstream", measuredMs)
 	}
+}
+
+// ComputeForMetrics rolls each raw bucket into its UI category: plugin.<name> ->
+// "plugins", middleware.<name> -> "middleware", key.selection -> "routing", and the
+// scheduling residual -> "miscellaneous". Raw span names must never leak into the metric.
+func TestComputeForMetrics_RollsUpToCategories(t *testing.T) {
+	base := time.Now()
+	root := span(base, "root", "", "/v1/chat/completions", schemas.SpanKindHTTPRequest, 0, 100)
+	root.Attributes = map[string]any{
+		schemas.AttrBifrostOverheadDurationMs: 20.0, // 20ms total overhead
+	}
+	trace := &schemas.Trace{
+		RootSpan: root,
+		Spans: []*schemas.Span{
+			root,
+			span(base, "mw", "root", "middleware.auth", schemas.SpanKindInternal, 0, 1),               // middleware 1ms
+			span(base, "keysel", "root", "key.selection", schemas.SpanKindInternal, 1, 3),             // routing 2ms
+			span(base, "gpre", "root", "plugin.governance.prehook", schemas.SpanKindPlugin, 3, 8),     // plugins 5ms
+			span(base, "gpost", "root", "plugin.governance.posthook", schemas.SpanKindPlugin, 90, 92), // plugins 2ms
+			span(base, "lpost", "root", "plugin.logging.posthook", schemas.SpanKindPlugin, 92, 94),    // plugins 2ms
+		},
+	}
+
+	got := overheadForTest(trace)
+	// plugins = governance 7ms + logging 2ms = 9ms.
+	if got["plugins"] != 9000 {
+		t.Errorf("plugins = %v us, want 9000 (governance 7ms + logging 2ms)", got["plugins"])
+	}
+	if got["middleware"] != 1000 {
+		t.Errorf("middleware = %v us, want 1000 (middleware.auth)", got["middleware"])
+	}
+	// key.selection rolls into the routing category, not its own bucket.
+	if got["routing"] != 2000 {
+		t.Errorf("routing = %v us, want 2000 (key.selection)", got["routing"])
+	}
+	// 20ms overhead - 12ms measured = 8ms residual, which rolls into miscellaneous.
+	if got["miscellaneous"] != 8000 {
+		t.Errorf("miscellaneous = %v us, want 8000 (scheduling residual)", got["miscellaneous"])
+	}
+	// Raw span names must never leak into the metric — only categories.
+	for _, name := range []string{"plugin.governance", "plugin.logging", "middleware.auth", "key.selection"} {
+		if _, ok := got[name]; ok {
+			t.Errorf("raw span name %q must not appear in metric map (categories only)", name)
+		}
+	}
+}
+
+// overheadForTest is a tiny wrapper so the assertions read cleanly; ComputeForMetrics
+// returns nil for an empty result, which ranges as an empty map.
+func overheadForTest(trace *schemas.Trace) map[string]float64 {
+	got := ComputeForMetrics(trace)
+	if got == nil {
+		return map[string]float64{}
+	}
+	return got
 }

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -9,7 +9,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -25,6 +24,7 @@ import (
 	"github.com/maximhq/bifrost/framework/logstore"
 	"github.com/maximhq/bifrost/framework/mcpcatalog"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/overhead"
 	"github.com/maximhq/bifrost/framework/streaming"
 )
 
@@ -2543,12 +2543,12 @@ func (p *LoggerPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
 	var upstreamMs, overheadMs float64
 	var upOK, ovOK bool
 	if trace.RootSpan != nil && trace.RootSpan.Attributes != nil {
-		upstreamMs, upOK = traceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostUpstreamDurationMs)
-		overheadMs, ovOK = traceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
+		upstreamMs, upOK = overhead.TraceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostUpstreamDurationMs)
+		overheadMs, ovOK = overhead.TraceAttrFloatMs(trace.RootSpan.Attributes, schemas.AttrBifrostOverheadDurationMs)
 	}
 	// Per-span self-time decomposition of overhead, attached to the same terminal
 	// row that receives the overhead number below.
-	overheadBreakdown, measuredOverheadMs, isStreaming := computeOverheadBreakdown(trace, overheadMs, ovOK, upstreamMs, upOK)
+	overheadBreakdown, measuredOverheadMs, isStreaming := overhead.Compute(trace, overheadMs, ovOK, upstreamMs, upOK)
 
 	p.logger.Debug("Inject: enqueuing %d log entries", len(pending.entries))
 	// Upstream/overhead are request-level: put them on one row per trace, not all.
@@ -2638,308 +2638,6 @@ func serializePluginLogs(logs []schemas.PluginLogEntry) string {
 		return ""
 	}
 	return string(data)
-}
-
-// spanWall is a span's wall-clock duration, guarding against unfinished spans
-// (zero or non-monotonic EndTime) which would otherwise read as huge negatives.
-func spanWall(s *schemas.Span) time.Duration {
-	if s.EndTime.IsZero() || !s.EndTime.After(s.StartTime) {
-		return 0
-	}
-	return s.EndTime.Sub(s.StartTime)
-}
-
-// spanOverlap is the duration of child that falls inside parent's time window. For a
-// genuinely nested child this equals the child's wall duration, so self-time is
-// unchanged; for a child re-parented by ID but running outside the parent (a
-// sequential sibling in wall-clock terms) it is zero. Guards unfinished spans.
-func spanOverlap(parent, child *schemas.Span) time.Duration {
-	if parent.EndTime.IsZero() || !parent.EndTime.After(parent.StartTime) {
-		return 0
-	}
-	if child.EndTime.IsZero() || !child.EndTime.After(child.StartTime) {
-		return 0
-	}
-	start := child.StartTime
-	if parent.StartTime.After(start) {
-		start = parent.StartTime
-	}
-	end := child.EndTime
-	if parent.EndTime.Before(end) {
-		end = parent.EndTime
-	}
-	if !end.After(start) {
-		return 0
-	}
-	return end.Sub(start)
-}
-
-// isOverheadSpanKind reports whether a span's self-time counts as attributable
-// Bifrost overhead. Only spans that tightly bracket Bifrost's own code qualify:
-// plugin hooks and internal operations (key.selection, etc). Deliberately excluded:
-//   - llm.call/retry/fallback and the media provider kinds: the upstream side.
-//   - the root http.request span: its self-time is the glue between child spans,
-//     which for streaming also contains response-body socket reads that happen
-//     outside any child span. That time is real upstream (and is already in the
-//     upstream accumulator), so counting it here would double-report it as overhead.
-//
-// Excluded spans still subtract from their parent's self-time via childDur, so their
-// time is removed from any bucket rather than mislabeled. The gap between the summed
-// buckets and the stamped overhead number is surfaced as the reconciliation line.
-func isOverheadSpanKind(kind schemas.SpanKind) bool {
-	switch kind {
-	case schemas.SpanKindPlugin, schemas.SpanKindInternal:
-		return true
-	default:
-		return false
-	}
-}
-
-// overheadBucketName maps an overhead-side span to its breakdown bucket.
-func overheadBucketName(s *schemas.Span) string {
-	if s.Kind == schemas.SpanKindPlugin {
-		// plugin.<name>.<phase> -> plugin.<name>, collapsing the hook phases.
-		n := strings.TrimPrefix(s.Name, "plugin.")
-		if i := strings.LastIndex(n, "."); i > 0 {
-			n = n[:i]
-		}
-		return "plugin." + n
-	}
-	return s.Name // key.selection and other internal spans keep their name
-}
-
-// computeOverheadBreakdown decomposes Bifrost overhead across spans by self-time:
-// each span's own wall duration minus the wall duration of its direct children.
-// Self-times across the tree are non-overlapping and sum to the root duration, so
-// summing the overhead-side buckets is an independent measure of overhead that does
-// not depend on the upstream socket accumulator. Only overhead-side spans produce a
-// bucket; provider/upstream spans still subtract from their parent's self-time.
-//
-// The remaining overhead (the stamped total, minus the measured plugin/internal
-// self-time) is attributed to a residual "scheduling" bucket: the goroutine-scheduling
-// latency between phases plus any glue no phase span has captured yet. Now that
-// request/response conversion, marshal, and parse each have their own phase span, this
-// residual is small. It is derived from overheadMs (which already excludes upstream),
-// not from the root span's self-time, so it never picks up streaming socket reads.
-// Buckets are returned with microsecond values, measured spans first (chronological)
-// then the scheduling residual.
-// computeOverheadBreakdown returns the per-phase buckets, the measured Bifrost-CPU
-// total in ms (the sum of those buckets), and whether this was a streaming request.
-// For streams the caller uses measuredMs as the overhead (see Inject): total-upstream
-// over-counts stream overhead because it includes off-CPU relay/scheduler wait between
-// chunks, which is not Bifrost work.
-func computeOverheadBreakdown(trace *schemas.Trace, overheadMs float64, overheadOK bool, upstreamMs float64, upstreamOK bool) ([]logstore.OverheadBucket, float64, bool) {
-	if trace == nil || len(trace.Spans) == 0 {
-		return nil, 0, false
-	}
-	// Sum direct-children time per parent, over ALL spans (upstream ones too), so
-	// excluded child spans are still removed from their parent's self-time. Only the
-	// portion of a child that temporally OVERLAPS its parent counts: a child
-	// re-parented for trace-hierarchy reasons but running outside the parent's window
-	// (e.g. llm.call is linked under key.selection but starts after it ends) then
-	// correctly subtracts nothing, instead of driving the parent's self-time negative.
-	spanByID := make(map[string]*schemas.Span, len(trace.Spans))
-	for _, s := range trace.Spans {
-		if s != nil && s.SpanID != "" {
-			spanByID[s.SpanID] = s
-		}
-	}
-	childDur := make(map[string]time.Duration, len(trace.Spans))
-	for _, s := range trace.Spans {
-		if s == nil || s.ParentID == "" {
-			continue
-		}
-		parent := spanByID[s.ParentID]
-		if parent == nil {
-			continue
-		}
-		childDur[s.ParentID] += spanOverlap(parent, s)
-	}
-
-	type agg struct {
-		dur   time.Duration
-		kind  schemas.SpanKind
-		first time.Time
-	}
-	buckets := make(map[string]*agg)
-	for _, s := range trace.Spans {
-		if s == nil || !isOverheadSpanKind(s.Kind) {
-			continue
-		}
-		self := spanWall(s) - childDur[s.SpanID]
-		if self <= 0 {
-			continue
-		}
-		name := overheadBucketName(s)
-		b := buckets[name]
-		if b == nil {
-			b = &agg{kind: s.Kind, first: s.StartTime}
-			buckets[name] = b
-		}
-		b.dur += self
-		if s.StartTime.Before(b.first) {
-			b.first = s.StartTime
-		}
-	}
-
-	// Streaming runs no per-chunk spans: the relay loop's JSON decode, struct->unified
-	// mapping, and downstream-backpressure stall are stamped as root-span attributes at
-	// stream end. Fold them into the same buckets as their unary equivalents (decode ->
-	// response-parse/Serialization, mapping -> convertor/Convertor) so a stream's numbers
-	// read like a unary request's. Backpressure has no unary twin and is not Bifrost CPU,
-	// so it gets its own bucket. Seeding the map here means measuredNs and core pick them
-	// up on the existing path, with no separate bookkeeping.
-	if trace.RootSpan != nil {
-		attrs := trace.RootSpan.Attributes
-		addStreamBucketMs := func(name string, ms float64) {
-			if ms <= 0 {
-				return
-			}
-			b := buckets[name]
-			if b == nil {
-				b = &agg{kind: schemas.SpanKindInternal, first: trace.RootSpan.StartTime}
-				buckets[name] = b
-			}
-			b.dur += time.Duration(ms * float64(time.Millisecond))
-		}
-		if ms, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamParseMs); ok {
-			addStreamBucketMs("response-parse", ms)
-		}
-		// Inbound per-chunk mapping (provider->Bifrost) is conversion work: it belongs
-		// in the Convertor category, as its own member so the stream split is visible.
-		if ms, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamConvertMs); ok {
-			addStreamBucketMs("convertor.stream-in", ms)
-		}
-		// Backpressure is the provider-side downstream wait that IS in the overhead
-		// total. Split it into (A) client-write vs (B) transport CPU using the transport
-		// goroutine's concurrent measurements as weights (those run in parallel and are
-		// not themselves in the total, so they weight rather than add). The (B) share is
-		// the outbound per-chunk mapping (Bifrost->client) -- also conversion work, so it
-		// joins the Convertor category as the outbound member. The (A) share is the client
-		// socket write and stays its own bucket. No transport timing (raw passthrough, or a
-		// client that disconnected) falls back to a single undifferentiated bucket.
-		if bp, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamBackpressureMs); ok && bp > 0 {
-			cpuMs, _ := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamTransportCPUMs)
-			writeMs, _ := traceAttrFloatMs(attrs, schemas.AttrBifrostStreamClientWriteMs)
-			if total := cpuMs + writeMs; total > 0 {
-				addStreamBucketMs("stream-client-write", bp*writeMs/total)
-				addStreamBucketMs("convertor.stream-out", bp*cpuMs/total)
-			}
-		}
-		// Worker->caller goroutine-hop latency (unary path): scheduling wall-time
-		// inside the overhead window that sits on no span. Carve it into its own
-		// "worker-handoff" bucket. The reverse hop is the queue-wait span.
-		if ms, ok := traceAttrFloatMs(attrs, schemas.AttrBifrostWorkerHandoffMs); ok {
-			addStreamBucketMs("worker-handoff", ms)
-		}
-	}
-
-	// Provider-agnostic catch-all. Every provider call runs inside an llm.call span
-	// (SpanKindLLMCall), which is not itself a bucket but envelops the upstream network
-	// call plus ALL provider-side glue. The hot pieces (request conversion/marshal/signing,
-	// response read/decompress/parse) now have their own phase spans; its self-time (wall
-	// minus the child phase spans) is therefore upstream plus whatever provider work no
-	// phase span captured. Subtracting the measured upstream leaves that uncaptured
-	// remainder, surfaced as "provider-internal" so a brand-new provider (or an unspanned
-	// step in an existing one) lands here, and its size tells us a provider needs finer
-	// spans. Summed across attempts: retries create
-	// one llm.call span each, and upstream latency likewise accumulates across them.
-	//
-	// STREAMING IS EXCLUDED. For a streamed response the llm.call span is DEFERRED — it
-	// covers the entire stream (ended on the final chunk), not just setup — while upstream
-	// is only time-to-first-byte. So llm.call self - upstream would capture the whole
-	// per-chunk relay, which is instead decomposed by the stream phases above
-	// (response-parse / convertor / backpressure via the stream accumulator). Computing
-	// provider-internal there would double-count that work and mislabel it. Detect
-	// streaming by the presence of any stream-overhead attribute on the root span.
-	isStreaming := false
-	if trace.RootSpan != nil && trace.RootSpan.Attributes != nil {
-		a := trace.RootSpan.Attributes
-		for _, k := range []string{schemas.AttrBifrostStreamParseMs, schemas.AttrBifrostStreamConvertMs, schemas.AttrBifrostStreamBackpressureMs} {
-			if _, ok := a[k]; ok {
-				isStreaming = true
-				break
-			}
-		}
-	}
-	if upstreamOK && !isStreaming {
-		var llmSelfNs int64
-		var firstLLM time.Time
-		for _, s := range trace.Spans {
-			if s == nil || s.Kind != schemas.SpanKindLLMCall {
-				continue
-			}
-			if self := spanWall(s) - childDur[s.SpanID]; self > 0 {
-				llmSelfNs += self.Nanoseconds()
-			}
-			if firstLLM.IsZero() || s.StartTime.Before(firstLLM) {
-				firstLLM = s.StartTime
-			}
-		}
-		// llmSelfNs and upstream are both provider-side wall time; the difference is the
-		// uninstrumented glue. Guard on a small floor so measurement skew (upstream
-		// stamped slightly larger than the enveloping span) never emits a noise bucket.
-		providerInternalUs := float64(llmSelfNs)/1000.0 - upstreamMs*1000.0
-		if providerInternalUs > 0.5 {
-			b := buckets["provider-internal"]
-			if b == nil {
-				b = &agg{kind: schemas.SpanKindInternal, first: firstLLM}
-				buckets["provider-internal"] = b
-			}
-			b.dur += time.Duration(providerInternalUs * float64(time.Microsecond))
-		}
-	}
-
-	out := make([]logstore.OverheadBucket, 0, len(buckets)+1)
-	var measuredNs int64
-	for name, b := range buckets {
-		measuredNs += b.dur.Nanoseconds()
-		out = append(out, logstore.OverheadBucket{
-			Name:       name,
-			Kind:       string(b.kind),
-			DurationUs: float64(b.dur.Nanoseconds()) / 1000.0,
-		})
-	}
-	sort.Slice(out, func(i, j int) bool {
-		return buckets[out[i].Name].first.Before(buckets[out[j].Name].first)
-	})
-
-	measuredMs := float64(measuredNs) / float64(time.Millisecond)
-
-	// Unary requests: whatever overhead is left over after every instrumented phase is
-	// the residual between phases — goroutine-scheduling latency (the request hops across
-	// the HTTP, core-pipeline and provider-worker goroutines) plus any not-yet-spanned
-	// transport edge.
-	//
-	// STREAMING IS EXCLUDED. For a stream, total-upstream is NOT Bifrost overhead: it
-	// includes the off-CPU relay/scheduler wait the request goroutine spends parked
-	// between provider chunks (confirmed ~2% CPU under load). All actual Bifrost CPU is
-	// already measured in the buckets above (parse/convert accumulators, aggregated
-	// per-chunk plugin timing, transport marshal/write).
-	if overheadOK && !isStreaming {
-		schedulingUs := overheadMs*1000.0 - float64(measuredNs)/1000.0
-		if schedulingUs > 0.5 {
-			out = append(out, logstore.OverheadBucket{Name: "scheduling", Kind: "scheduling", DurationUs: schedulingUs})
-		}
-	}
-	if len(out) == 0 {
-		return nil, measuredMs, isStreaming
-	}
-	return out, measuredMs, isStreaming
-}
-
-// traceAttrFloatMs reads a millisecond span attribute, tolerating int/int64/float64.
-func traceAttrFloatMs(attrs map[string]any, key string) (float64, bool) {
-	switch v := attrs[key].(type) {
-	case float64:
-		return v, true
-	case int64:
-		return float64(v), true
-	case int:
-		return float64(v), true
-	default:
-		return 0, false
-	}
 }
 
 // MCP Plugin Interface Implementation

--- a/plugins/otel/main.go
+++ b/plugins/otel/main.go
@@ -17,6 +17,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/overhead"
 	"go.opentelemetry.io/otel/attribute"
 	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
 )
@@ -112,6 +113,10 @@ type Profile struct {
 	MetricsEnabled      bool               `json:"metrics_enabled"`
 	MetricsEndpoint     *schemas.SecretVar `json:"metrics_endpoint,omitempty"`
 	MetricsPushInterval int                `json:"metrics_push_interval,omitempty"` // in seconds, default 15
+
+	// Exports bifrost_overhead_component_microseconds (split by overhead_component). Off by
+	// default. Needs MetricsEnabled and tracing on (the breakdown comes from completed spans).
+	OverheadBreakdownEnabled bool `json:"overhead_breakdown_enabled,omitempty"`
 
 	// RequestHeaders lists request-header name patterns (exact or wildcard like "x-custom-*"
 	// or "*") whose captured values are attached to the root span as attributes.
@@ -272,25 +277,26 @@ func profileCarriers(data []byte) []spanFilterCarrier {
 // flattened to plain strings ("env.VAR_NAME" or the literal value) for DB/config-file
 // persistence.
 type profileForStorage struct {
-	Enabled                bool              `json:"enabled"`
-	TracesEnabled          bool              `json:"traces_enabled"`
-	ServiceName            string            `json:"service_name"`
-	CollectorURL           string            `json:"collector_url"`
-	Headers                map[string]string `json:"headers,omitempty"`
-	TraceHeaders           map[string]string `json:"trace_headers,omitempty"`
-	MetricsHeaders         map[string]string `json:"metrics_headers,omitempty"`
-	TraceType              TraceType         `json:"trace_type"`
-	Protocol               Protocol          `json:"protocol"`
-	TLSCACert              string            `json:"tls_ca_cert,omitempty"`
-	Insecure               bool              `json:"insecure"`
-	ExportTimeout          int               `json:"export_timeout,omitempty"`
-	MetricsEnabled         bool              `json:"metrics_enabled"`
-	MetricsEndpoint        string            `json:"metrics_endpoint,omitempty"`
-	MetricsPushInterval    int               `json:"metrics_push_interval,omitempty"`
-	RequestHeaders         []string          `json:"request_headers,omitempty"`
-	DisableContentLogging  bool              `json:"disable_content_logging,omitempty"`
-	GroupTracesBySession   bool              `json:"group_traces_by_session,omitempty"`
-	DisableRootSpanContent bool              `json:"disable_root_span_content,omitempty"`
+	Enabled                  bool              `json:"enabled"`
+	TracesEnabled            bool              `json:"traces_enabled"`
+	ServiceName              string            `json:"service_name"`
+	CollectorURL             string            `json:"collector_url"`
+	Headers                  map[string]string `json:"headers,omitempty"`
+	TraceHeaders             map[string]string `json:"trace_headers,omitempty"`
+	MetricsHeaders           map[string]string `json:"metrics_headers,omitempty"`
+	TraceType                TraceType         `json:"trace_type"`
+	Protocol                 Protocol          `json:"protocol"`
+	TLSCACert                string            `json:"tls_ca_cert,omitempty"`
+	Insecure                 bool              `json:"insecure"`
+	ExportTimeout            int               `json:"export_timeout,omitempty"`
+	MetricsEnabled           bool              `json:"metrics_enabled"`
+	MetricsEndpoint          string            `json:"metrics_endpoint,omitempty"`
+	MetricsPushInterval      int               `json:"metrics_push_interval,omitempty"`
+	OverheadBreakdownEnabled bool              `json:"overhead_breakdown_enabled,omitempty"`
+	RequestHeaders           []string          `json:"request_headers,omitempty"`
+	DisableContentLogging    bool              `json:"disable_content_logging,omitempty"`
+	GroupTracesBySession     bool              `json:"group_traces_by_session,omitempty"`
+	DisableRootSpanContent   bool              `json:"disable_root_span_content,omitempty"`
 }
 
 // configForStorage is the persisted wrapper shape.
@@ -315,25 +321,26 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 			continue
 		}
 		out.Profiles = append(out.Profiles, profileForStorage{
-			Enabled:                p.Enabled,
-			TracesEnabled:          p.TracesEnabled,
-			ServiceName:            p.ServiceName,
-			CollectorURL:           schemas.SecretVarAsString(p.CollectorURL),
-			Headers:                p.Headers,
-			TraceHeaders:           p.TraceHeaders,
-			MetricsHeaders:         p.MetricsHeaders,
-			TraceType:              p.TraceType,
-			Protocol:               p.Protocol,
-			TLSCACert:              p.TLSCACert,
-			Insecure:               p.Insecure,
-			ExportTimeout:          p.ExportTimeout,
-			MetricsEnabled:         p.MetricsEnabled,
-			MetricsEndpoint:        schemas.SecretVarAsString(p.MetricsEndpoint),
-			MetricsPushInterval:    p.MetricsPushInterval,
-			RequestHeaders:         p.RequestHeaders,
-			DisableContentLogging:  p.DisableContentLogging,
-			GroupTracesBySession:   p.GroupTracesBySession,
-			DisableRootSpanContent: p.DisableRootSpanContent,
+			Enabled:                  p.Enabled,
+			TracesEnabled:            p.TracesEnabled,
+			ServiceName:              p.ServiceName,
+			CollectorURL:             schemas.SecretVarAsString(p.CollectorURL),
+			Headers:                  p.Headers,
+			TraceHeaders:             p.TraceHeaders,
+			MetricsHeaders:           p.MetricsHeaders,
+			TraceType:                p.TraceType,
+			Protocol:                 p.Protocol,
+			TLSCACert:                p.TLSCACert,
+			Insecure:                 p.Insecure,
+			ExportTimeout:            p.ExportTimeout,
+			MetricsEnabled:           p.MetricsEnabled,
+			MetricsEndpoint:          schemas.SecretVarAsString(p.MetricsEndpoint),
+			MetricsPushInterval:      p.MetricsPushInterval,
+			OverheadBreakdownEnabled: p.OverheadBreakdownEnabled,
+			RequestHeaders:           p.RequestHeaders,
+			DisableContentLogging:    p.DisableContentLogging,
+			GroupTracesBySession:     p.GroupTracesBySession,
+			DisableRootSpanContent:   p.DisableRootSpanContent,
 		})
 	}
 	return sonic.Marshal(out)
@@ -406,15 +413,16 @@ func hideResolvedEnvValue(v *schemas.SecretVar) *schemas.SecretVar {
 // plus an optional metrics exporter, along with the per-profile identity (service name)
 // used when converting traces for this destination.
 type otelTarget struct {
-	serviceName            string
-	url                    string
-	traceType              TraceType
-	client                 OtelClient
-	metricsExporter        *MetricsExporter
-	requestHeaders         []string
-	disableContentLogging  bool
-	groupTracesBySession   bool
-	disableRootSpanContent bool
+	serviceName              string
+	url                      string
+	traceType                TraceType
+	client                   OtelClient
+	metricsExporter          *MetricsExporter
+	requestHeaders           []string
+	disableContentLogging    bool
+	groupTracesBySession     bool
+	disableRootSpanContent   bool
+	overheadBreakdownEnabled bool
 
 	// exportTimeout bounds a single Emit. See Profile.ExportTimeout.
 	exportTimeout time.Duration
@@ -603,14 +611,20 @@ func (p *OtelPlugin) buildTarget(index int, profile *Profile) (*otelTarget, erro
 		return nil, fmt.Errorf("profile %d: %w", index, err)
 	}
 
+	// The breakdown needs the metrics exporter, built only when metrics_enabled; warn but keep the profile.
+	if profile.OverheadBreakdownEnabled && !profile.MetricsEnabled {
+		logger.Warn("otel profile %d: overhead_breakdown_enabled needs metrics_enabled; no overhead component metrics will be exported", index)
+	}
+
 	target := &otelTarget{
-		serviceName:            serviceName,
-		traceType:              profile.TraceType,
-		requestHeaders:         slices.Clone(profile.RequestHeaders),
-		disableContentLogging:  profile.DisableContentLogging,
-		groupTracesBySession:   profile.GroupTracesBySession,
-		disableRootSpanContent: profile.DisableRootSpanContent,
-		exportTimeout:          exportTimeout,
+		serviceName:              serviceName,
+		traceType:                profile.TraceType,
+		requestHeaders:           slices.Clone(profile.RequestHeaders),
+		disableContentLogging:    profile.DisableContentLogging,
+		groupTracesBySession:     profile.GroupTracesBySession,
+		disableRootSpanContent:   profile.DisableRootSpanContent,
+		overheadBreakdownEnabled: profile.OverheadBreakdownEnabled,
+		exportTimeout:            exportTimeout,
 	}
 
 	// Build the trace client only when traces are enabled; Inject skips a nil client.
@@ -850,6 +864,18 @@ func (p *OtelPlugin) RecordHTTPMetrics(ctx context.Context, path, method, status
 // Implements schemas.ObservabilityPlugin interface.
 // This method is called asynchronously by TracingMiddleware after the response
 // has been written to the client.
+// ConsumesOverheadSpans opts into the internal breakdown spans (schemas.OverheadSpanConsumer)
+// when any profile enables the histogram, so recordMetricsFromTrace can decompose overhead.
+// Independent of trace export, which still drops those spans per export_overhead_spans.
+func (p *OtelPlugin) ConsumesOverheadSpans() bool {
+	for _, t := range p.targets {
+		if t.overheadBreakdownEnabled {
+			return true
+		}
+	}
+	return false
+}
+
 func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 	if trace == nil {
 		return nil
@@ -865,7 +891,7 @@ func (p *OtelPlugin) Inject(ctx context.Context, trace *schemas.Trace) error {
 			// Metrics first: they are SDK-buffered and never touch the network here, so
 			// they still get recorded even when the trace endpoint is broken.
 			if t.metricsExporter != nil {
-				p.recordMetricsFromTrace(ctx, t.metricsExporter, trace)
+				p.recordMetricsFromTrace(ctx, t.metricsExporter, trace, t.overheadBreakdownEnabled)
 				p.recordMCPMetricsFromTrace(ctx, t.metricsExporter, trace)
 			}
 			if t.client == nil || t.breakerOpen() {
@@ -1189,7 +1215,7 @@ func (p *OtelPlugin) recordMCPMetricsFromTrace(ctx context.Context, exporter *Me
 // per llm.call/retry span so fallback attempts and failed retries are counted with
 // their own provider/model/fallback_index labels. Per-trace metrics (tokens, cost,
 // TTFT) are recorded once, keyed off the final (latest) attempt span.
-func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *MetricsExporter, trace *schemas.Trace) {
+func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *MetricsExporter, trace *schemas.Trace, recordOverheadBreakdown bool) {
 	if trace == nil || exporter == nil {
 		return
 	}
@@ -1242,6 +1268,15 @@ func (p *OtelPlugin) recordMetricsFromTrace(ctx context.Context, exporter *Metri
 			labelSpan = trace.RootSpan
 		}
 		exporter.RecordOverheadLatency(ctx, overheadMicros, buildSpanAttrs(labelSpan)...)
+
+		// Same overhead, split by overhead_component. Same base attrs as the scalar above,
+		// so the components sum to it per label set.
+		if recordOverheadBreakdown {
+			for component, micros := range overhead.ComputeForMetrics(trace) {
+				attrs := append(buildSpanAttrs(labelSpan), attribute.String("overhead_component", component))
+				exporter.RecordOverheadComponent(ctx, micros, attrs...)
+			}
+		}
 	}
 
 	if finalSpan == nil {

--- a/plugins/otel/metrics.go
+++ b/plugins/otel/metrics.go
@@ -56,6 +56,7 @@ type MetricsExporter struct {
 	// Bifrost metrics - histograms
 	upstreamLatencySeconds         *syncFloat64Histogram
 	overheadLatencyMicros          *syncFloat64Histogram
+	overheadComponentMicros        *syncFloat64Histogram
 	streamFirstTokenLatencySeconds *syncFloat64Histogram
 	streamInterTokenLatencySeconds *syncFloat64Histogram
 	requestRetries                 *syncFloat64Histogram
@@ -406,6 +407,14 @@ func (m *MetricsExporter) initMetrics() {
 		boundaries: overheadLatencyBuckets,
 	}
 
+	m.overheadComponentMicros = &syncFloat64Histogram{
+		name:       "bifrost_overhead_component_microseconds",
+		desc:       "Bifrost overhead latency broken down by internal component (overhead_component attribute), in microseconds. Off by default; enable with overhead_breakdown_enabled. Requires tracing to be active",
+		unit:       "us",
+		meter:      m.meter,
+		boundaries: overheadLatencyBuckets,
+	}
+
 	m.streamFirstTokenLatencySeconds = &syncFloat64Histogram{
 		name:       "bifrost_stream_first_token_latency_seconds",
 		desc:       "Latency of the first token of a stream response",
@@ -545,6 +554,12 @@ func (m *MetricsExporter) RecordUpstreamLatency(ctx context.Context, latencySeco
 // the underlying accumulator already spans every retry and fallback.
 func (m *MetricsExporter) RecordOverheadLatency(ctx context.Context, overheadMicros float64, attrs ...attribute.KeyValue) {
 	m.overheadLatencyMicros.Record(ctx, overheadMicros, metric.WithAttributes(attrs...))
+}
+
+// RecordOverheadComponent records one component's share of overhead (µs). Caller passes
+// overhead_component plus the same base attrs as RecordOverheadLatency.
+func (m *MetricsExporter) RecordOverheadComponent(ctx context.Context, overheadMicros float64, attrs ...attribute.KeyValue) {
+	m.overheadComponentMicros.Record(ctx, overheadMicros, metric.WithAttributes(attrs...))
 }
 
 // RecordStreamFirstTokenLatency records first token latency metric

--- a/plugins/otel/profiles_test.go
+++ b/plugins/otel/profiles_test.go
@@ -181,6 +181,7 @@ func TestMarshalForStorageRoundTrip(t *testing.T) {
 				"collector_url": "env.OTEL_URL",
 				"trace_type": "genai_extension",
 				"protocol": "grpc",
+				"overhead_breakdown_enabled": true,
 				"headers": {"Authorization": "env.OTEL_TOKEN", "X-Tenant": "acme"}
 			},
 			{
@@ -224,6 +225,13 @@ func TestMarshalForStorageRoundTrip(t *testing.T) {
 	}
 	if len(back.Profiles) != 2 {
 		t.Fatalf("round-trip profiles len = %d, want 2", len(back.Profiles))
+	}
+	// overhead_breakdown_enabled must survive the storage whitelist (profileForStorage).
+	if !back.Profiles[0].OverheadBreakdownEnabled {
+		t.Errorf("round-trip profile 0 overhead_breakdown_enabled = false, want true (dropped by storage whitelist)")
+	}
+	if back.Profiles[1].OverheadBreakdownEnabled {
+		t.Errorf("round-trip profile 1 overhead_breakdown_enabled = true, want false")
 	}
 	if back.PluginSpanFilter == nil || back.PluginSpanFilter.Mode != PluginSpanFilterModeExclude {
 		t.Fatalf("round-trip plugin_span_filter = %+v, want exclude", back.PluginSpanFilter)

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -18,6 +18,7 @@ import (
 	bifrost "github.com/maximhq/bifrost/core"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/modelcatalog"
+	"github.com/maximhq/bifrost/framework/overhead"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -83,13 +84,15 @@ func (c *Config) MarshalForStorage() ([]byte, error) {
 		BasicAuth      *basicAuthStorage `json:"basic_auth,omitempty"`
 	}
 	type configStorage struct {
-		CustomLabels   []string            `json:"custom_labels,omitempty"`
-		MetricsEnabled *bool               `json:"metrics_enabled,omitempty"`
-		PushGateway    *pushGatewayStorage `json:"push_gateway,omitempty"`
+		CustomLabels             []string            `json:"custom_labels,omitempty"`
+		MetricsEnabled           *bool               `json:"metrics_enabled,omitempty"`
+		OverheadBreakdownEnabled *bool               `json:"overhead_breakdown_enabled,omitempty"`
+		PushGateway              *pushGatewayStorage `json:"push_gateway,omitempty"`
 	}
 	storage := configStorage{
-		CustomLabels:   c.CustomLabels,
-		MetricsEnabled: c.MetricsEnabled,
+		CustomLabels:             c.CustomLabels,
+		MetricsEnabled:           c.MetricsEnabled,
+		OverheadBreakdownEnabled: c.OverheadBreakdownEnabled,
 	}
 	if c.PushGateway != nil {
 		pgw := &pushGatewayStorage{
@@ -167,6 +170,7 @@ type PrometheusPlugin struct {
 	UpstreamRequestsTotal          *prometheus.CounterVec
 	UpstreamLatencySeconds         *prometheus.HistogramVec
 	OverheadLatencyMicros          *prometheus.HistogramVec
+	OverheadComponentMicros        *prometheus.HistogramVec
 	SuccessRequestsTotal           *prometheus.CounterVec
 	ErrorRequestsTotal             *prometheus.CounterVec
 	InputTokensTotal               *prometheus.CounterVec
@@ -205,6 +209,21 @@ type PrometheusPlugin struct {
 
 	// MetricsEnabled gates the /metrics scrape endpoint.
 	metricsEnabled atomic.Bool
+
+	// gates bifrost_overhead_component_microseconds. Off by default.
+	overheadBreakdownEnabled atomic.Bool
+	// PostLLMHook-resolved labels handed to Inject, keyed by trace ID (values are
+	// *pendingOverheadEntry). Inject drains them; sweepPendingOverheadLabels bounds it.
+	pendingOverheadLabels sync.Map
+	overheadSweepTicker   *time.Ticker
+	overheadSweepStop     chan struct{}
+	overheadSweepWG       sync.WaitGroup
+	overheadSweepOnce     sync.Once // Cleanup runs once; the plugin is registered under multiple types
+}
+
+type pendingOverheadEntry struct {
+	labels    []string
+	createdAt time.Time // for the sweeper's staleness check
 }
 
 type Config struct {
@@ -213,6 +232,9 @@ type Config struct {
 	PushGateway  *PushGatewayConfig `json:"push_gateway"`
 	// MetricsEnabled controls whether the /metrics scrape endpoint is served.
 	MetricsEnabled *bool `json:"metrics_enabled,omitempty"`
+	// Exports bifrost_overhead_component_microseconds. Off by default. Needs tracing on
+	// (the breakdown comes from completed trace spans).
+	OverheadBreakdownEnabled *bool `json:"overhead_breakdown_enabled,omitempty"`
 }
 
 // Keep in sync with plugins/otel/metrics.go's identical arrays so the Prometheus
@@ -436,6 +458,23 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		append(defaultBifrostLabels, filteredCustomLabels...),
 	)
 
+	// Same overhead as above, split by overhead_component (the UI's categories; see
+	// framework/overhead). Same base labels + buckets, so the components sum to
+	// bifrost_overhead_latency_microseconds per label set. Observed only when enabled
+	// and the request is traced.
+	overheadComponentLabels := make([]string, 0, len(defaultBifrostLabels)+len(filteredCustomLabels)+1)
+	overheadComponentLabels = append(overheadComponentLabels, defaultBifrostLabels...)
+	overheadComponentLabels = append(overheadComponentLabels, filteredCustomLabels...)
+	overheadComponentLabels = append(overheadComponentLabels, "overhead_component")
+	bifrostOverheadComponentMicros := factory.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "bifrost_overhead_component_microseconds",
+			Help:    "Bifrost overhead latency broken down by internal component (overhead_component label), in microseconds. Off by default; enable with overhead_breakdown_enabled. Requires tracing to be active.",
+			Buckets: overheadLatencyBuckets,
+		},
+		overheadComponentLabels,
+	)
+
 	bifrostSuccessRequestsTotal := factory.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "bifrost_success_requests_total",
@@ -644,6 +683,7 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 		UpstreamRequestsTotal:          bifrostUpstreamRequestsTotal,
 		UpstreamLatencySeconds:         bifrostUpstreamLatencySeconds,
 		OverheadLatencyMicros:          bifrostOverheadLatencyMicros,
+		OverheadComponentMicros:        bifrostOverheadComponentMicros,
 		SuccessRequestsTotal:           bifrostSuccessRequestsTotal,
 		ErrorRequestsTotal:             bifrostErrorRequestsTotal,
 		InputTokensTotal:               bifrostInputTokensTotal,
@@ -679,6 +719,18 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 	}
 	plugin.metricsEnabled.Store(metricsEnabled)
 
+	// Opt-in: the per-component histogram multiplies overhead cardinality by component count.
+	if config.OverheadBreakdownEnabled != nil {
+		plugin.overheadBreakdownEnabled.Store(*config.OverheadBreakdownEnabled)
+	}
+	// Sweep the label handoff only when the breakdown is on (otherwise the map stays empty).
+	if plugin.overheadBreakdownEnabled.Load() {
+		plugin.overheadSweepStop = make(chan struct{})
+		plugin.overheadSweepTicker = time.NewTicker(time.Minute)
+		plugin.overheadSweepWG.Add(1)
+		go plugin.sweepPendingOverheadLabels()
+	}
+
 	// Start push gateway if configured
 	if config.PushGateway != nil && config.PushGateway.Enabled && config.PushGateway.PushGatewayURL.IsSet() {
 		if err := plugin.EnablePushGateway(config.PushGateway); err != nil {
@@ -693,6 +745,17 @@ func Init(config *Config, pricingManager *modelcatalog.ModelCatalog, logger sche
 // metrics on this instance. Safe to call from request-handling goroutines.
 func (p *PrometheusPlugin) IsMetricsEnabled() bool {
 	return p.metricsEnabled.Load()
+}
+
+// IsOverheadBreakdownEnabled reports whether bifrost_overhead_component_microseconds is observed.
+func (p *PrometheusPlugin) IsOverheadBreakdownEnabled() bool {
+	return p.overheadBreakdownEnabled.Load()
+}
+
+// ConsumesOverheadSpans opts into the internal breakdown spans (schemas.OverheadSpanConsumer)
+// when enabled, so Inject can decompose overhead. When off, we take the stripped trace.
+func (p *PrometheusPlugin) ConsumesOverheadSpans() bool {
+	return p.overheadBreakdownEnabled.Load()
 }
 
 func (p *PrometheusPlugin) GetRegistry() *prometheus.Registry {
@@ -795,6 +858,66 @@ func (p *PrometheusPlugin) recordOverhead(ctx *schemas.BifrostContext, total tim
 	}
 	if overhead, ok := schemas.CalculateOverhead(ctx, total); ok {
 		p.OverheadLatencyMicros.WithLabelValues(labels...).Observe(float64(overhead) / float64(time.Microsecond))
+	}
+}
+
+// Inject (schemas.ObservabilityPlugin) records the per-component overhead histogram from
+// the completed trace, using labels PostLLMHook stashed in pendingOverheadLabels (so it
+// shares the scalar metric's labels plus overhead_component). The breakdown needs the
+// finalized span tree, which only exists here; the scalar overhead is recorded in HTTPTransportPostHook.
+func (p *PrometheusPlugin) Inject(_ context.Context, trace *schemas.Trace) error {
+	if trace == nil {
+		return nil
+	}
+	// Always drain the handoff entry so a toggle flip mid-request can't leak it.
+	joinKey := trace.InternalID
+	if joinKey == "" {
+		joinKey = trace.TraceID
+	}
+	labelsVal, ok := p.pendingOverheadLabels.LoadAndDelete(joinKey)
+	if !ok || !p.overheadBreakdownEnabled.Load() {
+		return nil
+	}
+	entry, ok := labelsVal.(*pendingOverheadEntry)
+	if !ok || len(entry.labels) == 0 {
+		return nil
+	}
+	baseLabels := entry.labels
+	components := overhead.ComputeForMetrics(trace)
+	if len(components) == 0 {
+		return nil
+	}
+	for component, micros := range components {
+		labels := make([]string, 0, len(baseLabels)+1)
+		labels = append(labels, baseLabels...)
+		labels = append(labels, component)
+		p.OverheadComponentMicros.WithLabelValues(labels...).Observe(micros)
+	}
+	return nil
+}
+
+// Compile-time check that PrometheusPlugin implements ObservabilityPlugin, so
+// CollectObservabilityPlugins picks it up and the tracer delivers completed traces.
+var _ schemas.ObservabilityPlugin = (*PrometheusPlugin)(nil)
+
+// sweepPendingOverheadLabels evicts entries Inject never drained (the tracer drops a trace
+// when this plugin's inject semaphore is saturated), which would otherwise grow the map unbounded.
+func (p *PrometheusPlugin) sweepPendingOverheadLabels() {
+	defer p.overheadSweepWG.Done()
+	const ttl = 5 * time.Minute
+	for {
+		select {
+		case <-p.overheadSweepTicker.C:
+			cutoff := time.Now().Add(-ttl)
+			p.pendingOverheadLabels.Range(func(k, v any) bool {
+				if e, ok := v.(*pendingOverheadEntry); ok && e.createdAt.Before(cutoff) {
+					p.pendingOverheadLabels.Delete(k)
+				}
+				return true
+			})
+		case <-p.overheadSweepStop:
+			return
+		}
 	}
 }
 
@@ -1080,8 +1203,8 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		"customer_name":        customerName,
 		"business_unit_id":     businessUnitID,
 		"business_unit_name":   businessUnitName,
-		"project_id":          projectID,
-		"project_name":        projectName,
+		"project_id":           projectID,
+		"project_name":         projectName,
 	}
 
 	// Get all custom prometheus labels from context BEFORE the goroutine.
@@ -1109,6 +1232,13 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	// final attempt's labels win.
 	if isStreamFinal {
 		ctx.SetValue(overheadLabelsKey, slices.Clone(promLabelValues))
+		// Hand these labels to Inject (keyed by trace ID) for the breakdown histogram.
+		// Only when enabled and traced, so nothing is stored (or leaks) otherwise.
+		if p.overheadBreakdownEnabled.Load() {
+			if traceID, ok := ctx.Value(schemas.BifrostContextKeyTraceID).(string); ok && traceID != "" {
+				p.pendingOverheadLabels.Store(traceID, &pendingOverheadEntry{labels: slices.Clone(promLabelValues), createdAt: time.Now()})
+			}
+		}
 	}
 
 	// Calculate cost and record metrics in a separate goroutine to avoid blocking the main thread
@@ -1489,5 +1619,12 @@ func (p *PrometheusPlugin) doPush() {
 
 func (p *PrometheusPlugin) Cleanup() error {
 	p.DisablePushGateway()
+	if p.overheadSweepTicker != nil {
+		p.overheadSweepOnce.Do(func() {
+			p.overheadSweepTicker.Stop()
+			close(p.overheadSweepStop)
+			p.overheadSweepWG.Wait()
+		})
+	}
 	return nil
 }

--- a/plugins/telemetry/main_test.go
+++ b/plugins/telemetry/main_test.go
@@ -372,6 +372,47 @@ func TestMetricsEnabledGating(t *testing.T) {
 	}
 }
 
+// TestMarshalConfigForStorageKeepsToggles guards the hand-maintained storage whitelist
+// (Config.MarshalForStorage's configStorage struct): a toggle added to Config must be
+// added there too, or it is silently dropped on save and the UI reverts it. Regression
+// test for overhead_breakdown_enabled, which was initially dropped this way.
+func TestMarshalConfigForStorageKeepsToggles(t *testing.T) {
+	p := newTestPlugin(t)
+	out, err := p.MarshalConfigForStorage(map[string]any{
+		"overhead_breakdown_enabled": true,
+		"metrics_enabled":            false,
+	})
+	if err != nil {
+		t.Fatalf("MarshalConfigForStorage: %v", err)
+	}
+	if v, ok := out["overhead_breakdown_enabled"].(bool); !ok || !v {
+		t.Errorf("overhead_breakdown_enabled dropped by storage: got %v (%T), want true", out["overhead_breakdown_enabled"], out["overhead_breakdown_enabled"])
+	}
+	if v, ok := out["metrics_enabled"].(bool); !ok || v {
+		t.Errorf("metrics_enabled = %v, want false to survive storage round-trip", out["metrics_enabled"])
+	}
+}
+
+// TestCleanupIdempotent guards the shutdown crash: the plugin is registered under several
+// types, so Cleanup runs more than once. With the overhead sweeper enabled, a second call
+// must not double-close its stop channel. Also covers the disabled path (no sweeper).
+func TestCleanupIdempotent(t *testing.T) {
+	log := bifrost.NewDefaultLogger(schemas.LogLevelError)
+	for _, enabled := range []bool{true, false} {
+		p, err := Init(&Config{OverheadBreakdownEnabled: boolPtr(enabled)}, nil, log)
+		if err != nil {
+			t.Fatalf("Init(enabled=%v): %v", enabled, err)
+		}
+		if err := p.Cleanup(); err != nil {
+			t.Fatalf("Cleanup 1 (enabled=%v): %v", enabled, err)
+		}
+		// Second call must not panic on a closed channel.
+		if err := p.Cleanup(); err != nil {
+			t.Fatalf("Cleanup 2 (enabled=%v): %v", enabled, err)
+		}
+	}
+}
+
 // TestGetMetricsGathererCombinesRegistries asserts the /metrics scrape gatherer exposes both
 // Bifrost metrics (from p.registry) and the Go/process runtime collectors (from p.systemRegistry).
 func TestGetMetricsGathererCombinesRegistries(t *testing.T) {

--- a/transports/bifrost-http/server/plugins.go
+++ b/transports/bifrost-http/server/plugins.go
@@ -70,6 +70,9 @@ func loadBuiltinPlugin(ctx context.Context, name string, pluginConfig any, bifro
 				if extraConfig.MetricsEnabled != nil {
 					telConfig.MetricsEnabled = extraConfig.MetricsEnabled
 				}
+				if extraConfig.OverheadBreakdownEnabled != nil {
+					telConfig.OverheadBreakdownEnabled = extraConfig.OverheadBreakdownEnabled
+				}
 			}
 		}
 		return telemetry.Init(telConfig, bifrostConfig.ModelCatalog, logger)

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -2452,6 +2452,11 @@
                       },
                       "description": "Custom labels to add to Prometheus metrics"
                     },
+                    "overhead_breakdown_enabled": {
+                      "type": "boolean",
+                      "description": "Export the per-component overhead histogram bifrost_overhead_component_microseconds (overhead latency split by the overhead_component label). Off by default. Requires tracing to be active, since the breakdown is computed from completed trace spans.",
+                      "default": false
+                    },
                     "push_gateway": {
                       "type": "object",
                       "description": "Configuration for pushing metrics to a Prometheus Push Gateway for multi-node cluster deployments",
@@ -3501,6 +3506,11 @@
           "default": 15,
           "minimum": 1,
           "maximum": 300
+        },
+        "overhead_breakdown_enabled": {
+          "type": "boolean",
+          "description": "Export the per-component overhead histogram bifrost_overhead_component_microseconds (overhead latency split by the overhead_component attribute). Off by default. Requires metrics_enabled and an active trace, since the breakdown is computed from completed spans.",
+          "default": false
         },
         "request_headers": {
           "type": "array",

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -530,8 +530,8 @@ function formatMicros(us: number): string {
 // names are grouped into a handful of user-facing categories: Serialization (JSON
 // parse/encode), Conversion (API schema translation), Plugins, Middleware (auth/access),
 // Key selection, Processing (internal request pipeline), Networking
-// (client<->gateway<->provider handling), Client delivery (SSE egress to the client), and Scheduling (the
-// residual goroutine-hop latency between phases). "View details" drills into the member
+// (client<->gateway<->provider handling), Client delivery (SSE egress to the client), and Miscellaneous
+// (small glue on no dedicated span plus the residual goroutine-hop latency between phases). "View details" drills into the member
 // spans inside each grouped category with their friendly labels. See OVERHEAD_LABELS /
 // OVERHEAD_BUCKET_CATEGORY / overheadCategoryKey for the mapping.
 type OverheadCategory = {
@@ -556,7 +556,7 @@ const OVERHEAD_CATEGORY_META: Record<string, { label: string; colorClass: string
 	processing: { label: "Processing", colorClass: "bg-teal-500/70" },
 	networking: { label: "Networking", colorClass: "bg-emerald-500/70" },
 	streaming: { label: "Client delivery", colorClass: "bg-red-500/70" },
-	scheduling: { label: "Scheduling", colorClass: "bg-slate-500/70" },
+	miscellaneous: { label: "Miscellaneous", colorClass: "bg-slate-500/70" },
 	other: { label: "Other", colorClass: "bg-muted-foreground/50" },
 };
 
@@ -588,7 +588,7 @@ const OVERHEAD_LABELS: Record<string, string> = {
 	"worker-handoff": "Worker handoff",
 	"queue-wait": "Queue wait",
 	"attribute-population": "Attribute population",
-	miscellaneous: "Miscellaneous",
+	miscellaneous: "Uncaptured glue",
 	// Networking (client<->gateway<->provider handling)
 	"provider-internal": "Provider processing",
 	"transport-context": "Request context building",
@@ -599,7 +599,7 @@ const OVERHEAD_LABELS: Record<string, string> = {
 	// Streaming relay
 	"stream-backpressure": "Client backpressure",
 	"stream-client-write": "Client write",
-	scheduling: "Scheduling",
+	scheduling: "Scheduling residual",
 };
 
 // Category assignment for buckets that aren't matched by a prefix rule below. Every
@@ -616,7 +616,7 @@ const OVERHEAD_BUCKET_CATEGORY: Record<string, string> = {
 	"worker-handoff": "processing",
 	"queue-wait": "processing",
 	"attribute-population": "processing",
-	miscellaneous: "processing",
+	miscellaneous: "miscellaneous",
 	"provider-internal": "networking",
 	"transport-context": "networking",
 	"transport-response-headers": "networking",
@@ -625,7 +625,7 @@ const OVERHEAD_BUCKET_CATEGORY: Record<string, string> = {
 	"credentials-fetch": "networking",
 	"stream-backpressure": "streaming",
 	"stream-client-write": "streaming",
-	scheduling: "scheduling",
+	scheduling: "miscellaneous",
 };
 
 // Raw backend spans that split one user-facing step into internals a reader doesn't care

--- a/ui/app/workspace/observability/fragments/otelFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/otelFormFragment.tsx
@@ -36,6 +36,7 @@ interface StoredOtelProfile {
 	tls_ca_cert?: string;
 	insecure?: boolean;
 	metrics_enabled?: boolean;
+	overhead_breakdown_enabled?: boolean;
 	metrics_endpoint?: string | SecretVar;
 	metrics_push_interval?: number;
 	export_timeout?: number;
@@ -104,6 +105,7 @@ const emptyProfile = (): ProfileForm => ({
 	tls_ca_cert: "",
 	insecure: true,
 	metrics_enabled: false,
+	overhead_breakdown_enabled: false,
 	metrics_endpoint: emptySecretVar(),
 	metrics_push_interval: 15,
 	export_timeout: 5,
@@ -127,6 +129,7 @@ const toProfileForm = (p?: StoredOtelProfile): ProfileForm => ({
 	tls_ca_cert: p?.tls_ca_cert ?? "",
 	insecure: p?.insecure ?? true,
 	metrics_enabled: p?.metrics_enabled ?? false,
+	overhead_breakdown_enabled: p?.overhead_breakdown_enabled ?? false,
 	metrics_endpoint: toSecretVarFormValue(p?.metrics_endpoint),
 	metrics_push_interval: p?.metrics_push_interval ?? 15,
 	export_timeout: p?.export_timeout ?? 5,
@@ -783,6 +786,34 @@ function OtelProfileSection({ form, control, index, hasOtelAccess, canRemove, op
 												<Switch
 													// First profile keeps the legacy testid for existing e2e coverage.
 													data-testid={index === 0 ? "otel-metrics-export-toggle" : `otel-profile-${index}-metrics-export-toggle`}
+													checked={field.value}
+													onCheckedChange={field.onChange}
+													disabled={!hasOtelAccess}
+												/>
+											</div>
+										</div>
+									</FormItem>
+								)}
+							/>
+
+							<FormField
+								control={control}
+								name={`${base}.overhead_breakdown_enabled`}
+								render={({ field }) => (
+									<FormItem className="flex flex-row items-center gap-2">
+										<div className="flex w-full flex-row items-center gap-2">
+											<div className="flex flex-col gap-1">
+												<h3 className="text-sm font-medium">Overhead breakdown</h3>
+												<p className="text-muted-foreground text-xs">
+													Export per-component Bifrost overhead latency as a histogram.
+												</p>
+											</div>
+											<div className="ml-auto">
+												<Switch
+													aria-label="Enable overhead breakdown"
+													data-testid={
+														index === 0 ? "otel-overhead-breakdown-toggle" : `otel-profile-${index}-overhead-breakdown-toggle`
+													}
 													checked={field.value}
 													onCheckedChange={field.onChange}
 													disabled={!hasOtelAccess}

--- a/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
+++ b/ui/app/workspace/observability/fragments/prometheusFormFragment.tsx
@@ -19,6 +19,7 @@ import { useForm, type Resolver } from "react-hook-form";
 interface PrometheusFormFragmentProps {
 	currentConfig?: {
 		metrics_enabled?: boolean;
+		overhead_breakdown_enabled?: boolean;
 		push_gateway_enabled?: boolean;
 		push_gateway_url?: string | SecretVar;
 		job_name?: string;
@@ -41,6 +42,7 @@ const hasAuth = (v?: string | SecretVar): boolean =>
 
 const buildDefaults = (initialConfig?: PrometheusFormFragmentProps["currentConfig"]): PrometheusFormSchema => ({
 	metrics_enabled: initialConfig?.metrics_enabled ?? true,
+	overhead_breakdown_enabled: initialConfig?.overhead_breakdown_enabled ?? false,
 	push_gateway_enabled: initialConfig?.push_gateway_enabled ?? false,
 	prometheus_config: {
 		push_gateway_url: toSecretVarFormValue(initialConfig?.push_gateway_url),
@@ -54,7 +56,7 @@ const buildDefaults = (initialConfig?: PrometheusFormFragmentProps["currentConfi
 
 // Field paths considered "owned" by each tab — used for per-tab Reset and to
 // gate the per-tab Save button on whether *this* tab has unsaved changes.
-const PULL_FIELDS = ["metrics_enabled"] as const;
+const PULL_FIELDS = ["metrics_enabled", "overhead_breakdown_enabled"] as const;
 const PUSH_FIELDS = [
 	"push_gateway_enabled",
 	"prometheus_config.push_gateway_url",
@@ -128,6 +130,10 @@ export function PrometheusFormFragment({
 			shouldDirty: true,
 			shouldValidate: true,
 		});
+		form.setValue("overhead_breakdown_enabled", defaults.overhead_breakdown_enabled, {
+			shouldDirty: true,
+			shouldValidate: true,
+		});
 	};
 
 	const resetPushTab = () => {
@@ -179,7 +185,7 @@ export function PrometheusFormFragment({
 	// hunting through a tab they can't see.
 	const formIsInvalid = !form.formState.isValid;
 	const errors = form.formState.errors as Record<string, any>;
-	const hasPullErrors = !!errors.metrics_enabled;
+	const hasPullErrors = !!errors.metrics_enabled || !!errors.overhead_breakdown_enabled;
 	const hasPushErrors = !!errors.push_gateway_enabled || !!errors.prometheus_config;
 
 	const renderActions = (tabKey: "pull" | "push", tabDirty: boolean, onResetTab: () => void) => {
@@ -302,6 +308,30 @@ export function PrometheusFormFragment({
 							<p className="text-muted-foreground mt-2 text-xs">
 								Configure your Prometheus server to scrape this endpoint. Served only while Pull-based scraping is enabled.
 							</p>
+						</div>
+
+						<div className="flex items-center justify-between gap-4">
+							<div className="flex flex-col gap-1">
+								<h3 className="text-sm font-medium">Overhead breakdown</h3>
+								<p className="text-muted-foreground text-xs">Export per-component Bifrost overhead latency as a histogram.</p>
+							</div>
+							<FormField
+								control={form.control}
+								name="overhead_breakdown_enabled"
+								render={({ field }) => (
+									<FormItem className="flex items-center gap-2">
+										<FormLabel className="text-muted-foreground text-sm font-medium">Enabled</FormLabel>
+										<FormControl>
+											<Switch
+												checked={field.value}
+												onCheckedChange={field.onChange}
+												disabled={!hasPrometheusAccess}
+												data-testid="prometheus-overhead-breakdown-toggle"
+											/>
+										</FormControl>
+									</FormItem>
+								)}
+							/>
 						</div>
 
 						{renderActions("pull", isPullDirty, resetPullTab)}

--- a/ui/app/workspace/observability/views/plugins/prometheusView.tsx
+++ b/ui/app/workspace/observability/views/plugins/prometheusView.tsx
@@ -19,6 +19,7 @@ interface PushGatewayConfig {
 
 interface TelemetryConfig {
 	metrics_enabled?: boolean;
+	overhead_breakdown_enabled?: boolean;
 	push_gateway?: PushGatewayConfig;
 }
 
@@ -36,6 +37,7 @@ export default function PrometheusView({ onDelete, isDeleting }: PrometheusViewP
 		return {
 			...pushGateway,
 			metrics_enabled: metricsEnabled,
+			overhead_breakdown_enabled: telemetryConfig.overhead_breakdown_enabled ?? false,
 			push_gateway_enabled: pushGateway.enabled ?? false,
 		};
 	}, [selectedPlugin]);
@@ -68,6 +70,7 @@ export default function PrometheusView({ onDelete, isDeleting }: PrometheusViewP
 					enabled: true,
 					config: {
 						metrics_enabled: config.metrics_enabled,
+						overhead_breakdown_enabled: config.overhead_breakdown_enabled,
 						push_gateway: pushGatewayConfig,
 					},
 				},

--- a/ui/lib/types/schemas.ts
+++ b/ui/lib/types/schemas.ts
@@ -1065,6 +1065,8 @@ export const otelConfigSchema = z
 		export_timeout: z.number().int().min(1).max(60).default(5),
 		// Metrics push configuration
 		metrics_enabled: z.boolean().default(false),
+		// Export per-component Bifrost overhead latency as a histogram.
+		overhead_breakdown_enabled: z.boolean().default(false),
 		metrics_endpoint: secretVarSchema.optional(),
 		metrics_push_interval: z.number().int().min(1).max(300).default(15),
 		request_headers: z.array(z.string()).default([]),
@@ -1255,6 +1257,7 @@ export const prometheusConfigSchema = z
 export const prometheusFormSchema = z
 	.object({
 		metrics_enabled: z.boolean().default(true),
+		overhead_breakdown_enabled: z.boolean().default(false),
 		push_gateway_enabled: z.boolean().default(false),
 		prometheus_config: prometheusConfigSchema,
 	})


### PR DESCRIPTION
## Summary

Adds an opt-in `bifrost_overhead_component_microseconds` histogram that decomposes Bifrost's per-request overhead latency into the same ten categories shown in the log-detail overhead breakdown UI (`serialization`, `conversion`, `plugins`, `middleware`, `routing`, `processing`, `networking`, `streaming`, `miscellaneous`, `other`). Summing all components for a given label set reconstructs the existing scalar `bifrost_overhead_latency_microseconds` total. The metric is available for both Prometheus (telemetry plugin) and OpenTelemetry, and is populated only when tracing is active for the request.

## Changes

- Extracted the overhead breakdown computation from `plugins/logging/main.go` into a new shared `framework/overhead` package (`breakdown.go`), exposing `Compute`, `ComputeForMetrics`, `TraceAttrFloatMs`, and the ten `Category*` constants. The logging plugin now calls into this package instead of maintaining its own copy.
- Added `bifrost_overhead_component_microseconds` histogram to the telemetry (Prometheus) plugin, gated by a new `overhead_breakdown_enabled` config field. Label values are handed from `PostLLMHook` to `Inject` via a `sync.Map` keyed by trace ID, since the finalized span tree is only available in `Inject`. Both plugins implement `ConsumesOverheadSpans()` so the tracer delivers internal overhead spans when the breakdown is enabled.
- Added the same histogram and `overhead_breakdown_enabled` field to the OTel plugin's `Profile` and `profileForStorage`, with `RecordOverheadComponent` on `MetricsExporter`.
- Renamed the UI's `scheduling` overhead category to `miscellaneous`, folding the `miscellaneous` glue span and the `scheduling` residual into one category. Updated `OVERHEAD_CATEGORY_META`, `OVERHEAD_BUCKET_CATEGORY`, and `OVERHEAD_LABELS` accordingly, and updated the latency breakdown docs to match.
- Added `overhead_breakdown_enabled` toggle to the Prometheus and OTel observability UI forms, wired through the view layer and Zod schemas.
- Updated `config.schema.json` for both the telemetry and OTel plugin sections.
- Moved the breakdown test file to `framework/overhead/breakdown_test.go` and added `TestComputeForMetrics_RollsUpToCategories` and `TestMarshalConfigForStorageKeepsToggles` to guard the storage whitelist.
- Updated latency breakdown, Prometheus, OTel, and telemetry docs to document both new metrics and the `overhead_breakdown_enabled` toggle.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [x] Docs

## How to test

```sh
# Core/Transports
go test ./framework/overhead/... ./plugins/telemetry/... ./plugins/otel/... ./plugins/logging/...

# UI
cd ui
pnpm i
pnpm build
```

Enable the breakdown via config and confirm `bifrost_overhead_component_microseconds` appears in `/metrics` (Prometheus) or the OTLP metrics endpoint (OTel) only after a traced request. Verify that summing all `overhead_component` label values for a request reconstructs `bifrost_overhead_latency_microseconds`. With tracing disabled, confirm the histogram remains empty even when `overhead_breakdown_enabled` is `true`.

```json
{
  "plugins": [
    {
      "name": "telemetry",
      "enabled": true,
      "config": {
        "overhead_breakdown_enabled": true
      }
    }
  ]
}
```

## Breaking changes

- [ ] Yes
- [x] No

The `scheduling` UI category is renamed to `miscellaneous`. Existing Prometheus/OTel queries filtering on `overhead_component="scheduling"` will need to be updated to `overhead_component="miscellaneous"`. The `scheduling` bucket label in the raw breakdown data is preserved internally and mapped to `miscellaneous` at the metric layer.

## Related issues

## Security considerations

No new secrets, auth paths, or PII handling. The `pendingOverheadLabels` sync.Map in the telemetry plugin is always drained in `Inject` (even when the breakdown is disabled) to prevent label leaks across requests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable