### PR TITLE
chore: fix indentation in `virtualKeySheet.tsx`

### DIFF
--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -445,11 +445,11 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 					})),
 					rate_limit: config.rate_limit
 						? {
-								token_max_limit: config.rate_limit.token_max_limit ?? undefined,
-								token_reset_duration: config.rate_limit.token_reset_duration,
-								request_max_limit: config.rate_limit.request_max_limit ?? undefined,
-								request_reset_duration: config.rate_limit.request_reset_duration,
-							}
+							token_max_limit: config.rate_limit.token_max_limit ?? undefined,
+							token_reset_duration: config.rate_limit.token_reset_duration,
+							request_max_limit: config.rate_limit.request_max_limit ?? undefined,
+							request_reset_duration: config.rate_limit.request_reset_duration,
+						}
 						: undefined,
 					model_budgets: config.model_budgets?.map((mb) => ({
 						model_name: mb.model_name,
@@ -461,11 +461,11 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 						})),
 						rate_limit: mb.rate_limit
 							? {
-									token_max_limit: mb.rate_limit.token_max_limit ?? undefined,
-									token_reset_duration: mb.rate_limit.token_reset_duration,
-									request_max_limit: mb.rate_limit.request_max_limit ?? undefined,
-									request_reset_duration: mb.rate_limit.request_reset_duration,
-								}
+								token_max_limit: mb.rate_limit.token_max_limit ?? undefined,
+								token_reset_duration: mb.rate_limit.token_reset_duration,
+								request_max_limit: mb.rate_limit.request_max_limit ?? undefined,
+								request_reset_duration: mb.rate_limit.request_reset_duration,
+							}
 							: undefined,
 					})),
 				})) || [],
@@ -484,18 +484,18 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 			isActive: virtualKey?.is_active ?? true,
 			expiresAt: virtualKey?.expires_at
 				? (() => {
-						const d = new Date(virtualKey.expires_at);
-						return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
-					})()
+					const d = new Date(virtualKey.expires_at);
+					return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+				})()
 				: null,
 			budgets:
 				virtualKey?.budgets && virtualKey.budgets.length > 0
 					? virtualKey.budgets.map((b) => ({
-							id: b.id,
-							max_limit: b.max_limit,
-							reset_duration: b.reset_duration ?? "1M",
-							reset_config: b.reset_config,
-						}))
+						id: b.id,
+						max_limit: b.max_limit,
+						reset_duration: b.reset_duration ?? "1M",
+						reset_config: b.reset_config,
+					}))
 					: [],
 			budgetCalendarAligned: virtualKey?.calendar_aligned ?? false,
 			tokenMaxLimit: virtualKey?.rate_limit?.token_max_limit ?? undefined,
@@ -1118,7 +1118,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 													the key itself carries only a name and a description.
 												</>
 											) : (
-												<>
+												<p>
 													This virtual key will be managed by your access profile
 													{vkCreationPolicy?.profile_name ? (
 														<>
@@ -1128,7 +1128,7 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 													) : null}
 													. Set a name and description; providers, budgets, rate limits, and MCP access are applied from the profile on
 													creation.
-												</>
+												</p>
 											)}
 										</AlertDescription>
 									</Alert>
@@ -1529,9 +1529,9 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 																fallbackOption={
 																	field.value
 																		? {
-																				value: field.value,
-																				label: field.value === virtualKey?.team_id ? (virtualKey?.team?.name ?? field.value) : field.value,
-																			}
+																			value: field.value,
+																			label: field.value === virtualKey?.team_id ? (virtualKey?.team?.name ?? field.value) : field.value,
+																		}
 																		: null
 																}
 																disabled={isTeamLocked}
@@ -1559,12 +1559,12 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 																fallbackOption={
 																	field.value
 																		? {
-																				value: field.value,
-																				label:
-																					field.value === virtualKey?.customer_id
-																						? (virtualKey?.customer?.name ?? field.value)
-																						: field.value,
-																			}
+																			value: field.value,
+																			label:
+																				field.value === virtualKey?.customer_id
+																					? (virtualKey?.customer?.name ?? field.value)
+																					: field.value,
+																		}
 																		: null
 																}
 																triggerClassName="h-9"
@@ -1593,9 +1593,9 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 																fallbackOption={
 																	field.value
 																		? {
-																				value: field.value,
-																				label: field.value === assignedUserId ? assignedUserLabel : field.value,
-																			}
+																			value: field.value,
+																			label: field.value === assignedUserId ? assignedUserLabel : field.value,
+																		}
 																		: null
 																}
 																triggerClassName="h-9"


### PR DESCRIPTION
## Summary

Fixes inconsistent indentation in `virtualKeySheet.tsx` to align with the project's formatting conventions. Also replaces a `<>` fragment with a `<p>` tag in the access profile alert description for more semantically correct markup.

## Changes

- Corrected indentation of nested object literals inside ternary expressions for `rate_limit`, `budgets`, `expiresAt`, and `fallbackOption` fields to use consistent 2-space relative indentation
- Replaced a React fragment (`<>...</>`) with a `<p>` tag in the virtual key creation policy alert description

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i || npm i
pnpm build || npm run build
```

Verify the virtual key sheet renders correctly, including the access profile alert message and all form fields for rate limits, budgets, and assignments.

## Screenshots/Recordings

No visual changes expected.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable