### PR TITLE
feat: route prompt cache reloads through the server so enterprise can gossip them

### DIFF
--- a/transports/bifrost-http/handlers/prompts.go
+++ b/transports/bifrost-http/handlers/prompts.go
@@ -16,10 +16,12 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// PromptCacheReloader is implemented by the prompts plugin to allow the HTTP handler
-// to trigger an in-memory cache refresh after any repository mutation.
+// PromptCacheReloader triggers an in-memory prompt cache refresh after any
+// repository mutation. The server implements it rather than the plugin directly,
+// so enterprise can override the method and gossip the change to cluster peers
+// before delegating to the local reload (same shape as ReloadProvider).
 type PromptCacheReloader interface {
-	Reload(ctx context.Context) error
+	ReloadPromptCache(ctx context.Context) error
 }
 
 // PromptsHandler handles prompt repository endpoints
@@ -43,7 +45,7 @@ func (h *PromptsHandler) reloadCache(ctx context.Context) {
 	if h.reloader == nil {
 		return
 	}
-	if err := h.reloader.Reload(ctx); err != nil {
+	if err := h.reloader.ReloadPromptCache(ctx); err != nil {
 		logger.Error("failed to reload prompt cache: %v", err)
 	}
 }
@@ -864,6 +866,8 @@ func (h *PromptsHandler) createSession(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	h.reloadCache(ctx)
+
 	SendJSON(ctx, map[string]any{
 		"session": session,
 	})
@@ -930,6 +934,8 @@ func (h *PromptsHandler) updateSession(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	h.reloadCache(ctx)
+
 	SendJSON(ctx, map[string]any{
 		"session": session,
 	})
@@ -962,6 +968,8 @@ func (h *PromptsHandler) deleteSession(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
 		return
 	}
+
+	h.reloadCache(ctx)
 
 	SendJSON(ctx, map[string]any{
 		"message": "session deleted successfully",
@@ -1008,6 +1016,8 @@ func (h *PromptsHandler) renameSession(ctx *fasthttp.RequestCtx) {
 		SendError(ctx, fasthttp.StatusInternalServerError, err.Error())
 		return
 	}
+
+	h.reloadCache(ctx)
 
 	session.Name = req.Name
 	SendJSON(ctx, map[string]any{

--- a/transports/bifrost-http/handlers/prompts.go
+++ b/transports/bifrost-http/handlers/prompts.go
@@ -16,10 +16,7 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-// PromptCacheReloader triggers an in-memory prompt cache refresh after any
-// repository mutation. The server implements it rather than the plugin directly,
-// so enterprise can override the method and gossip the change to cluster peers
-// before delegating to the local reload (same shape as ReloadProvider).
+// PromptCacheReloader refreshes the in-memory prompt cache after a repository mutation.
 type PromptCacheReloader interface {
 	ReloadPromptCache(ctx context.Context) error
 }
@@ -139,28 +136,28 @@ type CreateVersionRequest struct {
 	ModelParams   tables.ModelParams     `json:"model_params"`
 	Provider      string                 `json:"provider"`
 	Model         string                 `json:"model"`
-	Variables     tables.PromptVariables  `json:"variables,omitempty"`
+	Variables     tables.PromptVariables `json:"variables,omitempty"`
 }
 
 // CreateSessionRequest represents the request body for creating a session
 type CreateSessionRequest struct {
-	Name        string                  `json:"name"`
-	VersionID   *uint                   `json:"version_id,omitempty"`
-	Messages    []tables.PromptMessage  `json:"messages,omitempty"`
-	ModelParams tables.ModelParams      `json:"model_params"`
-	Provider    string                  `json:"provider"`
-	Model       string                  `json:"model"`
-	Variables   tables.PromptVariables  `json:"variables,omitempty"`
+	Name        string                 `json:"name"`
+	VersionID   *uint                  `json:"version_id,omitempty"`
+	Messages    []tables.PromptMessage `json:"messages,omitempty"`
+	ModelParams tables.ModelParams     `json:"model_params"`
+	Provider    string                 `json:"provider"`
+	Model       string                 `json:"model"`
+	Variables   tables.PromptVariables `json:"variables,omitempty"`
 }
 
 // UpdateSessionRequest represents the request body for updating a session
 type UpdateSessionRequest struct {
-	Name        string                  `json:"name"`
-	Messages    []tables.PromptMessage  `json:"messages"`
-	ModelParams tables.ModelParams      `json:"model_params"`
-	Provider    string                  `json:"provider"`
-	Model       string                  `json:"model"`
-	Variables   tables.PromptVariables  `json:"variables,omitempty"`
+	Name        string                 `json:"name"`
+	Messages    []tables.PromptMessage `json:"messages"`
+	ModelParams tables.ModelParams     `json:"model_params"`
+	Provider    string                 `json:"provider"`
+	Model       string                 `json:"model"`
+	Variables   tables.PromptVariables `json:"variables,omitempty"`
 }
 
 // RenameSessionRequest represents the request body for renaming a session

--- a/transports/bifrost-http/handlers/promptsreload_test.go
+++ b/transports/bifrost-http/handlers/promptsreload_test.go
@@ -1,0 +1,228 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/maximhq/bifrost/framework/configstore"
+	"github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/require"
+	"github.com/valyala/fasthttp"
+	"gorm.io/gorm"
+)
+
+// promptReloadStore implements only the prompt repository slice of ConfigStore.
+// Every write succeeds unless writeErr is set, which is enough to tell apart
+// "the handler reloaded" from "the handler reloaded even though the write failed".
+type promptReloadStore struct {
+	configstore.ConfigStore
+	writeErr error
+}
+
+func (s *promptReloadStore) GetFolderByID(context.Context, string) (*tables.TableFolder, error) {
+	return &tables.TableFolder{ID: "folder-1", Name: "folder"}, nil
+}
+func (s *promptReloadStore) DeleteFolder(context.Context, string) error { return s.writeErr }
+func (s *promptReloadStore) GetPromptByID(context.Context, string) (*tables.TablePrompt, error) {
+	return &tables.TablePrompt{ID: "prompt-1", Name: "prompt"}, nil
+}
+func (s *promptReloadStore) CreatePrompt(context.Context, *tables.TablePrompt, ...*gorm.DB) error {
+	return s.writeErr
+}
+func (s *promptReloadStore) UpdatePrompt(context.Context, *tables.TablePrompt) error {
+	return s.writeErr
+}
+func (s *promptReloadStore) DeletePrompt(context.Context, string) error { return s.writeErr }
+func (s *promptReloadStore) CreatePromptVersion(context.Context, *tables.TablePromptVersion) error {
+	return s.writeErr
+}
+func (s *promptReloadStore) DeletePromptVersion(context.Context, uint) error { return s.writeErr }
+func (s *promptReloadStore) GetPromptSessionByID(context.Context, uint) (*tables.TablePromptSession, error) {
+	return &tables.TablePromptSession{
+		ID:       1,
+		PromptID: "prompt-1",
+		Name:     "session",
+		Messages: []tables.TablePromptSessionMessage{{PromptID: "prompt-1", Message: promptTestMessage}},
+	}, nil
+}
+func (s *promptReloadStore) CreatePromptSession(context.Context, *tables.TablePromptSession) error {
+	return s.writeErr
+}
+func (s *promptReloadStore) UpdatePromptSession(context.Context, *tables.TablePromptSession) error {
+	return s.writeErr
+}
+func (s *promptReloadStore) RenamePromptSession(context.Context, uint, string) error {
+	return s.writeErr
+}
+func (s *promptReloadStore) DeletePromptSession(context.Context, uint) error { return s.writeErr }
+
+// promptTestMessage is the smallest valid message body. PromptMessage is a
+// json.RawMessage alias, so a zero value fails to marshal.
+var promptTestMessage = tables.PromptMessage(`{"role":"user","content":"hi"}`)
+
+type countingPromptReloader struct {
+	calls int
+	err   error
+}
+
+func (r *countingPromptReloader) ReloadPromptCache(context.Context) error {
+	r.calls++
+	return r.err
+}
+
+// promptMutation is one write endpoint: the handler method, the route param it
+// reads, and a body that gets it as far as the store write.
+type promptMutation struct {
+	name    string
+	invoke  func(h *PromptsHandler, ctx *fasthttp.RequestCtx)
+	routeID string
+	body    any
+}
+
+func promptMutations() []promptMutation {
+	return []promptMutation{
+		{
+			name:    "deleteFolder",
+			invoke:  (*PromptsHandler).deleteFolder,
+			routeID: "folder-1",
+		},
+		{
+			name:   "createPrompt",
+			invoke: (*PromptsHandler).createPrompt,
+			body:   CreatePromptRequest{Name: "greeting"},
+		},
+		{
+			name:    "updatePrompt",
+			invoke:  (*PromptsHandler).updatePrompt,
+			routeID: "prompt-1",
+			body:    UpdatePromptRequest{Name: "greeting v2"},
+		},
+		{
+			name:    "deletePrompt",
+			invoke:  (*PromptsHandler).deletePrompt,
+			routeID: "prompt-1",
+		},
+		{
+			name:    "createVersion",
+			invoke:  (*PromptsHandler).createVersion,
+			routeID: "prompt-1",
+			body:    CreateVersionRequest{CommitMessage: "first", Messages: []tables.PromptMessage{promptTestMessage}},
+		},
+		{
+			name:    "deleteVersion",
+			invoke:  (*PromptsHandler).deleteVersion,
+			routeID: "1",
+		},
+		{
+			name:    "createSession",
+			invoke:  (*PromptsHandler).createSession,
+			routeID: "prompt-1",
+			body:    CreateSessionRequest{Name: "scratch", Messages: []tables.PromptMessage{promptTestMessage}},
+		},
+		{
+			name:    "updateSession",
+			invoke:  (*PromptsHandler).updateSession,
+			routeID: "1",
+			body:    UpdateSessionRequest{Name: "scratch", Messages: []tables.PromptMessage{promptTestMessage}},
+		},
+		{
+			name:    "deleteSession",
+			invoke:  (*PromptsHandler).deleteSession,
+			routeID: "1",
+		},
+		{
+			name:    "renameSession",
+			invoke:  (*PromptsHandler).renameSession,
+			routeID: "1",
+			body:    RenameSessionRequest{Name: "renamed"},
+		},
+		{
+			name:    "commitSession",
+			invoke:  (*PromptsHandler).commitSession,
+			routeID: "1",
+			body:    CommitSessionRequest{CommitMessage: "publish"},
+		},
+	}
+}
+
+func promptRequestCtx(t *testing.T, m promptMutation) *fasthttp.RequestCtx {
+	t.Helper()
+	ctx := &fasthttp.RequestCtx{}
+	if m.routeID != "" {
+		ctx.SetUserValue("id", m.routeID)
+	}
+	if m.body != nil {
+		payload, err := json.Marshal(m.body)
+		require.NoError(t, err)
+		ctx.Request.SetBody(payload)
+	}
+	return ctx
+}
+
+// Every write endpoint has to reload, because in a cluster the reload is also
+// what gossips the change to the other nodes. An endpoint that skips it leaves
+// peers resolving prompts against a stale in-memory index.
+func TestPromptMutationsReloadCache(t *testing.T) {
+	SetLogger(&mockLogger{})
+	for _, m := range promptMutations() {
+		t.Run(m.name, func(t *testing.T) {
+			reloader := &countingPromptReloader{}
+			handler := NewPromptsHandler(&promptReloadStore{}, reloader)
+			ctx := promptRequestCtx(t, m)
+
+			m.invoke(handler, ctx)
+
+			require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode(), string(ctx.Response.Body()))
+			require.Equal(t, 1, reloader.calls)
+		})
+	}
+}
+
+func TestPromptMutationsDoNotReloadOnStoreFailure(t *testing.T) {
+	SetLogger(&mockLogger{})
+	for _, m := range promptMutations() {
+		t.Run(m.name, func(t *testing.T) {
+			reloader := &countingPromptReloader{}
+			handler := NewPromptsHandler(&promptReloadStore{writeErr: errors.New("database unavailable")}, reloader)
+			ctx := promptRequestCtx(t, m)
+
+			m.invoke(handler, ctx)
+
+			require.Equal(t, fasthttp.StatusInternalServerError, ctx.Response.StatusCode())
+			require.Zero(t, reloader.calls, "peers must not be told to reload a write that did not land")
+		})
+	}
+}
+
+// The reloader is nil when the prompts plugin is not loaded, and a reload error
+// is logged rather than failing the write the user already made.
+func TestPromptMutationsSurviveReloaderProblems(t *testing.T) {
+	SetLogger(&mockLogger{})
+	body := CreatePromptRequest{Name: "greeting"}
+	payload, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	t.Run("nil reloader", func(t *testing.T) {
+		handler := NewPromptsHandler(&promptReloadStore{}, nil)
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetBody(payload)
+
+		handler.createPrompt(ctx)
+
+		require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+	})
+
+	t.Run("failing reloader", func(t *testing.T) {
+		reloader := &countingPromptReloader{err: errors.New("cluster unreachable")}
+		handler := NewPromptsHandler(&promptReloadStore{}, reloader)
+		ctx := &fasthttp.RequestCtx{}
+		ctx.Request.SetBody(payload)
+
+		handler.createPrompt(ctx)
+
+		require.Equal(t, fasthttp.StatusOK, ctx.Response.StatusCode())
+		require.Equal(t, 1, reloader.calls)
+	})
+}

--- a/transports/bifrost-http/handlers/promptsreload_test.go
+++ b/transports/bifrost-http/handlers/promptsreload_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 // promptReloadStore implements only the prompt repository slice of ConfigStore.
-// Every write succeeds unless writeErr is set, which is enough to tell apart
-// "the handler reloaded" from "the handler reloaded even though the write failed".
 type promptReloadStore struct {
 	configstore.ConfigStore
 	writeErr error
@@ -58,8 +56,7 @@ func (s *promptReloadStore) RenamePromptSession(context.Context, uint, string) e
 }
 func (s *promptReloadStore) DeletePromptSession(context.Context, uint) error { return s.writeErr }
 
-// promptTestMessage is the smallest valid message body. PromptMessage is a
-// json.RawMessage alias, so a zero value fails to marshal.
+// promptTestMessage is the smallest valid message body; a zero PromptMessage fails to marshal.
 var promptTestMessage = tables.PromptMessage(`{"role":"user","content":"hi"}`)
 
 type countingPromptReloader struct {
@@ -72,8 +69,7 @@ func (r *countingPromptReloader) ReloadPromptCache(context.Context) error {
 	return r.err
 }
 
-// promptMutation is one write endpoint: the handler method, the route param it
-// reads, and a body that gets it as far as the store write.
+// promptMutation is one write endpoint: its handler, route param, and request body.
 type promptMutation struct {
 	name    string
 	invoke  func(h *PromptsHandler, ctx *fasthttp.RequestCtx)
@@ -161,9 +157,7 @@ func promptRequestCtx(t *testing.T, m promptMutation) *fasthttp.RequestCtx {
 	return ctx
 }
 
-// Every write endpoint has to reload, because in a cluster the reload is also
-// what gossips the change to the other nodes. An endpoint that skips it leaves
-// peers resolving prompts against a stale in-memory index.
+// The reload is what gossips the change, so every write endpoint has to do it.
 func TestPromptMutationsReloadCache(t *testing.T) {
 	SetLogger(&mockLogger{})
 	for _, m := range promptMutations() {
@@ -196,8 +190,7 @@ func TestPromptMutationsDoNotReloadOnStoreFailure(t *testing.T) {
 	}
 }
 
-// The reloader is nil when the prompts plugin is not loaded, and a reload error
-// is logged rather than failing the write the user already made.
+// A missing plugin or a failed reload must not fail the write itself.
 func TestPromptMutationsSurviveReloaderProblems(t *testing.T) {
 	SetLogger(&mockLogger{})
 	body := CreatePromptRequest{Name: "greeting"}

--- a/transports/bifrost-http/server/promptcache_test.go
+++ b/transports/bifrost-http/server/promptcache_test.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
+	"github.com/stretchr/testify/require"
+)
+
+type fakePromptsPlugin struct {
+	name    string
+	reloads int
+	err     error
+}
+
+func (p *fakePromptsPlugin) GetName() string { return p.name }
+func (p *fakePromptsPlugin) Cleanup() error  { return nil }
+func (p *fakePromptsPlugin) Reload(context.Context) error {
+	p.reloads++
+	return p.err
+}
+
+func promptCacheServer(plugins ...schemas.BasePlugin) *BifrostHTTPServer {
+	config := &lib.Config{}
+	config.BasePlugins.Store(&plugins)
+	return &BifrostHTTPServer{
+		Config: config,
+		Ctx:    schemas.NewBifrostContext(context.Background(), schemas.NoDeadline),
+	}
+}
+
+func TestReloadPromptCacheReloadsThePlugin(t *testing.T) {
+	plugin := &fakePromptsPlugin{name: "prompts"}
+	server := promptCacheServer(plugin)
+
+	require.NoError(t, server.ReloadPromptCache(context.Background()))
+	require.Equal(t, 1, plugin.reloads)
+}
+
+// A prompt write must not fail just because the prompts plugin is disabled,
+// which is what the handler's previously-nil reloader allowed for.
+func TestReloadPromptCacheWithoutPluginIsNoOp(t *testing.T) {
+	server := promptCacheServer()
+
+	require.NoError(t, server.ReloadPromptCache(context.Background()))
+}
+
+func TestReloadPromptCacheUsesPluginNameFromContext(t *testing.T) {
+	plugin := &fakePromptsPlugin{name: "enterprise-prompts"}
+	server := promptCacheServer(plugin)
+	ctx := context.WithValue(context.Background(), schemas.BifrostContextKeyPromptsPluginName, "enterprise-prompts")
+	server.Ctx = schemas.NewBifrostContext(ctx, schemas.NoDeadline)
+
+	require.NoError(t, server.ReloadPromptCache(context.Background()))
+	require.Equal(t, 1, plugin.reloads, "enterprise registers the plugin under its own name")
+}
+
+func TestReloadPromptCacheReturnsPluginError(t *testing.T) {
+	plugin := &fakePromptsPlugin{name: "prompts", err: errors.New("database unavailable")}
+	server := promptCacheServer(plugin)
+
+	require.ErrorContains(t, server.ReloadPromptCache(context.Background()), "database unavailable")
+}

--- a/transports/bifrost-http/server/promptcache_test.go
+++ b/transports/bifrost-http/server/promptcache_test.go
@@ -40,8 +40,7 @@ func TestReloadPromptCacheReloadsThePlugin(t *testing.T) {
 	require.Equal(t, 1, plugin.reloads)
 }
 
-// A prompt write must not fail just because the prompts plugin is disabled,
-// which is what the handler's previously-nil reloader allowed for.
+// A prompt write must not fail just because the prompts plugin is disabled.
 func TestReloadPromptCacheWithoutPluginIsNoOp(t *testing.T) {
 	server := promptCacheServer()
 

--- a/transports/bifrost-http/server/promptcache_test.go
+++ b/transports/bifrost-http/server/promptcache_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/maximhq/bifrost/transports/bifrost-http/lib"
 	"github.com/stretchr/testify/require"
@@ -23,7 +24,14 @@ func (p *fakePromptsPlugin) Reload(context.Context) error {
 	return p.err
 }
 
+// nonReloadingPlugin is registered under the prompts plugin name but cannot reload.
+type nonReloadingPlugin struct{ name string }
+
+func (p *nonReloadingPlugin) GetName() string { return p.name }
+func (p *nonReloadingPlugin) Cleanup() error  { return nil }
+
 func promptCacheServer(plugins ...schemas.BasePlugin) *BifrostHTTPServer {
+	SetLogger(bifrost.NewNoOpLogger())
 	config := &lib.Config{}
 	config.BasePlugins.Store(&plugins)
 	return &BifrostHTTPServer{
@@ -62,4 +70,11 @@ func TestReloadPromptCacheReturnsPluginError(t *testing.T) {
 	server := promptCacheServer(plugin)
 
 	require.ErrorContains(t, server.ReloadPromptCache(context.Background()), "database unavailable")
+}
+
+// A plugin that cannot reload must not fail the write, but it does warn rather than pass silently.
+func TestReloadPromptCacheWithIncompatiblePluginIsNoOp(t *testing.T) {
+	server := promptCacheServer(&nonReloadingPlugin{name: "prompts"})
+
+	require.NoError(t, server.ReloadPromptCache(context.Background()))
 }

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -548,11 +548,18 @@ type promptCacheReloadable interface {
 
 // ReloadPromptCache rebuilds the prompts plugin's in-memory index; no-op when the plugin is not loaded.
 func (s *BifrostHTTPServer) ReloadPromptCache(ctx context.Context) error {
-	plugin, err := lib.FindPluginAs[promptCacheReloadable](s.Config, s.getPromptsPluginName())
+	name := s.getPromptsPluginName()
+	plugin, err := lib.FindPluginAs[schemas.BasePlugin](s.Config, name)
 	if err != nil || plugin == nil {
 		return nil
 	}
-	return plugin.Reload(ctx)
+	reloader, ok := plugin.(promptCacheReloadable)
+	if !ok {
+		// A plugin registered under this name that cannot reload leaves the cache stale silently.
+		logger.Warn("plugin %s does not support prompt cache reload", name)
+		return nil
+	}
+	return reloader.Reload(ctx)
 }
 
 // getGovernancePlugin safely retrieves the governance plugin with proper locking.

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -142,9 +142,6 @@ type ServerCallbacks interface {
 	ListComplexityGenerations(ctx context.Context) ([]complexity.GenerationInfo, error)
 	DeleteComplexityGeneration(ctx context.Context, namespace string) error
 	// Prompt repository related callbacks
-	// ReloadPromptCache refreshes the prompts plugin's in-memory index after a
-	// prompt, version, folder, or session write. Enterprise overrides it to
-	// gossip the change so peer nodes rebuild their own index.
 	ReloadPromptCache(ctx context.Context) error
 	// Webhook related callbacks
 	ReloadWebhookEndpoint(ctx context.Context, id string) error
@@ -544,16 +541,12 @@ func (s *BifrostHTTPServer) getPromptsPluginName() string {
 	return prompts.PluginName
 }
 
-// promptCacheReloadable is the prompts plugin's cache refresh entry point. It is
-// declared here rather than reused from handlers because the handler-facing
-// interface is named after the server callback, not the plugin method.
+// promptCacheReloadable is the prompts plugin's cache refresh entry point.
 type promptCacheReloadable interface {
 	Reload(ctx context.Context) error
 }
 
-// ReloadPromptCache rebuilds the prompts plugin's in-memory index from the config
-// store after a prompt repository write. It is a no-op when the plugin is not
-// loaded, which is what the handler's previously-nil reloader did.
+// ReloadPromptCache rebuilds the prompts plugin's in-memory index; no-op when the plugin is not loaded.
 func (s *BifrostHTTPServer) ReloadPromptCache(ctx context.Context) error {
 	plugin, err := lib.FindPluginAs[promptCacheReloadable](s.Config, s.getPromptsPluginName())
 	if err != nil || plugin == nil {

--- a/transports/bifrost-http/server/server.go
+++ b/transports/bifrost-http/server/server.go
@@ -141,6 +141,11 @@ type ServerCallbacks interface {
 	GetComplexityLLMStatus(ctx context.Context) (complexity.LLMStatusInfo, error)
 	ListComplexityGenerations(ctx context.Context) ([]complexity.GenerationInfo, error)
 	DeleteComplexityGeneration(ctx context.Context, namespace string) error
+	// Prompt repository related callbacks
+	// ReloadPromptCache refreshes the prompts plugin's in-memory index after a
+	// prompt, version, folder, or session write. Enterprise overrides it to
+	// gossip the change so peer nodes rebuild their own index.
+	ReloadPromptCache(ctx context.Context) error
 	// Webhook related callbacks
 	ReloadWebhookEndpoint(ctx context.Context, id string) error
 	RemoveWebhookEndpoint(ctx context.Context, id string) error
@@ -537,6 +542,24 @@ func (s *BifrostHTTPServer) getPromptsPluginName() string {
 		return name
 	}
 	return prompts.PluginName
+}
+
+// promptCacheReloadable is the prompts plugin's cache refresh entry point. It is
+// declared here rather than reused from handlers because the handler-facing
+// interface is named after the server callback, not the plugin method.
+type promptCacheReloadable interface {
+	Reload(ctx context.Context) error
+}
+
+// ReloadPromptCache rebuilds the prompts plugin's in-memory index from the config
+// store after a prompt repository write. It is a no-op when the plugin is not
+// loaded, which is what the handler's previously-nil reloader did.
+func (s *BifrostHTTPServer) ReloadPromptCache(ctx context.Context) error {
+	plugin, err := lib.FindPluginAs[promptCacheReloadable](s.Config, s.getPromptsPluginName())
+	if err != nil || plugin == nil {
+		return nil
+	}
+	return plugin.Reload(ctx)
 }
 
 // getGovernancePlugin safely retrieves the governance plugin with proper locking.
@@ -2380,10 +2403,6 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 		}
 		return p
 	})
-	var promptsReloader handlers.PromptCacheReloader
-	if promptsPlugin, err := lib.FindPluginAs[handlers.PromptCacheReloader](s.Config, s.getPromptsPluginName()); err == nil && promptsPlugin != nil {
-		promptsReloader = promptsPlugin
-	}
 	// Websocket handler needs to go below UI handler
 	logger.Debug("initializing websocket server")
 	if s.WebSocketHandler == nil {
@@ -2414,7 +2433,7 @@ func (s *BifrostHTTPServer) RegisterAPIRoutes(ctx context.Context, callbacks Ser
 	configHandler := handlers.NewConfigHandler(callbacks, s.Config)
 	pluginsHandler := handlers.NewPluginsHandler(callbacks, s.Config.ConfigStore)
 	sessionHandler := handlers.NewSessionHandler(s.Config.ConfigStore, s.WSTicketStore)
-	promptsHandler := handlers.NewPromptsHandler(s.Config.ConfigStore, promptsReloader)
+	promptsHandler := handlers.NewPromptsHandler(s.Config.ConfigStore, callbacks)
 	featureFlagsHandler := handlers.NewFeatureFlagsHandler(s.Config.FeatureFlags, s.Config.ConfigStore)
 	// Going ahead with API handlers
 	oauth2DiscoveryHandler := handlers.NewOAuth2DiscoveryHandler(s.Config)


### PR DESCRIPTION
## Summary

The prompts plugin keeps an in-memory index of prompts and their versions (`promptsByID`, `versionsByPromptAndNumber`), rebuilt only by its `Reload` method. `PromptsHandler` resolved the plugin directly and called it, so a reload never left the process that served the write.

The prompt rows themselves reach every node through the shared config store, so list endpoints and the UI were always correct. What did not travel is the index. On a multi-node deployment a prompt published on node A leaves node B resolving `x-bf-prompt-id` / `x-bf-prompt-version` against a stale index until it restarts: an unknown version errors, and `latest` serves the old content.

This PR moves the reload onto `ServerCallbacks` so enterprise can wrap it. The gossip itself lives in the enterprise PR; nothing here changes OSS behaviour.

## Changes

- `ServerCallbacks` gains `ReloadPromptCache(ctx) error`, implemented on `BifrostHTTPServer` next to `getPromptsPluginName`. Same shape as `ReloadProvider` and `ReloadVirtualKey`, which is how every other OSS handler already reaches enterprise cluster gossip.
- `RegisterAPIRoutes` passes `callbacks` to `NewPromptsHandler` instead of resolving the plugin itself. The old lookup is gone.
- `PromptCacheReloader.Reload` renamed to `ReloadPromptCache` so it can sit on the callbacks interface without colliding with the other `Reload*` methods.
- `createSession`, `updateSession`, `deleteSession` and `renameSession` now reload too. Sessions are not in the plugin index, so this does not affect request resolution, but the reload is also what invalidates the UI store. Without it a session saved on one node is invisible to a browser attached to another.

A missing plugin stays a no-op and a reload error is still logged rather than failing the write the user already made.

## Testing

`transports/bifrost-http/handlers/promptsreload_test.go` covers all eleven write endpoints: each reloads exactly once on success, none reloads when the store write fails, and a nil or failing reloader does not fail the request.

`transports/bifrost-http/server/promptcache_test.go` covers the plugin lookup: reloads the plugin, no-ops when it is absent, honours the plugin name from context (enterprise registers under `enterprise-prompts`), and propagates the plugin's error.

```
cd transports && go test ./bifrost-http/handlers/ ./bifrost-http/server/
```

Both packages pass in full, and `go vet ./...` is clean.

## Notes

`createFolder` and `updateFolder` still do not reload, as before. Folders are not in the plugin index so request resolution is unaffected, but a folder created on one node will not refresh another node's UI. Left out of this PR deliberately; happy to fold it in if reviewers would rather it were consistent.

Pairs with the enterprise PR that adds the `prompt` gossip entity type. Merge this one first.
