### PR TITLE
docs: update virtual-key and project error shapes to top-level `type` with corrected codes, messages, and new `mcp_tool_blocked` example

### DIFF
--- a/docs/enterprise/projects.mdx
+++ b/docs/enterprise/projects.mdx
@@ -106,7 +106,7 @@ Send one or the other. If `x-bf-project-id` is present at all it decides the out
 
 A request may name **one** project. There is no list form, and no request is placed in a project implicitly: activation is always the explicit header.
 
-When a named project cannot scope the request, the answer is `403` with `error.type` of `access_blocked` and the message `project "<name>" not found. It does not exist or does not admit this request.` That single answer deliberately covers both "no such project" and "you are not one of its members": a caller who may not use a project has no business learning whether it exists.
+When a named project cannot scope the request, the answer is `403` with a top-level `type` of `access_blocked` and the message `project "<name>" not found. It does not exist or does not admit this request.` That single answer deliberately covers both "no such project" and "you are not one of its members": a caller who may not use a project has no business learning whether it exists.
 
 A request that names no project is served exactly as it is today, against the caller's own access and ledgers.
 
@@ -205,7 +205,7 @@ A project can hold money at three tiers, and a request is checked against all of
 - **Per-provider budgets and rate limits**, on a provider configuration.
 - **Per-model budgets and rate limits**, on a model under a provider configuration.
 
-Whichever cap binds first refuses the request, and the refusal names the tier that ran out rather than the project as a whole. A budget refusal is `402` with `error.type` of `budget_exceeded`; a rate-limit refusal is `429` as `rate_limited`, `token_limited` or `request_limited`. Rate limits are checked before budgets, so a caller who is both throttled and out of money gets the cheaper answer consistently.
+Whichever cap binds first refuses the request, and the refusal names the tier that ran out rather than the project as a whole. A budget refusal is `402` with a top-level `type` of `budget_exceeded`; a rate-limit refusal is `429` as `rate_limited`, `token_limited` or `request_limited`. The type is a field beside `status_code` rather than inside `error`, which carries only the message. Rate limits are checked before budgets, so a caller who is both throttled and out of money gets the cheaper answer consistently.
 
 ### Splitting caps between members
 

--- a/docs/features/governance/virtual-keys.mdx
+++ b/docs/features/governance/virtual-keys.mdx
@@ -759,10 +759,10 @@ Timestamps must be RFC3339 and in the future; otherwise the API returns `400`. O
 **Expired key rejection:**
 ```json
 {
-  "type": "virtual_key_blocked",
+  "type": "access_blocked",
   "status_code": 403,
   "error": {
-    "message": "Virtual key has expired"
+    "message": "virtual key has expired"
   }
 }
 ```
@@ -898,52 +898,42 @@ curl -X PUT http://localhost:8080/api/config \
 
 ### Error Responses
 
-- Virtual Key Not Found (400)
+`type` is a **top-level** field, beside `status_code`, and `error` carries only the
+message. A client branching on the refusal reads `type`, not `error.type`.
+
+- Authentication Required (401), when no credential was presented and virtual keys are mandatory
 ```json
 {
+  "type": "virtual_key_required",
+  "status_code": 401,
   "error": {
-    "type": "virtual_key_required",
-    "message": "virtual key is missing in headers"
+    "message": "virtual key is required. Provide a virtual key via the x-bf-vk header."
   }
 }
 ```
 
-- Virtual Key Blocked (403)
+- Inactive or Expired (403), when the credential is real but may not be used
 ```json
 {
+  "type": "access_blocked",
+  "status_code": 403,
   "error": {
-    "type": "virtual_key_blocked", 
-    "message": "Virtual key is inactive"
+    "message": "virtual key is inactive"
   }
 }
 ```
 
-- Rate Limit Exceeded (429)
-```json
-{
-  "error": {
-    "type": "rate_limited",
-    "message": "Rate limits exceeded: [token limit exceeded (1500/1000, resets every 1h)]"
-  }
-}
-```
+  A key that is both inactive and expired reports `is inactive`: the check runs in that
+  order and answers on the first that matches. The same type and shape covers an expired
+  key (`virtual key has expired`) and an access profile that is inactive or expired.
 
-- Token Limit Exceeded (429)
+- Rate Limit Exceeded (429): `rate_limited`, or `token_limited` / `request_limited` for the dimension that ran out
 ```json
 {
+  "type": "token_limited",
+  "status_code": 429,
   "error": {
-    "type": "token_limited",
-    "message": "Rate limits exceeded: [token limit exceeded (1500/1000, resets every 1h)]"
-  }
-}
-```
-
-- Request Limit Exceeded (429)
-```json
-{
-  "error": {
-    "type": "request_limited", 
-    "message": "Rate limits exceeded: [request limit exceeded (101/100, resets every 1m)]"
+    "message": "Rate limit exceeded: rate limit violated for vk_model_config * : [token limit exceeded (1500/1000, resets every 1h)]"
   }
 }
 ```
@@ -951,19 +941,24 @@ curl -X PUT http://localhost:8080/api/config \
 - Budget Exceeded (402)
 ```json
 {
+  "type": "budget_exceeded",
+  "status_code": 402,
   "error": {
-    "type": "budget_exceeded",
-    "message": "Budget exceeded: VK budget exceeded: 105.50 > 100.00 dollars"
+    "message": "Budget exceeded: vk_model_config * budget exceeded: 105.5000 >= 100.0000 dollars"
   }
 }
 ```
 
+  The name after the holder kind is what ran out, so a refusal says which tier stopped the
+  request rather than only that something did.
+
 - Model Not Allowed (403)
 ```json
 {
+  "type": "model_blocked",
+  "status_code": 403,
   "error": {
-    "type": "model_blocked",
-    "message": "Model 'gpt-4o' is not allowed for this virtual key"
+    "message": "Model 'gpt-4o' is not allowed for virtual key 'my-key'"
   }
 }
 ```
@@ -971,9 +966,21 @@ curl -X PUT http://localhost:8080/api/config \
 - Provider Not Allowed (403)
 ```json
 {
+  "type": "provider_blocked",
+  "status_code": 403,
   "error": {
-    "type": "provider_blocked",
-    "message": "Provider 'anthropic' is not allowed for this virtual key"
+    "message": "Provider 'anthropic' is not allowed for virtual key 'my-key'"
+  }
+}
+```
+
+- MCP Tool Not Allowed (403)
+```json
+{
+  "type": "mcp_tool_blocked",
+  "status_code": 403,
+  "error": {
+    "message": "MCP tool 'filesystem-write_file' is not allowed for virtual key 'my-key'"
   }
 }
 ```


### PR DESCRIPTION
## Summary

Clarifies the shape of error responses returned by virtual keys and projects, ensuring documentation accurately reflects that `type` is a top-level field alongside `status_code`, not nested inside `error`.

## Changes

- Corrected references from `error.type` to top-level `type` in the projects documentation for `access_blocked` and `budget_exceeded` responses, and added a note that `error` carries only the message.
- Updated the virtual keys error response section to reflect the correct response shape, with `type` and `status_code` at the top level.
- Changed the expired key rejection type from `virtual_key_blocked` to `access_blocked` and lowercased the message to match actual behavior.
- Changed the missing key response from a `400` with `virtual_key_required` inside `error` to a `401` with `type: virtual_key_required` at the top level, with an updated message.
- Changed inactive key rejection type from `virtual_key_blocked` to `access_blocked`, and clarified that inactive is checked before expired, with both sharing the same type and shape.
- Added a note explaining the priority order: inactive is reported before expired.
- Updated rate limit, budget, model, and provider error examples to show `type` and `status_code` at the top level with accurate messages matching real output.
- Added a new `mcp_tool_blocked` (403) error response example for MCP tool restrictions.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated documentation to confirm that all error response examples reflect the correct structure, with `type` and `status_code` as top-level fields and `error` containing only `message`. Cross-reference against live API responses for virtual key and project-scoped requests to validate accuracy.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. These are documentation-only changes describing existing authentication and authorization error responses.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable