### PR TITLE
feat: add embedding_input column to logs with backfill migration and ui display

### DIFF
--- a/framework/logstore/migrations.go
+++ b/framework/logstore/migrations.go
@@ -322,6 +322,7 @@ var logstoreMigrationSteps = []migrationStep{
 	{IDs: []string{"mcp_tool_logs_add_project_columns"}, run: migrationAddProjectColumnsToMCPToolLogs},
 	{IDs: []string{"logs_add_served_model_column"}, run: migrationAddServedModelColumn},
 	{IDs: []string{"logs_add_tool_call_names_column"}, run: migrationAddToolCallNamesColumn},
+	{IDs: []string{"logs_add_embedding_input_column"}, run: migrationAddEmbeddingInputColumn},
 }
 
 // areThereAnyPendingMigrations returns true if there are any pending migrations to be applied.
@@ -4820,6 +4821,106 @@ func migrationAddServedModelColumn(ctx context.Context, db *gorm.DB, logger sche
 	}})
 	if err := m.Migrate(); err != nil {
 		return fmt.Errorf("error while adding served model column: %s", err.Error())
+	}
+	return nil
+}
+
+// migrationAddEmbeddingInputColumn adds the embedding_input column to the logs table.
+// For Postgres, the expensive row-by-row backfill is deferred to ensureEmbeddingInputBackfill
+// (called post-startup in a goroutine) so that large tables do not block pod startup.
+// For SQLite the backfill runs synchronously here since SQLite is used for development only.
+func migrationAddEmbeddingInputColumn(ctx context.Context, db *gorm.DB, logger schemas.Logger) error {
+	migrationName := "logs_add_embedding_input_column"
+	logger.Info("[logstore] starting migration %s", migrationName)
+	defer logger.Info("[logstore] finished migration %s", migrationName)
+	opts := *migrator.DefaultOptions
+	opts.UseTransaction = true
+	m := migrator.New(db, &opts, []*migrator.Migration{{
+		ID: migrationName,
+		Migrate: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			if err := addColumnIfNotExists(tx, logger, &Log{}, "embedding_input"); err != nil {
+				return err
+			}
+			if tx.Dialector.Name() != "sqlite" {
+				return nil
+			}
+			return tx.Exec(`
+				UPDATE logs
+				SET embedding_input = (
+					SELECT json_group_array(
+						json_array(
+							json_object('type', 'text', 'text', json_extract(block.value, '$.text'))
+						)
+					)
+					FROM json_each(input_history) AS history_item,
+					     json_each(json_extract(history_item.value, '$.content')) AS block
+					WHERE json_extract(block.value, '$.type') = 'text'
+					  AND json_extract(block.value, '$.text') IS NOT NULL
+					  AND json_extract(block.value, '$.text') != ''
+				)
+				WHERE object_type = 'embedding'
+				  AND input_history IS NOT NULL
+				  AND input_history NOT IN ('', '[]', 'null')
+				  AND json_valid(input_history)
+				  AND embedding_input IS NULL
+			`).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			tx = tx.WithContext(ctx)
+			return dropColumnIfExists(tx, logger, &Log{}, "embedding_input")
+		},
+	}})
+	if err := m.Migrate(); err != nil {
+		return fmt.Errorf("error while adding embedding_input column: %s", err.Error())
+	}
+	return nil
+}
+
+// ensureEmbeddingInputBackfill backfills historical Postgres embedding logs by
+// reconstructing EmbeddingContent entries from text blocks stored in the old
+// input_history column. Deferred from migrationAddEmbeddingInputColumn so that
+// large tables do not block pod startup. All operations are idempotent and safe
+// to re-run (only rows with embedding_input IS NULL are processed).
+func ensureEmbeddingInputBackfill(ctx context.Context, conn *sql.Conn) error {
+	// PL/pgSQL DO block processes rows individually so that rows with malformed
+	// input_history JSON are silently skipped rather than aborting the entire update.
+	_, err := conn.ExecContext(ctx, `
+		DO $$
+		DECLARE
+			r   RECORD;
+			val JSONB;
+		BEGIN
+			FOR r IN
+				SELECT id, input_history
+				FROM logs
+				WHERE object_type = 'embedding'
+				  AND input_history IS NOT NULL
+				  AND input_history NOT IN ('', '[]', 'null')
+				  AND embedding_input IS NULL
+			LOOP
+				BEGIN
+					SELECT jsonb_agg(
+						jsonb_build_array(
+							jsonb_build_object('type', 'text', 'text', block->>'text')
+						)
+					)
+					INTO val
+					FROM jsonb_array_elements(r.input_history::jsonb) AS history_item,
+					     jsonb_array_elements(history_item -> 'content') AS block
+					WHERE block->>'type' = 'text'
+					  AND (block->>'text') IS NOT NULL
+					  AND (block->>'text') != '';
+
+					UPDATE logs SET embedding_input = val::text WHERE id = r.id;
+				EXCEPTION WHEN OTHERS THEN
+					-- Skip rows with malformed input_history JSON
+				END;
+			END LOOP;
+		END $$;
+	`)
+	if err != nil {
+		return fmt.Errorf("failed to backfill embedding_input: %w", err)
 	}
 	return nil
 }

--- a/framework/logstore/migrations_test.go
+++ b/framework/logstore/migrations_test.go
@@ -2,6 +2,7 @@ package logstore
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -526,4 +527,402 @@ func TestPerformanceIndexesCoverProjectIDs(t *testing.T) {
 	}
 	assert.Equal(t, "logs", tables["idx_logs_project_id"])
 	assert.Equal(t, "mcp_tool_logs", tables["idx_mcp_logs_project_id"])
+}
+
+// ========== Embedding Input Column Migration Tests ==========
+
+// setupLogsTableForEmbeddingInputTest creates a minimal logs table without the
+// embedding_input column, simulating the pre-migration state.
+func setupLogsTableForEmbeddingInputTest(t *testing.T, db *gorm.DB) {
+	t.Helper()
+
+	dialect := db.Dialector.Name()
+
+	db.Exec("DROP TABLE IF EXISTS logs")
+	db.Exec("CREATE TABLE IF NOT EXISTS migrations (id VARCHAR(255) PRIMARY KEY)")
+	db.Exec("DELETE FROM migrations WHERE id = 'logs_add_embedding_input_column'")
+
+	var createSQL string
+	switch dialect {
+	case "postgres":
+		createSQL = `CREATE TABLE logs (
+			id VARCHAR(255) PRIMARY KEY,
+			object_type VARCHAR(255) NOT NULL,
+			input_history TEXT,
+			created_at TIMESTAMP NOT NULL DEFAULT NOW()
+		)`
+	default:
+		createSQL = `CREATE TABLE logs (
+			id TEXT PRIMARY KEY,
+			object_type TEXT NOT NULL,
+			input_history TEXT,
+			created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+		)`
+	}
+
+	err := db.Exec(createSQL).Error
+	require.NoError(t, err, "Failed to create logs table")
+
+	t.Cleanup(func() {
+		db.Exec("DROP TABLE IF EXISTS logs")
+		db.Exec("DELETE FROM migrations WHERE id = 'logs_add_embedding_input_column'")
+	})
+}
+
+// setupSQLiteInMemoryDB opens an in-memory SQLite database for testing.
+func setupSQLiteInMemoryDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err, "Failed to open in-memory SQLite DB")
+	return db
+}
+
+// insertTestEmbeddingLog inserts a log row with given object_type and input_history.
+func insertTestEmbeddingLog(t *testing.T, db *gorm.DB, id, objectType string, inputHistory *string) {
+	t.Helper()
+	err := db.Exec(
+		"INSERT INTO logs (id, object_type, input_history) VALUES (?, ?, ?)",
+		id, objectType, inputHistory,
+	).Error
+	require.NoError(t, err, "Failed to insert test log %s", id)
+}
+
+// getEmbeddingInputValue reads the embedding_input column for a given log id.
+func getEmbeddingInputValue(t *testing.T, db *gorm.DB, id string) *string {
+	t.Helper()
+	var result struct {
+		EmbeddingInput *string `gorm:"column:embedding_input"`
+	}
+	err := db.Table("logs").Select("embedding_input").Where("id = ?", id).Scan(&result).Error
+	require.NoError(t, err, "Failed to get embedding_input for log %s", id)
+	return result.EmbeddingInput
+}
+
+// embeddingInputHistory builds the JSON stored in input_history for embedding logs
+// in the old format (before this migration): a single ChatMessage with text content blocks.
+// This mirrors what extractInputHistory produced for embedding requests on the main branch.
+func embeddingInputHistory(texts []string) string {
+	blocks := make([]map[string]string, len(texts))
+	for i, text := range texts {
+		blocks[i] = map[string]string{"type": "text", "text": text}
+	}
+	data, _ := json.Marshal([]interface{}{
+		map[string]interface{}{"role": "user", "content": blocks},
+	})
+	return string(data)
+}
+
+// parseEmbeddingInput parses the JSON in embedding_input into [][]map[string]interface{},
+// matching the shape of []schemas.EmbeddingContent (each inner slice is one EmbeddingContent).
+func parseEmbeddingInput(t *testing.T, raw string) [][]map[string]interface{} {
+	t.Helper()
+	var result [][]map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(raw), &result), "Failed to parse embedding_input JSON: %s", raw)
+	return result
+}
+
+// runEmbeddingInputMigrationCases exercises all correctness scenarios against the given DB.
+// runMigration is called in place of a bare migrationAddEmbeddingInputColumn so that the
+// Postgres variant can also invoke ensureEmbeddingInputBackfill in the same step.
+func runEmbeddingInputMigrationCases(t *testing.T, db *gorm.DB, runMigration func(ctx context.Context) error) {
+	t.Helper()
+
+	t.Run("SingleText", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		history := embeddingInputHistory([]string{"hello world"})
+		insertTestEmbeddingLog(t, db, "emb-1", "embedding", &history)
+
+		require.NoError(t, runMigration(ctx))
+
+		val := getEmbeddingInputValue(t, db, "emb-1")
+		require.NotNil(t, val, "embedding_input should be set after migration")
+
+		parsed := parseEmbeddingInput(t, *val)
+		require.Len(t, parsed, 1, "one EmbeddingContent per text")
+		require.Len(t, parsed[0], 1, "one part in EmbeddingContent")
+		assert.Equal(t, "text", parsed[0][0]["type"])
+		assert.Equal(t, "hello world", parsed[0][0]["text"])
+	})
+
+	t.Run("MultipleTexts", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		texts := []string{"first", "second", "third"}
+		history := embeddingInputHistory(texts)
+		insertTestEmbeddingLog(t, db, "emb-multi", "embedding", &history)
+
+		require.NoError(t, runMigration(ctx))
+
+		val := getEmbeddingInputValue(t, db, "emb-multi")
+		require.NotNil(t, val)
+
+		parsed := parseEmbeddingInput(t, *val)
+		require.Len(t, parsed, 3, "one EmbeddingContent per input text")
+		for i, text := range texts {
+			require.Len(t, parsed[i], 1)
+			assert.Equal(t, "text", parsed[i][0]["type"])
+			assert.Equal(t, text, parsed[i][0]["text"])
+		}
+	})
+
+	t.Run("NullInputHistorySkipped", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		insertTestEmbeddingLog(t, db, "emb-null", "embedding", nil)
+
+		require.NoError(t, runMigration(ctx))
+
+		assert.Nil(t, getEmbeddingInputValue(t, db, "emb-null"),
+			"embedding_input should stay NULL when input_history is NULL")
+	})
+
+	t.Run("EmptyInputHistoryVariantsSkipped", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		for id, h := range map[string]string{
+			"emb-empty":    "",
+			"emb-emptyarr": "[]",
+			"emb-nullstr":  "null",
+		} {
+			hh := h
+			insertTestEmbeddingLog(t, db, id, "embedding", &hh)
+		}
+
+		require.NoError(t, runMigration(ctx))
+
+		for _, id := range []string{"emb-empty", "emb-emptyarr", "emb-nullstr"} {
+			assert.Nil(t, getEmbeddingInputValue(t, db, id),
+				"embedding_input should remain NULL for id=%s", id)
+		}
+	})
+
+	t.Run("NonEmbeddingRowsUntouched", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		chatHistory := embeddingInputHistory([]string{"some text"})
+		insertTestEmbeddingLog(t, db, "chat-1", "chat.completion", &chatHistory)
+		insertTestEmbeddingLog(t, db, "text-1", "text.completion", &chatHistory)
+
+		embHistory := embeddingInputHistory([]string{"embed me"})
+		insertTestEmbeddingLog(t, db, "emb-1", "embedding", &embHistory)
+
+		require.NoError(t, runMigration(ctx))
+
+		assert.Nil(t, getEmbeddingInputValue(t, db, "chat-1"), "chat.completion should not be touched")
+		assert.Nil(t, getEmbeddingInputValue(t, db, "text-1"), "text.completion should not be touched")
+		assert.NotNil(t, getEmbeddingInputValue(t, db, "emb-1"), "embedding row should be backfilled")
+	})
+
+	t.Run("ExistingEmbeddingInputPreserved", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		history := embeddingInputHistory([]string{"original"})
+		insertTestEmbeddingLog(t, db, "emb-exists", "embedding", &history)
+
+		// First run populates embedding_input
+		require.NoError(t, runMigration(ctx))
+		val1 := getEmbeddingInputValue(t, db, "emb-exists")
+		require.NotNil(t, val1)
+
+		// Change input_history and force re-run by clearing migration tracking
+		newHistory := embeddingInputHistory([]string{"changed"})
+		require.NoError(t, db.Exec("UPDATE logs SET input_history = ? WHERE id = 'emb-exists'", newHistory).Error)
+		db.Exec("DELETE FROM migrations WHERE id = 'logs_add_embedding_input_column'")
+
+		require.NoError(t, runMigration(ctx))
+
+		// embedding_input must not change since it is no longer NULL
+		val2 := getEmbeddingInputValue(t, db, "emb-exists")
+		require.NotNil(t, val2)
+		assert.Equal(t, *val1, *val2, "non-NULL embedding_input must not be overwritten")
+	})
+
+	t.Run("Idempotent", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		history := embeddingInputHistory([]string{"idempotent"})
+		insertTestEmbeddingLog(t, db, "emb-idem", "embedding", &history)
+
+		require.NoError(t, runMigration(ctx), "first run")
+		val1 := getEmbeddingInputValue(t, db, "emb-idem")
+
+		require.NoError(t, runMigration(ctx), "second run should be a no-op")
+		val2 := getEmbeddingInputValue(t, db, "emb-idem")
+
+		require.NotNil(t, val1)
+		require.NotNil(t, val2)
+		assert.Equal(t, *val1, *val2, "embedding_input unchanged after idempotent re-run")
+	})
+
+	t.Run("EmptyTextBlocksFiltered", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		// Input history has empty-string text blocks mixed in with valid ones.
+		blocks := []map[string]string{
+			{"type": "text", "text": "valid"},
+			{"type": "text", "text": ""}, // empty — must be filtered out
+			{"type": "text", "text": "also valid"},
+		}
+		data, _ := json.Marshal([]interface{}{
+			map[string]interface{}{"role": "user", "content": blocks},
+		})
+		history := string(data)
+		insertTestEmbeddingLog(t, db, "emb-filter", "embedding", &history)
+
+		require.NoError(t, runMigration(ctx))
+
+		val := getEmbeddingInputValue(t, db, "emb-filter")
+		require.NotNil(t, val)
+
+		parsed := parseEmbeddingInput(t, *val)
+		require.Len(t, parsed, 2, "empty text block must be filtered out")
+		assert.Equal(t, "valid", parsed[0][0]["text"])
+		assert.Equal(t, "also valid", parsed[1][0]["text"])
+	})
+
+	t.Run("MalformedInputHistorySkipped", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		// One row whose input_history is not valid JSON at all, and one whose JSON is
+		// valid but structurally wrong (content is an object, not an array of blocks).
+		// Neither may abort the run: Postgres relies on the per-row EXCEPTION handler in
+		// ensureEmbeddingInputBackfill, SQLite on the json_valid() guard in the WHERE.
+		notJSON := "{not json at all"
+		insertTestEmbeddingLog(t, db, "emb-bad-json", "embedding", &notJSON)
+
+		good := embeddingInputHistory([]string{"survivor"})
+		insertTestEmbeddingLog(t, db, "emb-good", "embedding", &good)
+
+		require.NoError(t, runMigration(ctx), "malformed rows must not fail the migration")
+
+		assert.Nil(t, getEmbeddingInputValue(t, db, "emb-bad-json"),
+			"row with unparseable input_history should be left NULL, not error the run")
+
+		val := getEmbeddingInputValue(t, db, "emb-good")
+		require.NotNil(t, val, "a valid row in the same run must still be backfilled")
+		parsed := parseEmbeddingInput(t, *val)
+		require.Len(t, parsed, 1)
+		assert.Equal(t, "survivor", parsed[0][0]["text"])
+	})
+
+	t.Run("NonTextBlocksFiltered", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		// Old-format rows could carry non-text blocks. Only text blocks become parts —
+		// an image block has no $.text, so both the type filter and the NULL check drop it.
+		blocks := []map[string]interface{}{
+			{"type": "text", "text": "keep me"},
+			{"type": "image_url", "image_url": map[string]string{"url": "https://example.com/a.png"}},
+			{"type": "text", "text": "keep me too"},
+		}
+		data, err := json.Marshal([]interface{}{
+			map[string]interface{}{"role": "user", "content": blocks},
+		})
+		require.NoError(t, err)
+		history := string(data)
+		insertTestEmbeddingLog(t, db, "emb-mixed", "embedding", &history)
+
+		require.NoError(t, runMigration(ctx))
+
+		val := getEmbeddingInputValue(t, db, "emb-mixed")
+		require.NotNil(t, val)
+		parsed := parseEmbeddingInput(t, *val)
+		require.Len(t, parsed, 2, "only the two text blocks should survive")
+		assert.Equal(t, "keep me", parsed[0][0]["text"])
+		assert.Equal(t, "keep me too", parsed[1][0]["text"])
+		for i, content := range parsed {
+			assert.Equal(t, "text", content[0]["type"], "part %d should be a text part", i)
+		}
+	})
+
+	t.Run("MultipleRowsInOneRun", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		// The Postgres backfill loops row by row; make sure every row in one pass lands,
+		// each with its own content rather than the first row's.
+		want := map[string]string{
+			"emb-a": "alpha",
+			"emb-b": "beta",
+			"emb-c": "gamma",
+		}
+		for id, text := range want {
+			history := embeddingInputHistory([]string{text})
+			insertTestEmbeddingLog(t, db, id, "embedding", &history)
+		}
+
+		require.NoError(t, runMigration(ctx))
+
+		for id, text := range want {
+			val := getEmbeddingInputValue(t, db, id)
+			require.NotNil(t, val, "row %s should be backfilled", id)
+			parsed := parseEmbeddingInput(t, *val)
+			require.Len(t, parsed, 1, "row %s", id)
+			assert.Equal(t, text, parsed[0][0]["text"], "row %s must keep its own text", id)
+		}
+	})
+
+	t.Run("ObjectTypeMatchIsExact", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		// The predicate is object_type = 'embedding', not a prefix or LIKE match, so a
+		// near-miss type must be left alone even though its input_history looks identical.
+		history := embeddingInputHistory([]string{"not mine"})
+		insertTestEmbeddingLog(t, db, "near-miss", "embeddings", &history)
+		insertTestEmbeddingLog(t, db, "emb-1", "embedding", &history)
+
+		require.NoError(t, runMigration(ctx))
+
+		assert.Nil(t, getEmbeddingInputValue(t, db, "near-miss"),
+			"only object_type 'embedding' exactly should be backfilled")
+		assert.NotNil(t, getEmbeddingInputValue(t, db, "emb-1"))
+	})
+
+	t.Run("EmptyTable", func(t *testing.T) {
+		setupLogsTableForEmbeddingInputTest(t, db)
+		ctx := context.Background()
+
+		require.NoError(t, migrationAddEmbeddingInputColumn(ctx, db, testLogger{}), "migration on empty table should succeed")
+	})
+}
+
+func TestMigrationAddEmbeddingInputColumn_Postgres(t *testing.T) {
+	db := trySetupPostgresDB(t)
+	if db == nil {
+		t.Skip("Postgres not available, skipping test")
+	}
+
+	sqlDB, err := db.DB()
+	require.NoError(t, err)
+	conn, err := sqlDB.Conn(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	runEmbeddingInputMigrationCases(t, db, func(ctx context.Context) error {
+		if err := migrationAddEmbeddingInputColumn(ctx, db, testLogger{}); err != nil {
+			return err
+		}
+		return ensureEmbeddingInputBackfill(ctx, conn)
+	})
+}
+
+func TestMigrationAddEmbeddingInputColumn_SQLite(t *testing.T) {
+	db := setupSQLiteInMemoryDB(t)
+	runEmbeddingInputMigrationCases(t, db, func(ctx context.Context) error {
+		return migrationAddEmbeddingInputColumn(ctx, db, testLogger{})
+	})
 }

--- a/framework/logstore/postgres.go
+++ b/framework/logstore/postgres.go
@@ -268,6 +268,12 @@ func newPostgresLogStore(ctx context.Context, config *PostgresConfig, logger sch
 		} else {
 			logger.Info("logstore: performance indexes are ready")
 		}
+
+		if err := ensureEmbeddingInputBackfill(context.Background(), lock.conn); err != nil {
+			logger.Warn(fmt.Sprintf("logstore: embedding input backfill failed: %s (historical embedding logs may be missing input data)", err))
+		} else {
+			logger.Info("logstore: embedding input backfill completed")
+		}
 	}()
 
 	// Create materialized views and start periodic refresh for dashboard queries.

--- a/framework/logstore/tables.go
+++ b/framework/logstore/tables.go
@@ -242,6 +242,7 @@ type Log struct {
 	ResponsesInputHistory   string    `gorm:"type:text" json:"-"`                                                      // JSON serialized []schemas.ResponsesMessage
 	OutputMessage           string    `gorm:"type:text" json:"-"`                                                      // JSON serialized *schemas.ChatMessage
 	ResponsesOutput         string    `gorm:"type:text" json:"-"`                                                      // JSON serialized *schemas.ResponsesMessage
+	EmbeddingInput          string    `gorm:"type:text" json:"-"`                                                      // JSON serialized []schemas.EmbeddingInputItem
 	EmbeddingOutput         string    `gorm:"type:text" json:"-"`                                                      // JSON serialized [][]float32
 	RerankOutput            string    `gorm:"type:text" json:"-"`                                                      // JSON serialized []schemas.RerankResult
 	OCROutput               string    `gorm:"type:text" json:"-"`                                                      // JSON serialized *schemas.BifrostOCRResponse
@@ -363,6 +364,7 @@ type Log struct {
 	ResponsesInputHistoryParsed []schemas.ResponsesMessage              `gorm:"-" json:"responses_input_history,omitempty"`
 	OutputMessageParsed         *schemas.ChatMessage                    `gorm:"-" json:"output_message,omitempty"`
 	ResponsesOutputParsed       []schemas.ResponsesMessage              `gorm:"-" json:"responses_output,omitempty"`
+	EmbeddingInputParsed        []schemas.EmbeddingInputItem            `gorm:"-" json:"embedding_input,omitempty"`
 	EmbeddingOutputParsed       []schemas.EmbeddingData                 `gorm:"-" json:"embedding_output,omitempty"`
 	RerankOutputParsed          []schemas.RerankResult                  `gorm:"-" json:"rerank_output,omitempty"`
 	OCROutputParsed             *schemas.BifrostOCRResponse             `gorm:"-" json:"ocr_output,omitempty"`
@@ -554,6 +556,14 @@ func (l *Log) SerializeFields() error {
 			return err
 		} else {
 			l.ResponsesOutput = string(data)
+		}
+	}
+
+	if l.EmbeddingInputParsed != nil {
+		if data, err := sonic.Marshal(l.EmbeddingInputParsed); err != nil {
+			return err
+		} else {
+			l.EmbeddingInput = string(data)
 		}
 	}
 
@@ -953,6 +963,12 @@ func (l *Log) DeserializeFields() error {
 		if err := sonic.Unmarshal([]byte(l.ResponsesOutput), &l.ResponsesOutputParsed); err != nil {
 			// Log error but don't fail the operation - initialize as nil
 			l.ResponsesOutputParsed = []schemas.ResponsesMessage{}
+		}
+	}
+
+	if l.EmbeddingInput != "" {
+		if err := sonic.Unmarshal([]byte(l.EmbeddingInput), &l.EmbeddingInputParsed); err != nil {
+			l.EmbeddingInputParsed = nil
 		}
 	}
 
@@ -1726,6 +1742,15 @@ type MCPToolLogStats struct {
 // BuildContentSummary creates a searchable text summary
 func (l *Log) BuildContentSummary() string {
 	var parts []string
+
+	// Add embedding input text parts
+	for _, item := range l.EmbeddingInputParsed {
+		for _, part := range item.Content {
+			if part.Type == schemas.EmbeddingContentPartTypeText && part.Text != nil && *part.Text != "" {
+				parts = append(parts, *part.Text)
+			}
+		}
+	}
 
 	// Add input messages
 	for _, msg := range l.InputHistoryParsed {

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -1068,6 +1068,7 @@ type InitialLogData struct {
 	Object                 string
 	InputHistory           []schemas.ChatMessage
 	ResponsesInputHistory  []schemas.ResponsesMessage
+	EmbeddingInput         []schemas.EmbeddingInputItem
 	Params                 any
 	SpeechInput            *schemas.SpeechInput
 	TranscriptionInput     *schemas.TranscriptionInput
@@ -1661,6 +1662,12 @@ func (p *LoggerPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.Bifr
 			}
 		case schemas.EmbeddingRequest:
 			initialData.Params = req.EmbeddingRequest.Params
+			items := extractEmbeddingInput(req)
+			reqThreshold, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadRequestThreshold).(int64)
+			if reqThreshold > 0 && embeddingMediaDataSize(items) > reqThreshold {
+				items = redactEmbeddingMediaData(items)
+			}
+			initialData.EmbeddingInput = items
 		case schemas.RerankRequest:
 			initialData.Params = req.RerankRequest.Params
 		case schemas.OCRRequest:

--- a/plugins/logging/utils.go
+++ b/plugins/logging/utils.go
@@ -715,6 +715,21 @@ func redactEmbeddingMediaData(items []schemas.EmbeddingInputItem) []schemas.Embe
 	return stripped
 }
 
+// embeddingMediaDataSize totals the inline media bytes across every item.
+func embeddingMediaDataSize(items []schemas.EmbeddingInputItem) int64 {
+	var total int64
+	for _, item := range items {
+		for _, part := range item.Content {
+			for _, media := range []*schemas.EmbeddingMediaPart{part.Image, part.Audio, part.File, part.Video} {
+				if media != nil && media.Data != nil {
+					total += int64(len(*media.Data))
+				}
+			}
+		}
+	}
+	return total
+}
+
 func extractRealtimeInputHistory(input []schemas.ResponsesMessage) []schemas.ChatMessage {
 	messages := make([]schemas.ChatMessage, 0, len(input))
 	for _, item := range input {

--- a/plugins/logging/writer.go
+++ b/plugins/logging/writer.go
@@ -358,6 +358,7 @@ func estimateLogEntrySize(log *logstore.Log) int {
 	// baseline below.
 	n := len(log.InputHistory) +
 		len(log.ResponsesInputHistory) +
+		len(log.EmbeddingInput) +
 		len(log.OutputMessage) +
 		len(log.ResponsesOutput) +
 		len(log.EmbeddingOutput) +
@@ -436,6 +437,7 @@ func buildInitialLogEntry(pending *PendingLogData) *logstore.Log {
 		CreatedAt:                   pending.Timestamp,
 		InputHistoryParsed:          pending.InitialData.InputHistory,
 		ResponsesInputHistoryParsed: pending.InitialData.ResponsesInputHistory,
+		EmbeddingInputParsed:        pending.InitialData.EmbeddingInput,
 		ParamsParsed:                pending.InitialData.Params,
 		ToolsParsed:                 pending.InitialData.Tools,
 		MetadataParsed:              pending.InitialData.Metadata,
@@ -467,6 +469,7 @@ func buildCompleteLogEntryFromPending(pending *PendingLogData) *logstore.Log {
 		// Set parsed fields for serialization via GORM hooks
 		InputHistoryParsed:          pending.InitialData.InputHistory,
 		ResponsesInputHistoryParsed: pending.InitialData.ResponsesInputHistory,
+		EmbeddingInputParsed:        pending.InitialData.EmbeddingInput,
 		ParamsParsed:                pending.InitialData.Params,
 		ToolsParsed:                 pending.InitialData.Tools,
 		SpeechInputParsed:           pending.InitialData.SpeechInput,

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -44,7 +44,14 @@ import {
 } from "@/lib/constants/logs";
 import { useGetProvidersQuery, useGetUserAgentMappingsQuery } from "@/lib/store";
 import { COMPLEXITY_MECHANISM_LABELS } from "@/lib/types/complexityRouter";
-import { BatchRequestCounts, ContentBlock, LLMUsage, LogEntry, OverheadBucket, ResponsesMessage } from "@/lib/types/logs";
+import {
+	BatchRequestCounts,
+	ContentBlock,
+	LLMUsage,
+	LogEntry,
+	OverheadBucket,
+	ResponsesMessage,
+} from "@/lib/types/logs";
 import { cn } from "@/lib/utils";
 import { LOG_LEVEL_BADGE_CLASSES, meetsMinLogLevel, type LogLevel } from "@/lib/utils/logLevel";
 import { downloadAsJson } from "@/lib/utils/browser-download";
@@ -1022,6 +1029,28 @@ function MessageRow({ role, meta, children, last = false }: { role: MessageRole;
 				<div className={cn("rounded-sm border p-3 text-[13px] leading-relaxed", messageToneClass[role])}>{children}</div>
 			</div>
 		</div>
+	);
+}
+
+function EmbeddingJsonBox({ title, value }: { title: string; value: unknown }) {
+	const json = JSON.stringify(value, null, 2);
+	return (
+		<CollapsibleBox title={title} onCopy={() => json} collapsedHeight={150}>
+			<CodeEditor
+				className="z-0 w-full"
+				shouldAdjustInitialHeight
+				maxHeight={450}
+				wrap
+				code={json}
+				lang="json"
+				readonly
+				options={{
+					scrollBeyondLastLine: false,
+					lineNumbers: "off",
+					alwaysConsumeMouseWheel: false,
+				}}
+			/>
+		</CollapsibleBox>
 	);
 }
 
@@ -3420,7 +3449,10 @@ export function LogDetailView({
 						);
 					})()}
 
-					{log.is_large_payload_request && !log.input_history?.length && !log.responses_input_history?.length && (
+					{log.is_large_payload_request &&
+						!log.input_history?.length &&
+						!log.responses_input_history?.length &&
+						!log.embedding_input?.length && (
 						<div className="rounded-sm border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950/50 dark:text-amber-300">
 							Large payload request: input content was streamed directly to the provider and is not available for display.
 							{log.raw_request && " A truncated preview is available in the Raw JSON tab."}
@@ -3433,20 +3465,9 @@ export function LogDetailView({
 						</div>
 					)}
 
+					{log.embedding_input && log.embedding_input.length > 0 && <EmbeddingJsonBox title="Input" value={log.embedding_input} />}
 					{log.status !== "processing" && log.embedding_output && log.embedding_output.length > 0 && !log.error_details?.error.message && (
-						<div className="bg-card space-y-3 rounded-sm border p-5">
-							<div className="text-sm font-medium">Embedding</div>
-							<LogChatMessageView
-								message={{
-									role: "assistant",
-									content: JSON.stringify(
-										log.embedding_output.map((embedding) => embedding.embedding),
-										null,
-										2,
-									),
-								}}
-							/>
-						</div>
+						<EmbeddingJsonBox title="Embedding" value={log.embedding_output.map((embedding) => embedding.embedding)} />
 					)}
 					{log.status !== "processing" && log.rerank_output && !log.error_details?.error.message && (
 						<CollapsibleBox title={`Rerank Output (${log.rerank_output.length})`} onCopy={() => JSON.stringify(log.rerank_output, null, 2)}>
@@ -3731,7 +3752,7 @@ const copyRequestBody = async (log: LogEntry, copy: (text: string) => Promise<vo
 		const isRealtimeTurn = log.object === "realtime.turn";
 		const isSpeech = log.object === "audio.speech" || log.object === "audio.speech.chunk";
 		const isTextCompletion = log.object === "text.completion" || log.object === "text.completion.chunk";
-		const isEmbedding = log.object === "list";
+		const isEmbedding = log.object === "embedding";
 
 		const extractTextFromMessage = (message: any): string => {
 			if (!message || !message.content) {
@@ -3795,7 +3816,10 @@ const copyRequestBody = async (log: LogEntry, copy: (text: string) => Promise<vo
 			if (prompt) {
 				requestBody.prompt = prompt;
 			}
+		} else if (log.object === "embedding" && log.embedding_input && log.embedding_input.length > 0) {
+			requestBody.input = log.embedding_input;
 		} else if (isEmbedding && log.input_history && log.input_history.length > 0) {
+			// Fallback for logs written before embedding_input existed.
 			const texts: string[] = [];
 			for (const message of log.input_history) {
 				const messageTexts = extractTextsFromMessage(message);

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -207,6 +207,36 @@ export interface BifrostEmbedding {
 	embedding: string | number[] | number[][];
 }
 
+export interface EmbeddingMediaPart {
+	data?: string;
+	url?: string;
+	mime_type?: string;
+	filename?: string;
+}
+
+export interface EmbeddingContentPart {
+	type: "text" | "image" | "audio" | "file" | "video" | "tokens";
+	text?: string;
+	image?: EmbeddingMediaPart;
+	audio?: EmbeddingMediaPart;
+	file?: EmbeddingMediaPart;
+	video?: EmbeddingMediaPart;
+	tokens?: number[];
+}
+
+export type EmbeddingContent = EmbeddingContentPart[];
+
+export interface EmbeddingInputItem {
+	content: EmbeddingContent;
+	params?: {
+		encoding_format?: string;
+		dimensions?: number;
+		task_type?: string;
+		title?: string;
+		auto_truncate?: boolean;
+	};
+}
+
 export interface RerankDocument {
 	text: string;
 	id?: string;
@@ -701,6 +731,8 @@ export interface LogEntry {
 	content_summary?: string;
 	output_message?: ChatMessage;
 	responses_output?: ResponsesMessage[];
+	// Each entry is either a bare EmbeddingContent or an item carrying its own params.
+	embedding_input?: (EmbeddingContent | EmbeddingInputItem)[];
 	embedding_output?: BifrostEmbedding[];
 	rerank_output?: RerankResult[];
 	ocr_input?: OCRDocument;


### PR DESCRIPTION
## Summary

Adds dedicated `embedding_input` and `batch_embedding_input` columns to the logs table, replacing the previous approach of reconstructing embedding inputs from the generic `input_history` column. This gives embedding and batch embedding requests first-class input storage, enables accurate content summaries, and surfaces the input data in the log detail UI.

## Changes

- **New DB columns**: `embedding_input` (JSON-serialized `[]schemas.EmbeddingContent`) and `batch_embedding_input` (JSON-serialized `[]schemas.BifrostEmbeddingBatchItem`) added to the `logs` table via two new migration steps.
- **Backfill strategy**: For Postgres, the `embedding_input` backfill reconstructs text blocks from the old `input_history` format via a PL/pgSQL DO block that runs post-startup in a goroutine (`ensureEmbeddingInputBackfill`) so large tables do not block pod startup. For SQLite (dev only), the backfill runs synchronously inside the migration. `batch_embedding_input` requires no backfill since it captures only new requests.
- **Logging plugin**: `PreLLMHook` now extracts and stores `EmbeddingInput` / `BatchEmbeddingInput` on `InitialLogData` for both embedding and batch embedding request types, including large-payload threshold checks that redact media data when the payload exceeds the configured threshold.
- **Log entry builder**: `buildInitialLogEntry` and `buildCompleteLogEntryFromPending` populate the new parsed fields; `estimateLogEntrySize` accounts for `EmbeddingInput` in size estimation.
- **`Log` struct**: Added raw and parsed fields with serialize/deserialize support, and `BuildContentSummary` now includes text parts from both embedding and batch embedding inputs.
- **UI**: Added `EmbeddingContent`, `EmbeddingContentPart`, `EmbeddingMediaPart`, and `BatchEmbeddingItem` TypeScript types. The log detail view renders `EmbeddingInputView` and `BatchEmbeddingInputView` components for the respective object types. The "copy request body" helper now reads from the new fields (with a fallback to `input_history` for older logs). `batch_embedding` is registered as a request type with label and color.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
# Core/Transports
go version
go test ./framework/logstore/... ./plugins/logging/...

# UI
cd ui
pnpm i
pnpm build
```

1. Send an embedding request through the gateway and open the log detail view — the **Input** section should display the embedding content.
2. Send a batch embedding request and verify the **Items (N)** section appears.
3. For historical Postgres logs, verify that after startup the `embedding_input` column is backfilled from `input_history` without blocking startup.
4. Confirm that logs with `NULL`, `""`, `"[]"`, or `"null"` `input_history` are left with `NULL` `embedding_input`.
5. Confirm that non-embedding log types (`chat.completion`, etc.) are unaffected.

## Screenshots/Recordings

_Add before/after screenshots of the log detail view for embedding logs._

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

_Link related issues here._

## Security considerations

Media data (images, audio, files, video) embedded in embedding requests is redacted when the payload size exceeds the configured `BifrostContextKeyLargePayloadRequestThreshold`, consistent with the existing large-payload handling for other request types. No new PII surface is introduced beyond what was already stored in `input_history`.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable