### PR TITLE
[fix]: honor Retry-After in the core retry loop

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -6178,6 +6178,7 @@ func executeRequestWithRetries[T any](
 	// True iff the previous attempt failed on rejected encrypted reasoning and we stripped
 	// it. Used to skip backoff: the payload changed, so there is nothing to wait out.
 	lastWasEncryptedContentStrip := false
+	var retryAfter time.Time
 
 	for attempts = 0; attempts <= config.NetworkConfig.MaxRetries+extraAttempts; attempts++ {
 		ctx.SetValue(schemas.BifrostContextKeyNumberOfRetries, attempts)
@@ -6345,8 +6346,27 @@ func executeRequestWithRetries[T any](
 
 			if !((lastWasPermanentKeyFailure && keyChanged) || lastWasEncryptedContentStrip) {
 				backoff := calculateBackoff(attempts-1, config)
+				if !retryAfter.IsZero() {
+					backoff = max(backoff, time.Until(retryAfter))
+				}
 				logger.Debug("sleeping for %s before retry", backoff)
-				time.Sleep(backoff)
+				if err := waitForRetry(ctx, backoff); err != nil {
+					var zero T
+					result = zero
+					bifrostError = &schemas.BifrostError{
+						IsBifrostError: true,
+						StatusCode:     Ptr(499),
+						Error: &schemas.ErrorField{
+							Type:    Ptr(schemas.RequestCancelled),
+							Message: "request cancelled during retry backoff",
+							Error:   err,
+						},
+					}
+					if errors.Is(err, context.DeadlineExceeded) {
+						bifrostError = providerUtils.NewBifrostTimeoutError("request timed out during retry backoff", err)
+					}
+					break
+				}
 			}
 		}
 
@@ -6441,6 +6461,9 @@ func executeRequestWithRetries[T any](
 		}
 
 		// Attempt the request
+		// Headers belong to one attempt; a failure before receiving a new response
+		// must not inherit Retry-After from an earlier retry or fallback provider.
+		ctx.ClearValue(schemas.BifrostContextKeyProviderResponseHeaders)
 		result, bifrostError = requestHandler(currentKey)
 
 		// Detect errors carried inside HTTP 200 streams before returning success.
@@ -6651,6 +6674,21 @@ func executeRequestWithRetries[T any](
 		}
 		lastWasPerKeyFailure = isPerKeyFailure
 		lastWasPermanentKeyFailure = isPermanentKeyFailure
+		retryAfter = time.Time{}
+		if !lastWasPermanentKeyFailure && !lastWasEncryptedContentStrip && attempts < config.NetworkConfig.MaxRetries+extraAttempts {
+			now := time.Now()
+			headers, _ := ctx.Value(schemas.BifrostContextKeyProviderResponseHeaders).(map[string]string)
+			retryAfter = retryAfterTime(headers, now)
+			if delay := retryAfter.Sub(now); delay > 0 {
+				deadline, hasDeadline := ctx.Deadline()
+				if delay > config.NetworkConfig.RetryBackoffMax || (hasDeadline && !retryAfter.Before(deadline)) {
+					// Do not shorten the provider's minimum wait or exceed the caller's
+					// budget. Preserve the upstream error for the existing fallback policy.
+					ctx.AppendRoutingEngineLog(schemas.RoutingEngineCore, schemas.LogLevelInfo, "Stopped retries: provider Retry-After exceeds the backoff or request budget")
+					break
+				}
+			}
+		}
 		// Remember the key used on this attempt so the next iteration's backoff check
 		// can detect whether key selection genuinely picked a different credential.
 		previousKeyID = currentKey.ID

--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,1 +1,2 @@
 - fix: drop namespace tools whose name Amazon Bedrock reserves (`web`, `image_gen`, `browser`, `python`) on the Bedrock and Bedrock Mantle Responses paths instead of forwarding them into a `tools.namespace` collision 400; a dropped Codex `web` namespace becomes the hosted `web_search` tool on Bedrock Mantle
+- [fix]: honor Retry-After within retry and request budgets [@jjj-n](https://github.com/jjj-n)

--- a/core/retryafter.go
+++ b/core/retryafter.go
@@ -1,0 +1,58 @@
+package bifrost
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// retryAfterTime returns the earliest retry time advertised by the current response.
+// A missing or malformed hint leaves the existing exponential backoff in control.
+func retryAfterTime(headers map[string]string, now time.Time) time.Time {
+	for name, value := range headers {
+		if !strings.EqualFold(name, "Retry-After") {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return time.Time{}
+		}
+		isSeconds := true
+		for _, c := range value {
+			if c < '0' || c > '9' {
+				isSeconds = false
+				break
+			}
+		}
+		if isSeconds {
+			seconds, err := strconv.ParseUint(value, 10, 64)
+			// Saturate valid but enormous hints rather than overflowing or retrying early.
+			if err != nil || seconds > uint64(math.MaxInt64/int64(time.Second)) {
+				return now.Add(time.Duration(math.MaxInt64))
+			}
+			return now.Add(time.Duration(seconds) * time.Second)
+		}
+		if date, err := http.ParseTime(value); err == nil {
+			return date
+		}
+		return time.Time{}
+	}
+	return time.Time{}
+}
+
+func waitForRetry(ctx context.Context, delay time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return ctx.Err()
+	}
+}

--- a/core/retryafter_test.go
+++ b/core/retryafter_test.go
@@ -1,0 +1,278 @@
+package bifrost
+
+import (
+	"context"
+	"math"
+	"net/http"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestRetryAfterHonorsProviderDelay(t *testing.T) {
+	for _, format := range []string{"seconds", "http-date"} {
+		t.Run(format, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+				ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+				config := createTestConfig(1, time.Millisecond, 5*time.Second)
+				start := time.Now()
+				header := "2"
+				if format == "http-date" {
+					header = start.Add(2 * time.Second).UTC().Format(http.TimeFormat)
+				}
+				calls := 0
+				result, err := executeRequestWithRetries(ctx, config, func(_ schemas.Key) (string, *schemas.BifrostError) {
+					calls++
+					if calls == 1 {
+						ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"retry-after": header})
+						return "", createBifrostError("rate limit exceeded", Ptr(429), nil, false)
+					}
+					if elapsed := time.Since(start); elapsed < 2*time.Second {
+						t.Errorf("retried after %s, before the provider's 2s Retry-After", elapsed)
+					}
+					return "success", nil
+				}, nil, schemas.ChatCompletionRequest, schemas.OpenAI, "test-model", nil, NewDefaultLogger(schemas.LogLevelError))
+				if err != nil || result != "success" || calls != 2 {
+					t.Fatalf("result=%q err=%v calls=%d", result, err, calls)
+				}
+			})
+		})
+	}
+}
+
+func TestRetryAfterStopsWhenWaitExceedsBudget(t *testing.T) {
+	for _, budget := range []string{"backoff cap", "request deadline"} {
+		t.Run(budget, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				deadline := schemas.NoDeadline
+				if budget == "request deadline" {
+					deadline = time.Now().Add(time.Second)
+				}
+				ctx := schemas.NewBifrostContext(context.Background(), deadline)
+				defer ctx.Cancel()
+				ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+				config := createTestConfig(2, time.Millisecond, 5*time.Second)
+				header := "60"
+				if budget == "request deadline" {
+					header = "2"
+				}
+				upstreamErr := createBifrostError("rate limit exceeded", Ptr(429), nil, false)
+				calls := 0
+				_, err := executeRequestWithRetries(ctx, config, func(_ schemas.Key) (string, *schemas.BifrostError) {
+					calls++
+					ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"Retry-After": header})
+					return "", upstreamErr
+				}, nil, schemas.ChatCompletionRequest, schemas.OpenAI, "test-model", nil, NewDefaultLogger(schemas.LogLevelError))
+				if calls != 1 || err != upstreamErr {
+					t.Fatalf("must preserve upstream error without retrying early: calls=%d err=%v", calls, err)
+				}
+			})
+		})
+	}
+}
+
+func TestRetryAfterDoesNotReuseResponseHeaders(t *testing.T) {
+	for _, reuse := range []string{"next attempt", "fallback"} {
+		t.Run(reuse, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+				ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+				config := createTestConfig(2, time.Millisecond, 5*time.Second)
+				calls := 0
+				var secondCall time.Time
+				if reuse == "fallback" {
+					ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"Retry-After": "60"})
+					clearCtxForFallback(ctx)
+				}
+				result, err := executeRequestWithRetries(ctx, config, func(_ schemas.Key) (string, *schemas.BifrostError) {
+					calls++
+					if calls == 1 && reuse == "next attempt" {
+						ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"Retry-After": "2"})
+						return "", createBifrostError("rate limit exceeded", Ptr(429), nil, false)
+					}
+					if (calls == 2 && reuse == "next attempt") || (calls == 1 && reuse == "fallback") {
+						secondCall = time.Now()
+						// A network failure before receiving headers must not reuse the previous response.
+						return "", createBifrostError("connection failed", Ptr(502), nil, false)
+					}
+					if elapsed := time.Since(secondCall); elapsed > 3*time.Millisecond {
+						t.Errorf("stale Retry-After delayed the next attempt by %s", elapsed)
+					}
+					return "success", nil
+				}, nil, schemas.ChatCompletionRequest, schemas.OpenAI, "test-model", nil, NewDefaultLogger(schemas.LogLevelError))
+				if err != nil || result != "success" {
+					t.Fatalf("result=%q err=%v", result, err)
+				}
+			})
+		})
+	}
+}
+
+func TestRetryAfterWaitIsCancellable(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		defer ctx.Cancel()
+		ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+		config := createTestConfig(1, time.Millisecond, 5*time.Second)
+		start := time.Now()
+		calls := 0
+		_, err := executeRequestWithRetries(ctx, config, func(_ schemas.Key) (string, *schemas.BifrostError) {
+			calls++
+			if calls == 1 {
+				ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"Retry-After": "2"})
+				time.AfterFunc(100*time.Millisecond, ctx.Cancel)
+			}
+			return "", createBifrostError("rate limit exceeded", Ptr(429), nil, false)
+		}, nil, schemas.ChatCompletionRequest, schemas.OpenAI, "test-model", nil, NewDefaultLogger(schemas.LogLevelError))
+		if calls != 1 || time.Since(start) != 100*time.Millisecond {
+			t.Fatalf("cancellation should stop the retry wait: calls=%d elapsed=%s", calls, time.Since(start))
+		}
+		if err == nil || err.Error == nil || err.Error.Type == nil || *err.Error.Type != schemas.RequestCancelled {
+			t.Fatalf("expected request cancellation, got %v", err)
+		}
+	})
+}
+
+func TestRetryAfterParsing(t *testing.T) {
+	now := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+	for _, tt := range []struct {
+		name, value string
+		want        time.Time
+	}{
+		{"seconds", "2", now.Add(2 * time.Second)},
+		{"whitespace", " 2\t", now.Add(2 * time.Second)},
+		{"zero", "0", now},
+		{"leading zeros", "002", now.Add(2 * time.Second)},
+		{"http date", now.Add(time.Minute).Format(http.TimeFormat), now.Add(time.Minute)},
+		{"past date", now.Add(-time.Minute).Format(http.TimeFormat), now.Add(-time.Minute)},
+		{"duration overflow", "9223372037", now.Add(time.Duration(math.MaxInt64))},
+		{"integer overflow", "18446744073709551616", now.Add(time.Duration(math.MaxInt64))},
+		{"empty", "", time.Time{}},
+		{"negative", "-1", time.Time{}},
+		{"signed", "+1", time.Time{}},
+		{"fraction", "0.5", time.Time{}},
+		{"multiple values", "2, 3", time.Time{}},
+		{"invalid date", "tomorrow", time.Time{}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := retryAfterTime(map[string]string{"rEtRy-AfTeR": tt.value}, now)
+			if !got.Equal(tt.want) {
+				t.Errorf("retryAfterTime(%q)=%v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryAfterAllowsWaitAtBackoffCap(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+		config := createTestConfig(1, time.Millisecond, 2*time.Second)
+		start := time.Now()
+		calls := 0
+		result, err := executeRequestWithRetries(ctx, config, func(_ schemas.Key) (string, *schemas.BifrostError) {
+			calls++
+			if calls == 1 {
+				ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"Retry-After": "2"})
+				return "", createBifrostError("rate limit exceeded", Ptr(429), nil, false)
+			}
+			return "success", nil
+		}, nil, schemas.ChatCompletionRequest, schemas.OpenAI, "test-model", nil, NewDefaultLogger(schemas.LogLevelError))
+		if calls != 2 || result != "success" || err != nil || time.Since(start) != 2*time.Second {
+			t.Fatalf("a hint equal to the cap must be honored: calls=%d result=%q err=%v elapsed=%s", calls, result, err, time.Since(start))
+		}
+	})
+}
+
+func TestRetryAfterDeadlineExpiresDuringLocalBackoff(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		start := time.Now()
+		ctx := schemas.NewBifrostContext(context.Background(), start.Add(1500*time.Millisecond))
+		defer ctx.Cancel()
+		ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+		config := createTestConfig(1, 2*time.Second, 5*time.Second)
+		calls := 0
+		_, err := executeRequestWithRetries(ctx, config, func(_ schemas.Key) (string, *schemas.BifrostError) {
+			calls++
+			// The provider hint fits the deadline, but the longer local backoff does not.
+			ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"Retry-After": "1"})
+			return "", createBifrostError("rate limit exceeded", Ptr(429), nil, false)
+		}, nil, schemas.ChatCompletionRequest, schemas.OpenAI, "test-model", nil, NewDefaultLogger(schemas.LogLevelError))
+		if calls != 1 || time.Since(start) != 1500*time.Millisecond {
+			t.Fatalf("deadline must stop the wait: calls=%d elapsed=%s", calls, time.Since(start))
+		}
+		if err == nil || err.StatusCode == nil || *err.StatusCode != http.StatusGatewayTimeout {
+			t.Fatalf("expected a timeout error, got %v", err)
+		}
+	})
+}
+
+func TestRetryAfterPreservesLocalBackoff(t *testing.T) {
+	for _, hint := range []string{"", "invalid", "0", "1", "past"} {
+		t.Run(hint, func(t *testing.T) {
+			synctest.Test(t, func(t *testing.T) {
+				if hint == "past" {
+					hint = time.Now().Add(-time.Minute).UTC().Format(http.TimeFormat)
+				}
+				ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+				ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+				config := createTestConfig(1, 2*time.Second, 5*time.Second)
+				calls := 0
+				start := time.Now()
+				_, err := executeRequestWithRetries(ctx, config, func(_ schemas.Key) (string, *schemas.BifrostError) {
+					calls++
+					if calls == 1 {
+						ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"Retry-After": hint})
+						return "", createBifrostError("unavailable", Ptr(503), nil, false)
+					}
+					return "success", nil
+				}, nil, schemas.ChatCompletionRequest, schemas.OpenAI, "test-model", nil, NewDefaultLogger(schemas.LogLevelError))
+				if elapsed := time.Since(start); elapsed < 1600*time.Millisecond || elapsed > 2400*time.Millisecond || calls != 2 || err != nil {
+					t.Fatalf("local backoff changed: elapsed=%s calls=%d err=%v", elapsed, calls, err)
+				}
+			})
+		})
+	}
+}
+
+func TestRetryAfterStreamKeyRotation(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+		ctx.SetValue(schemas.BifrostContextKeyTracer, &schemas.NoOpTracer{})
+		config := createTestConfig(1, time.Millisecond, 5*time.Second)
+		keyProvider := func(used, dead map[string]bool) (schemas.Key, error) {
+			if used["a"] {
+				return schemas.Key{ID: "b"}, nil
+			}
+			return schemas.Key{ID: "a"}, nil
+		}
+		start := time.Now()
+		calls := 0
+		stream, err := executeRequestWithRetries(ctx, config, func(key schemas.Key) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
+			calls++
+			chunks := make(chan *schemas.BifrostStreamChunk, 1)
+			if calls == 1 {
+				ctx.SetValue(schemas.BifrostContextKeyProviderResponseHeaders, map[string]string{"Retry-After": "2"})
+				chunks <- &schemas.BifrostStreamChunk{BifrostError: createBifrostError("rate limit exceeded", Ptr(429), nil, false)}
+			} else {
+				if key.ID != "b" || time.Since(start) != 2*time.Second {
+					t.Errorf("rotation must honor account-level wait: key=%s elapsed=%s", key.ID, time.Since(start))
+				}
+				chunks <- &schemas.BifrostStreamChunk{}
+			}
+			close(chunks)
+			return chunks, nil
+		}, keyProvider, schemas.ChatCompletionStreamRequest, schemas.OpenAI, "test-model", nil, NewDefaultLogger(schemas.LogLevelError))
+		if err != nil || calls != 2 {
+			t.Fatalf("calls=%d err=%v", calls, err)
+		}
+		for chunk := range stream {
+			if chunk.BifrostError != nil {
+				t.Fatal("failed attempt escaped to caller")
+			}
+		}
+	})
+}

--- a/docs/features/retries-and-fallbacks.mdx
+++ b/docs/features/retries-and-fallbacks.mdx
@@ -73,6 +73,26 @@ With the defaults of `retry_backoff_initial = 500ms` and `retry_backoff_max = 50
 | 4th retry | 4000 ms | 3.2–4.8 s |
 | 5th+ retry | 5000 ms (capped) | 4–5 s |
 
+### Provider `Retry-After` hints
+
+For retryable responses, Bifrost honors the standard `Retry-After` response header
+as either a non-negative integer number of seconds or an HTTP date. The next
+attempt waits for the longer of the existing exponential backoff and the remaining
+provider-specified delay. Missing, invalid, zero, or past hints do not shorten the
+local backoff. Provider-specific rate-limit reset headers and prose in error
+messages are not interpreted as `Retry-After`.
+
+If the provider's minimum wait exceeds `retry_backoff_max`, or reaches beyond the
+remaining request deadline, Bifrost stops retrying that provider and returns its
+last error to the existing fallback policy. It does not clamp the hint and retry
+early. For example, `Retry-After: 60` with a 5-second backoff cap stops retries;
+increase the cap to at least 60 seconds if waiting that long is acceptable.
+
+Hints are scoped to the response from the current attempt, including retries that
+rotate a rate-limited API key. They are not reused after a network failure with no
+response headers or when another provider is tried. Retry waits exit when the
+request context is cancelled or its deadline expires.
+
 ### What triggers a retry
 
 | Condition | Retried? | Key rotation? | Backoff before next attempt? |

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -145436,6 +145436,158 @@
           }
         }
       ]
+    },
+    {
+      "name": "77. OpenAI Retry-After (#6971)",
+      "description": "Local fixture regression for core retry scheduling. Follow runners/retry-after-fixture.md and set retryAfterFixture=1. The fixture returns 429 with Retry-After, then rejects any early retry with 400. Cases cover delta-seconds, HTTP-date, streaming startup, and a hint exceeding retry_backoff_max. Do not skip 429/400 as infrastructure noise: those statuses are the behavior under test.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "if (pm.variables.get('retryAfterFixture') !== '1') { pm.execution.skipRequest(); }"
+            ]
+          }
+        }
+      ],
+      "item": [
+        {
+          "name": "OpenAI retry-after-test-model seconds - #6971",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('OpenAI Retry-After seconds - #6971', function () {",
+                  "  var body = pm.response.text();",
+                  "  pm.expect(pm.response.code, body).to.equal(200);",
+                  "  pm.expect(body).not.to.include('retry-before-retry-after');",
+                  "  pm.expect(pm.response.json().choices[0].message.content, body).to.equal('hello');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/retry-after-seconds\",\"messages\":[{\"role\":\"user\",\"content\":\"{{$guid}}\"}],\"stream\":false}"
+            },
+            "url": "{{baseUrl}}/v1/chat/completions"
+          }
+        },
+        {
+          "name": "OpenAI retry-after-test-model HTTP date - #6971",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('OpenAI Retry-After HTTP date - #6971', function () {",
+                  "  var body = pm.response.text();",
+                  "  pm.expect(pm.response.code, body).to.equal(200);",
+                  "  pm.expect(body).not.to.include('retry-before-retry-after');",
+                  "  pm.expect(pm.response.json().choices[0].message.content, body).to.equal('hello');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/retry-after-date\",\"messages\":[{\"role\":\"user\",\"content\":\"{{$guid}}\"}],\"stream\":false}"
+            },
+            "url": "{{baseUrl}}/v1/chat/completions"
+          }
+        },
+        {
+          "name": "OpenAI retry-after-test-model streaming - #6971",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('OpenAI Retry-After streaming - #6971', function () {",
+                  "  var body = pm.response.text();",
+                  "  pm.expect(pm.response.code, body).to.equal(200);",
+                  "  pm.expect(body).not.to.include('retry-before-retry-after');",
+                  "  pm.expect(pm.response.headers.get('Content-Type')).to.include('text/event-stream');",
+                  "  pm.expect(body).to.include('hello');",
+                  "  pm.expect(body).to.include('[DONE]');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/retry-after-seconds\",\"messages\":[{\"role\":\"user\",\"content\":\"{{$guid}}\"}],\"stream\":true}"
+            },
+            "url": "{{baseUrl}}/v1/chat/completions"
+          }
+        },
+        {
+          "name": "OpenAI retry-after-test-model backoff cap - #6971",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('OpenAI Retry-After backoff cap - #6971', function () {",
+                  "  var body = pm.response.text();",
+                  "  pm.expect(pm.response.code, body).to.equal(429);",
+                  "  pm.expect(body).not.to.include('retry-before-retry-after');",
+                  "  pm.expect(pm.response.headers.get('Retry-After')).to.equal('60');",
+                  "  pm.expect(body).to.include('fixture rate limit');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"openai/retry-after-cap\",\"messages\":[{\"role\":\"user\",\"content\":\"{{$guid}}\"}],\"stream\":false}"
+            },
+            "url": "{{baseUrl}}/v1/chat/completions"
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/e2e/api/runners/retry-after-fixture.md
+++ b/tests/e2e/api/runners/retry-after-fixture.md
@@ -1,0 +1,51 @@
+# Local Retry-After regression (#6971)
+
+These cases use a local OpenAI-compatible fixture, not a paid model. The fixture
+first returns `429` and a `Retry-After` hint, then returns `400` with
+`retry-before-retry-after` if Bifrost retries too soon. Correctly delayed requests
+receive `hello`. A fresh GUID in each request body separates repeated runs.
+
+1. Start the fixture from the repository root:
+
+   ```sh
+   node tests/e2e/api/runners/retry-after-fixture.mjs
+   ```
+
+2. Start an **isolated** Bifrost gateway with this OpenAI provider configuration.
+   Do not replace a real provider configuration. If the gateway runs in Docker,
+   use an address it can reach instead of its own loopback.
+
+   ```json
+   {
+     "providers": {
+       "openai": {
+         "keys": [{"name": "fixture", "value": "fixture-only", "weight": 1}],
+         "network_config": {
+           "base_url": "http://127.0.0.1:8790/v1",
+           "max_retries": 1,
+           "retry_backoff_initial": 10,
+           "retry_backoff_max": 5000,
+           "allow_private_network": true
+         }
+       }
+     }
+   }
+   ```
+
+3. Filter and run the four opt-in cases:
+
+   ```sh
+   node tests/e2e/api/runners/augment-provider-harness.mjs --source tests/e2e/api/collections/provider-harness.json --out /tmp/retry-after-augmented.json
+   node tests/e2e/api/runners/filter-collection.mjs --source /tmp/retry-after-augmented.json --out /tmp/retry-after-filtered.json --provider openai --feature '#6971'
+   newman run /tmp/retry-after-filtered.json --env-var baseUrl=http://localhost:8080 --env-var retryAfterFixture=1
+   ```
+
+The cases pin seconds, HTTP-date, streaming startup, and the configured backoff
+cap. A 60-second hint with a 5-second cap must return the original 429 and its
+header without sending an early retry. Before the fix these cases receive 400;
+after the fix the first three receive 200 and the cap case receives 429.
+
+The folder skips requests unless `retryAfterFixture=1`. Do not enable it against
+a real provider. No authentication/rate-limit error guard is used: those statuses
+are part of this controlled regression. Cancellation, deadline, key rotation,
+overflow, and stale-header behavior are covered by `core/retryafter_test.go`.

--- a/tests/e2e/api/runners/retry-after-fixture.mjs
+++ b/tests/e2e/api/runners/retry-after-fixture.mjs
@@ -1,0 +1,61 @@
+import http from "node:http";
+import { createHash } from "node:crypto";
+
+const port = Number(process.env.RETRY_AFTER_FIXTURE_PORT || "8790");
+const attempts = new Map();
+const server = http.createServer(async (req, res) => {
+	if (req.method !== "POST" || req.url !== "/v1/chat/completions") {
+		res.writeHead(404).end();
+		return;
+	}
+	try {
+		let body = "";
+		for await (const chunk of req) body += chunk;
+		const { model, stream } = JSON.parse(body);
+		if (!["retry-after-seconds", "retry-after-date", "retry-after-cap"].includes(model)) {
+			res.writeHead(400).end("unknown fixture model");
+			return;
+		}
+		const key = createHash("sha256").update(body).digest("hex");
+		const now = Date.now();
+		// Keep a bounded history even when the gateway correctly stops without retrying.
+		for (const [id, entry] of attempts) {
+			if (now - entry.created > 120000) attempts.delete(id);
+		}
+		if (!attempts.has(key)) {
+			const delay = model === "retry-after-cap" ? 60 : 2;
+			const until = model === "retry-after-date"
+				? Math.floor((now + delay * 1000) / 1000) * 1000
+				: now + delay * 1000;
+			attempts.set(key, { created: now, until });
+			const hint = model === "retry-after-date" ? new Date(until).toUTCString() : String(delay);
+			res.writeHead(429, { "Content-Type": "application/json", "Retry-After": hint });
+			res.end(JSON.stringify({ error: { message: "fixture rate limit", type: "rate_limit_error" } }));
+			return;
+		}
+		if (now < attempts.get(key).until) {
+			// Non-retryable: an early attempt must fail loudly rather than eventually succeed.
+			res.writeHead(400, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ error: { message: "retry-before-retry-after", type: "invalid_request_error" } }));
+			return;
+		}
+		attempts.delete(key);
+		const base = { id: "retry-after-ok", created: 1, model };
+		if (stream) {
+			res.writeHead(200, { "Content-Type": "text/event-stream" });
+			res.write(`data: ${JSON.stringify({ ...base, object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant", content: "hello" }, finish_reason: null }] })}\n\n`);
+			res.write(`data: ${JSON.stringify({ ...base, object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] })}\n\n`);
+			res.end("data: [DONE]\n\n");
+		} else {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ ...base, object: "chat.completion", choices: [{ index: 0, message: { role: "assistant", content: "hello" }, finish_reason: "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } }));
+		}
+	} catch {
+		res.writeHead(400).end("invalid fixture request");
+	}
+});
+
+server.listen(port, "127.0.0.1", () => console.log(`Retry-After fixture: http://127.0.0.1:${port}/v1`));
+for (const signal of ["SIGINT", "SIGTERM"]) {
+	process.on(signal, () => server.close(() => process.exit(0)));
+}


### PR DESCRIPTION
## Summary

When an upstream returns `429` with `Retry-After: 2`, core currently retries after its local backoff, potentially well before the provider permits another request. Honor the standard header in the shared retry loop, including streaming startup failures and rate-limited key rotation.

Closes #6971.

## Changes

- Parse delta-seconds and HTTP-date values from the response headers already captured on the context. Preserve local backoff for missing, invalid, zero, or past hints; handle integer overflow without retrying early.
- Wait for the later of local backoff and the provider's advertised retry time. Make the wait interruptible by cancellation or deadline expiry.
- Clear response headers immediately before each provider attempt so a network failure cannot reuse a previous response's hint.
- Stop the current provider's retries and preserve its original error when the hint exceeds `retry_backoff_max` or reaches the request deadline. The existing fallback policy can then apply.
- Add deterministic Go regression tests, retry documentation, and four opt-in provider-harness cases backed by a local fixture.

**Policy for review:** a 60-second hint with a 5-second backoff cap stops retries rather than truncating the provider's minimum wait. A hint equal to the cap is allowed. Maintainer confirmation of this choice is still pending on #6971.

Reuses the cancellable retry wait and terminal cancellation/timeout classification now present on `dev` from #7105, removing this PR's duplicate wait helper. The cancellation audit regression now asserts the terminal routing-engine entry. Fixture commands use a per-run temporary directory. This log-only follow-up has no new wire-visible behavior; the four existing provider-harness cases remain the wire regressions. PR #7021 clears headers at fallback boundaries; this change clears them immediately before each actual provider attempt, including same-provider retries. Neither the jitter calculation nor provider-specific reset headers/error-message hints are changed.

## Type of change

- [x] Bug fix
- [x] Documentation

## Affected areas

- [x] Core (Go)
- [x] Docs
- Provider-harness regression tests

## How to test

Validated on 2026-09-21 against `dev` at `1a17949cd` with Linux / Go 1.27.1:

```sh
cd core
go test -race . -run 'TestRetryAfter|TestExecuteRequestWithRetries|TestCalculateBackoff|TestAzureResponsesRetriesAfterStartupEvents|TestWaitRetryBackoff' -count=1 -timeout=90s
go test -race . -count=1 -timeout=120s
```

Targeted retry/backoff/Azure startup tests pass with the race detector (4.473s). The full core package passes with the race detector (39.760s), with no tests excluded. The cancellation test `TestRotationWithoutBackoffStopsWhenRequestCancelled`, which previously timed out on the older upstream baseline, now passes as part of this full run.

This synchronization preserves upstream changes and keeps the existing Retry-After policy unchanged. The changelog retains only this unreleased fix after upstream cleared its prior entries. All 115 upstream provider-harness folders and collection metadata are preserved; the four existing Retry-After cases are appended as folder 105. No new wire behavior or regression cases are introduced by this merge.

The existing cancellation audit assertion was previously verified red against the pre-fix implementation. Original Retry-After regression coverage remains in place for seconds, HTTP dates, cancellation, deadlines, cap equality, stale headers, and streaming key rotation.

From the repository root:

```sh
node tests/e2e/api/runners/augment-provider-harness.mjs --source tests/e2e/api/collections/provider-harness.json --out tmp/harness-augmented.json
node tests/e2e/api/runners/filter-collection.mjs --source tmp/harness-augmented.json --out tmp/harness-filtered.json --provider openai --feature '#6971'
node --check tests/e2e/api/runners/retry-after-fixture.mjs
git diff --check
```

Structural validation passes (639 generated requests, 268 chained-variable guards) and selects exactly four cases. The three HTTP-status policy runner tests also pass, as do fixture syntax, Go formatting (normalizing Windows checkout line endings in the isolated Linux copy), and PR diff whitespace checks. They require `retryAfterFixture=1` and an isolated gateway using the local fixture; setup is documented in `tests/e2e/api/runners/retry-after-fixture.md`. Full gateway/Newman execution, paid provider tests, and multi-module `make test-all` were not run.

## Breaking changes

No API or configuration fields are added. Retryable responses with a valid `Retry-After` can now wait longer or stop retrying when the advertised wait exceeds the configured/request budget.

## Security considerations

No new external endpoints or credentials. The regression fixture uses dummy credentials and is opt-in.

## Checklist

- [x] Read the repository agent instructions and the contributing guide linked from README (the template's `docs/contributing/README.md` path is absent)
- [x] Added regression tests and provider-harness cases
- [x] Updated documentation and core changelog
- [x] Verified the core package builds and passes Linux race-enabled tests
- [ ] Full gateway/UI builds and full CI suite (not run)


