### PR TITLE
fix(helm): support multiple access profiles on governance roles

### DIFF
--- a/helm-charts/bifrost/README.md
+++ b/helm-charts/bifrost/README.md
@@ -8,6 +8,10 @@ Official Helm charts for deploying [Bifrost](https://github.com/maximhq/bifrost)
 
 ## Changelog
 
+### 2.1.41
+
+- Added `bifrost.governance.roles[].access_profiles` for granting multiple access profiles to a role. The plural list takes precedence over the deprecated singular `access_profile`; an explicit empty list removes all profile grants.
+
 ### 2.1.40
 
 - Added `bifrost.governance.roles[].entity_dac` — per-entity Data Access Control overrides keyed by resource name, each set to `own-data`, `team-data`, or `all-data`. Resources accepting an override today: `Logs`, `MCPLogs`, `AuditLogs`, `VirtualKeys`, `Users`, `Teams`, `Customers`, `BusinessUnits`, `RBAC`, `APIKeys`, `AccessProfiles`, `PromptRepository`, `RoutingRules`, `GuardrailsConfig`, `MCPGateway`, `VirtualMCPs`, `Projects` 

--- a/helm-charts/bifrost/templates/_helpers.tpl
+++ b/helm-charts/bifrost/templates/_helpers.tpl
@@ -591,7 +591,11 @@ false
 {{- if .description }}{{- $_ := set $role "description" .description }}{{- end }}
 {{- if .dac }}{{- $_ := set $role "dac" .dac }}{{- end }}
 {{- if .entity_dac }}{{- $_ := set $role "entity_dac" .entity_dac }}{{- end }}
-{{- if .access_profile }}{{- $_ := set $role "access_profile" .access_profile }}{{- end }}
+{{- if hasKey . "access_profiles" }}
+{{- $_ := set $role "access_profiles" .access_profiles }}
+{{- else if .access_profile }}
+{{- $_ := set $role "access_profile" .access_profile }}
+{{- end }}
 {{- if .permissions }}{{- $_ := set $role "permissions" .permissions }}{{- end }}
 {{- $roles = append $roles $role }}
 {{- end }}

--- a/helm-charts/bifrost/values.schema.json
+++ b/helm-charts/bifrost/values.schema.json
@@ -1888,6 +1888,13 @@
                   "access_profile": {
                     "type": "string"
                   },
+                  "access_profiles": {
+                    "type": "array",
+                    "description": "Names of all access profiles granted by this role. When present, this field takes precedence over access_profile; an empty list removes all profile grants.",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
                   "permissions": {
                     "type": "array",
                     "items": {

--- a/helm-charts/bifrost/values.yaml
+++ b/helm-charts/bifrost/values.yaml
@@ -879,7 +879,8 @@ bifrost:
       #   # GuardrailsConfig, MCPGateway, VirtualMCPs, Projects.
       #   entity_dac:
       #     VirtualKeys: "own-data"  # team-data everywhere else, but only their own keys
-      #   access_profile: "analyst-profile"  # Optional: name of an access_profile to attach
+      #   access_profiles:                    # Optional: names of all access profiles to grant
+      #     - "analyst-profile"              # Takes precedence over deprecated access_profile
       #   permissions:
       #     - resource: "Logs"
       #       operation: "View"

--- a/transports/config.schema.json
+++ b/transports/config.schema.json
@@ -892,6 +892,13 @@
                 "type": "string",
                 "description": "Name of the access profile (defined in access_profiles) to attach as the default for this role. Changing this field triggers a re-sync on next startup. Leave unset to let the dashboard manage the assignment."
               },
+              "access_profiles": {
+                "type": "array",
+                "description": "Names of all access profiles granted by this role. When present, this field takes precedence over access_profile; an empty list removes all profile grants.",
+                "items": {
+                  "type": "string"
+                }
+              },
               "permissions": {
                 "type": "array",
                 "description": "List of resource+operation permission pairs to grant to this role",


### PR DESCRIPTION
## Summary

Adds Helm support for assigning multiple access profiles to a governance role through `access_profiles`.

Bifrost supports multiple access profiles, but the Helm and config schemas currently accept only the deprecated singular `access_profile`, making the plural configuration unavailable through the chart.

## Changes

- Added `access_profiles` as an array of strings to the role definitions in `helm-charts/bifrost/values.schema.json` and `transports/config.schema.json`.
- Updated `_helpers.tpl` to render `access_profiles`.
- Preserved compatibility with the singular `access_profile` field.
- Made the plural field authoritative when both fields are present.
- Preserved an explicit `access_profiles: []`, allowing existing profile grants to be cleared.
- Updated the example in `values.yaml`.
- Added the change to the Helm `2.1.41` README changelog.

## Compatibility

Existing configurations using `access_profile` continue to render unchanged.

When both fields are supplied, `access_profiles` takes precedence. An explicitly empty plural list is rendered instead of falling back to the singular field.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## Validation

- `helm lint`
- Repository Helm template validation
- Repository Helm/config schema validation
- Schema synchronization validation
- Template renders covering multiple access profiles, plural precedence, an explicit empty plural list, and singular-field compatibility

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

This change does not alter access-profile evaluation. It exposes the existing plural role configuration through Helm while preserving the current singular-field behavior for existing installations.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [x] I verified the applicable Helm validation passes
