### PR TITLE
chore: test fixes for authenticated MCPs

### DIFF
--- a/.github/workflows/release-pipeline.yml
+++ b/.github/workflows/release-pipeline.yml
@@ -1666,6 +1666,7 @@ jobs:
         env:
           CI: "1"
           SKIP_GATEWAY_BUILD: "1"
+          BIFROST_SETUP_TOKEN: bifrost-e2e-setup-token
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/scripts/test-api-integrations.sh
+++ b/.github/workflows/scripts/test-api-integrations.sh
@@ -150,6 +150,14 @@ jq --arg host "$POSTGRES_HOST" --arg port "$POSTGRES_PORT" --arg user "$POSTGRES
      "logs_store":   {"enabled": true, "type": "postgres", "config": {"host": $host, "port": $port, "user": $user, "password": $pass, "db_name": $db, "ssl_mode": $ssl}}
    }' "$SOURCE_CONFIG" > "$MERGED_CONFIG"
 
+# The authenticated newman pass needs a first admin account. Creating it is the one
+# config write the server accepts unauthenticated, and it demands a bootstrap token
+# the server resolves at boot from BIFROST_SETUP_TOKEN. Export it here so both the
+# server process and the runner (which reads BIFROST_E2E_SETUP_TOKEN) share it;
+# without it set-auth-config skips the auth pass and the MCP/vMCP tests run nowhere.
+export BIFROST_SETUP_TOKEN="${BIFROST_SETUP_TOKEN:-bifrost-e2e-setup-token}"
+export BIFROST_E2E_SETUP_TOKEN="$BIFROST_SETUP_TOKEN"
+
 echo "🚀 Starting bifrost-http on port $PORT..."
 "$BIFROST_BINARY" --app-dir "$TEMP_DIR" --port "$PORT" --log-level debug > "$SERVER_LOG" 2>&1 &
 BIFROST_PID=$!

--- a/.github/workflows/scripts/test-e2e-api.sh
+++ b/.github/workflows/scripts/test-e2e-api.sh
@@ -86,6 +86,13 @@ PYEOF
     fi
   fi
 
+  # The authenticated newman pass needs a first admin account, whose creation
+  # requires a bootstrap token the server resolves at boot from BIFROST_SETUP_TOKEN.
+  # Export it so the server process and the runner (BIFROST_E2E_SETUP_TOKEN) share it;
+  # without it set-auth-config skips the auth pass and the MCP/vMCP tests run nowhere.
+  export BIFROST_SETUP_TOKEN="${BIFROST_SETUP_TOKEN:-bifrost-e2e-setup-token}"
+  export BIFROST_E2E_SETUP_TOKEN="$BIFROST_SETUP_TOKEN"
+
   echo "🚀 Starting Bifrost on port $PORT..."
   "$BIFROST_BINARY" --app-dir "$TEMP_DIR" --port "$PORT" --log-level debug > "$SERVER_LOG" 2>&1 &
   BIFROST_PID=$!

--- a/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-api-management.postman_collection.json
@@ -1574,7 +1574,7 @@
           "  'List Prompt Versions (Coverage Probe)': ['versions'],",
           "  'List Prompt Sessions (Coverage Probe)': ['sessions'],",
           "  'Issue WS Ticket (Coverage Probe)': ['ticket'],",
-          "  'Get Virtual Key Quota': ['virtual_key_name', 'is_active', 'budgets', 'rate_limit', 'provider_configs', 'model_configs'],",
+          "  'Get Virtual Key Quota': ['virtual_key_name', 'is_active', 'budgets', 'rate_limit', 'rate_limits', 'provider_configs', 'model_configs'],",
           "  'Update Metadata (Coverage Probe)': ['success'],",
           "  'List Feature Flags (Coverage Probe)': ['flags'],",
           "  'Update Feature Flag (Coverage Probe)': ['id', 'enabled', 'source', 'locked', 'enterprise_only', 'registered', 'updated_at'],",
@@ -3356,7 +3356,7 @@
                   "if (pm.response.code >= 200 && pm.response.code < 300) {",
                   "  var body = pm.response.json();",
                   "  pm.test('Quota response contains all fields with seeded data', function () {",
-                  "    pm.expect(body).to.have.all.keys('virtual_key_name', 'is_active', 'budgets', 'rate_limit', 'provider_configs', 'model_configs');",
+                  "    pm.expect(body).to.have.all.keys('virtual_key_name', 'is_active', 'budgets', 'rate_limit', 'rate_limits', 'provider_configs', 'model_configs');",
                   "    pm.expect(body.virtual_key_name).to.equal(pm.collectionVariables.get('vk_expected_name'));",
                   "    pm.expect(body.is_active).to.equal(true);",
                   "    pm.expect(body.budgets).to.be.an('array').with.length.greaterThan(0);",
@@ -4455,6 +4455,22 @@
             }
           }
         }
+      ],
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// #6757 SSRF/auth gate: registering a loopback MCP client (http://localhost:3001/)",
+              "// requires a genuine admin, so this folder runs only in the authenticated pass.",
+              "// Skip it in the unauthenticated pass (no admin_auth_header); no 403 is tolerated.",
+              "if (!pm.variables.get('admin_auth_header') && !pm.environment.get('admin_auth_header')) {",
+              "  if (typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "}"
+            ]
+          }
+        }
       ]
     },
     {
@@ -5392,6 +5408,22 @@
                 "{{vmcp_client_id}}"
               ]
             }
+          }
+        }
+      ],
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "// #6757 SSRF/auth gate: registering a loopback MCP client (http://localhost:3001/)",
+              "// requires a genuine admin, so this folder runs only in the authenticated pass.",
+              "// Skip it in the unauthenticated pass (no admin_auth_header); no 403 is tolerated.",
+              "if (!pm.variables.get('admin_auth_header') && !pm.environment.get('admin_auth_header')) {",
+              "  if (typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "}"
+            ]
           }
         }
       ]

--- a/tests/e2e/api/runners/set-auth-config.mjs
+++ b/tests/e2e/api/runners/set-auth-config.mjs
@@ -79,6 +79,13 @@ if (mode === "enable" && setupToken) {
   authConfig.setup_token = setupToken;
 }
 
+// The server reports log_retention_days:0 by default but rejects that on write
+// (it must be >= 1), so a straight round-trip of client_config would 400. Coerce
+// the invalid default so enabling/disabling auth through this PUT succeeds.
+if (current.client_config && !(current.client_config.log_retention_days >= 1)) {
+  current.client_config.log_retention_days = 1;
+}
+
 await request("PUT", "/api/config", {
   client_config: current.client_config,
   framework_config: current.framework_config,


### PR DESCRIPTION
## Summary

Fixes a chain of failures that prevented the authenticated E2E newman pass from running MCP and virtual-MCP tests. The root cause was that creating the first admin account requires a bootstrap token (`BIFROST_SETUP_TOKEN`) that was not being exported before the server started, causing `set-auth-config` to silently skip the auth setup step. Additionally, a round-trip bug in `set-auth-config` caused a `400` when writing back the server's default `log_retention_days: 0`, and MCP/vMCP folder tests were not being skipped gracefully in the unauthenticated pass.

## Changes

- Exports `BIFROST_SETUP_TOKEN` (defaulting to `bifrost-e2e-setup-token`) and mirrors it as `BIFROST_E2E_SETUP_TOKEN` in both `test-api-integrations.sh` and `test-e2e-api.sh` so the server process and the newman runner share the same bootstrap token at startup.
- Adds `BIFROST_SETUP_TOKEN: bifrost-e2e-setup-token` to the release pipeline CI environment so the token is available in CI without requiring a secret.
- Coerces `log_retention_days` to `1` in `set-auth-config.mjs` when the server returns the invalid default of `0`, preventing a `400` on the config `PUT` round-trip.
- Adds pre-request scripts to the MCP and vMCP Postman folders that skip those requests when no `admin_auth_header` is present, preventing spurious `403` failures in the unauthenticated pass.
- Updates the `Get Virtual Key Quota` response assertions to include the `rate_limits` field alongside the existing `rate_limit` field.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the E2E API test suite end-to-end and confirm the authenticated newman pass completes, including the MCP and vMCP folders, without `403` or `400` errors:

```sh
BIFROST_SETUP_TOKEN=bifrost-e2e-setup-token bash .github/workflows/scripts/test-e2e-api.sh
```

Confirm that:
- The server starts with the bootstrap token in scope.
- `set-auth-config enable` succeeds without a `400`.
- The authenticated newman pass runs MCP/vMCP tests and they pass.
- The unauthenticated pass skips MCP/vMCP requests cleanly with no `403`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6757

## Security considerations

The bootstrap token (`BIFROST_SETUP_TOKEN`) is used only for the one-time creation of the first admin account. It is set to a fixed test value in CI and is not a production secret. The MCP/vMCP SSRF gate (loopback registration requiring a genuine admin) is preserved and enforced; the pre-request skip logic ensures unauthenticated runs never attempt those requests.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable