### PR TITLE
fix: stop bifrost_active_requests drifting negative on streaming

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6434,10 +6434,15 @@ func executeRequestWithRetries[T any](
 		}
 
 		// The previous failed stream has drained before reaching this retry.
-		if checkAzurePreamble && attempts > 0 {
+		// Clear StreamEndIndicator for every streaming retry (not only Azure): a
+		// sticky terminal flag on the shared context makes per-chunk post-hooks
+		// treat every subsequent chunk as final (e.g. bifrost_active_requests).
+		if IsStreamRequestType(requestType) && attempts > 0 {
 			ctx.ClearValue(schemas.BifrostContextKeyStreamEndIndicator)
-			ctx.ClearValue(schemas.BifrostContextKeyStreamBodyExhausted)
-			ctx.ClearValue(schemas.BifrostContextKeyStreamParkedAfterFinish)
+			if checkAzurePreamble {
+				ctx.ClearValue(schemas.BifrostContextKeyStreamBodyExhausted)
+				ctx.ClearValue(schemas.BifrostContextKeyStreamParkedAfterFinish)
+			}
 		}
 
 		// Attempt the request
@@ -6463,12 +6468,10 @@ func executeRequestWithRetries[T any](
 				}
 				if firstChunkErr != nil {
 					<-drainDone
-					// The dead stream's teardown (ReleaseStreamingResponse) claimed the
-					// connection_closed flag on the shared context. That claim is scoped
-					// to the response it released; clear it so the retry or fallback
-					// attempt that follows doesn't see its own fresh stream as already
-					// closed and fail every read with ErrStreamClosed.
-					ctx.ClearValue(schemas.BifrostContextKeyConnectionClosed)
+					// The dead stream's teardown left stream-lifecycle flags on the
+					// shared context; wipe them so the retry does not inherit a
+					// sticky terminal / closed state (see clearCtxForStreamRetry).
+					clearCtxForStreamRetry(ctx)
 					bifrostError = firstChunkErr
 				} else if checkedStream == nil {
 					// Empty stream (zero chunks before close — includes the large-payload

--- a/core/utils.go
+++ b/core/utils.go
@@ -409,6 +409,19 @@ func clearCtxForFallback(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeySupportsAssistantPrefill)
 }
 
+// clearCtxForStreamRetry clears stream-lifecycle flags left on the shared request
+// context by a failed streaming attempt before the same-provider retry starts.
+// Without this, a sticky StreamEndIndicator makes every subsequent chunk look
+// terminal to per-chunk post-hooks (e.g. telemetry's ActiveRequests Dec).
+// Mirrors the stream-key subset of clearCtxForFallback; ConnectionClosed is
+// included because ReleaseStreamingResponse on the dead attempt claims it.
+func clearCtxForStreamRetry(ctx *schemas.BifrostContext) {
+	ctx.ClearValue(schemas.BifrostContextKeyConnectionClosed)
+	ctx.ClearValue(schemas.BifrostContextKeyStreamEndIndicator)
+	ctx.ClearValue(schemas.BifrostContextKeyStreamBodyExhausted)
+	ctx.ClearValue(schemas.BifrostContextKeyStreamParkedAfterFinish)
+}
+
 // ClearContextForInternalRequest clears context state that is specific to the
 // caller's original request, so a context derived from it can carry an
 // internal sub-request (e.g. a plugin generating an embedding for its own

--- a/core/utils_test.go
+++ b/core/utils_test.go
@@ -417,6 +417,40 @@ func TestClearCtxForFallback(t *testing.T) {
 	}
 }
 
+// A same-provider streaming retry reuses the request context. Stream-lifecycle flags
+// claimed by the failed attempt must be wiped first; otherwise every chunk of the
+// retry looks terminal to per-chunk post-hooks (#7005).
+func TestClearCtxForStreamRetry(t *testing.T) {
+	cleared := []schemas.BifrostContextKey{
+		schemas.BifrostContextKeyConnectionClosed,
+		schemas.BifrostContextKeyStreamEndIndicator,
+		schemas.BifrostContextKeyStreamBodyExhausted,
+		schemas.BifrostContextKeyStreamParkedAfterFinish,
+	}
+	preserved := []schemas.BifrostContextKey{
+		schemas.BifrostContextKeyAPIKeyID,
+		schemas.BifrostContextKeyVirtualKey,
+	}
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	for _, key := range append(append([]schemas.BifrostContextKey{}, cleared...), preserved...) {
+		ctx.SetValue(key, "set")
+	}
+
+	clearCtxForStreamRetry(ctx)
+
+	for _, key := range cleared {
+		if ctx.Value(key) != nil {
+			t.Errorf("%v survived into the streaming retry", key)
+		}
+	}
+	for _, key := range preserved {
+		if ctx.Value(key) == nil {
+			t.Errorf("%v was cleared, but stream retry must keep attempt-routing identity", key)
+		}
+	}
+}
+
 // TestValidateKeyGithubCopilot pins that validateKey rejects the same credentials the
 // provider would reject at request time. Accepting a whitespace-only field here defers the
 // failure to the first inference call, where it reads like a runtime fault rather than a

--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -32,9 +32,14 @@ const (
 const (
 	startTimeKey         schemas.BifrostContextKey = "bf-prom-start-time"
 	activeRequestTypeKey schemas.BifrostContextKey = "bf-prom-active-req-type"
-	mcpStartTimeKey      schemas.BifrostContextKey = "bf-prom-mcp-start-time"
-	mcpClientNameKey     schemas.BifrostContextKey = "bf-prom-mcp-client-name"
-	mcpToolNameKey       schemas.BifrostContextKey = "bf-prom-mcp-tool-name"
+	// activeRequestDecrementedKey latches the ActiveRequests Dec so a sticky
+	// BifrostContextKeyStreamEndIndicator cannot drive the gauge negative when
+	// PostLLMHook runs again for later stream chunks (client disconnect with
+	// queued chunks, or a streaming retry that left the terminal flag set).
+	activeRequestDecrementedKey schemas.BifrostContextKey = "bf-prom-active-req-dec"
+	mcpStartTimeKey             schemas.BifrostContextKey = "bf-prom-mcp-start-time"
+	mcpClientNameKey            schemas.BifrostContextKey = "bf-prom-mcp-client-name"
+	mcpToolNameKey              schemas.BifrostContextKey = "bf-prom-mcp-tool-name"
 
 	// Overhead is measured across the transport hooks rather than the LLM hooks,
 	// so the window matches the OTEL root span. See recordOverhead.
@@ -829,11 +834,31 @@ func (p *PrometheusPlugin) ObserveWarmupRoutingEmbedding(provider, model string,
 	}
 }
 
+// decrementActiveRequestOnce decrements bifrost_active_requests at most once
+// per PreLLMHook Inc. Streaming PostLLMHook runs per chunk and StreamEndIndicator
+// is sticky on the shared request context, so without this latch a terminal flag
+// set mid-stream (disconnect, first-chunk error before retry) would Dec on every
+// subsequent chunk and drive the gauge negative.
+func (p *PrometheusPlugin) decrementActiveRequestOnce(ctx *schemas.BifrostContext) {
+	if ctx == nil {
+		return
+	}
+	if prev := ctx.GetAndSetValue(activeRequestDecrementedKey, true); prev != nil {
+		return
+	}
+	if method, ok := ctx.Value(activeRequestTypeKey).(schemas.RequestType); ok {
+		p.ActiveRequests.WithLabelValues(string(method)).Dec()
+	}
+}
+
 // PreLLMHook records the start time of the request in the context.
 // This time is used later in PostLLMHook to calculate request duration.
 func (p *PrometheusPlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.BifrostRequest) (*schemas.BifrostRequest, *schemas.LLMPluginShortCircuit, error) {
 	ctx.SetValue(startTimeKey, time.Now())
 	ctx.SetValue(activeRequestTypeKey, req.RequestType)
+	// PreLLMHook runs again on each fallback attempt (Inc pairs with that attempt's
+	// terminal Dec). Clear the latch so the new Inc can be decremented once.
+	ctx.ClearValue(activeRequestDecrementedKey)
 	p.ActiveRequests.WithLabelValues(string(req.RequestType)).Inc()
 	return req, nil, nil
 }
@@ -1014,15 +1039,16 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	// Skip pre-dispatch rejections (no provider and no model) to avoid empty-label
 	// series. Decrement ActiveRequests first, since PreLLMHook incremented it.
 	if provider == "" && model == "" {
-		if method, ok := ctx.Value(activeRequestTypeKey).(schemas.RequestType); ok {
-			p.ActiveRequests.WithLabelValues(string(method)).Dec()
-		}
+		p.decrementActiveRequestOnce(ctx)
 		return result, bifrostErr, nil
 	}
 
 	startTime, ok := ctx.Value(startTimeKey).(time.Time)
 	if !ok {
 		p.logger.Warn("Warning: startTime not found in context for Prometheus PostLLMHook")
+		// Still release the in-flight gauge if PreLLMHook ran (activeRequestTypeKey
+		// is set) so a missing startTime cannot leak ActiveRequests upward.
+		p.decrementActiveRequestOnce(ctx)
 		return result, bifrostErr, nil
 	}
 	// Capture the LLM-hook window synchronously, before the goroutine below and its
@@ -1094,12 +1120,12 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	streamEndIndicatorValue := ctx.Value(schemas.BifrostContextKeyStreamEndIndicator)
 	isFinalChunk, hasFinalChunkIndicator := streamEndIndicatorValue.(bool)
 
-	// Decrement active requests on the final (or only) call for this request
+	// Decrement active requests on the final (or only) call for this request.
+	// The latch inside decrementActiveRequestOnce makes this idempotent even when
+	// StreamEndIndicator stays true across later per-chunk PostLLMHook calls.
 	isStreamFinal := !bifrost.IsStreamRequestType(requestType) || (hasFinalChunkIndicator && isFinalChunk)
 	if isStreamFinal {
-		if method, ok := ctx.Value(activeRequestTypeKey).(schemas.RequestType); ok {
-			p.ActiveRequests.WithLabelValues(string(method)).Dec()
-		}
+		p.decrementActiveRequestOnce(ctx)
 	}
 
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))

--- a/plugins/telemetry/main_test.go
+++ b/plugins/telemetry/main_test.go
@@ -563,3 +563,144 @@ func TestApplyCustomLabels(t *testing.T) {
 		})
 	}
 }
+
+// gaugeTotal sums every series of the named gauge family.
+func gaugeTotal(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	fams, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range fams {
+		if mf.GetName() != name {
+			continue
+		}
+		var sum float64
+		for _, m := range mf.GetMetric() {
+			sum += m.GetGauge().GetValue()
+		}
+		return sum
+	}
+	return 0
+}
+
+// streamChatResponse builds a minimal stream chunk response with provider/model
+// so PostLLMHook does not take the empty-label early return.
+func streamChatResponse() *schemas.BifrostResponse {
+	resp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+	}}
+	resp.PopulateExtraFields(schemas.ChatCompletionStreamRequest, schemas.OpenAI, "gpt-4o-mini", "gpt-4o-mini")
+	return resp
+}
+
+// TestActiveRequestsStreamEndIndicatorDoesNotDoubleDecrement locks the fix for
+// #7005: StreamEndIndicator is sticky on the shared request context while
+// PostLLMHook runs per chunk. Without a one-shot Dec latch, every post-hook
+// after the terminal flag is set would decrement bifrost_active_requests and
+// drive the gauge negative (client disconnect with queued chunks; streaming
+// retry that left the flag set).
+func TestActiveRequestsStreamEndIndicatorDoesNotDoubleDecrement(t *testing.T) {
+	p := newTestPlugin(t)
+	req := &schemas.BifrostRequest{RequestType: schemas.ChatCompletionStreamRequest}
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(time.Minute))
+
+	if _, _, err := p.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook: %v", err)
+	}
+	if got := gaugeTotal(t, p.registry, "bifrost_active_requests"); got != 1 {
+		t.Fatalf("after PreLLMHook gauge = %v, want 1", got)
+	}
+
+	// Intermediate chunk: no StreamEndIndicator → gauge stays elevated.
+	if _, _, err := p.PostLLMHook(ctx, streamChatResponse(), nil); err != nil {
+		t.Fatalf("PostLLMHook intermediate: %v", err)
+	}
+	if got := gaugeTotal(t, p.registry, "bifrost_active_requests"); got != 1 {
+		t.Fatalf("after intermediate chunk gauge = %v, want 1", got)
+	}
+
+	// Terminal path (e.g. HandleStreamCancellation) sets the sticky flag.
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	if _, _, err := p.PostLLMHook(ctx, streamChatResponse(), nil); err != nil {
+		t.Fatalf("PostLLMHook terminal: %v", err)
+	}
+	if got := gaugeTotal(t, p.registry, "bifrost_active_requests"); got != 0 {
+		t.Fatalf("after first terminal PostLLMHook gauge = %v, want 0", got)
+	}
+
+	// Queued chunks after cancel (or a retry that left the flag set) still see
+	// StreamEndIndicator=true. Dec must not fire again.
+	for i := 0; i < 5; i++ {
+		if _, _, err := p.PostLLMHook(ctx, streamChatResponse(), nil); err != nil {
+			t.Fatalf("PostLLMHook sticky #%d: %v", i, err)
+		}
+	}
+	if got := gaugeTotal(t, p.registry, "bifrost_active_requests"); got != 0 {
+		t.Fatalf("after sticky StreamEndIndicator PostLLMHooks gauge = %v, want 0 (must not go negative)", got)
+	}
+}
+
+// TestActiveRequestsLatchResetsOnFallbackPreLLMHook ensures each fallback
+// attempt (which re-runs PreLLMHook and Inc's again) can Dec exactly once.
+func TestActiveRequestsLatchResetsOnFallbackPreLLMHook(t *testing.T) {
+	p := newTestPlugin(t)
+	req := &schemas.BifrostRequest{RequestType: schemas.ChatCompletionRequest}
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(time.Minute))
+
+	if _, _, err := p.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook primary: %v", err)
+	}
+	primaryResp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+	}}
+	primaryResp.PopulateExtraFields(schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4o-mini", "gpt-4o-mini")
+	if _, _, err := p.PostLLMHook(ctx, primaryResp, nil); err != nil {
+		t.Fatalf("PostLLMHook primary: %v", err)
+	}
+	if got := gaugeTotal(t, p.registry, "bifrost_active_requests"); got != 0 {
+		t.Fatalf("after primary attempt gauge = %v, want 0", got)
+	}
+
+	// Fallback attempt: PreLLMHook runs again.
+	if _, _, err := p.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook fallback: %v", err)
+	}
+	if got := gaugeTotal(t, p.registry, "bifrost_active_requests"); got != 1 {
+		t.Fatalf("after fallback PreLLMHook gauge = %v, want 1", got)
+	}
+	fallbackResp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+	}}
+	fallbackResp.PopulateExtraFields(schemas.ChatCompletionRequest, schemas.Anthropic, "claude-haiku", "claude-haiku")
+	if _, _, err := p.PostLLMHook(ctx, fallbackResp, nil); err != nil {
+		t.Fatalf("PostLLMHook fallback: %v", err)
+	}
+	if got := gaugeTotal(t, p.registry, "bifrost_active_requests"); got != 0 {
+		t.Fatalf("after fallback PostLLMHook gauge = %v, want 0", got)
+	}
+}
+
+// TestActiveRequestsDecrementsWhenStartTimeMissing covers the secondary leak in
+// #7005: if startTime is absent, PostLLMHook used to return before Dec'ing.
+func TestActiveRequestsDecrementsWhenStartTimeMissing(t *testing.T) {
+	p := newTestPlugin(t)
+	req := &schemas.BifrostRequest{RequestType: schemas.ChatCompletionRequest}
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(time.Minute))
+
+	if _, _, err := p.PreLLMHook(ctx, req); err != nil {
+		t.Fatalf("PreLLMHook: %v", err)
+	}
+	ctx.ClearValue(startTimeKey)
+
+	resp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2},
+	}}
+	resp.PopulateExtraFields(schemas.ChatCompletionRequest, schemas.OpenAI, "gpt-4o-mini", "gpt-4o-mini")
+	if _, _, err := p.PostLLMHook(ctx, resp, nil); err != nil {
+		t.Fatalf("PostLLMHook: %v", err)
+	}
+	if got := gaugeTotal(t, p.registry, "bifrost_active_requests"); got != 0 {
+		t.Fatalf("after PostLLMHook without startTime gauge = %v, want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #7005 — `bifrost_active_requests` drifts negative on streaming request types because `PostLLMHook` runs per chunk while `BifrostContextKeyStreamEndIndicator` is sticky on the shared request context. After a client disconnect (or a first-chunk stream error before retry), every subsequent post-hook observes the terminal flag and `Dec()`s again.

**Root cause:** the gauge is incremented once in `PreLLMHook`, but decremented on every post-hook invocation that sees `StreamEndIndicator == true`. That flag is cleared for fallbacks (`clearCtxForFallback`) but not for same-provider streaming retries, and nothing made the telemetry `Dec` idempotent.

## Changes

- `plugins/telemetry/main.go`: one-shot latch (`GetAndSetValue`) around `ActiveRequests.Dec`; clear the latch on each `PreLLMHook` so fallback attempts can Inc/Dec correctly; also Dec on the missing-`startTime` early return so the gauge cannot leak upward.
- `core/utils.go`: add `clearCtxForStreamRetry` to wipe stream-lifecycle flags (`ConnectionClosed`, `StreamEndIndicator`, `StreamBodyExhausted`, `StreamParkedAfterFinish`).
- `core/bifrost.go`: call `clearCtxForStreamRetry` after a first-chunk stream error; clear `StreamEndIndicator` at the start of every streaming retry (not only the Azure-preamble path).
- Regression tests in `plugins/telemetry/main_test.go` and `core/utils_test.go`.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
# With go.work (or CI workspace) linking local core + plugins/telemetry:
go test -count=1 -run 'TestActiveRequests' ./plugins/telemetry/
go test -count=1 -run 'TestClearCtxForStreamRetry|TestClearCtxForFallback$' ./core/
```

Red-before-green: `TestActiveRequestsStreamEndIndicatorDoesNotDoubleDecrement` fails on `dev` (gauge goes negative after sticky-flag PostLLMHook repeats) and passes with this change.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #7005

## Security considerations

None. Metrics-only; no auth, PII, or request-path behavior change beyond clearing sticky stream flags that should not survive a retry (matching existing fallback cleanup).

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable

Made with [Cursor](https://cursor.com)