### PR TITLE
fix: vk UI for managed keys

### DIFF
--- a/docs/openapi/paths/management/governanceextensions.yaml
+++ b/docs/openapi/paths/management/governanceextensions.yaml
@@ -206,14 +206,14 @@ user-vk-creation-policy:
         </Note>
     summary: Get the calling user's virtual-key creation policy
     description: |
-      Reports whether virtual keys the **calling** user creates will be adopted into one of their
-      access profiles, and if so which one. The create form uses this to lock the policy fields
-      up front rather than letting a user author a policy that is about to be overwritten.
+      Resolves the access profile that would govern a virtual key the **calling** user creates,
+      returning its name or none. Whether governance applies at all is decided separately from the
+      `VirtualKeys:CreateStandalone` permission (see `/api/governance/users/me/permissions`); this
+      endpoint only resolves the profile, and the create form combines the two.
 
       Self-scoped: it always describes the caller and takes no user ID. Returns
-      `{"governed": false}` when the caller has no per-user identity (local admin or password
-      auth) or when no profile they hold has **Govern virtual keys created by members** enabled.
-      When more than one of their profiles has it on, the first such profile governs.
+      `{"has_access_profile": false}` when the caller has no per-user identity (local admin) or holds
+      no active access profile. When several of their profiles qualify, the highest-ranked one governs.
     tags: [Users, Virtual Keys]
     security:
       - ManagementBearerAuth: []
@@ -224,14 +224,14 @@ user-vk-creation-policy:
           application/json:
             schema:
               type: object
-              required: [governed]
+              required: [has_access_profile]
               properties:
-                governed:
+                has_access_profile:
                   type: boolean
-                  description: Whether an access profile will adopt keys this user creates.
+                  description: Whether the caller holds an access profile that would govern keys they create.
                 profile_name:
                   type: string
-                  description: Name of the governing access profile. Present only when `governed` is true.
+                  description: Name of the governing access profile. Present only when `has_access_profile` is true.
       '500':
         $ref: '../../openapi.yaml#/components/responses/InternalError'
 

--- a/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
+++ b/ui/app/_fallbacks/enterprise/lib/contexts/rbacContext.tsx
@@ -51,6 +51,7 @@ export enum RbacOperation {
 	Delete = "Delete",
 	Reveal = "Reveal",
 	Download = "Download",
+	CreateStandalone = "CreateStandalone",
 }
 
 interface RbacContextType {

--- a/ui/app/_fallbacks/enterprise/lib/types/accessProfile.ts
+++ b/ui/app/_fallbacks/enterprise/lib/types/accessProfile.ts
@@ -44,6 +44,6 @@ export interface GetUserAccessProfilesResponse {
 }
 
 export interface VKCreationPolicyResponse {
-	governed: boolean;
+	has_access_profile: boolean;
 	profile_name?: string;
 }

--- a/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
+++ b/ui/app/workspace/virtual-keys/views/virtualKeySheet.tsx
@@ -302,18 +302,20 @@ export default function VirtualKeySheet({ virtualKey, defaultTeamId, onSave, onC
 
 	const hasCreateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Create);
 	const hasUpdateAccess = useRbac(RbacResource.VirtualKeys, RbacOperation.Update);
+	const hasCreateStandalone = useRbac(RbacResource.VirtualKeys, RbacOperation.CreateStandalone);
 	const canSubmit = isEditing ? hasUpdateAccess : hasCreateAccess;
 
 	// Detect AP-managed status via the managing profile's virtual_key_ids, not just by the presence
 	// of assignees — directly-attached users don't imply an access-profile relation.
 	const { assignedUsers, isManagedByProfile: isManagedByProfileHook, managingProfile } = useVirtualKeyUsage(virtualKey);
-	// On create, check whether the user's access profile will govern the new VK. If so,
-	// lock the governance fields up front — the server applies the profile regardless.
+	// On create, the VK is governed unless the role grants CreateStandalone (the freedom to
+	// create ungoverned keys); the profile that will apply comes from vkCreationPolicy. If
+	// governed, lock the governance fields up front — the server applies the profile regardless.
 	const { data: vkCreationPolicy } = useGetMyVKCreationPolicyQuery(undefined, {
 		skip: isEditing,
 		refetchOnMountOrArgChange: true,
 	});
-	const willBeGovernedOnCreate = !isEditing && !!vkCreationPolicy?.governed;
+	const willBeGovernedOnCreate = !isEditing && !hasCreateStandalone;
 	const isManagedByProfile = (isEditing && isManagedByProfileHook) || willBeGovernedOnCreate;
 	// User assignment is enterprise-only: OSS registers no picker, so the option stays hidden.
 	const UserPicker = getUserPicker();


### PR DESCRIPTION
## Summary

Introduces a new `CreateStandalone` RBAC operation for virtual keys, allowing role-based control over whether a user can create ungoverned (standalone) virtual keys. Previously, governance on creation was determined solely by the server-side `vkCreationPolicy.governed` flag; now it is driven by whether the user's role grants `CreateStandalone`, giving finer-grained permission control.

## Changes

- Added `CreateStandalone` to the `RbacOperation` enum, representing the ability to create virtual keys outside of access profile governance.
- Renamed `governed` to `has_access_profile` in `VKCreationPolicyResponse` to more accurately reflect what the field represents.
- Updated `virtualKeySheet.tsx` to derive `willBeGovernedOnCreate` from the absence of the `CreateStandalone` permission rather than from `vkCreationPolicy.governed`, aligning governance locking behavior with RBAC role grants instead of a server-returned boolean.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Log in as a user whose role does **not** include `CreateStandalone` on virtual keys.
2. Navigate to the virtual keys creation sheet.
3. Confirm that governance fields are locked and the access profile is applied automatically.
4. Log in as a user whose role **does** include `CreateStandalone`.
5. Navigate to the virtual keys creation sheet.
6. Confirm that governance fields are editable and the key can be created without an access profile.

```sh
cd ui
pnpm i || npm i
pnpm test || npm test
pnpm build || npm run build
```

## Breaking changes

- [x] Yes
- [ ] No

The `VKCreationPolicyResponse` field `governed` has been renamed to `has_access_profile`. Any consumers of this API response field will need to be updated accordingly.

## Security considerations

This change tightens governance control by tying ungoverned key creation to an explicit RBAC permission (`CreateStandalone`). Users without this permission will always have their new virtual keys governed by their access profile, reducing the risk of ungoverned keys being created unintentionally.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable