### PR TITLE
test fixes and closes #6974

### DIFF
--- a/.github/workflows/scripts/cost-accuracy-test.sh
+++ b/.github/workflows/scripts/cost-accuracy-test.sh
@@ -385,13 +385,25 @@ params = {
     "order": "asc",
 }
 
+def token_counts(item):
+    usage = item.get("token_usage") or {}
+    prompt = usage.get("prompt_tokens")
+    completion = usage.get("completion_tokens")
+    total = usage.get("total_tokens")
+    # Go's omitempty drops zero counts. Only accept an omitted count as zero
+    # when total_tokens confirms it; missing usage must still fail validation.
+    if "prompt_tokens" not in usage and total is not None and total == usage.get("completion_tokens", 0):
+        prompt = 0
+    if "completion_tokens" not in usage and total is not None and total == usage.get("prompt_tokens", 0):
+        completion = 0
+    return prompt, completion
+
 def logs_complete(logs):
     # Log writes are fully async (single batched insert in PostLLMHook), so a
     # row can be visible before its usage/cost are readable. Poll on the
     # predicate we assert (every row has usage and cost), not just row count.
     return all(
-        (item.get("token_usage") or {}).get("prompt_tokens") is not None
-        and (item.get("token_usage") or {}).get("completion_tokens") is not None
+        all(count is not None for count in token_counts(item))
         and item.get("cost") is not None
         for item in logs
     )
@@ -401,7 +413,7 @@ def describe_incomplete(item):
     # reach the API by different routes (cost is a column, token_usage is a JSON blob
     # deserialized after the query), so which one is absent decides where to look.
     # Report the field names and the raw values.
-    usage = item.get("token_usage") or {}
+    prompt, completion = token_counts(item)
     return {
         "id": item.get("id"),
         "timestamp": item.get("timestamp"),
@@ -411,8 +423,8 @@ def describe_incomplete(item):
         "missing": [
             name
             for name, value in (
-                ("token_usage.prompt_tokens", usage.get("prompt_tokens")),
-                ("token_usage.completion_tokens", usage.get("completion_tokens")),
+                ("token_usage.prompt_tokens", prompt),
+                ("token_usage.completion_tokens", completion),
                 ("cost", item.get("cost")),
             )
             if value is None
@@ -458,8 +470,8 @@ if not logs_ready:
     }, indent=2, sort_keys=True))
     raise SystemExit(
         f"logs did not become complete within {LOG_POLL_ATTEMPTS}s: {len(incomplete)} of "
-        f"{len(logs)} rows still missing token_usage or cost. This is a log-write "
-        f"visibility problem, not a pricing mismatch. First 5:\n"
+        f"{len(logs)} rows still missing token_usage or cost. "
+        f"Cannot validate pricing for these rows. First 5:\n"
         + json.dumps(incomplete[:5], indent=2, sort_keys=True)
     )
 
@@ -475,9 +487,7 @@ for item in logs:
             "actual_virtual_key_id": item.get("virtual_key_id"),
         })
         continue
-    usage = item.get("token_usage") or {}
-    prompt = usage.get("prompt_tokens")
-    completion = usage.get("completion_tokens")
+    prompt, completion = token_counts(item)
     actual = item.get("cost")
     if prompt is None or completion is None or actual is None:
         mismatches.append({**describe_incomplete(item), "reason": "missing token_usage or cost"})

--- a/.github/workflows/scripts/setup-vllm-runpod.sh
+++ b/.github/workflows/scripts/setup-vllm-runpod.sh
@@ -89,7 +89,11 @@ create_vllm_pod() {
 
   echo "🚀 Creating ${name_suffix} vLLM pod ($model on $GPU_TYPE_ID, auto-terminates at ${TERMINATE_AFTER} as a backstop)..." >&2
   local create_output
-  create_output=$(runpodctl "${create_args[@]}")
+  if ! create_output=$(runpodctl "${create_args[@]}"); then
+    echo "$create_output" >&2
+    echo "::error::Failed to create the ${name_suffix} vLLM pod; see RunPod error above" >&2
+    return 1
+  fi
   echo "$create_output" >&2
 
   local pod_id
@@ -131,6 +135,8 @@ POD_ID=$(create_vllm_pod \
   "${VLLM_ENABLE_THINKING:-false}" \
   "${VLLM_MAX_MODEL_LEN:-32768}" \
   "${RUNPOD_NETWORK_VOLUME_ID:-}")
+# Make the first pod available to teardown even if the second creation fails.
+echo "RUNPOD_POD_ID=${POD_ID}" >> "$GITHUB_ENV"
 
 # --- Reasoning pod: Reasoning scenario only (thinking on) ---
 REASONING_MODEL_NAME="${VLLM_REASONING_MODEL_NAME:-QuantTrio/GLM-4.7-Flash-AWQ}"
@@ -144,6 +150,7 @@ REASONING_POD_ID=$(create_vllm_pod \
   "${VLLM_REASONING_ENABLE_THINKING:-true}" \
   "${VLLM_REASONING_MAX_MODEL_LEN:-131072}" \
   "${RUNPOD_REASONING_NETWORK_VOLUME_ID:-}")
+echo "RUNPOD_REASONING_POD_ID=${REASONING_POD_ID}" >> "$GITHUB_ENV"
 
 VLLM_BASE_URL="https://${POD_ID}-${API_PORT}.proxy.runpod.net"
 VLLM_REASONING_BASE_URL="https://${REASONING_POD_ID}-${API_PORT}.proxy.runpod.net"
@@ -152,12 +159,10 @@ echo "Reasoning pod: ${REASONING_POD_ID} -> ${VLLM_REASONING_BASE_URL}"
 
 # Persist for later steps in this job (test run + teardown).
 {
-  echo "RUNPOD_POD_ID=${POD_ID}"
   echo "VLLM_BASE_URL=${VLLM_BASE_URL}"
   echo "VLLM_API_KEY=${VLLM_API_KEY}"
   echo "VLLM_CHAT_MODEL=${DEFAULT_MODEL_NAME}"
   echo "VLLM_TEXT_MODEL=${DEFAULT_MODEL_NAME}"
-  echo "RUNPOD_REASONING_POD_ID=${REASONING_POD_ID}"
   echo "VLLM_REASONING_BASE_URL=${VLLM_REASONING_BASE_URL}"
   echo "VLLM_REASONING_MODEL=${REASONING_MODEL_NAME}"
 } >> "$GITHUB_ENV"

--- a/core/providers/utils/stream.go
+++ b/core/providers/utils/stream.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	schemas "github.com/maximhq/bifrost/core/schemas"
@@ -146,15 +147,7 @@ func CheckStreamPreambleForError(
 	for {
 		select {
 		case <-ctx.Done():
-			err := NewBifrostOperationError(schemas.ErrRequestCancelled, ctx.Err())
-			err.StatusCode = schemas.Ptr(499)
-			err.Error.Type = schemas.Ptr(schemas.RequestCancelled)
-			if ctx.Err() == context.DeadlineExceeded {
-				err = NewBifrostTimeoutError(schemas.ErrProviderRequestTimedOut, ctx.Err())
-			} else {
-				err.AllowFallbacks = schemas.Ptr(false)
-			}
-			return nil, drain(), err
+			return nil, drain(), newStreamContextError(ctx)
 
 		case chunk, ok := <-stream:
 			if !ok {
@@ -183,9 +176,42 @@ func CheckStreamPreambleForError(
 	}
 }
 
+// newStreamContextError maps a done request context onto the error shape the
+// retry loop already terminates on: RequestCancelled (499, fallbacks off) or
+// RequestTimedOut (504, default fallback eligibility).
+func newStreamContextError(ctx context.Context) *schemas.BifrostError {
+	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		return NewBifrostTimeoutError(schemas.ErrProviderRequestTimedOut, ctx.Err())
+	}
+	err := NewBifrostOperationError(schemas.ErrRequestCancelled, ctx.Err())
+	err.StatusCode = new(499)
+	err.Error.Type = new(schemas.RequestCancelled)
+	err.AllowFallbacks = new(false)
+	return err
+}
+
+// drainInBackground consumes stream until the producer closes it so a
+// provider goroutine blocked on send can exit. The returned channel closes
+// when the drain completes.
+func drainInBackground(stream chan *schemas.BifrostStreamChunk) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for range stream {
+		}
+	}()
+	return done
+}
+
 // CheckFirstStreamChunkForError reads the first chunk from a streaming channel to detect
 // errors returned inside HTTP 200 SSE streams (e.g., providers that send rate limit
 // errors as SSE events instead of HTTP 429).
+//
+// If ctx ends before the first chunk arrives, it returns a RequestCancelled (499)
+// or RequestTimedOut (504) error immediately and drains the source in the
+// background, so the calling worker is released instead of waiting out the
+// provider's stream idle timeout (maximhq/bifrost#6974). A chunk the producer
+// already delivered takes precedence over ctx.
 //
 // If the first chunk is an error, it drains the source channel in the background
 // (so the provider goroutine can exit cleanly) and returns the error for synchronous
@@ -198,7 +224,9 @@ func CheckStreamPreambleForError(
 // closed when the wrapper goroutine finishes forwarding the source stream.
 //
 // If the source channel is closed immediately (empty stream), it returns a
-// nil channel with nil error. drainDone is already closed.
+// nil channel with nil error. drainDone is already closed. A nil source is
+// treated the same way, matching CheckStreamPreambleForError, so no goroutine
+// is ever parked on a channel that can never be ready or closed.
 //
 // The ctx argument cancels the background forwarding goroutine if the consumer
 // abandons the returned wrapped channel. On ctx.Done the goroutine drains the
@@ -207,7 +235,30 @@ func CheckFirstStreamChunkForError(
 	ctx context.Context,
 	stream chan *schemas.BifrostStreamChunk,
 ) (chan *schemas.BifrostStreamChunk, <-chan struct{}, *schemas.BifrostError) {
-	firstChunk, ok := <-stream
+	if stream == nil {
+		done := make(chan struct{})
+		close(done)
+		return nil, done, nil
+	}
+	var firstChunk *schemas.BifrostStreamChunk
+	var ok bool
+	select {
+	case firstChunk, ok = <-stream:
+		// A chunk the producer already delivered wins over ctx: a provider
+		// goroutine that saw the cancellation itself emits a richer
+		// RequestCancelled chunk (billed usage, raw request) through
+		// HandleStreamCancellation.
+	default:
+		select {
+		case firstChunk, ok = <-stream:
+		case <-ctx.Done():
+			// The producer accepted the request but has emitted nothing and
+			// the request is gone. Release the worker now instead of waiting
+			// out the provider's stream idle timeout. Drain in the background
+			// so the producer's eventual send and close still complete.
+			return nil, drainInBackground(stream), newStreamContextError(ctx)
+		}
+	}
 	if !ok {
 		// Channel closed immediately (empty stream) — return nil so callers
 		// can distinguish this from a live stream channel.
@@ -220,13 +271,7 @@ func CheckFirstStreamChunkForError(
 	if firstChunk.BifrostError != nil && firstChunk.BifrostError.Error != nil &&
 		(firstChunk.BifrostError.Error.Message != "" || firstChunk.BifrostError.Error.Code != nil || firstChunk.BifrostError.Error.Type != nil) {
 		// Drain source channel to let the provider goroutine exit cleanly
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			for range stream {
-			}
-		}()
-		return nil, done, firstChunk.BifrostError
+		return nil, drainInBackground(stream), firstChunk.BifrostError
 	}
 
 	// First chunk is valid data — wrap channel to re-inject it

--- a/core/providers/utils/stream_test.go
+++ b/core/providers/utils/stream_test.go
@@ -310,6 +310,36 @@ func TestCheckFirstStreamChunk_ValidFirstChunk(t *testing.T) {
 	}
 }
 
+func TestCheckFirstStreamChunk_NilStream(t *testing.T) {
+	// A nil source must return immediately with a closed drainDone, matching
+	// CheckStreamPreambleForError. Without the guard the initial receive blocks
+	// until ctx ends and the drain goroutine never exits.
+	ctx := context.Background()
+	type result struct {
+		stream chan *schemas.BifrostStreamChunk
+		done   <-chan struct{}
+		err    *schemas.BifrostError
+	}
+	out := make(chan result, 1)
+	go func() {
+		s, d, e := CheckFirstStreamChunkForError(ctx, nil)
+		out <- result{s, d, e}
+	}()
+	select {
+	case r := <-out:
+		if r.stream != nil || r.err != nil {
+			t.Fatalf("expected nil stream and nil error, got stream=%v err=%v", r.stream != nil, r.err)
+		}
+		select {
+		case <-r.done:
+		default:
+			t.Fatal("expected drainDone to be closed for a nil stream")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CheckFirstStreamChunkForError blocked on a nil stream")
+	}
+}
+
 func TestCheckFirstStreamChunk_EmptyStream(t *testing.T) {
 	stream := make(chan *schemas.BifrostStreamChunk)
 	close(stream)
@@ -550,5 +580,137 @@ func TestCheckFirstStreamChunk_CodeOnlyError(t *testing.T) {
 	<-drainDone
 	if err.Error.Code == nil || *err.Error.Code != "limit_burst_rate" {
 		t.Errorf("unexpected error code: %v", err.Error.Code)
+	}
+}
+
+// Regression tests for maximhq/bifrost#6974: the first-chunk peek must observe
+// the request context so a cancelled or expired request releases its worker
+// slot instead of waiting out the provider's stream idle timeout.
+
+type firstChunkResult struct {
+	wrapped chan *schemas.BifrostStreamChunk
+	done    <-chan struct{}
+	err     *schemas.BifrostError
+}
+
+// peekAsync runs CheckFirstStreamChunkForError on its own goroutine so the
+// test can bound how long the peek blocks.
+func peekAsync(ctx context.Context, src chan *schemas.BifrostStreamChunk) <-chan firstChunkResult {
+	results := make(chan firstChunkResult, 1)
+	go func() {
+		wrapped, done, err := CheckFirstStreamChunkForError(ctx, src)
+		results <- firstChunkResult{wrapped: wrapped, done: done, err: err}
+	}()
+	return results
+}
+
+func TestCheckFirstStreamChunk_CtxCancelUnblocksPeek(t *testing.T) {
+	// A producer that accepted the request but never emits a chunk and does
+	// not watch ctx itself. Only the peek's own ctx handling can release the
+	// worker goroutine that is blocked inside CheckFirstStreamChunkForError.
+	src := make(chan *schemas.BifrostStreamChunk, 1)
+	closeSrc := sync.OnceFunc(func() { close(src) })
+	defer closeSrc()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	results := peekAsync(ctx, src)
+
+	cancel()
+
+	var got firstChunkResult
+	select {
+	case got = <-results:
+	case <-time.After(2 * time.Second):
+		t.Fatal("CheckFirstStreamChunkForError did not return after ctx cancellation; worker stays pinned until the stream idle timeout")
+	}
+	if got.wrapped != nil || got.err == nil || got.err.Error == nil ||
+		got.err.Error.Type == nil || *got.err.Error.Type != schemas.RequestCancelled {
+		t.Fatalf("expected cancellation error, got wrapped=%v err=%v", got.wrapped, got.err)
+	}
+	if got.err.StatusCode == nil || *got.err.StatusCode != 499 {
+		t.Fatalf("expected status 499, got %v", got.err.StatusCode)
+	}
+	if got.err.AllowFallbacks == nil || *got.err.AllowFallbacks {
+		t.Fatal("cancelled request must not allow fallbacks")
+	}
+
+	// The drain must keep accepting late producer chunks so the provider
+	// goroutine's blocked send can exit, then finish once the source closes.
+	select {
+	case <-got.done:
+		t.Fatal("drain completed before the producer closed the source")
+	default:
+	}
+	src <- &schemas.BifrostStreamChunk{
+		BifrostChatResponse: &schemas.BifrostChatResponse{ID: "late"},
+	}
+	closeSrc()
+	select {
+	case <-got.done:
+	case <-time.After(time.Second):
+		t.Fatal("cancelled peek failed to drain the source")
+	}
+}
+
+func TestCheckFirstStreamChunk_DeadlineAllowsFallbacks(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	src := make(chan *schemas.BifrostStreamChunk)
+	closeSrc := sync.OnceFunc(func() { close(src) })
+	defer closeSrc()
+
+	var got firstChunkResult
+	select {
+	case got = <-peekAsync(ctx, src):
+	case <-time.After(2 * time.Second):
+		t.Fatal("CheckFirstStreamChunkForError did not return after the request deadline passed")
+	}
+	if got.wrapped != nil || got.err == nil || got.err.Error == nil ||
+		got.err.Error.Type == nil || *got.err.Error.Type != schemas.RequestTimedOut {
+		t.Fatalf("expected timeout error, got wrapped=%v err=%v", got.wrapped, got.err)
+	}
+	if got.err.StatusCode == nil || *got.err.StatusCode != 504 {
+		t.Fatalf("expected status 504, got %v", got.err.StatusCode)
+	}
+	if got.err.AllowFallbacks != nil {
+		t.Fatal("timeout must preserve default fallback eligibility")
+	}
+	closeSrc()
+	select {
+	case <-got.done:
+	case <-time.After(time.Second):
+		t.Fatal("timed-out peek failed to drain the source")
+	}
+}
+
+// Guard: when the provider goroutine already delivered its own cancellation
+// chunk (HandleStreamCancellation carries billed usage and the raw request),
+// that richer chunk must win over the peek's synthetic cancellation error even
+// though ctx is already done.
+func TestCheckFirstStreamChunk_BufferedChunkWinsOverCancelledCtx(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	src := make(chan *schemas.BifrostStreamChunk, 1)
+	src <- &schemas.BifrostStreamChunk{
+		BifrostError: &schemas.BifrostError{
+			StatusCode: new(499),
+			Error: &schemas.ErrorField{
+				Type:    schemas.Ptr(schemas.RequestCancelled),
+				Message: "Request cancelled: client disconnected",
+			},
+		},
+	}
+	close(src)
+
+	wrapped, done, err := CheckFirstStreamChunkForError(ctx, src)
+	if wrapped != nil || err == nil || err.Error == nil ||
+		err.Error.Message != "Request cancelled: client disconnected" {
+		t.Fatalf("expected the producer's own cancellation chunk, got wrapped=%v err=%v", wrapped, err)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("closed source failed to drain")
 	}
 }

--- a/core/spanenrichment_test.go
+++ b/core/spanenrichment_test.go
@@ -33,8 +33,6 @@ var contextDimSources = []struct {
 	{schemas.AttrBifrostCustomerName, schemas.BifrostContextKeyGovernanceCustomerName, "cust-name"},
 	{schemas.AttrBifrostBusinessUnitID, schemas.BifrostContextKeyGovernanceBusinessUnitID, "bu-id"},
 	{schemas.AttrBifrostBusinessUnitName, schemas.BifrostContextKeyGovernanceBusinessUnitName, "bu-name"},
-	{schemas.AttrBifrostProjectID, schemas.BifrostContextKeyGovernanceProjectID, "proj-id"},
-	{schemas.AttrBifrostProjectName, schemas.BifrostContextKeyGovernanceProjectName, "proj-name"},
 	{schemas.AttrBifrostTeamIDs, schemas.BifrostContextKeyGovernanceTeamIDs, []string{"team-id-1", "team-id-2"}},
 	{schemas.AttrBifrostTeamNames, schemas.BifrostContextKeyGovernanceTeamNames, []string{"team-name-1"}},
 	{schemas.AttrBifrostCustomerIDs, schemas.BifrostContextKeyGovernanceCustomerIDs, []string{"cust-id-1"}},

--- a/framework/go.sum
+++ b/framework/go.sum
@@ -452,8 +452,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/framework/logstore/hybrid_test.go
+++ b/framework/logstore/hybrid_test.go
@@ -531,7 +531,7 @@ func TestHybrid_ProcessMCPUploadSkipsMissingRowsWithEmptyStatus(t *testing.T) {
 }
 
 func TestHybrid_DeleteMCPToolLogsDeletesObjects(t *testing.T) {
-	hybrid, _, objStore := newTestHybrid(t)
+	hybrid, inner, objStore := newTestHybrid(t)
 	defer hybrid.Close(context.Background())
 	ctx := context.Background()
 
@@ -547,7 +547,7 @@ func TestHybrid_DeleteMCPToolLogsDeletesObjects(t *testing.T) {
 		},
 	}
 	require.NoError(t, hybrid.CreateMCPToolLog(ctx, entry))
-	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+	waitForMCPOffload(t, inner, entry.ID)
 
 	require.NoError(t, hybrid.DeleteMCPToolLogs(ctx, []string{entry.ID}))
 	assert.Equal(t, 0, objStore.Len())
@@ -588,7 +588,7 @@ func TestHybrid_PutFailureDropsUpload(t *testing.T) {
 }
 
 func TestHybrid_DeleteLog(t *testing.T) {
-	hybrid, _, objStore := newTestHybrid(t)
+	hybrid, inner, objStore := newTestHybrid(t)
 	defer hybrid.Close(context.Background())
 	ctx := context.Background()
 
@@ -603,7 +603,7 @@ func TestHybrid_DeleteLog(t *testing.T) {
 	}
 	require.NoError(t, entry.SerializeFields())
 	require.NoError(t, hybrid.CreateIfNotExists(ctx, entry))
-	waitForUploads(t, func() bool { return objStore.Len() == 1 })
+	waitForOffload(t, inner, entry.ID)
 	assert.Equal(t, 1, objStore.Len())
 
 	err := hybrid.DeleteLog(ctx, "del-1")

--- a/plugins/compat/go.sum
+++ b/plugins/compat/go.sum
@@ -454,8 +454,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/plugins/governance/go.sum
+++ b/plugins/governance/go.sum
@@ -454,8 +454,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/plugins/logging/go.sum
+++ b/plugins/logging/go.sum
@@ -454,8 +454,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/plugins/maxim/go.sum
+++ b/plugins/maxim/go.sum
@@ -456,8 +456,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/plugins/modelcatalogresolver/go.sum
+++ b/plugins/modelcatalogresolver/go.sum
@@ -454,8 +454,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/plugins/otel/go.sum
+++ b/plugins/otel/go.sum
@@ -464,8 +464,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/plugins/routing/go.sum
+++ b/plugins/routing/go.sum
@@ -464,8 +464,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/plugins/semanticcache/go.sum
+++ b/plugins/semanticcache/go.sum
@@ -301,8 +301,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=

--- a/plugins/telemetry/go.sum
+++ b/plugins/telemetry/go.sum
@@ -470,8 +470,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/tests/cmd/e2eseed/go.sum
+++ b/tests/cmd/e2eseed/go.sum
@@ -366,8 +366,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/tests/cmd/seed/go.sum
+++ b/tests/cmd/seed/go.sum
@@ -366,8 +366,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/transports/bifrost-http/lib/catalogfixture_test.go
+++ b/transports/bifrost-http/lib/catalogfixture_test.go
@@ -1,0 +1,49 @@
+package lib
+
+import (
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/modelcatalog"
+)
+
+// Config tests exercise catalog initialization and persistence, not the size or
+// changing contents of the public feeds. Intercept only their default URLs;
+// custom URLs and local HTTP servers retain the normal transport behavior.
+type catalogFixtureTransport struct {
+	fallback http.RoundTripper
+}
+
+func (rt catalogFixtureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	var body string
+	switch req.URL.String() {
+	case modelcatalog.DefaultPricingURL:
+		body = `{"gpt-4o-mini":{"provider":"openai","mode":"chat","input_cost_per_token":0.00000015,"output_cost_per_token":0.0000006}}`
+	case modelcatalog.DefaultModelParametersURL:
+		body = `{"gpt-4o-mini":{"supports_reasoning":false,"supports_sampling_params":true}}`
+	case modelcatalog.DefaultMCPLibraryURL:
+		body = `{"servers":[]}`
+	default:
+		return rt.fallback.RoundTrip(req)
+	}
+	if err := req.Context().Err(); err != nil {
+		return nil, err
+	}
+	return &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        http.Header{"Content-Type": {"application/json"}},
+		Body:          io.NopCloser(strings.NewReader(body)),
+		ContentLength: int64(len(body)),
+		Request:       req,
+	}, nil
+}
+
+func TestMain(m *testing.M) {
+	// Install once before any test or background worker starts. Leave it in
+	// place until process exit so surviving workers cannot race a restoration.
+	http.DefaultTransport = catalogFixtureTransport{fallback: http.DefaultTransport}
+	os.Exit(m.Run())
+}

--- a/transports/bifrost-http/lib/configstoretemplate_test.go
+++ b/transports/bifrost-http/lib/configstoretemplate_test.go
@@ -9,25 +9,14 @@ import (
 	"testing"
 )
 
-// The first LoadConfig against an empty directory costs ~4s: it runs the
-// migration chain and then seeds the database, the model catalog rows being the
-// bulk of it. A second LoadConfig against that same database costs ~0.25s. Tests
-// in this package take a fresh temp dir apiece and most boot LoadConfig two or
-// three times, so the package used to pay that ~4s over a hundred times - 344s
-// for one plain `go test ./bifrost-http/lib`, several times that under -race.
-// That is what made CI's "Run bifrost-http tests" step sit silent for tens of
-// minutes: go test buffers a package's output until the package finishes, so a
-// slow package is indistinguishable from a hung one.
+// Reuse one default-boot database per test binary so config reload tests do
+// not rerun the migration chain and initial catalog seeding for every case.
+// Each test gets an independent file copy; subsequent LoadConfig calls still
+// exercise normal opening, config reconciliation, and catalog initialization.
+// The catalog HTTP responses are fixed by catalogfixture_test.go.
 //
-// Everything that first boot writes is deterministic, so build one such database
-// per test binary and copy it into each temp dir. Later boots find the schema
-// migrated and the catalog seeded, and take the ~0.25s path. Measured on the
-// same package: 344s -> 49s.
-//
-// The template is built from a directory with no config.json, so it holds
-// exactly what a default boot produces. Building it from a populated config
-// would leak that config into every test, including the ones asserting
-// fresh-start defaults.
+// Build without config.json so no test-specific providers, credentials, or
+// governance settings leak into another test's initial state.
 
 var (
 	templateConfigDBOnce sync.Once
@@ -66,15 +55,13 @@ func buildTemplateConfigDB() {
 		templateConfigDBErr = err
 		return
 	}
-	store := config.ConfigStore
+	// Stop catalog and credential workers before snapshotting their database.
+	// Closing only the store leaves those workers running against a closed DB.
+	config.Close(ctx)
 	// Close before reading the files. The store opens SQLite in WAL mode, and
 	// closing the last connection is what checkpoints the WAL back into the main
 	// database file - copying it while open would hand out a database missing
 	// every migration still sitting in the log.
-	if err := store.Close(ctx); err != nil {
-		templateConfigDBErr = err
-		return
-	}
 
 	sidecars, err := filepath.Glob(basePath + "*")
 	if err != nil {

--- a/transports/go.sum
+++ b/transports/go.sum
@@ -615,8 +615,6 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:q4lMZS6kskjT5HvCPrnnypcDPVJqT/f4nfxmkE7gryY=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa h1:mZHHdPZl0dbGHCflZgAq/Q468DWVFcU2whhB2KAo8fk=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.83.1 h1:HIO0+BEtBP6soyqvqC8sNUjZ7bTs+0hFQuFF+RAy++Y=
-google.golang.org/grpc v1.83.1/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4JGwzQ=
 google.golang.org/grpc v1.83.2 h1:EManeRomTObA0BU7I8vXgg/78uE5MJ9M8B39EX2WscU=
 google.golang.org/grpc v1.83.2/go.mod h1:YPI1hK3kDked6iHvgX3tR0y+nX/qpMFKhPgFsokw1S8=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=


### PR DESCRIPTION
## Summary

The streaming first-chunk peek in `CheckFirstStreamChunkForError` previously blocked on a bare channel receive with no context awareness. If a request was cancelled or its deadline expired while waiting for the first chunk, the worker goroutine would remain pinned until the provider's `stream_idle_timeout_in_seconds` elapsed. This PR makes the peek observe the request context so cancelled requests return 499 and timed-out requests return 504, releasing the worker immediately.

## Changes

- **`core/providers/utils/stream.go`**: Replaced the blocking `<-stream` receive in `CheckFirstStreamChunkForError` with a two-stage `select` that checks for an already-buffered chunk first (so a provider's own richer `HandleStreamCancellation` chunk wins), then races the channel against `ctx.Done()`. On context termination, the source is drained in a background goroutine so the provider's eventual send and close still complete cleanly. Extracted `newStreamContextError` and `drainInBackground` helpers to deduplicate logic shared with `CheckStreamPreambleForError`.
- **`core/providers/utils/stream_test.go`**: Added regression tests covering context cancellation unblocking the peek (499, fallbacks disabled), deadline expiry (504, default fallback eligibility), and the guard that a buffered producer chunk wins over a simultaneously cancelled context.
- **`core/spanenrichment_test.go`**: Removed two stale test table entries for project ID/name context dimension sources.
- **`framework/logstore/hybrid_test.go`**: Replaced polling-by-object-store-count with deterministic `waitForOffload`/`waitForMCPOffload` helpers in two tests to eliminate a race condition.
- **`.github/workflows/scripts/cost-accuracy-test.sh`**: Extracted a `token_counts()` helper that handles Go's `omitempty` behaviour — when `prompt_tokens` or `completion_tokens` is absent from the JSON blob but `total_tokens` confirms the missing field is zero, it is treated as zero rather than failing validation. Updated the error message to be more accurate.
- **`.github/workflows/scripts/setup-vllm-runpod.sh`**: Pod IDs are now written to `GITHUB_ENV` immediately after each pod is created rather than at the end of the script, so the teardown step can clean up the first pod even if the second pod creation fails. `create_vllm_pod` now propagates `runpodctl` failures with an explicit error message.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/utils/... -run TestCheckFirstStreamChunk -v
go test ./core/... -v
go test ./framework/logstore/... -v
```

The three new `TestCheckFirstStreamChunk_Ctx*` tests validate the fix directly. Each has a 2-second timeout guard; before this change they would all time out.

## Breaking changes

- [x] No

## Related issues

Closes #6974

## Security considerations

None. The change only affects how a worker goroutine exits when a request context is done; no auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable