### PR TITLE
feat: trust upstream-stamped user identity before JWT verification in MCP server auth

### DIFF
--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -605,14 +605,27 @@ func (h *MCPServerHandler) discoveryEnabled() bool {
 // by governance, from the grant it resolves for it, so both paths refuse it the same way.
 //
 // Authentication priority:
-//  1. JWT Bearer token (when MCPServerAuthMode is both or oauth)
-//  2. Header credentials, or an identity an upstream auth layer stamped (headers or both)
-//  3. Anonymous access (when EnforceAuthOnInference is false)
+//  1. An identity an upstream auth layer already authenticated (headers or both)
+//  2. JWT Bearer token (when MCPServerAuthMode is both or oauth)
+//  3. Header credentials (headers or both)
+//  4. Anonymous access (when EnforceAuthOnInference is false)
 //
 // When MCPServerAuthMode is oauth (strict), header credentials are rejected.
 func (h *MCPServerHandler) authenticate(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) error {
 	enforceAuth, authMode := h.authSettings()
 	discoveryEnabled := authMode == tables.MCPServerAuthModeBoth || authMode == tables.MCPServerAuthModeOAuth
+
+	// --- Identity an upstream auth layer already authenticated ---
+	// An upstream auth layer that verified the request's bearer against its own identity
+	// provider stamps the user it names, and converting the request copied that onto
+	// bifrostCtx. Such a bearer is a JWT this server never issued, so the JWT path below
+	// would refuse it on the key id; the stamped user is the settled identity, and
+	// governance resolves what it may reach. Accepted wherever header credentials are:
+	// oauth strict mode admits only tokens this server issued and is excluded.
+	if authMode != tables.MCPServerAuthModeOAuth &&
+		bifrost.GetStringFromContext(bifrostCtx, schemas.BifrostContextKeyUserID) != "" {
+		return nil
+	}
 
 	// --- JWT path ---
 	if rawJWT := extractBearerJWT(ctx); rawJWT != "" && discoveryEnabled {

--- a/transports/bifrost-http/handlers/mcpserver_auth_test.go
+++ b/transports/bifrost-http/handlers/mcpserver_auth_test.go
@@ -247,6 +247,51 @@ func TestAuthenticate_JWTPath(t *testing.T) {
 		require.Error(t, h.authenticate(ctx, bifrostCtx))
 	})
 
+	// A bearer an upstream auth layer verified against its own identity provider is a JWT this
+	// server never issued: its key id is not the signing key's. The user that layer stamped is the
+	// settled identity, so the token is not verified again here.
+	idpToken := mintTestToken(t, priv, "idp-key-id", func(c jwt.MapClaims) {
+		c["sub"] = "idp-subject"
+	})
+
+	t.Run("both mode: a bearer an upstream auth layer authenticated is accepted as the stamped user", func(t *testing.T) {
+		store := &mockOAuth2Store{signingKey: key}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true))
+
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+idpToken)
+		bifrostCtx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
+		assert.Equal(t, "user-1", stringFromCtx(bifrostCtx, schemas.BifrostContextKeyUserID))
+		assert.Empty(t, ctx.Response.Header.Peek("WWW-Authenticate"))
+	})
+
+	t.Run("both mode: a bearer no upstream auth layer authenticated is refused on its key id", func(t *testing.T) {
+		store := &mockOAuth2Store{signingKey: key}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true))
+
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+idpToken)
+
+		err := h.authenticate(ctx, bifrostCtx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown key id")
+	})
+
+	t.Run("oauth strict mode verifies the bearer even when an identity is stamped upstream", func(t *testing.T) {
+		store := &mockOAuth2Store{signingKey: key}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, true))
+
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+idpToken)
+		bifrostCtx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		err := h.authenticate(ctx, bifrostCtx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown key id")
+	})
+
 	t.Run("session JWT is rejected when auth is enforced", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
 		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true))


### PR DESCRIPTION
## Summary

When an upstream auth layer (e.g., an API gateway or reverse proxy) verifies a request's bearer token against its own identity provider, it stamps the authenticated user onto the request context. That bearer is a JWT this server never issued, so its key ID is unknown and the existing JWT verification path would reject it. This PR adds a fast-path that accepts the stamped identity directly, skipping re-verification, while preserving strict OAuth mode behavior which continues to verify all tokens regardless.

## Changes

- Added a new first-priority authentication path in `authenticate()` that short-circuits when an upstream auth layer has already stamped a user ID onto `bifrostCtx` and the server is not in OAuth strict mode. This prevents the JWT path from incorrectly rejecting a valid upstream-authenticated identity due to an unknown key ID.
- Reordered the documented authentication priority to reflect the new ordering: upstream-stamped identity → JWT bearer → header credentials → anonymous.
- Added tests covering: upstream-stamped identity accepted in `both` mode, an unstamped foreign bearer still rejected on key ID in `both` mode, and OAuth strict mode ignoring the stamped identity and verifying the bearer anyway (resulting in rejection for an unknown key ID).

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./transports/bifrost-http/handlers/...
```

The three new test cases validate:
1. A bearer from an upstream IDP with a stamped user is accepted without re-verification in `both` mode.
2. The same bearer without a stamped user is rejected with `unknown key id`.
3. In OAuth strict mode, even a stamped user does not bypass JWT verification, and the foreign bearer is rejected.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

The upstream-stamped identity fast-path is intentionally excluded from OAuth strict mode (`MCPServerAuthModeOAuth`). In strict mode, all bearers must be tokens this server issued and signed, ensuring no upstream-stamped identity can bypass local token verification. In `both` and `headers` modes, the stamped identity is trusted because governance still controls what that identity may access via grant resolution — the same enforcement applied to header credentials.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable