### PR TITLE
fix(telemetry): decrement active-requests gauge exactly once per request

### DIFF
--- a/plugins/telemetry/main.go
+++ b/plugins/telemetry/main.go
@@ -32,9 +32,16 @@ const (
 const (
 	startTimeKey         schemas.BifrostContextKey = "bf-prom-start-time"
 	activeRequestTypeKey schemas.BifrostContextKey = "bf-prom-active-req-type"
-	mcpStartTimeKey      schemas.BifrostContextKey = "bf-prom-mcp-start-time"
-	mcpClientNameKey     schemas.BifrostContextKey = "bf-prom-mcp-client-name"
-	mcpToolNameKey       schemas.BifrostContextKey = "bf-prom-mcp-tool-name"
+	// activeRequestsDecrementedKey marks that the in-flight gauge has already
+	// been decremented for this request. PostLLMHook runs once per stream
+	// chunk, and the stream-end indicator is sticky once any path sets it, so
+	// a plain bool check decrements once per chunk and drives the gauge
+	// negative. This flag is set-and-cleared atomically via GetAndSetValue,
+	// making the decrement idempotent per request (#7005).
+	activeRequestsDecrementedKey schemas.BifrostContextKey = "bf-prom-active-req-dec"
+	mcpStartTimeKey              schemas.BifrostContextKey = "bf-prom-mcp-start-time"
+	mcpClientNameKey             schemas.BifrostContextKey = "bf-prom-mcp-client-name"
+	mcpToolNameKey               schemas.BifrostContextKey = "bf-prom-mcp-tool-name"
 
 	// Overhead is measured across the transport hooks rather than the LLM hooks,
 	// so the window matches the OTEL root span. See recordOverhead.
@@ -999,6 +1006,15 @@ func canonicalEntitySet(ctx context.Context, idsKey, namesKey, scalarIDKey, scal
 func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
 	requestType, provider, originalModel, resolvedModel := bifrost.GetResponseFields(result, bifrostErr)
 
+	// Decrement the in-flight gauge exactly once, as early as possible: every
+	// later early return (pre-dispatch rejection, missing startTime) would
+	// otherwise leak the gauge upward (#7005).
+	if method, ok := ctx.Value(activeRequestTypeKey).(schemas.RequestType); ok {
+		if prev, _ := ctx.GetAndSetValue(activeRequestsDecrementedKey, true).(bool); !prev {
+			p.ActiveRequests.WithLabelValues(string(method)).Dec()
+		}
+	}
+
 	// Effective model + alias (mirrors logging's applyModelAlias). model is normalized
 	// so it doesn't split across series; alias keeps the raw requested name.
 	model := originalModel
@@ -1012,11 +1028,8 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 	model = schemas.NormalizeModelName(model)
 
 	// Skip pre-dispatch rejections (no provider and no model) to avoid empty-label
-	// series. Decrement ActiveRequests first, since PreLLMHook incremented it.
+	// series. The ActiveRequests decrement already happened above.
 	if provider == "" && model == "" {
-		if method, ok := ctx.Value(activeRequestTypeKey).(schemas.RequestType); ok {
-			p.ActiveRequests.WithLabelValues(string(method)).Dec()
-		}
 		return result, bifrostErr, nil
 	}
 
@@ -1080,8 +1093,8 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 		"customer_name":        customerName,
 		"business_unit_id":     businessUnitID,
 		"business_unit_name":   businessUnitName,
-		"project_id":          projectID,
-		"project_name":        projectName,
+		"project_id":           projectID,
+		"project_name":         projectName,
 	}
 
 	// Get all custom prometheus labels from context BEFORE the goroutine.
@@ -1096,11 +1109,6 @@ func (p *PrometheusPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *sche
 
 	// Decrement active requests on the final (or only) call for this request
 	isStreamFinal := !bifrost.IsStreamRequestType(requestType) || (hasFinalChunkIndicator && isFinalChunk)
-	if isStreamFinal {
-		if method, ok := ctx.Value(activeRequestTypeKey).(schemas.RequestType); ok {
-			p.ActiveRequests.WithLabelValues(string(method)).Dec()
-		}
-	}
 
 	pricingScopes := modelcatalog.PricingLookupScopesFromContext(ctx, string(provider))
 

--- a/plugins/telemetry/main_test.go
+++ b/plugins/telemetry/main_test.go
@@ -563,3 +563,85 @@ func TestApplyCustomLabels(t *testing.T) {
 		})
 	}
 }
+
+// gaugeValue gathers the named gauge family from the registry and sums every series' value.
+func gaugeValue(t *testing.T, reg *prometheus.Registry, name string) float64 {
+	t.Helper()
+	fams, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Gather: %v", err)
+	}
+	for _, mf := range fams {
+		if mf.GetName() != name {
+			continue
+		}
+		var sum float64
+		for _, m := range mf.GetMetric() {
+			sum += m.GetGauge().GetValue()
+		}
+		return sum
+	}
+	return 0
+}
+
+// TestPostLLMHookActiveRequestsIdempotentDecrement covers #7005: PostLLMHook
+// runs once per stream chunk, and the stream-end indicator is sticky once any
+// path sets it. The decrement must happen exactly once per request no matter
+// how many subsequent chunk hooks observe the stale flag — the gauge must not
+// drift negative.
+func TestPostLLMHookActiveRequestsIdempotentDecrement(t *testing.T) {
+	p := newTestPlugin(t)
+	ctx := newHookContext(schemas.ChatCompletionStreamRequest)
+
+	// PreLLMHook's Inc, replicated for the test (the hook itself also sets
+	// startTimeKey, which newHookContext already primes).
+	p.ActiveRequests.WithLabelValues(string(schemas.ChatCompletionStreamRequest)).Inc()
+
+	resp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 5, CompletionTokens: 5, TotalTokens: 10},
+	}}
+	resp.PopulateExtraFields(schemas.ChatCompletionStreamRequest, "openai", "m", "m")
+
+	// Simulate the sticky stream-end flag being set (e.g. by a cancellation
+	// handler mid-stream), then run the post hook for the "final" chunk and
+	// for several already-queued trailing chunks.
+	ctx.SetValue(schemas.BifrostContextKeyStreamEndIndicator, true)
+	const queuedChunks = 5
+	for i := 0; i <= queuedChunks; i++ {
+		if _, _, err := p.PostLLMHook(ctx, resp, nil); err != nil {
+			t.Fatalf("PostLLMHook chunk %d: %v", i, err)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if got := gaugeValue(t, p.registry, "bifrost_active_requests"); got != 0 {
+		t.Errorf("bifrost_active_requests = %v after 1 inc + %d dec-candidate hooks, want exactly 0",
+			got, queuedChunks+1)
+	}
+}
+
+// TestPostLLMHookActiveRequestsDecrementOnMissingStartTime covers the
+// opposite leak from #7005: PostLLMHook used to return early when
+// startTime was missing, leaving the gauge incremented forever.
+func TestPostLLMHookActiveRequestsDecrementOnMissingStartTime(t *testing.T) {
+	p := newTestPlugin(t)
+	ctx := schemas.NewBifrostContext(context.Background(), time.Now().Add(time.Minute))
+	ctx.SetValue(activeRequestTypeKey, schemas.ChatCompletionRequest)
+	p.ActiveRequests.WithLabelValues(string(schemas.ChatCompletionRequest)).Inc()
+
+	resp := &schemas.BifrostResponse{ChatResponse: &schemas.BifrostChatResponse{
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 5, CompletionTokens: 5, TotalTokens: 10},
+	}}
+	resp.PopulateExtraFields(schemas.ChatCompletionRequest, "openai", "m", "m")
+
+	// No startTimeKey set: the hook warns and skips metric recording, but the
+	// gauge must still come back to zero.
+	if _, _, err := p.PostLLMHook(ctx, resp, nil); err != nil {
+		t.Fatalf("PostLLMHook: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	if got := gaugeValue(t, p.registry, "bifrost_active_requests"); got != 0 {
+		t.Errorf("bifrost_active_requests = %v, want 0 (missing startTime must not leak the gauge)", got)
+	}
+}


### PR DESCRIPTION
## Description

`bifrost_active_requests` drifted **negative** on streaming request types (observed in production alongside ~1,275 HTTP 499s: `-9` on `method="chat_completion_stream"`).

The gauge is incremented once per request in `PreLLMHook`, but `PostLLMHook` decrements it whenever it observes the stream-end indicator — and that indicator is **sticky** on the shared per-request context: it is set in 50+ terminal-chunk/cancellation/error paths and cleared in exactly one (`clearCtxForFallback`). Since `PostLLMHook` runs once per stream chunk, every already-queued chunk after the flag was set decremented again.

Two concrete paths:

1. **Client disconnects mid-stream**: `HandleStreamCancellation` sets the flag and decrements (correct), but the provider goroutine's remaining queued chunks each see the stale flag and decrement again.
2. **Streaming retry after a first-chunk error**: attempt 1 sets the flag and decrements; `executeRequestWithRetries` clears `ConnectionClosed` but **not** `StreamEndIndicator`, so every retry chunk sees the stale flag. (Fallbacks are unaffected because `clearCtxForFallback` clears the key — the asymmetry suggests the retry case was the oversight.)

### Fix

Make the decrement **idempotent** with a dedicated context flag flipped via `ctx.GetAndSetValue` (the same primitive `HandleStreamCancellation` already uses to guard its own decrement). The decrement now happens exactly once, at the top of `PostLLMHook`.

This also fixes a second leak in the opposite direction: the early return on missing `startTime` used to skip the decrement entirely, so any path reaching `PostLLMHook` without `PreLLMHook` (short-circuit, plugin-order change) leaked the gauge upward permanently.

### Trade-off note

The gauge now decrements at hook entry rather than after the request's terminal bookkeeping — meaning the "active" window for a request is measured up to the first `PostLLMHook` invocation rather than the stream's true end. For streaming that is per-chunk anyway (the old code decremented on the final chunk's hook, not after the stream closed), so the semantic change is minimal and strictly better than a negative gauge.

## Testing

- `TestPostLLMHookActiveRequestsIdempotentDecrement`: sticky flag set, then 1 final + 5 queued-chunk hook invocations → gauge lands at exactly `0` (was `-5` pre-fix; verified red-green).
- `TestPostLLMHookActiveRequestsDecrementOnMissingStartTime`: missing `startTime` no longer leaks the increment (verified red-green).
- Full `plugins/telemetry` suite: `ok`; `go vet` / `gofmt` clean.

Fixes #7005
