### PR TITLE
docs: remove resolved MCP auth warning from v2.1.0 changelog

### DIFF
--- a/docs/changelogs/v2.1.0.mdx
+++ b/docs/changelogs/v2.1.0.mdx
@@ -3,10 +3,6 @@ title: "v2.1.0"
 description: "v2.1.0 changelog - 2026-09-08"
 ---
 
-<Warning>
-We have identified an issue with MCP server auth when the selected configuration is "both" and you use IDP issued JWT. It's fixed in 2.1.1.
-</Warning>
-
 <Tabs>
   <Tab title="NPX">
     ```bash


### PR DESCRIPTION
## Summary

Removes the warning banner from the v2.1.0 changelog that flagged an MCP server auth issue with the "both" configuration and IDP issued JWTs, as this issue has been resolved in v2.1.1.

## Changes

- Removed the `<Warning>` block from the v2.1.0 changelog that pointed users to v2.1.1 for a fix. Since the fix is now available and documented elsewhere, the warning is no longer necessary on the v2.1.0 changelog page.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Verify the v2.1.0 changelog page renders correctly without the warning banner.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable