### PR TITLE
docs: remove `mcp-tool-groups` from nav and references, fix broken project link in virtual-mcps

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -327,7 +327,6 @@
               "enterprise/rbac",
               "enterprise/data-access-control",
               "enterprise/virtual-mcps",
-              "enterprise/mcp-tool-groups",
               "enterprise/projects",
               {
                 "group": "Guardrails",

--- a/docs/enterprise/access-profiles.mdx
+++ b/docs/enterprise/access-profiles.mdx
@@ -351,6 +351,5 @@ curl -X POST "http://localhost:8080/api/governance/model-configs" \
 - **[RBAC](/enterprise/rbac)** - Define the roles that profiles auto-attach to.
 - **[Virtual Keys](/features/governance/virtual-keys)** - Understand the underlying virtual key concept.
 - **[Virtual MCPs](/enterprise/virtual-mcps)** - Bundle MCP tools for reuse inside profiles.
-- **[MCP Tool Groups](/enterprise/mcp-tool-groups)** - Bundle MCP tools for reuse inside profiles.
 - **[Model Limits](/features/governance/model-limits#per-user-model-limits-enterprise)** - How a profile's per-model budgets surface as per-user limits.
 - **[Audit Logs](/enterprise/audit-logs)** - Cross-reference profile changes with downstream impact.

--- a/docs/enterprise/virtual-mcps.mdx
+++ b/docs/enterprise/virtual-mcps.mdx
@@ -44,7 +44,7 @@ Operators without any of those relationships do not see the vMCP. Attach and det
 
 ## Projects
 
-A [project](/enterprise/access-profiles) can be assigned Virtual MCPs, so a project's members reach the assigned vMCPs. Assignment is managed on the project's MCP access surface and, under a **Restrict** access rule, tools run only through the assigned Virtual MCPs.
+A [project](/enterprise/projects) can be assigned Virtual MCPs, so a project's members reach the assigned vMCPs. Assignment is managed on the project's MCP access surface and, under a **Restrict** access rule, tools run only through the assigned Virtual MCPs.
 
 ---
 


### PR DESCRIPTION
## Summary

Removes the `MCP Tool Groups` documentation page from the navigation and replaces it with `Virtual MCPs` as the canonical concept. Also fixes an incorrect internal link in `virtual-mcps.mdx` that pointed to `access-profiles` instead of `projects`.

## Changes

- Removed `enterprise/mcp-tool-groups` from the docs navigation in `docs.json`
- Removed the `MCP Tool Groups` link from the `access-profiles.mdx` related links section, as it duplicated the `Virtual MCPs` entry
- Fixed a broken internal link in `virtual-mcps.mdx` where the Projects section linked to `/enterprise/access-profiles` instead of the correct `/enterprise/projects`

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Navigate the documentation site and verify:
- The `MCP Tool Groups` page no longer appears in the sidebar under Enterprise
- The `Virtual MCPs` page's Projects section links correctly to `/enterprise/projects`
- The `Access Profiles` related links section no longer contains a duplicate MCP tools entry

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable