### PR TITLE
fix: record per-mode grant identity in `injectJWTContext` so vk-mode tokens settle as a key credential and session-mode tokens record nothing

### DIFF
--- a/plugins/governance/mcpgatewayidentity_test.go
+++ b/plugins/governance/mcpgatewayidentity_test.go
@@ -1,0 +1,63 @@
+package governance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/framework/configstore"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/grant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The /mcp handler settles what a verified token stood for onto the grant before admission: a
+// vk-mode token as the key it names, a session-mode token as nothing presented. Admission resolves
+// those exactly as it resolves a key from a header and a request with no credential.
+func TestMCPGatewayAdmissionOfTokenIdentities(t *testing.T) {
+	vk := buildVKForMCPStamping([]string{"read_file"})
+	logger := NewMockLogger()
+	local, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil, &mockInMemoryStore{})
+	require.NoError(t, err)
+	plugin, err := InitFromStore(context.Background(), &Config{IsVkMandatory: boolPtr(false)}, logger, local, nil, nil, nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, plugin.Cleanup()) })
+
+	admit := func(ctx *schemas.BifrostContext) *schemas.BifrostError {
+		_, refused := plugin.Evaluate(ctx, &EvaluationRequest{RequestType: schemas.MCPToolExecutionRequest})
+		return refused
+	}
+
+	t.Run("a vk-mode token settled as its key resolves the key's permit", func(t *testing.T) {
+		ctx := emptyCtx()
+		ctx.SetValue(schemas.BifrostContextKeyVirtualKey, mcpTestVKValue)
+		ctx.Grant().SetIdentity(grant.NewIdentity(grant.NewCredential(grant.CredentialVirtualKey, mcpTestVKValue), nil, nil, nil, nil, nil, nil))
+
+		require.Nil(t, admit(ctx))
+		require.NotNil(t, ctx.Grant().Access())
+		assert.Equal(t, []string{"sentry-read_file"}, ctx.Grant().Access().MCPToolIncludeList())
+		assert.Equal(t, vk.ID, ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID))
+	})
+
+	t.Run("a token settled as something other than a key does not present the key on the context", func(t *testing.T) {
+		ctx := emptyCtx()
+		ctx.SetValue(schemas.BifrostContextKeyVirtualKey, mcpTestVKValue)
+		ctx.Grant().SetIdentity(grant.NewIdentity(grant.NewCredential(grant.CredentialMCPToken, vk.ID), nil, nil, nil, nil, nil, nil))
+
+		refused := admit(ctx)
+		require.NotNil(t, refused)
+		require.NotNil(t, refused.StatusCode)
+		assert.Equal(t, 401, *refused.StatusCode)
+	})
+
+	t.Run("a session-mode token settled as nothing presented is admitted unrestricted", func(t *testing.T) {
+		ctx := emptyCtx()
+		ctx.SetValue(schemas.BifrostContextKeyMCPSessionID, "sess-1")
+
+		require.Nil(t, admit(ctx))
+		assert.Nil(t, ctx.Grant().Access())
+	})
+}

--- a/transports/bifrost-http/handlers/mcpoauth2jwt.go
+++ b/transports/bifrost-http/handlers/mcpoauth2jwt.go
@@ -126,9 +126,9 @@ func verifyMCPJWT(ctx *fasthttp.RequestCtx, rawToken string, store *lib.Config, 
 // mirroring what header auth sets today so everything downstream (governance,
 // per-user upstream OAuth, tool-group filtering) works unchanged.
 //
-// bf_mode=user    → BifrostContextKeyUserID
-// bf_mode=vk      → BifrostContextKeyVirtualKey (governance derives the VK row ID from it)
-// bf_mode=session → BifrostContextKeyMCPSessionID
+// bf_mode=user    → BifrostContextKeyUserID; the user is recorded on the grant
+// bf_mode=vk      → BifrostContextKeyVirtualKey; the key is recorded on the grant as the credential
+// bf_mode=session → BifrostContextKeyMCPSessionID; nothing is recorded on the grant
 func injectJWTContext(bifrostCtx *schemas.BifrostContext, claims *jwtMCPClaims, vk *configtables.TableVirtualKey) error {
 	sub := claims.Subject
 	if sub == "" {
@@ -136,7 +136,11 @@ func injectJWTContext(bifrostCtx *schemas.BifrostContext, claims *jwtMCPClaims, 
 	}
 	switch schemas.MCPAuthMode(claims.BfMode) {
 	case schemas.MCPAuthModeUser:
+		// The token names the user directly: the request is attributed to the user and goes by
+		// the token that authenticated it.
 		bifrostCtx.SetValue(schemas.BifrostContextKeyUserID, sub)
+		lib.RecordCredential(bifrostCtx, grant.NewCredential(grant.CredentialMCPToken, sub))
+		lib.RecordUser(bifrostCtx, &schemas.UserRef{ID: sub})
 	case schemas.MCPAuthModeVK:
 		if vk == nil {
 			return fmt.Errorf("VK not provided for vk-mode JWT injection")
@@ -146,17 +150,16 @@ func injectJWTContext(bifrostCtx *schemas.BifrostContext, claims *jwtMCPClaims, 
 		// path before the per-user credential resolver needs it — the same way the
 		// x-bf-vk header path does, which never stamps the row ID at ingress either.
 		bifrostCtx.SetValue(schemas.BifrostContextKeyVirtualKey, vk.Value.GetValue())
+		// The token stands for the key it names: the request goes by that key, settled as a key
+		// presented in a header is, which is what governance resolves a key's permit from.
+		lib.RecordCredential(bifrostCtx, grant.NewCredential(grant.CredentialVirtualKey, vk.Value.GetValue()))
 	case schemas.MCPAuthModeSession:
+		// A session token carries no verified identity. Nothing is recorded on the grant, so the
+		// request is admitted as one that presented nothing: anonymous, and refused by
+		// authenticate whenever authentication is enforced.
 		bifrostCtx.SetValue(schemas.BifrostContextKeyMCPSessionID, sub)
 	default:
 		return fmt.Errorf("unknown bf_mode %q in JWT", claims.BfMode)
-	}
-	// Whatever the token stood for, the request authenticated by the token: the key or user it
-	// names is what resolution attributes the request to, not what it presented. A user-mode token
-	// names the user directly, so that much is recorded here.
-	lib.RecordCredential(bifrostCtx, grant.NewCredential(grant.CredentialMCPToken, sub))
-	if schemas.MCPAuthMode(claims.BfMode) == schemas.MCPAuthModeUser {
-		lib.RecordUser(bifrostCtx, &schemas.UserRef{ID: sub})
 	}
 	return nil
 }

--- a/transports/bifrost-http/handlers/mcpoauth2jwt_test.go
+++ b/transports/bifrost-http/handlers/mcpoauth2jwt_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/framework/configstore"
 	configtables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/maximhq/bifrost/framework/grant"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -409,6 +410,11 @@ func TestInjectJWTContext(t *testing.T) {
 		}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "user-1", bc.Value(schemas.BifrostContextKeyUserID))
+		identity := bc.Grant().Identity()
+		require.NotNil(t, identity)
+		assert.Equal(t, grant.NewCredential(grant.CredentialMCPToken, "user-1"), identity.Credential())
+		require.NotNil(t, identity.User())
+		assert.Equal(t, "user-1", identity.User().ID)
 	})
 
 	t.Run("vk mode sets the raw vk value and lets governance derive the id", func(t *testing.T) {
@@ -421,6 +427,11 @@ func TestInjectJWTContext(t *testing.T) {
 		// The VK row ID is resolved later by governance's PreMCPConnectionHook from
 		// the value, not stamped here — mirrors the x-bf-vk header path.
 		assert.Nil(t, bc.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID))
+		// Settled as the key, the way a header key is, so governance resolves the key's permit.
+		identity := bc.Grant().Identity()
+		require.NotNil(t, identity)
+		assert.Equal(t, grant.NewCredential(grant.CredentialVirtualKey, "sk-bf-active"), identity.Credential())
+		assert.Nil(t, identity.User())
 	})
 
 	t.Run("vk mode without vk errors", func(t *testing.T) {
@@ -438,6 +449,8 @@ func TestInjectJWTContext(t *testing.T) {
 		}, nil)
 		require.NoError(t, err)
 		assert.Equal(t, "session-abc", bc.Value(schemas.BifrostContextKeyMCPSessionID))
+		// Nothing verified, nothing recorded: the request is admitted as anonymous.
+		assert.Nil(t, bc.Grant())
 	})
 
 	t.Run("missing sub errors", func(t *testing.T) {

--- a/transports/bifrost-http/handlers/mcpserver.go
+++ b/transports/bifrost-http/handlers/mcpserver.go
@@ -605,14 +605,27 @@ func (h *MCPServerHandler) discoveryEnabled() bool {
 // by governance, from the grant it resolves for it, so both paths refuse it the same way.
 //
 // Authentication priority:
-//  1. JWT Bearer token (when MCPServerAuthMode is both or oauth)
-//  2. Header credentials, or an identity an upstream auth layer stamped (headers or both)
-//  3. Anonymous access (when EnforceAuthOnInference is false)
+//  1. An identity an upstream auth layer already authenticated (headers or both)
+//  2. JWT Bearer token (when MCPServerAuthMode is both or oauth)
+//  3. Header credentials (headers or both)
+//  4. Anonymous access (when EnforceAuthOnInference is false)
 //
 // When MCPServerAuthMode is oauth (strict), header credentials are rejected.
 func (h *MCPServerHandler) authenticate(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) error {
 	enforceAuth, authMode := h.authSettings()
 	discoveryEnabled := authMode == tables.MCPServerAuthModeBoth || authMode == tables.MCPServerAuthModeOAuth
+
+	// --- Identity an upstream auth layer already authenticated ---
+	// An upstream auth layer that verified the request's bearer against its own identity
+	// provider stamps the user it names, and converting the request copied that onto
+	// bifrostCtx. Such a bearer is a JWT this server never issued, so the JWT path below
+	// would refuse it on the key id; the stamped user is the settled identity, and
+	// governance resolves what it may reach. Accepted wherever header credentials are:
+	// oauth strict mode admits only tokens this server issued and is excluded.
+	if authMode != tables.MCPServerAuthModeOAuth &&
+		bifrost.GetStringFromContext(bifrostCtx, schemas.BifrostContextKeyUserID) != "" {
+		return nil
+	}
 
 	// --- JWT path ---
 	if rawJWT := extractBearerJWT(ctx); rawJWT != "" && discoveryEnabled {

--- a/transports/bifrost-http/handlers/mcpserver_auth_test.go
+++ b/transports/bifrost-http/handlers/mcpserver_auth_test.go
@@ -247,6 +247,51 @@ func TestAuthenticate_JWTPath(t *testing.T) {
 		require.Error(t, h.authenticate(ctx, bifrostCtx))
 	})
 
+	// A bearer an upstream auth layer verified against its own identity provider is a JWT this
+	// server never issued: its key id is not the signing key's. The user that layer stamped is the
+	// settled identity, so the token is not verified again here.
+	idpToken := mintTestToken(t, priv, "idp-key-id", func(c jwt.MapClaims) {
+		c["sub"] = "idp-subject"
+	})
+
+	t.Run("both mode: a bearer an upstream auth layer authenticated is accepted as the stamped user", func(t *testing.T) {
+		store := &mockOAuth2Store{signingKey: key}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true))
+
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+idpToken)
+		bifrostCtx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		require.NoError(t, h.authenticate(ctx, bifrostCtx))
+		assert.Equal(t, "user-1", stringFromCtx(bifrostCtx, schemas.BifrostContextKeyUserID))
+		assert.Empty(t, ctx.Response.Header.Peek("WWW-Authenticate"))
+	})
+
+	t.Run("both mode: a bearer no upstream auth layer authenticated is refused on its key id", func(t *testing.T) {
+		store := &mockOAuth2Store{signingKey: key}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true))
+
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+idpToken)
+
+		err := h.authenticate(ctx, bifrostCtx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown key id")
+	})
+
+	t.Run("oauth strict mode verifies the bearer even when an identity is stamped upstream", func(t *testing.T) {
+		store := &mockOAuth2Store{signingKey: key}
+		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeOAuth, true))
+
+		ctx, bifrostCtx := newRequestCtx()
+		ctx.Request.Header.Set("Authorization", "Bearer "+idpToken)
+		bifrostCtx.SetValue(schemas.BifrostContextKeyUserID, "user-1")
+
+		err := h.authenticate(ctx, bifrostCtx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unknown key id")
+	})
+
 	t.Run("session JWT is rejected when auth is enforced", func(t *testing.T) {
 		store := &mockOAuth2Store{signingKey: key}
 		h := newTestMCPHandler(newTestOAuth2Config(store, configtables.MCPServerAuthModeBoth, true))


### PR DESCRIPTION
## Summary

MCP JWT token modes now record distinct identities on the grant rather than uniformly stamping every token as a `CredentialMCPToken`. This ensures governance resolves the correct permit for each mode: vk-mode tokens are settled as the key they name (matching the header key path), user-mode tokens are attributed to the user with the MCP token credential, and session-mode tokens record nothing, making the request anonymous.

## Changes

- `injectJWTContext` now records credentials per-mode instead of unconditionally after the switch:
  - **user mode**: records `CredentialMCPToken` with the subject and sets the user ref on the grant
  - **vk mode**: records `CredentialVirtualKey` with the raw VK value, so governance resolves the key's permit the same way a header-presented key does
  - **session mode**: records nothing on the grant, so the request is treated as anonymous and refused when authentication is enforced
- Added `TestMCPGatewayAdmissionOfTokenIdentities` in the governance plugin to verify that admission correctly handles all three settled identity shapes end-to-end
- Extended `TestInjectJWTContext` assertions to verify the identity recorded on the grant for user, vk, and session modes

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./plugins/governance/...
go test ./transports/bifrost-http/handlers/...
```

- A vk-mode token should resolve the VK's permit (e.g. tool include list) and stamp the VK row ID on the context.
- A user-mode token should attribute the request to the named user with an MCP token credential.
- A session-mode token should be admitted anonymously (no identity on the grant) and refused when VK is mandatory.

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

Session-mode tokens previously recorded a `CredentialMCPToken` on the grant, which could have caused them to be treated as carrying a verified identity. They now record nothing, ensuring unauthenticated session requests are correctly refused when authentication is enforced. VK-mode tokens are now settled as `CredentialVirtualKey`, aligning their identity with the header key path and ensuring governance applies the key's permit rather than treating the token as an opaque credential.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable