### PR TITLE
fix(core): clear provider response headers on fallback boundaries

### DIFF
--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -3345,6 +3345,19 @@ func TestClearCtxForFallback_DropsCallerSuppliedKey(t *testing.T) {
 		t.Fatalf("RoutingPinnedAPIKeyID survived clearCtxForFallback: %q", pin)
 	}
 
+	// #6973: provider response headers belong to the provider that produced
+	// them. If a fallback attempt fails pre-flight, the previous provider's
+	// headers must not survive on the context and be forwarded with the
+	// fallback's error response.
+	ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{
+		"retry-after":                  "60",
+		"x-ratelimit-remaining-tokens": "0",
+	})
+	clearCtxForFallback(ctx)
+	if headers, ok := ctx.Value(schemas.BifrostContextKeyProviderResponseHeaders).(map[string]string); ok {
+		t.Fatalf("ProviderResponseHeaders survived clearCtxForFallback: %v", headers)
+	}
+
 	keys, _, err := bifrost.selectKeyFromProviderForModelWithPool(ctx, schemas.ChatCompletionRequest, schemas.Anthropic, "claude-opus-4-5", schemas.Anthropic)
 	if err != nil {
 		t.Fatalf("selectKeyFromProviderForModelWithPool: %v", err)

--- a/core/utils.go
+++ b/core/utils.go
@@ -407,6 +407,11 @@ func clearCtxForFallback(ctx *schemas.BifrostContext) {
 	ctx.ClearValue(schemas.BifrostContextKeyStreamBodyExhausted)
 	ctx.ClearValue(schemas.BifrostContextKeyStreamParkedAfterFinish)
 	ctx.ClearValue(schemas.BifrostContextKeySupportsAssistantPrefill)
+	// Provider response headers belong to the provider that produced them.
+	// If a fallback attempt fails pre-flight (no HTTP request issued), the
+	// previous provider's headers would otherwise survive on the context and
+	// be forwarded with the fallback's error response (#6973).
+	ctx.ClearValue(schemas.BifrostContextKeyProviderResponseHeaders)
 }
 
 // ClearContextForInternalRequest clears context state that is specific to the


### PR DESCRIPTION
## Description

`clearCtxForFallback` wipes the context keys resolved for the *previous* provider before a fallback attempt runs — but it misses `BifrostContextKeyProviderResponseHeaders`.

Providers set that key from their own HTTP response **before** the status check, so error paths can forward it. Normally the fallback's own provider overwrites it, but when a fallback attempt fails **pre-flight** (key selection fails for the fallback provider, a plugin short-circuits it, the queue is retiring), nothing overwrites the key and the **primary's** headers survive on the context. The transport then forwards them verbatim on the fallback's error response.

**Consequence**: the client receives a response attributed to provider B (`x-bifrost-routing-info-provider: anthropic`) carrying provider A's `Retry-After: 60` and `x-ratelimit-remaining-*` — and a compliant client will wait according to a limit belonging to a provider that never served the request, with no way to reconcile the disagreement from the response alone.

This is the same class of staleness `clearCtxForFallback` already guards against for key pins and the attempt trail; this key just seems to have been missed when it was added.

## Fix

One line: clear `BifrostContextKeyProviderResponseHeaders` in `clearCtxForFallback`, with a comment explaining why.

## Testing

- Regression test added to the existing `clearCtxForFallback` coverage in `core/bifrost_test.go`: headers set to simulate the primary (`retry-after`, `x-ratelimit-remaining-tokens`) do not survive the call. Verified red-green (fails on current `dev` with the exact "survived clearCtxForFallback" message).
- Full `core` suite: only pre-existing failure is `TestContextSpanAttributesEmit` (fails identically on unmodified `dev`; unrelated to this change). `go vet` / `gofmt` clean.

Fixes #6973
