### PR TITLE
fix: responses event action string

### DIFF
--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -2037,6 +2037,7 @@ type ResponsesCodeExecutionCall struct {
 }
 
 type ResponsesToolMessageActionStruct struct {
+	ResponsesToolCallActionStr        *string // Bare-string action (e.g. image_generation_call's "generate")
 	ResponsesComputerToolCallAction   *ResponsesComputerToolCallAction
 	ResponsesWebSearchToolCallAction  *ResponsesWebSearchToolCallAction
 	ResponsesWebFetchToolCallAction   *ResponsesWebFetchToolCallAction
@@ -2045,6 +2046,9 @@ type ResponsesToolMessageActionStruct struct {
 }
 
 func (action ResponsesToolMessageActionStruct) MarshalJSON() ([]byte, error) {
+	if action.ResponsesToolCallActionStr != nil {
+		return MarshalSorted(*action.ResponsesToolCallActionStr)
+	}
 	if action.ResponsesComputerToolCallAction != nil {
 		return MarshalSorted(action.ResponsesComputerToolCallAction)
 	}
@@ -2064,6 +2068,13 @@ func (action ResponsesToolMessageActionStruct) MarshalJSON() ([]byte, error) {
 }
 
 func (action *ResponsesToolMessageActionStruct) UnmarshalJSON(data []byte) error {
+	// Some actions are bare strings, not objects (e.g. image_generation_call's "generate")
+	var str string
+	if err := Unmarshal(data, &str); err == nil {
+		action.ResponsesToolCallActionStr = &str
+		return nil
+	}
+
 	// First, peek at the type field to determine which variant to unmarshal
 	var typeStruct struct {
 		Type string `json:"type"`
@@ -2380,6 +2391,13 @@ type ResponsesReasoningSummary struct {
 // ResponsesImageGenerationCall represents an image generation tool call
 type ResponsesImageGenerationCall struct {
 	Result string `json:"result"`
+
+	// Generation settings echoed back on the completed item.
+	Background    *string `json:"background,omitempty"`
+	OutputFormat  *string `json:"output_format,omitempty"`
+	Quality       *string `json:"quality,omitempty"`
+	RevisedPrompt *string `json:"revised_prompt,omitempty"`
+	Size          *string `json:"size,omitempty"`
 }
 
 // -----------------------------------------------------------------------------
@@ -3585,6 +3603,7 @@ type ResponsesToolCodeInterpreter struct {
 
 // ResponsesToolImageGeneration represents a tool image generation
 type ResponsesToolImageGeneration struct {
+	Action            *string                                     `json:"action,omitempty"`             // "generate" | "edit" | "auto"
 	Background        *string                                     `json:"background,omitempty"`         // "transparent" | "opaque" | "auto"
 	InputFidelity     *string                                     `json:"input_fidelity,omitempty"`     // "high" | "low"
 	InputImageMask    *ResponsesToolImageGenerationInputImageMask `json:"input_image_mask,omitempty"`   // Optional mask for inpainting

--- a/core/schemas/responsestoolunmarshal_test.go
+++ b/core/schemas/responsestoolunmarshal_test.go
@@ -324,3 +324,142 @@ func TestResponsesToolMarshalUnmarshalRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+// =============================================================================
+// image_generation_call — OpenAI sends `action` as a bare string, not an object
+// =============================================================================
+
+// TestResponsesToolMessageBareStringAction locks in the fix for the
+// image_generation_call decode failure. OpenAI emits the completed item as
+// {"type":"image_generation_call","action":"generate","result":"<base64>"},
+// but ResponsesToolMessageActionStruct.UnmarshalJSON opened by peeking at
+// `.type`, which cannot be read out of a JSON string. Decoding failed with
+// "failed to peek at type field", which killed the whole non-streaming
+// response and silently dropped the two stream events carrying the image
+// (response.output_item.done and response.completed) — leaving the stream with
+// no terminal event and surfacing as a bogus "provider closed the stream"
+// truncation error.
+func TestResponsesToolMessageBareStringAction(t *testing.T) {
+	const event = `{"type":"response.output_item.done","output_index":0,"sequence_number":6,` +
+		`"item":{"id":"ig_1","type":"image_generation_call","status":"completed",` +
+		`"action":"generate","result":"iVBORw0KGgoAAAANSUhEUg=="}}`
+
+	var stream BifrostResponsesStreamResponse
+	require.NoError(t, Unmarshal([]byte(event), &stream),
+		"a bare-string action must not break the item decode")
+
+	require.NotNil(t, stream.Item)
+	require.NotNil(t, stream.Item.ResponsesToolMessage)
+	require.NotNil(t, stream.Item.ResponsesToolMessage.Action)
+	require.NotNil(t, stream.Item.ResponsesToolMessage.Action.ResponsesToolCallActionStr)
+	assert.Equal(t, "generate", *stream.Item.ResponsesToolMessage.Action.ResponsesToolCallActionStr)
+
+	require.NotNil(t, stream.Item.ResponsesToolMessage.ResponsesImageGenerationCall)
+	assert.Equal(t, "iVBORw0KGgoAAAANSUhEUg==",
+		stream.Item.ResponsesToolMessage.ResponsesImageGenerationCall.Result,
+		"the base64 image must survive the decode")
+
+	out, err := MarshalSorted(stream.Item)
+	require.NoError(t, err)
+	assert.JSONEq(t,
+		`{"id":"ig_1","type":"image_generation_call","status":"completed",`+
+			`"action":"generate","result":"iVBORw0KGgoAAAANSUhEUg=="}`,
+		string(out),
+		"action must be re-emitted verbatim for drop-in clients")
+}
+
+// TestResponsesToolMessageObjectActionsUnchanged guards the object variants of
+// the action union against the string probe added ahead of the type peek.
+func TestResponsesToolMessageObjectActionsUnchanged(t *testing.T) {
+	tests := []struct {
+		name   string
+		action string
+		assert func(t *testing.T, a *ResponsesToolMessageActionStruct)
+	}{
+		{
+			name:   "web search action",
+			action: `{"type":"search","query":"sunset"}`,
+			assert: func(t *testing.T, a *ResponsesToolMessageActionStruct) {
+				require.NotNil(t, a.ResponsesWebSearchToolCallAction)
+			},
+		},
+		{
+			name:   "computer use action",
+			action: `{"type":"click","button":"left","x":10,"y":20}`,
+			assert: func(t *testing.T, a *ResponsesToolMessageActionStruct) {
+				require.NotNil(t, a.ResponsesComputerToolCallAction)
+			},
+		},
+		{
+			name:   "local shell action",
+			action: `{"type":"exec","command":["ls"]}`,
+			assert: func(t *testing.T, a *ResponsesToolMessageActionStruct) {
+				require.NotNil(t, a.ResponsesLocalShellToolCallAction)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var action ResponsesToolMessageActionStruct
+			require.NoError(t, Unmarshal([]byte(tt.action), &action))
+			assert.Nil(t, action.ResponsesToolCallActionStr,
+				"an object action must not be captured by the string probe")
+			tt.assert(t, &action)
+		})
+	}
+}
+
+// TestResponsesImageGenerationCallSettings covers the rest of the completed
+// image_generation_call item. ResponsesImageGenerationCall modelled only
+// `result`, so the settings OpenAI echoes back alongside the base64 image were
+// dropped from the item Bifrost re-emits on the native /v1 path.
+func TestResponsesImageGenerationCallSettings(t *testing.T) {
+	const item = `{"id":"ig_1","type":"image_generation_call","status":"completed",` +
+		`"action":"generate","background":"opaque","output_format":"png","quality":"low",` +
+		`"size":"1024x1024","revised_prompt":"a sunset over mountains","result":"iVBORw0KGgo="}`
+
+	var msg ResponsesMessage
+	require.NoError(t, Unmarshal([]byte(item), &msg))
+
+	require.NotNil(t, msg.ResponsesToolMessage)
+	call := msg.ResponsesToolMessage.ResponsesImageGenerationCall
+	require.NotNil(t, call)
+
+	assert.Equal(t, "iVBORw0KGgo=", call.Result)
+	for name, got := range map[string]*string{
+		"background":     call.Background,
+		"output_format":  call.OutputFormat,
+		"quality":        call.Quality,
+		"size":           call.Size,
+		"revised_prompt": call.RevisedPrompt,
+	} {
+		require.NotNil(t, got, "%s must survive the decode", name)
+	}
+	assert.Equal(t, "opaque", *call.Background)
+	assert.Equal(t, "png", *call.OutputFormat)
+	assert.Equal(t, "low", *call.Quality)
+	assert.Equal(t, "1024x1024", *call.Size)
+	assert.Equal(t, "a sunset over mountains", *call.RevisedPrompt)
+
+	out, err := MarshalSorted(msg)
+	require.NoError(t, err)
+	assert.JSONEq(t, item, string(out), "the completed item must round-trip unchanged")
+}
+
+// TestResponsesToolImageGenerationAction covers `action` on the image_generation
+// tool definition, which selects generate/edit/auto for the tool's calls.
+func TestResponsesToolImageGenerationAction(t *testing.T) {
+	const def = `{"type":"image_generation","action":"edit","quality":"high","size":"1024x1536"}`
+
+	var tool ResponsesTool
+	require.NoError(t, Unmarshal([]byte(def), &tool))
+
+	require.NotNil(t, tool.ResponsesToolImageGeneration)
+	require.NotNil(t, tool.ResponsesToolImageGeneration.Action)
+	assert.Equal(t, "edit", *tool.ResponsesToolImageGeneration.Action)
+
+	out, err := MarshalSorted(tool)
+	require.NoError(t, err)
+	assert.JSONEq(t, def, string(out))
+}

--- a/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
+++ b/tests/e2e/api/HARNESS_COVERAGE_BACKLOG.md
@@ -55,7 +55,7 @@ Sources:
 - [ ] **File search** (dropped earlier; needs vector_store setup) — `tools: [{ type: "file_search", vector_store_ids: [...] }]`
 - [ ] **Computer use preview** (`tools: [{ type: "computer_use_preview", display_width, display_height, environment }]`)
 - [~] **MCP tool** (`tools: [{ type: "mcp", server_label, server_url }]`) — drop-path covered for non-MCP providers (Bedrock + Vertex) via "MCP Tool Handling cross-cut" (regression #3795); **OpenAI/Anthropic forward-to-connector path still untested**
-- [ ] **Image generation** (`tools: [{ type: "image_generation" }]` requires gpt-image-1 access)
+- [x] **Image generation** (`tools: [{ type: "image_generation" }]` requires gpt-image-1 access) — folder 76 (#7059 / PR #7060): bare-string `action` decode + the settings echoed back on the completed item, across native `/v1/responses` (non-streaming + streaming) and the `/openai` drop-in stream
 - [x] **Reasoning summary** (`reasoning: { summary: "auto" }`) — OpenAI passthrough in "12. Backlog Coverage" (`summary_index + obfuscation preserved`); the `reasoning_summary_*` event fields themselves across Gemini/Vertex/Anthropic/Bedrock in "72. Reasoning Summary Streaming Event Fields"
 - [ ] **Background mode** (`background: true`) — async execution
 - [ ] **Truncation strategy** (`truncation: "auto"`)

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -145280,6 +145280,162 @@
           }
         }
       ]
+    },
+    {
+      "name": "76. OpenAI image_generation tool call decode (#7059 / PR #7060)",
+      "description": "Regression coverage for PR #7060 (fixes #7059): OpenAI emits an image_generation_call item with `action` as a bare JSON string (\"generate\"), but ResponsesToolMessageActionStruct.UnmarshalJSON opened by peeking at `.type`, which cannot be read out of a JSON string. Non-streaming, that killed the whole decode with \"failed to peek at type field\" wrapped in \"failed to unmarshal response from provider API\". Streaming, the per-event decode in OpenAIProvider.ResponsesStream logs and continues, so it silently dropped the two events carrying the image (response.output_item.done and response.completed); the loop then hit EOF with no terminal event and SendStreamTruncatedError surfaced a bogus 502 \"provider closed the stream before sending a completion marker\". The fix probes for a bare string before the type peek, and fills in the generation settings OpenAI echoes back on the completed item (background, output_format, quality, revised_prompt, size), which ResponsesImageGenerationCall previously dropped. The native /v1/responses cases are the ones that pin the typed re-emit - the /openai drop-in returns RawResponse verbatim, so it would stay green even if the typed path were lossy. image_generation had zero coverage in this collection before this folder (HARNESS_COVERAGE_BACKLOG.md, OpenAI Responses server tools).",
+      "item": [
+        {
+          "name": "openai/gpt-5.4 native responses image_generation non-streaming decodes item settings - #7059",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "// 500/502 are deliberately NOT skipped: they are the #7059 failure signatures.",
+                  "pm.test('image_generation_call decodes and keeps its settings - #7059', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'pre-fix decode failure resurfaced').to.not.include('failed to peek at type field');",
+                  "  pm.expect(body, 'pre-fix decode failure resurfaced').to.not.include('failed to unmarshal response from provider API');",
+                  "  pm.expect(pm.response.code, 'request failed: ' + body.slice(0, 600)).to.be.below(400);",
+                  "  var out = (pm.response.json() || {}).output || [];",
+                  "  var img = null;",
+                  "  for (var i = 0; i < out.length; i++) { if (out[i].type === 'image_generation_call') { img = out[i]; break; } }",
+                  "  pm.expect(img, 'expected an image_generation_call item in output').to.not.equal(null);",
+                  "  pm.expect(img.result, 'expected base64 image data on the item').to.be.a('string');",
+                  "  pm.expect(img.result.length, 'expected non-trivial base64 image data').to.be.above(1000);",
+                  "  pm.expect(img.action, 'bare-string action must survive the decode').to.equal('generate');",
+                  "  pm.expect(img.output_format, 'output_format must survive the typed re-emit').to.be.a('string');",
+                  "  pm.expect(img.background, 'background must survive the typed re-emit').to.be.a('string');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-5.4\",\"input\":\"Generate an image of a sunset over mountains\",\"tools\":[{\"type\":\"image_generation\",\"quality\":\"low\",\"size\":\"1024x1024\",\"output_format\":\"jpeg\",\"output_compression\":30}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai/gpt-5.4 native responses image_generation streaming reaches terminal event - #7059",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "// 500/502 are deliberately NOT skipped: they are the #7059 failure signatures.",
+                  "pm.test('image_generation stream is not truncated - #7059', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'pre-fix decode failure resurfaced').to.not.include('failed to peek at type field');",
+                  "  pm.expect(body, 'pre-fix truncation error resurfaced').to.not.include('provider closed the stream');",
+                  "  pm.expect(body, 'pre-fix truncation error resurfaced').to.not.include('unexpected EOF');",
+                  "  pm.expect(pm.response.code, 'stream request failed: ' + body.slice(0, 600)).to.equal(200);",
+                  "  pm.expect(body, 'expected SSE frames').to.include('data:');",
+                  "  pm.expect(body, 'expected the image item to reach the client').to.include('image_generation_call');",
+                  "  pm.expect(body, 'bare-string action must survive the stream decode').to.include('\"action\":\"generate\"');",
+                  "  pm.expect(body, 'expected a terminal response.completed event').to.include('response.completed');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/gpt-5.4\",\"input\":\"Generate an image of a sunset over mountains\",\"stream\":true,\"tools\":[{\"type\":\"image_generation\",\"quality\":\"low\",\"size\":\"1024x1024\",\"output_format\":\"jpeg\",\"output_compression\":30}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        },
+        {
+          "name": "openai/gpt-5.4 /openai drop-in responses image_generation streaming no truncation - #7059",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "// 500/502 are deliberately NOT skipped: they are the #7059 failure signatures.",
+                  "pm.test('drop-in image_generation stream reaches its terminal event - #7059', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'pre-fix decode failure resurfaced').to.not.include('failed to peek at type field');",
+                  "  pm.expect(body, 'pre-fix truncation error resurfaced').to.not.include('provider closed the stream');",
+                  "  pm.expect(body, 'pre-fix truncation error resurfaced').to.not.include('unexpected EOF');",
+                  "  pm.expect(pm.response.code, 'stream request failed: ' + body.slice(0, 600)).to.equal(200);",
+                  "  pm.expect(body, 'expected the image item to reach the client').to.include('image_generation_call');",
+                  "  pm.expect(body, 'expected a terminal response.completed event').to.include('response.completed');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"gpt-5.4\",\"input\":\"Generate an image of a sunset over mountains\",\"stream\":true,\"tools\":[{\"type\":\"image_generation\",\"quality\":\"low\",\"size\":\"1024x1024\",\"output_format\":\"jpeg\",\"output_compression\":30}]}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/openai/v1/responses",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "openai",
+                "v1",
+                "responses"
+              ]
+            }
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes a decode failure for `image_generation_call` items where OpenAI emits `action` as a bare JSON string (e.g. `"generate"`) rather than an object. The previous `UnmarshalJSON` implementation immediately tried to peek at a `.type` field, which cannot be read from a JSON string, causing the entire decode to fail with `"failed to peek at type field"`. This silently dropped the `response.output_item.done` and `response.completed` stream events carrying the image, leaving the stream without a terminal event and surfacing as a bogus `"provider closed the stream"` truncation error.

## Changes

- `ResponsesToolMessageActionStruct` now attempts to unmarshal the action as a bare string before falling back to the object type-peek, allowing `image_generation_call`'s `"generate"` (and similar) actions to decode correctly and round-trip through `MarshalJSON`.
- `ResponsesImageGenerationCall` gains fields for the generation settings OpenAI echoes back on completed items (`background`, `output_format`, `quality`, `revised_prompt`, `size`), which were previously dropped on the native `/v1` path.
- `ResponsesToolImageGeneration` gains an `action` field (`"generate"` | `"edit"` | `"auto"`) on the tool definition itself.
- Tests added to lock in the bare-string action fix, guard existing object action variants against regression, verify the new `ResponsesImageGenerationCall` settings fields round-trip correctly, and cover the `action` field on the tool definition.

## Type of change

- [x] Bug fix
- [x] Feature

## Affected areas

- [x] Core (Go)

## How to test

```sh
go test ./core/schemas/... -run TestResponsesToolMessageBareStringAction
go test ./core/schemas/... -run TestResponsesToolMessageObjectActionsUnchanged
go test ./core/schemas/... -run TestResponsesImageGenerationCallSettings
go test ./core/schemas/... -run TestResponsesToolImageGenerationAction
go test ./...
```

All four new tests should pass. Existing round-trip tests for computer use, web search, and local shell actions must continue to pass without capturing the string probe.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. Changes are limited to JSON marshal/unmarshal logic for image generation tool call schemas.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable