### PR TITLE
fix: add project and complexity fields to dimensions list

### DIFF
--- a/core/spanenrichment_test.go
+++ b/core/spanenrichment_test.go
@@ -31,6 +31,8 @@ var contextDimSources = []struct {
 	{schemas.AttrBifrostCustomerName, schemas.BifrostContextKeyGovernanceCustomerName, "cust-name"},
 	{schemas.AttrBifrostBusinessUnitID, schemas.BifrostContextKeyGovernanceBusinessUnitID, "bu-id"},
 	{schemas.AttrBifrostBusinessUnitName, schemas.BifrostContextKeyGovernanceBusinessUnitName, "bu-name"},
+	{schemas.AttrBifrostProjectID, schemas.BifrostContextKeyGovernanceProjectID, "proj-id"},
+	{schemas.AttrBifrostProjectName, schemas.BifrostContextKeyGovernanceProjectName, "proj-name"},
 	{schemas.AttrBifrostTeamIDs, schemas.BifrostContextKeyGovernanceTeamIDs, []string{"team-id-1", "team-id-2"}},
 	{schemas.AttrBifrostTeamNames, schemas.BifrostContextKeyGovernanceTeamNames, []string{"team-name-1"}},
 	{schemas.AttrBifrostCustomerIDs, schemas.BifrostContextKeyGovernanceCustomerIDs, []string{"cust-id-1"}},
@@ -52,8 +54,10 @@ var dimsEmittedElsewhere = map[string]string{
 	schemas.AttrBifrostProviderName:      "request-sourced: span creation in bifrost.go",
 	schemas.AttrRequestModel:             "request-sourced: span creation in bifrost.go",
 	schemas.AttrLegacyRequestType:        "request-sourced: span creation in bifrost.go",
-	schemas.AttrBifrostAlias:             "framework ExtractedFields: framework/tracing/tracer.go",
-	schemas.AttrBifrostRoutingEngineUsed: "framework ExtractedFields: framework/tracing/tracer.go",
+	schemas.AttrBifrostAlias:               "framework ExtractedFields: framework/tracing/tracer.go",
+	schemas.AttrBifrostRoutingEngineUsed:   "framework ExtractedFields: framework/tracing/tracer.go",
+	schemas.AttrBifrostComplexityTier:      "context-sourced post-response: framework/tracing/tracer.go",
+	schemas.AttrBifrostComplexityMechanism: "context-sourced post-response: framework/tracing/tracer.go",
 }
 
 // TestContextSpanAttributesEmit drives applyContextSpanAttributes with every


### PR DESCRIPTION
## Summary

Adds test coverage for project-level governance dimensions (`ProjectID` and `ProjectName`) in span enrichment, and registers `ComplexityTier` and `ComplexityMechanism` as attributes that are emitted elsewhere (post-response via the framework tracer) rather than through `applyContextSpanAttributes`.

## Changes

- Added `AttrBifrostProjectID` and `AttrBifrostProjectName` to the `contextDimSources` test table, ensuring these governance context keys are validated as part of span attribute enrichment.
- Added `AttrBifrostComplexityTier` and `AttrBifrostComplexityMechanism` to the `dimsEmittedElsewhere` map, documenting that these attributes are sourced from context post-response in `framework/tracing/tracer.go` and should not be expected from `applyContextSpanAttributes`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/...
```

The updated test table will exercise the new project governance dimension sources, and the `dimsEmittedElsewhere` map will prevent false negatives for complexity-related attributes in the span enrichment coverage check.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

No security implications. Changes are limited to test coverage for span attribute enrichment of governance metadata.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable