### PR TITLE
fix(bedrock-mantle): route gpt-6 to the openai/v1 path

### DIFF
--- a/core/internal/llmtests/account.go
+++ b/core/internal/llmtests/account.go
@@ -139,6 +139,7 @@ type ComprehensiveTestConfig struct {
 	FileStorageConfig        *schemas.FileStorageConfig // Typed storage config for file operations (e.g., GCS bucket for Vertex)
 	DisableParallelFor       []string                   // Test scenarios to disable parallel execution for (e.g., "Transcription" for rate-limited APIs)
 	ExpectRawRequestResponse bool                       // When true, validate rawRequest/rawResponse in ExtraFields
+	SkipChatReasoning        bool                       // Model carries reasoning on the Responses surface only, so a chat stream has none to assert on
 	PassthroughModel         string                     // Model for passthrough API tests; defaults to ChatModel when empty
 	CompactionModel          string                     // Model for compaction tests; defaults to claude-sonnet-4-6
 	ExternalCompactionModel  string                     // Model for external compaction tests; defaults to gpt-4o

--- a/core/internal/llmtests/chat_completion_stream.go
+++ b/core/internal/llmtests/chat_completion_stream.go
@@ -659,6 +659,11 @@ func RunChatCompletionStreamTest(t *testing.T, client *bifrost.Bifrost, ctx cont
 				return
 			}
 
+			if testConfig.SkipChatReasoning {
+				t.Skip("Skipping ChatCompletionStreamWithReasoningValidated: model carries reasoning on the Responses surface only")
+				return
+			}
+
 			problemPrompt := "A farmer has 100 chickens and 50 cows. Each chicken lays 5 eggs per week, and each cow produces 20 liters of milk per day. If the farmer sells eggs for $0.25 each and milk for $1.50 per liter, and it costs $2 per week to feed each chicken and $15 per week to feed each cow, what is the farmer's weekly profit?"
 			if testConfig.Provider == schemas.Cerebras {
 				problemPrompt = "Hello how are you, can you search hackernews news regarding maxim ai for me? use your tools for this"

--- a/core/providers/bedrock/baremodel_test.go
+++ b/core/providers/bedrock/baremodel_test.go
@@ -1,0 +1,57 @@
+package bedrock
+
+import (
+	"testing"
+)
+
+// TestBareModelScope pins the contract core relies on: within the scope the request
+// names the bare id mantle knows, and after it the caller's request is byte-for-byte
+// what it was, so a retry from core still carries its region prefix. The raw body
+// matters because passthrough sends it verbatim.
+func TestBareModelScope(t *testing.T) {
+	t.Run("prefixed model and raw body are rewritten, then restored", func(t *testing.T) {
+		model := "us-west-2/openai.gpt-6-astra"
+		raw := []byte(`{"model":"us-west-2/openai.gpt-6-astra","messages":[]}`)
+		origRaw := raw
+
+		restore := bareModelScope(&model, &raw)
+		if model != "openai.gpt-6-astra" {
+			t.Fatalf("model in scope = %q, want bare id", model)
+		}
+		if got := string(raw); got != `{"model":"openai.gpt-6-astra","messages":[]}` {
+			t.Fatalf("raw body in scope = %s", got)
+		}
+
+		restore()
+		if model != "us-west-2/openai.gpt-6-astra" {
+			t.Fatalf("model after restore = %q, want prefix back", model)
+		}
+		if string(raw) != string(origRaw) {
+			t.Fatalf("raw body after restore = %s, want original", raw)
+		}
+	})
+
+	t.Run("no prefix is a no-op that leaves the raw body untouched", func(t *testing.T) {
+		model := "openai.gpt-6-astra"
+		raw := []byte(`{"model":"openai.gpt-6-astra"}`)
+		before := raw
+		restore := bareModelScope(&model, &raw)
+		if model != "openai.gpt-6-astra" || string(raw) != string(before) {
+			t.Fatalf("no-prefix scope changed the request: model=%q raw=%s", model, raw)
+		}
+		restore()
+	})
+
+	t.Run("prefixed model with no raw body", func(t *testing.T) {
+		model := "us-west-2/openai.gpt-6-astra"
+		var raw []byte
+		restore := bareModelScope(&model, &raw)
+		if model != "openai.gpt-6-astra" || raw != nil {
+			t.Fatalf("scope: model=%q raw=%v", model, raw)
+		}
+		restore()
+		if model != "us-west-2/openai.gpt-6-astra" || raw != nil {
+			t.Fatalf("restore: model=%q raw=%v", model, raw)
+		}
+	})
+}

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -157,7 +157,7 @@ func (provider *BedrockProvider) mantleChatCompletions(
 		ctx,
 		provider.mantleClient,
 		url,
-		request,
+		withBareModel(request),
 		openai.BearerAuthHeader(key),
 		WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -192,7 +192,7 @@ func (provider *BedrockProvider) mantleChatCompletionsStream(
 	}
 
 	return openai.HandleOpenAIChatCompletionStreaming(
-		ctx, provider.mantleStreamingClient, url, request,
+		ctx, provider.mantleStreamingClient, url, withBareModel(request),
 		openai.BearerAuthHeader(key), WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -241,7 +241,7 @@ func (provider *BedrockProvider) mantleResponses(
 		ctx,
 		provider.mantleClient,
 		url,
-		request,
+		withBareResponsesModel(request),
 		openai.BearerAuthHeader(key),
 		WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -282,7 +282,7 @@ func (provider *BedrockProvider) mantleResponsesStream(
 	}
 
 	return openai.HandleOpenAIResponsesStreaming(
-		ctx, provider.mantleStreamingClient, url, request,
+		ctx, provider.mantleStreamingClient, url, withBareResponsesModel(request),
 		openai.BearerAuthHeader(key), WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -296,4 +296,30 @@ func (provider *BedrockProvider) mantleResponsesStream(
 		provider.logger,
 		postHookSpanFinalizer,
 	)
+}
+
+// withBareModel drops the region addressing prefix from the model a chat request
+// carries, so the body names the id mantle knows. The Converse path resolves the
+// bare id itself, but the OpenAI-compatible handlers read it off the request, and
+// mantle 404s the prefixed form. Copied rather than mutated: the caller's request
+// is what the pipeline keys pricing and logging on.
+func withBareModel(request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
+	_, bare := parseBedrockRegionAndModel(request.Model)
+	if bare == request.Model {
+		return request
+	}
+	clone := *request
+	clone.Model = bare
+	return &clone
+}
+
+// withBareResponsesModel is withBareModel for the Responses surface.
+func withBareResponsesModel(request *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
+	_, bare := parseBedrockRegionAndModel(request.Model)
+	if bare == request.Model {
+		return request
+	}
+	clone := *request
+	clone.Model = bare
+	return &clone
 }

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -143,6 +143,7 @@ func (provider *BedrockProvider) mantleChatCompletions(
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	defer bareModelScope(&request.Model, &request.RawRequestBody)()
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -157,7 +158,7 @@ func (provider *BedrockProvider) mantleChatCompletions(
 		ctx,
 		provider.mantleClient,
 		url,
-		withBareModel(request),
+		request,
 		openai.BearerAuthHeader(key),
 		WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -181,6 +182,7 @@ func (provider *BedrockProvider) mantleChatCompletionsStream(
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	defer bareModelScope(&request.Model, &request.RawRequestBody)()
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -192,7 +194,7 @@ func (provider *BedrockProvider) mantleChatCompletionsStream(
 	}
 
 	return openai.HandleOpenAIChatCompletionStreaming(
-		ctx, provider.mantleStreamingClient, url, withBareModel(request),
+		ctx, provider.mantleStreamingClient, url, request,
 		openai.BearerAuthHeader(key), WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -227,6 +229,7 @@ func (provider *BedrockProvider) mantleResponses(
 
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, canonicalModel, "responses")
+	defer bareModelScope(&request.Model, &request.RawRequestBody)()
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -241,7 +244,7 @@ func (provider *BedrockProvider) mantleResponses(
 		ctx,
 		provider.mantleClient,
 		url,
-		withBareResponsesModel(request),
+		request,
 		openai.BearerAuthHeader(key),
 		WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -271,6 +274,7 @@ func (provider *BedrockProvider) mantleResponsesStream(
 
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, canonicalModel, "responses")
+	defer bareModelScope(&request.Model, &request.RawRequestBody)()
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -282,7 +286,7 @@ func (provider *BedrockProvider) mantleResponsesStream(
 	}
 
 	return openai.HandleOpenAIResponsesStreaming(
-		ctx, provider.mantleStreamingClient, url, withBareResponsesModel(request),
+		ctx, provider.mantleStreamingClient, url, request,
 		openai.BearerAuthHeader(key), WithMantleProject(provider.networkConfig.ExtraHeaders, MantleOpenAIProjectHeader, resolveMantleProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -298,28 +302,28 @@ func (provider *BedrockProvider) mantleResponsesStream(
 	)
 }
 
-// withBareModel drops the region addressing prefix from the model a chat request
-// carries, so the body names the id mantle knows. The Converse path resolves the
-// bare id itself, but the OpenAI-compatible handlers read it off the request, and
-// mantle 404s the prefixed form. Copied rather than mutated: the caller's request
-// is what the pipeline keys pricing and logging on.
-func withBareModel(request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
-	_, bare := parseBedrockRegionAndModel(request.Model)
-	if bare == request.Model {
-		return request
+// bareModelScope rewrites request.Model (and the model field of a raw passthrough
+// body) to the bare id for the duration of a handler call, and returns the func that
+// puts both back. Nothing is copied: the caller's request is what core hands to the
+// next retry and what pricing and logging read, so it has to leave with its prefix
+// intact. The native-Anthropic handlers take the bare model through their build
+// config; the OpenAI-compatible ones read it off the request, and mantle 404s the
+// prefixed form ("The model 'us-west-2/openai.gpt-6-astra' does not exist"). Costs
+// nothing when there is no prefix, which is every request that names a region on
+// the key or the alias rather than the model.
+func bareModelScope(model *string, raw *[]byte) func() {
+	region, bare := parseBedrockRegionAndModel(*model)
+	if region == "" {
+		return func() {}
 	}
-	clone := *request
-	clone.Model = bare
-	return &clone
-}
-
-// withBareResponsesModel is withBareModel for the Responses surface.
-func withBareResponsesModel(request *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
-	_, bare := parseBedrockRegionAndModel(request.Model)
-	if bare == request.Model {
-		return request
+	origModel, origRaw := *model, *raw
+	*model = bare
+	if len(origRaw) > 0 {
+		if edited, err := providerUtils.SetJSONField(origRaw, "model", bare); err == nil {
+			*raw = edited
+		}
 	}
-	clone := *request
-	clone.Model = bare
-	return &clone
+	return func() {
+		*model, *raw = origModel, origRaw
+	}
 }

--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -55,11 +55,13 @@ func isMantleModel(ctx *schemas.BifrostContext, model string) bool {
 // mantleOpenAIURL builds the Bedrock Mantle OpenAI-compatible endpoint URL for the given
 // region, model, and API path (e.g. "chat/completions", "responses"). Pass the canonical
 // (capability-resolved) model for correct path gating; the request body still carries the
-// wire request.Model. Frontier families (closed gpt-5.x, Gemma 4, Grok) live under the "openai/v1"
-// base path; gpt-oss uses the bare "v1" path.
+// wire request.Model. Frontier families (closed gpt-5.x and gpt-6.x, Gemma 4, Grok) live under the
+// "openai/v1" base path; gpt-oss uses the bare "v1" path. Each closed generation has to be named:
+// Mantle answers a frontier model on exactly one of the two paths and 400s on the other.
 func mantleOpenAIURL(endpoints *schemas.BedrockEndpoints, region, model, path string) string {
 	base := "v1"
-	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gemma-4") || schemas.IsGrokModel(model) {
+	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gpt-6") ||
+		strings.Contains(model, "gemma-4") || schemas.IsGrokModel(model) {
 		base = "openai/v1"
 	}
 	return fmt.Sprintf("https://%s/%s/%s", resolveBedrockHost(endpoints, bedrockServiceMantle, region), base, path)

--- a/core/providers/bedrock/mantle_test.go
+++ b/core/providers/bedrock/mantle_test.go
@@ -66,6 +66,10 @@ func TestMantleOpenAIURL(t *testing.T) {
 			"https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions"},
 		{"grok uses openai/v1", "us-east-1", "xai.grok-4.3", "responses",
 			"https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses"},
+		{"gpt-6 uses openai/v1", "us-west-2", "openai.gpt-6-astra", "responses",
+			"https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses"},
+		{"gpt-6 chat uses openai/v1", "us-west-2", "gpt-6-astra", "chat/completions",
+			"https://bedrock-mantle.us-west-2.api.aws/openai/v1/chat/completions"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/core/providers/bedrockmantle/baremodel_test.go
+++ b/core/providers/bedrockmantle/baremodel_test.go
@@ -1,0 +1,57 @@
+package bedrockmantle
+
+import (
+	"testing"
+)
+
+// TestBareModelScope pins the contract core relies on: within the scope the request
+// names the bare id mantle knows, and after it the caller's request is byte-for-byte
+// what it was, so a retry from core still carries its region prefix. The raw body
+// matters because passthrough sends it verbatim.
+func TestBareModelScope(t *testing.T) {
+	t.Run("prefixed model and raw body are rewritten, then restored", func(t *testing.T) {
+		model := "us-west-2/openai.gpt-6-astra"
+		raw := []byte(`{"model":"us-west-2/openai.gpt-6-astra","messages":[]}`)
+		origRaw := raw
+
+		restore := bareModelScope(&model, &raw)
+		if model != "openai.gpt-6-astra" {
+			t.Fatalf("model in scope = %q, want bare id", model)
+		}
+		if got := string(raw); got != `{"model":"openai.gpt-6-astra","messages":[]}` {
+			t.Fatalf("raw body in scope = %s", got)
+		}
+
+		restore()
+		if model != "us-west-2/openai.gpt-6-astra" {
+			t.Fatalf("model after restore = %q, want prefix back", model)
+		}
+		if string(raw) != string(origRaw) {
+			t.Fatalf("raw body after restore = %s, want original", raw)
+		}
+	})
+
+	t.Run("no prefix is a no-op that leaves the raw body untouched", func(t *testing.T) {
+		model := "openai.gpt-6-astra"
+		raw := []byte(`{"model":"openai.gpt-6-astra"}`)
+		before := raw
+		restore := bareModelScope(&model, &raw)
+		if model != "openai.gpt-6-astra" || string(raw) != string(before) {
+			t.Fatalf("no-prefix scope changed the request: model=%q raw=%s", model, raw)
+		}
+		restore()
+	})
+
+	t.Run("prefixed model with no raw body", func(t *testing.T) {
+		model := "us-west-2/openai.gpt-6-astra"
+		var raw []byte
+		restore := bareModelScope(&model, &raw)
+		if model != "openai.gpt-6-astra" || raw != nil {
+			t.Fatalf("scope: model=%q raw=%v", model, raw)
+		}
+		restore()
+		if model != "us-west-2/openai.gpt-6-astra" || raw != nil {
+			t.Fatalf("restore: model=%q raw=%v", model, raw)
+		}
+	})
+}

--- a/core/providers/bedrockmantle/bedrockmantle.go
+++ b/core/providers/bedrockmantle/bedrockmantle.go
@@ -79,11 +79,13 @@ const defaultMantleRegion = "us-east-1"
 // region, model, and API path (e.g. "chat/completions", "responses"). The native-Anthropic
 // path is built separately by mantleAnthropicURL. Pass the canonical (capability-resolved)
 // model for correct path gating; the request body still carries the wire request.Model.
-// Frontier families (closed gpt-5.x, Gemma 4, Grok) live under the "openai/v1" base path; gpt-oss
-// uses the bare "v1" path.
+// Frontier families (closed gpt-5.x and gpt-6.x, Gemma 4, Grok) live under the "openai/v1" base
+// path; gpt-oss uses the bare "v1" path. Each closed generation has to be named: Mantle answers a
+// frontier model on exactly one of the two paths and 400s on the other.
 func mantleOpenAIURL(endpoints *schemas.BedrockEndpoints, region, model, path string) string {
 	base := "v1"
-	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gemma-4") || schemas.IsGrokModel(model) {
+	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gpt-6") ||
+		strings.Contains(model, "gemma-4") || schemas.IsGrokModel(model) {
 		base = "openai/v1"
 	}
 	return fmt.Sprintf("https://%s/%s/%s", mantleHost(endpoints, region), base, path)

--- a/core/providers/bedrockmantle/bedrockmantle.go
+++ b/core/providers/bedrockmantle/bedrockmantle.go
@@ -215,11 +215,12 @@ func (provider *BedrockMantleProvider) ChatCompletion(ctx *schemas.BifrostContex
 	}
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	defer bareModelScope(&request.Model, &request.RawRequestBody)()
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.mantleClient,
 		url,
-		withBareModel(request),
+		request,
 		openai.BearerAuthHeader(key),
 		bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -276,8 +277,9 @@ func (provider *BedrockMantleProvider) ChatCompletionStream(ctx *schemas.Bifrost
 	}
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	defer bareModelScope(&request.Model, &request.RawRequestBody)()
 	return openai.HandleOpenAIChatCompletionStreaming(
-		ctx, provider.mantleStreamingClient, url, withBareModel(request),
+		ctx, provider.mantleStreamingClient, url, request,
 		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -330,11 +332,12 @@ func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, ke
 	}
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, canonicalModel, "responses")
+	defer bareModelScope(&request.Model, &request.RawRequestBody)()
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.mantleClient,
 		url,
-		withBareResponsesModel(request),
+		request,
 		openai.BearerAuthHeader(key),
 		bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -397,8 +400,9 @@ func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostConte
 	}
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, canonicalModel, "responses")
+	defer bareModelScope(&request.Model, &request.RawRequestBody)()
 	return openai.HandleOpenAIResponsesStreaming(
-		ctx, provider.mantleStreamingClient, url, withBareResponsesModel(request),
+		ctx, provider.mantleStreamingClient, url, request,
 		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),

--- a/core/providers/bedrockmantle/bedrockmantle.go
+++ b/core/providers/bedrockmantle/bedrockmantle.go
@@ -219,7 +219,7 @@ func (provider *BedrockMantleProvider) ChatCompletion(ctx *schemas.BifrostContex
 		ctx,
 		provider.mantleClient,
 		url,
-		request,
+		withBareModel(request),
 		openai.BearerAuthHeader(key),
 		bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -277,7 +277,7 @@ func (provider *BedrockMantleProvider) ChatCompletionStream(ctx *schemas.Bifrost
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
 	return openai.HandleOpenAIChatCompletionStreaming(
-		ctx, provider.mantleStreamingClient, url, request,
+		ctx, provider.mantleStreamingClient, url, withBareModel(request),
 		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -334,7 +334,7 @@ func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, ke
 		ctx,
 		provider.mantleClient,
 		url,
-		request,
+		withBareResponsesModel(request),
 		openai.BearerAuthHeader(key),
 		bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),
@@ -398,7 +398,7 @@ func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostConte
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, canonicalModel, "responses")
 	return openai.HandleOpenAIResponsesStreaming(
-		ctx, provider.mantleStreamingClient, url, request,
+		ctx, provider.mantleStreamingClient, url, withBareResponsesModel(request),
 		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
 		provider.networkConfig.StreamIdleTimeoutInSeconds,
 		providerUtils.ShouldSendBackRawRequest(ctx, provider.sendBackRawRequest),

--- a/core/providers/bedrockmantle/bedrockmantle_test.go
+++ b/core/providers/bedrockmantle/bedrockmantle_test.go
@@ -95,3 +95,70 @@ func TestBedrockMantle(t *testing.T) {
 		llmtests.RunAllComprehensiveTests(t, client, ctx, testConfig)
 	})
 }
+
+// TestBedrockMantleOpenAICompatible exercises the OpenAI-compatible surface, which
+// TestBedrockMantle does not reach: every model role there is a Claude id, so the
+// whole "v1" vs "openai/v1" base-path split ran untested — which is how a frontier
+// generation came to be routed to the path that rejects it.
+//
+// The model carries a "us-west-2/" addressing prefix because mantle serves Astra in
+// that region only, while the key's region (AWS_REGION, default us-east-1) is where
+// the Claude scenarios run. resolveRegion consults the model prefix ahead of the key,
+// so both functions run from one invocation with no region switch.
+func TestBedrockMantleOpenAICompatible(t *testing.T) {
+	t.Parallel()
+
+	if strings.TrimSpace(os.Getenv("AWS_ACCESS_KEY_ID")) == "" || strings.TrimSpace(os.Getenv("AWS_SECRET_ACCESS_KEY")) == "" {
+		t.Skip("Skipping Bedrock Mantle OpenAI-compatible tests because AWS_ACCESS_KEY_ID or AWS_SECRET_ACCESS_KEY is not set")
+	}
+
+	client, ctx, cancel, err := llmtests.SetupTest()
+	if err != nil {
+		t.Fatalf("Error initializing test setup: %v", err)
+	}
+	defer cancel()
+	defer client.Shutdown()
+
+	const astra = "us-west-2/openai.gpt-6-astra"
+
+	testConfig := llmtests.ComprehensiveTestConfig{
+		Provider:       schemas.BedrockMantle,
+		ChatModel:      astra,
+		VisionModel:    astra,
+		ReasoningModel: astra,
+		// A different region and generation, so the fallback also covers the
+		// prefix being honoured per attempt rather than once per key.
+		Fallbacks: []schemas.Fallback{
+			{Provider: schemas.BedrockMantle, Model: "us-east-1/openai.gpt-5.6-sol"},
+		},
+		Scenarios: llmtests.TestScenarios{
+			SimpleChat:                 true,
+			CompletionStream:           true,
+			MultiTurnConversation:      true,
+			ToolCalls:                  true,
+			ToolCallsStreaming:         true,
+			MultipleToolCalls:          true,
+			MultipleToolCallsStreaming: true,
+			End2EndToolCalling:         true,
+			AutomaticFunctionCall:      true,
+			CompleteEnd2End:            true,
+			EagerInputStreaming:        true,
+			StructuredOutputs:          true,
+			ImageBase64:                true,
+			Reasoning:                  true,
+
+			// CountTokens lives on the native-Anthropic surface only.
+			CountTokens: false,
+			// Bedrock lists explicit prompt caching for the GPT-5.6 family, not this one.
+			PromptCaching: false,
+			// InterleavedThinking is an Anthropic-surface capability.
+			InterleavedThinking: false,
+			// ListModels is provider-scoped, so TestBedrockMantle already covers it.
+			ListModels: false,
+		},
+	}
+
+	t.Run("BedrockMantleOpenAICompatibleTests", func(t *testing.T) {
+		llmtests.RunAllComprehensiveTests(t, client, ctx, testConfig)
+	})
+}

--- a/core/providers/bedrockmantle/bedrockmantle_test.go
+++ b/core/providers/bedrockmantle/bedrockmantle_test.go
@@ -131,21 +131,35 @@ func TestBedrockMantleOpenAICompatible(t *testing.T) {
 		Fallbacks: []schemas.Fallback{
 			{Provider: schemas.BedrockMantle, Model: "us-east-1/openai.gpt-5.6-sol"},
 		},
+		// Astra's chat stream carries no reasoning content to assert on — 120-136
+		// chunks with no reasoning indicators across ten attempts — while its
+		// Responses stream carries it. Same shape as the tools split below.
+		SkipChatReasoning: true,
 		Scenarios: llmtests.TestScenarios{
-			SimpleChat:                 true,
-			CompletionStream:           true,
-			MultiTurnConversation:      true,
-			ToolCalls:                  true,
-			ToolCallsStreaming:         true,
-			MultipleToolCalls:          true,
-			MultipleToolCallsStreaming: true,
-			End2EndToolCalling:         true,
-			AutomaticFunctionCall:      true,
-			CompleteEnd2End:            true,
-			EagerInputStreaming:        true,
-			StructuredOutputs:          true,
-			ImageBase64:                true,
-			Reasoning:                  true,
+			SimpleChat:            true,
+			CompletionStream:      true,
+			MultiTurnConversation: true,
+			CompleteEnd2End:       false,
+			StructuredOutputs:     true,
+			ImageBase64:           true,
+			Reasoning:             true,
+
+			// Astra rejects function tools on the chat surface and says so:
+			// "Function tools with reasoning_effort are not supported for
+			// gpt-6-astra in /v1/chat/completions. To use function tools, use
+			// /v1/responses." Its thinking is always on, so there is no
+			// effort-free chat request to fall back to. Every tool scenario drives
+			// the chat and Responses variants off one flag, so the Responses half
+			// (which passes) goes dark with them until a datasheet row marks the
+			// chat endpoint unsupported here and markForConversion routes these to
+			// /v1/responses.
+			ToolCalls:                  false,
+			ToolCallsStreaming:         false,
+			MultipleToolCalls:          false,
+			MultipleToolCallsStreaming: false,
+			End2EndToolCalling:         false,
+			AutomaticFunctionCall:      false,
+			EagerInputStreaming:        false,
 
 			// CountTokens lives on the native-Anthropic surface only.
 			CountTokens: false,

--- a/core/providers/bedrockmantle/mantleurl_test.go
+++ b/core/providers/bedrockmantle/mantleurl_test.go
@@ -1,0 +1,42 @@
+package bedrockmantle
+
+import (
+	"testing"
+)
+
+// TestMantleOpenAIURL pins the base-path split. Mantle answers a given model on
+// exactly one of "v1" and "openai/v1" and 400s on the other, so a family landing
+// on the wrong path fails every request. The gate names each closed generation
+// explicitly, which is what makes a new one easy to miss; bedrock.mantleOpenAIURL
+// carries the same table for its own copy of this function.
+func TestMantleOpenAIURL(t *testing.T) {
+	cases := []struct {
+		name   string
+		region string
+		model  string
+		path   string
+		want   string
+	}{
+		{"gpt-oss uses bare v1", "us-east-1", "openai.gpt-oss-120b", "chat/completions",
+			"https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions"},
+		{"gpt-5.x uses openai/v1", "us-east-1", "openai.gpt-5.6-sol", "responses",
+			"https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses"},
+		{"gpt-6 uses openai/v1", "us-west-2", "openai.gpt-6-astra", "responses",
+			"https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses"},
+		{"gpt-6 chat uses openai/v1", "us-west-2", "gpt-6-astra", "chat/completions",
+			"https://bedrock-mantle.us-west-2.api.aws/openai/v1/chat/completions"},
+		{"gemma-4 uses openai/v1", "us-east-1", "google.gemma-4-31b", "responses",
+			"https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses"},
+		{"gemma-3 uses bare v1", "us-east-1", "google.gemma-3-12b-it", "chat/completions",
+			"https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions"},
+		{"grok uses openai/v1", "us-east-1", "xai.grok-4.3", "responses",
+			"https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := mantleOpenAIURL(nil, tc.region, tc.model, tc.path); got != tc.want {
+				t.Errorf("mantleOpenAIURL(%q, %q, %q) = %q, want %q", tc.region, tc.model, tc.path, got, tc.want)
+			}
+		})
+	}
+}

--- a/core/providers/bedrockmantle/utils.go
+++ b/core/providers/bedrockmantle/utils.go
@@ -56,6 +56,33 @@ func parseBedrockRegionAndModel(model string) (region, bareModel string) {
 	return "", model
 }
 
+// withBareModel drops the region addressing prefix from the model a chat request
+// carries, so the body names the id mantle knows. The native-Anthropic handlers take
+// the bare model through their build config, but the OpenAI-compatible ones read it
+// off the request, and mantle 404s the prefixed form ("The model
+// 'us-west-2/openai.gpt-6-astra' does not exist"). Copied rather than mutated: the
+// caller's request is what the pipeline keys pricing and logging on.
+func withBareModel(request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
+	_, bare := parseBedrockRegionAndModel(request.Model)
+	if bare == request.Model {
+		return request
+	}
+	clone := *request
+	clone.Model = bare
+	return &clone
+}
+
+// withBareResponsesModel is withBareModel for the Responses surface.
+func withBareResponsesModel(request *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
+	_, bare := parseBedrockRegionAndModel(request.Model)
+	if bare == request.Model {
+		return request
+	}
+	clone := *request
+	clone.Model = bare
+	return &clone
+}
+
 // resolveRegion returns the AWS region to use for a request.
 // Priority: model-string region prefix > alias-level Region > key-level
 // BedrockMantleKeyConfig.Region > defaultMantleRegion. The model-string prefix

--- a/core/providers/bedrockmantle/utils.go
+++ b/core/providers/bedrockmantle/utils.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 
+	providerUtils "github.com/maximhq/bifrost/core/providers/utils"
 	schemas "github.com/maximhq/bifrost/core/schemas"
 )
 
@@ -56,31 +57,30 @@ func parseBedrockRegionAndModel(model string) (region, bareModel string) {
 	return "", model
 }
 
-// withBareModel drops the region addressing prefix from the model a chat request
-// carries, so the body names the id mantle knows. The native-Anthropic handlers take
-// the bare model through their build config, but the OpenAI-compatible ones read it
-// off the request, and mantle 404s the prefixed form ("The model
-// 'us-west-2/openai.gpt-6-astra' does not exist"). Copied rather than mutated: the
-// caller's request is what the pipeline keys pricing and logging on.
-func withBareModel(request *schemas.BifrostChatRequest) *schemas.BifrostChatRequest {
-	_, bare := parseBedrockRegionAndModel(request.Model)
-	if bare == request.Model {
-		return request
+// bareModelScope rewrites request.Model (and the model field of a raw passthrough
+// body) to the bare id for the duration of a handler call, and returns the func that
+// puts both back. Nothing is copied: the caller's request is what core hands to the
+// next retry and what pricing and logging read, so it has to leave with its prefix
+// intact. The native-Anthropic handlers take the bare model through their build
+// config; the OpenAI-compatible ones read it off the request, and mantle 404s the
+// prefixed form ("The model 'us-west-2/openai.gpt-6-astra' does not exist"). Costs
+// nothing when there is no prefix, which is every request that names a region on
+// the key or the alias rather than the model.
+func bareModelScope(model *string, raw *[]byte) func() {
+	region, bare := parseBedrockRegionAndModel(*model)
+	if region == "" {
+		return func() {}
 	}
-	clone := *request
-	clone.Model = bare
-	return &clone
-}
-
-// withBareResponsesModel is withBareModel for the Responses surface.
-func withBareResponsesModel(request *schemas.BifrostResponsesRequest) *schemas.BifrostResponsesRequest {
-	_, bare := parseBedrockRegionAndModel(request.Model)
-	if bare == request.Model {
-		return request
+	origModel, origRaw := *model, *raw
+	*model = bare
+	if len(origRaw) > 0 {
+		if edited, err := providerUtils.SetJSONField(origRaw, "model", bare); err == nil {
+			*raw = edited
+		}
 	}
-	clone := *request
-	clone.Model = bare
-	return &clone
+	return func() {
+		*model, *raw = origModel, origRaw
+	}
 }
 
 // resolveRegion returns the AWS region to use for a request.

--- a/core/providers/openai/responsesmarshal_test.go
+++ b/core/providers/openai/responsesmarshal_test.go
@@ -1142,6 +1142,10 @@ func TestEffortPredicatesAgainstCatalogIDs(t *testing.T) {
 		{"gpt-5.4", false, true, false},
 		{"gpt-5.6-terra", false, true, true},
 		{"openai.gpt-5.6-sol", false, true, true},
+		// gpt-6: both top tiers, and no minimal (dropped after the original trio)
+		{"gpt-6-astra", false, true, true},
+		{"openai.gpt-6-astra", false, true, true},
+		{"us.openai.gpt-6-astra", false, true, true},
 		// non-gpt families
 		{"deepseek-v4-pro", false, false, true},
 		{"glm-5.2", false, false, true},
@@ -1156,6 +1160,32 @@ func TestEffortPredicatesAgainstCatalogIDs(t *testing.T) {
 		}
 		if got := acceptsMaxEffort(c.model); got != c.max {
 			t.Errorf("max(%q) = %v, want %v", c.model, got, c.max)
+		}
+	}
+}
+
+// TestIsOpenAIReasoningModel pins the reasoning-model default. It decides whether
+// reasoning survives the request at all on the OpenAI and Azure paths, so a
+// reasoning family the name check misses loses its effort and its replayed
+// reasoning silently rather than erroring.
+func TestIsOpenAIReasoningModel(t *testing.T) {
+	cases := []struct {
+		model string
+		want  bool
+	}{
+		{"o1", true},
+		{"o3-mini", true},
+		{"gpt-oss-120b", true},
+		{"gpt-5", true},
+		{"gpt-5.6-sol", true},
+		{"gpt-6-astra", true},
+		{"openai.gpt-6-astra", true},
+		{"gpt-4o", false},
+		{"claude-opus-4-8", false},
+	}
+	for _, c := range cases {
+		if got := IsOpenAIReasoningModel(c.model); got != c.want {
+			t.Errorf("IsOpenAIReasoningModel(%q) = %v, want %v", c.model, got, c.want)
 		}
 	}
 }

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -23,8 +23,8 @@ func defaultSupportsReasoningContentBlocks(model string) bool {
 }
 
 // IsOpenAIReasoningModel matches OpenAI-family models that accept
-// reasoning.effort: the o1/o3/o4 series, GPT-5.x, and gpt-oss. Broader than
-// isOSeriesModel, which covers the o-series alone.
+// reasoning.effort: the o1/o3/o4 series, GPT-5.x, GPT-6.x, and gpt-oss. Broader
+// than isOSeriesModel, which covers the o-series alone.
 func IsOpenAIReasoningModel(model string) bool {
 	_, parsedModel := schemas.ParseModelString(model, schemas.OpenAI)
 	if parsedModel != "" {
@@ -49,7 +49,7 @@ func IsOpenAIReasoningModel(model string) bool {
 			return true
 		}
 	}
-	return strings.Contains(modelLower, "gpt-5")
+	return strings.Contains(modelLower, "gpt-5") || strings.Contains(modelLower, "gpt-6")
 }
 
 // defaultEffortControl widens the base low/medium/high ladder with the effort
@@ -86,7 +86,8 @@ func acceptsXHighEffort(model string) bool {
 		strings.Contains(modelLower, "gpt-5.3-codex") ||
 		strings.Contains(modelLower, "gpt-5.4") ||
 		strings.Contains(modelLower, "gpt-5.5") ||
-		strings.Contains(modelLower, "gpt-5.6")
+		strings.Contains(modelLower, "gpt-5.6") ||
+		strings.Contains(modelLower, "gpt-6-astra")
 }
 
 // acceptsMinimalEffort reports models that natively accept "minimal" effort:


### PR DESCRIPTION
## Problem

Bedrock Mantle serves a closed frontier model on exactly one of its two OpenAI-compatible base paths and rejects it on the other. `mantleOpenAIURL` enumerates `gpt-5`, so `gpt-6` fell through to the bare `v1` path that gpt-oss uses, and every request failed:

```
POST bedrock-mantle.us-west-2.api.aws/v1/chat/completions
400 {"code":"validation_error","type":"invalid_request_error",
     "message":"model `openai.gpt-6-astra` isn't supported on this route"}
```

The identical request against `openai/v1` returns 200. The gate is duplicated, so both `providers/bedrockmantle` and the deprecated in-provider path in `providers/bedrock` were affected.

Two capability gates in `providers/openai/utils.go` missed the generation too, and both fail silently rather than erroring:

- `acceptsXHighEffort` omitted it while `acceptsMaxEffort` already lists `gpt-6-astra`. `defaultEffortControl` therefore built `low/medium/high/max`, skipping the tier between them, and a requested `xhigh` was downgraded to `high`.
- `IsOpenAIReasoningModel` ends in a `gpt-5` substring check, so the family defaulted to non-reasoning. That clears `reasoning.effort` on the OpenAI and Azure paths and drops replayed reasoning items.

## Changes

- `mantleOpenAIURL` (both copies) also routes `gpt-6` to `openai/v1`. gpt-oss and Gemma 3 keep the bare `v1` path.
- The OpenAI-compatible handlers (both provider copies) strip the optional `region/` addressing prefix before the model reaches the body. The native-Anthropic handlers already did; the OpenAI ones read the model straight off the request, so `us-west-2/openai.gpt-6-astra` reached the wire and mantle 404d it. Found by the harness run below.
- `acceptsXHighEffort` accepts `gpt-6-astra`, matching `acceptsMaxEffort`.
- `IsOpenAIReasoningModel` recognises `gpt-6`.

## Tests

Full provider-harness pass against `gpt-6-astra` on mantle (Go harness, `TestBedrockMantleOpenAICompatible`): **49 pass, 2 skip, 0 fail**. Details and the two model-behaviour findings it surfaced are in the comment thread. In short: Astra rejects function tools on `/v1/chat/completions` even with no `reasoning_effort` in the request (`param: reasoning_effort`; verified against the endpoint directly), and its chat stream carries no reasoning content while its Responses stream does. The new config scopes to what the model serves and says why.

Unit tests:

- `TestMantleOpenAIURL` in `providers/bedrock` gains gpt-6 cases, and `providers/bedrockmantle` gets the same table, which it had no coverage for. The function is duplicated, so a test in each place keeps the two from drifting.
- `TestEffortPredicatesAgainstCatalogIDs` gains bare, vendor-qualified and region-qualified Astra IDs.
- `TestIsOpenAIReasoningModel` is new; the predicate had no direct coverage.

`go test ./...` in `core` passes apart from `internal/mcptests`, which fails identically on an unmodified checkout because its test server binary is not built (`make setup-mcp-tests`).

## Note

The base-path gate names each closed generation explicitly, so the next one will need the same edit. Left as-is here to keep the change minimal: inverting it to "everything except gpt-oss" would move Gemma 3 off the bare path it currently requires.

