### PR TITLE
fixes reserved namespace redaction for bedrock

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,0 +1,1 @@
+- fix: drop namespace tools whose name Amazon Bedrock reserves (`web`, `image_gen`, `browser`, `python`) on the Bedrock and Bedrock Mantle Responses paths instead of forwarding them into a `tools.namespace` collision 400; a dropped Codex `web` namespace becomes the hosted `web_search` tool on Bedrock Mantle

--- a/core/providers/openai/responses.go
+++ b/core/providers/openai/responses.go
@@ -60,6 +60,51 @@ var ProviderFeatures = map[schemas.ModelProvider]ResponsesFeatureSupport{
 	schemas.BedrockMantle: {AdditionalToolsItem: false, ContextManagement: false},
 }
 
+// reservedToolNamespaces lists the namespace-tool names a provider keeps for
+// its own server-side tools. Bedrock rejects a user-defined namespace with one
+// of these names outright on both the bedrock-mantle and bedrock-runtime
+// Responses endpoints: "Invalid Value: 'tools.namespace'. User-defined namespace
+// 'web' collides with an existing tool namespace." (HTTP 400). Codex registers a
+// client-side "web" namespace (web.run) whenever it believes it is talking to
+// OpenAI, which is the case when Bifrost is configured through openai_base_url.
+// Live-verified against openai.gpt-5.6-luna on 2026-09-09.
+var reservedToolNamespaces = map[schemas.ModelProvider]map[string]bool{
+	schemas.Bedrock:       {"web": true, "image_gen": true, "browser": true, "python": true},
+	schemas.BedrockMantle: {"web": true, "image_gen": true, "browser": true, "python": true},
+}
+
+// dropReservedNamespaceTools returns a copy of tools without the namespace tools
+// the provider reserves. A dropped "web" namespace is Codex's client-side web.run
+// tool, which only executes against OpenAI's search endpoint anyway. When
+// substituteWebSearch is set (bedrock-mantle, which hosts web search) and the
+// caller sent no web_search tool, the hosted tool is appended with
+// external_web_access=false, matching what Codex sends to non-OpenAI providers and
+// what AWS documents for Codex on Mantle
+// (https://docs.aws.amazon.com/bedrock/latest/userguide/web-search.html).
+func dropReservedNamespaceTools(tools []schemas.ResponsesTool, reserved map[string]bool, substituteWebSearch bool) []schemas.ResponsesTool {
+	out := make([]schemas.ResponsesTool, 0, len(tools)+1)
+	droppedWeb, hasWebSearch := false, false
+	for _, tool := range tools {
+		if tool.Type == schemas.ResponsesToolTypeWebSearch {
+			hasWebSearch = true
+		}
+		if tool.Type == schemas.ResponsesToolTypeNamespace && tool.Name != nil && reserved[*tool.Name] {
+			if *tool.Name == "web" {
+				droppedWeb = true
+			}
+			continue
+		}
+		out = append(out, tool)
+	}
+	if substituteWebSearch && droppedWeb && !hasWebSearch {
+		out = append(out, schemas.ResponsesTool{
+			Type:                   schemas.ResponsesToolTypeWebSearch,
+			ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{ExternalWebAccess: new(false)},
+		})
+	}
+	return out
+}
+
 // supportsAdditionalToolsItem reports whether provider accepts codex
 // additional_tools input items. Unlisted providers are assumed to.
 func supportsAdditionalToolsItem(provider schemas.ModelProvider) bool {
@@ -606,6 +651,17 @@ func ToOpenAIResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.B
 	// normalization below so hoisted function tools get the same treatment.
 	if len(hoistedTools) > 0 {
 		req.Tools = append(append(make([]schemas.ResponsesTool, 0, len(req.Tools)+len(hoistedTools)), req.Tools...), hoistedTools...)
+	}
+
+	// Drop namespace tools the provider reserves; they are a hard 400. Runs after
+	// the hoist so additional_tools namespaces get the same treatment, and before
+	// filterUnsupportedTools so a substituted web_search goes through its copy path.
+	// Match on the base provider: a custom provider built on bedrock reports its own
+	// key, which the map does not know, so the reserved namespace would reach AWS.
+	toolProvider := schemas.ResolveBaseProvider(ctx, bifrostReq.Provider)
+	if reserved := reservedToolNamespaces[toolProvider]; len(reserved) > 0 && len(req.Tools) > 0 {
+		substitute := toolProvider == schemas.BedrockMantle && caps.SupportsWebSearch(true)
+		req.Tools = dropReservedNamespaceTools(req.Tools, reserved, substitute)
 	}
 
 	// Normalize function tool parameters for deterministic JSON serialization, and

--- a/core/providers/openai/responses_test.go
+++ b/core/providers/openai/responses_test.go
@@ -1,6 +1,7 @@
 package openai
 
 import (
+	"context"
 	"encoding/json"
 	"net/url"
 	"strings"
@@ -2779,4 +2780,147 @@ func TestReasoningContentBlocksGateReadsDatasheet(t *testing.T) {
 		require.Len(t, out, 1)
 		require.Nil(t, out[0].Content, "summaries must stay as summaries")
 	})
+}
+
+// Bedrock (mantle and runtime) rejects a user-defined namespace tool whose name
+// it reserves for its own server-side tools with HTTP 400 "User-defined
+// namespace 'web' collides with an existing tool namespace". Codex sends such a
+// "web" namespace (web.run) whenever it believes the provider is OpenAI, so the
+// serializer must drop it, and on Mantle replace it with the hosted web_search
+// tool AWS documents for Codex.
+func TestToOpenAIResponsesRequest_DropsReservedNamespaceForBedrock(t *testing.T) {
+	webNS := schemas.ResponsesTool{
+		Type: schemas.ResponsesToolTypeNamespace,
+		Name: schemas.Ptr("web"),
+		ResponsesToolNamespace: &schemas.ResponsesToolNamespace{Tools: []schemas.ResponsesTool{{
+			Type:                  schemas.ResponsesToolTypeFunction,
+			Name:                  schemas.Ptr("run"),
+			ResponsesToolFunction: &schemas.ResponsesToolFunction{},
+		}}},
+	}
+	keepNS := webNS
+	keepNS.Name = schemas.Ptr("multi_agent_v1")
+	hostedWebSearch := schemas.ResponsesTool{
+		Type:                   schemas.ResponsesToolTypeWebSearch,
+		ResponsesToolWebSearch: &schemas.ResponsesToolWebSearch{ExternalWebAccess: schemas.Ptr(true)},
+	}
+
+	tests := []struct {
+		name     string
+		provider schemas.ModelProvider
+		// baseProvider, when set, is stamped on the context the way core does for
+		// a custom provider, so provider reads as a user-defined key.
+		baseProvider schemas.ModelProvider
+		tools        []schemas.ResponsesTool
+		wantTypes    []schemas.ResponsesToolType
+		wantNames    []string
+		// wantExternalWebAccess asserts the external_web_access flag on the
+		// resulting web_search tool when non-nil.
+		wantExternalWebAccess *bool
+	}{
+		{
+			name:                  "mantle drops web namespace and substitutes hosted web_search",
+			provider:              schemas.BedrockMantle,
+			tools:                 []schemas.ResponsesTool{keepNS, webNS},
+			wantTypes:             []schemas.ResponsesToolType{schemas.ResponsesToolTypeNamespace, schemas.ResponsesToolTypeWebSearch},
+			wantNames:             []string{"multi_agent_v1", ""},
+			wantExternalWebAccess: schemas.Ptr(false),
+		},
+		{
+			name:                  "mantle keeps a caller-supplied web_search untouched",
+			provider:              schemas.BedrockMantle,
+			tools:                 []schemas.ResponsesTool{webNS, hostedWebSearch},
+			wantTypes:             []schemas.ResponsesToolType{schemas.ResponsesToolTypeWebSearch},
+			wantNames:             []string{""},
+			wantExternalWebAccess: schemas.Ptr(true),
+		},
+		{
+			name:      "bedrock runtime drops web namespace without substitution",
+			provider:  schemas.Bedrock,
+			tools:     []schemas.ResponsesTool{keepNS, webNS},
+			wantTypes: []schemas.ResponsesToolType{schemas.ResponsesToolTypeNamespace},
+			wantNames: []string{"multi_agent_v1"},
+		},
+		{
+			name:      "openai keeps the web namespace",
+			provider:  schemas.OpenAI,
+			tools:     []schemas.ResponsesTool{keepNS, webNS},
+			wantTypes: []schemas.ResponsesToolType{schemas.ResponsesToolTypeNamespace, schemas.ResponsesToolTypeNamespace},
+			wantNames: []string{"multi_agent_v1", "web"},
+		},
+		{
+			name:                  "custom provider on a mantle base drops web namespace and substitutes",
+			provider:              schemas.ModelProvider("my-mantle"),
+			baseProvider:          schemas.BedrockMantle,
+			tools:                 []schemas.ResponsesTool{keepNS, webNS},
+			wantTypes:             []schemas.ResponsesToolType{schemas.ResponsesToolTypeNamespace, schemas.ResponsesToolTypeWebSearch},
+			wantNames:             []string{"multi_agent_v1", ""},
+			wantExternalWebAccess: schemas.Ptr(false),
+		},
+		{
+			name:         "custom provider on a bedrock base drops web namespace without substitution",
+			provider:     schemas.ModelProvider("my-bedrock"),
+			baseProvider: schemas.Bedrock,
+			tools:        []schemas.ResponsesTool{keepNS, webNS},
+			wantTypes:    []schemas.ResponsesToolType{schemas.ResponsesToolTypeNamespace},
+			wantNames:    []string{"multi_agent_v1"},
+		},
+		{
+			name:         "custom provider on an openai base keeps the web namespace",
+			provider:     schemas.ModelProvider("my-openai"),
+			baseProvider: schemas.OpenAI,
+			tools:        []schemas.ResponsesTool{keepNS, webNS},
+			wantTypes:    []schemas.ResponsesToolType{schemas.ResponsesToolTypeNamespace, schemas.ResponsesToolTypeNamespace},
+			wantNames:    []string{"multi_agent_v1", "web"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			bifrostReq := &schemas.BifrostResponsesRequest{
+				Provider: tc.provider,
+				Model:    "openai.gpt-5.6-luna",
+				Input: []schemas.ResponsesMessage{{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("hi")},
+				}},
+				Params: &schemas.ResponsesParameters{Tools: tc.tools},
+			}
+			var ctx *schemas.BifrostContext
+			if tc.baseProvider != "" {
+				ctx = schemas.NewBifrostContextWithValue(context.Background(), schemas.NoDeadline,
+					schemas.BifrostContextKeyBaseProviderType, tc.baseProvider)
+			}
+			result := ToOpenAIResponsesRequest(ctx, bifrostReq)
+			require.NotNil(t, result)
+
+			gotTypes := make([]schemas.ResponsesToolType, 0, len(result.Tools))
+			gotNames := make([]string, 0, len(result.Tools))
+			for _, tool := range result.Tools {
+				gotTypes = append(gotTypes, tool.Type)
+				name := ""
+				if tool.Name != nil {
+					name = *tool.Name
+				}
+				gotNames = append(gotNames, name)
+			}
+			require.Equal(t, tc.wantTypes, gotTypes)
+			require.Equal(t, tc.wantNames, gotNames)
+
+			if tc.wantExternalWebAccess != nil {
+				var ws *schemas.ResponsesToolWebSearch
+				for _, tool := range result.Tools {
+					if tool.Type == schemas.ResponsesToolTypeWebSearch {
+						ws = tool.ResponsesToolWebSearch
+					}
+				}
+				require.NotNil(t, ws)
+				require.NotNil(t, ws.ExternalWebAccess)
+				require.Equal(t, *tc.wantExternalWebAccess, *ws.ExternalWebAccess)
+			}
+
+			// The caller's slice must not be mutated.
+			require.Len(t, bifrostReq.Params.Tools, len(tc.tools))
+		})
+	}
 }

--- a/docs/cli-agents/codex-cli.mdx
+++ b/docs/cli-agents/codex-cli.mdx
@@ -31,10 +31,20 @@ export OPENAI_API_KEY=<bifrost_virtual_key>
 ```
 
 ```toml
-openai_base_url="http://localhost:8080/openai/v1"
-env_key="OPENAI_API_KEY"
 model = "openai/gpt-5.4"
+model_provider = "bifrost"
+
+[model_providers.bifrost]
+name = "Bifrost"
+base_url = "http://localhost:8080/openai/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "responses"
+supports_websockets = false
 ```
+
+<Warning>
+Use a named `model_providers` entry rather than `openai_base_url`. With `openai_base_url`, Codex keeps its built-in OpenAI provider and sends its client-side `web` namespace tool (standalone web search), which Amazon Bedrock rejects with `User-defined namespace 'web' collides with an existing tool namespace`. With a named provider, Codex sends the hosted `web_search` tool instead, which Bedrock Mantle supports.
+</Warning>
 
 Always run `codex` from the same terminal session where you exported variables, or restart the terminal after changing your profile. GUI-launched terminals or IDEs may not pick up shell-profile exports unless the environment is configured there as well.
 


### PR DESCRIPTION
## Summary

Amazon Bedrock (both the runtime and Mantle Responses endpoints) rejects user-defined namespace tools whose names collide with its reserved server-side namespaces (`web`, `image_gen`, `browser`, `python`), returning HTTP 400 `User-defined namespace 'web' collides with an existing tool namespace`. Codex sends a client-side `web` namespace tool (`web.run`) whenever it believes it is talking to OpenAI, which happens when Bifrost is configured via `openai_base_url`. This PR drops those reserved namespace tools before forwarding requests to Bedrock, and on Bedrock Mantle substitutes a dropped `web` namespace with the hosted `web_search` tool (`external_web_access=false`), matching what AWS documents for Codex on Mantle.

## Changes

- Added `reservedToolNamespaces` mapping for `Bedrock` and `BedrockMantle` providers listing the four names Bedrock reserves (`web`, `image_gen`, `browser`, `python`).
- Added `dropReservedNamespaceTools` which filters out reserved namespace tools and, when targeting Bedrock Mantle and no `web_search` tool is already present, appends the hosted `web_search` tool with `external_web_access=false`.
- Wired the drop logic into `ToOpenAIResponsesRequest` after the additional-tools hoist step and before `filterUnsupportedTools`, so both user-supplied and hoisted namespace tools are handled and any substituted `web_search` goes through the normal copy path.
- Updated the Codex CLI docs to recommend using a named `model_providers` entry instead of `openai_base_url`, which causes Codex to send the hosted `web_search` tool rather than the client-side `web` namespace, avoiding the collision entirely.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

```sh
go test ./core/providers/openai/... -run TestToOpenAIResponsesRequest_DropsReservedNamespaceForBedrock -v
go test ./...
```

Expected: the new test cases pass, confirming that:
- Bedrock Mantle drops the `web` namespace and appends `web_search` with `external_web_access=false` when no `web_search` was already present.
- Bedrock Mantle preserves a caller-supplied `web_search` tool with its original `external_web_access` value.
- Bedrock runtime drops the `web` namespace without substitution.
- OpenAI passes the `web` namespace through unchanged.
- The caller's original tool slice is not mutated in any case.

To validate end-to-end, configure Codex with a named `model_providers.bifrost` entry pointing at a Bifrost instance backed by a Bedrock Mantle model and confirm requests succeed without a 400 namespace collision error.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Live-verified against `openai.gpt-5.6-luna` on Bedrock Mantle on 2026-09-09.

## Security considerations

None. This change only filters tool definitions before forwarding to the provider; no auth, secrets, or PII are involved.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable