### PR TITLE
[fix]: preserve bare-string tool call actions in streaming deep copy

### DIFF
--- a/framework/streaming/responses.go
+++ b/framework/streaming/responses.go
@@ -358,6 +358,10 @@ func deepCopyResponsesMessage(original schemas.ResponsesMessage) schemas.Respons
 				copyAction := *original.ResponsesToolMessage.Action.ResponsesMCPApprovalRequestAction
 				copy.ResponsesToolMessage.Action.ResponsesMCPApprovalRequestAction = &copyAction
 			}
+
+			// Bare-string actions (e.g. image_generation_call's "generate") live in a
+			// field the Framework's pinned Core release may predate; copy it by name.
+			copyOptionalStringFieldByName(copy.ResponsesToolMessage.Action, original.ResponsesToolMessage.Action, "ResponsesToolCallActionStr")
 		}
 
 		if original.ResponsesToolMessage.Caller != nil {
@@ -502,7 +506,7 @@ func copyRawMessageFieldByName(dst *schemas.ResponsesMessage, src schemas.Respon
 	}
 }
 
-func copyOptionalStringFieldByName(dst *schemas.ResponsesToolMessage, src *schemas.ResponsesToolMessage, fieldName string) {
+func copyOptionalStringFieldByName(dst, src any, fieldName string) {
 	srcField := reflect.ValueOf(src).Elem().FieldByName(fieldName)
 	if !srcField.IsValid() || srcField.IsNil() {
 		return

--- a/framework/streaming/responses_test.go
+++ b/framework/streaming/responses_test.go
@@ -2,6 +2,7 @@ package streaming
 
 import (
 	"fmt"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -151,6 +152,34 @@ func TestDeepCopyResponsesStreamResponseCopiesToolCaller(t *testing.T) {
 	}
 	if copied.Item.ResponsesToolMessage.Caller.ToolID == original.Item.ResponsesToolMessage.Caller.ToolID {
 		t.Fatal("caller tool id pointer was aliased")
+	}
+}
+
+// TestDeepCopyResponsesMessagePreservesBareStringAction verifies that a
+// bare-string action (e.g. image_generation_call's "generate") survives the
+// accumulator's deep copy instead of being dropped as an empty action struct.
+func TestDeepCopyResponsesMessagePreservesBareStringAction(t *testing.T) {
+	action := &schemas.ResponsesToolMessageActionStruct{}
+	actionField := reflect.ValueOf(action).Elem().FieldByName("ResponsesToolCallActionStr")
+	if !actionField.IsValid() {
+		t.Skip("released core dependency predates bare-string tool call actions")
+	}
+	actionField.Set(reflect.ValueOf(schemas.Ptr("generate")))
+
+	copied := deepCopyResponsesMessage(schemas.ResponsesMessage{
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			Action: action,
+		},
+	})
+	if copied.ResponsesToolMessage == nil || copied.ResponsesToolMessage.Action == nil {
+		t.Fatalf("unexpected copied message: %#v", copied)
+	}
+	copiedField := reflect.ValueOf(copied.ResponsesToolMessage.Action).Elem().FieldByName("ResponsesToolCallActionStr")
+	if copiedField.IsNil() || copiedField.Elem().String() != "generate" {
+		t.Fatal("bare-string action was not preserved")
+	}
+	if copiedField.Pointer() == actionField.Pointer() {
+		t.Fatal("bare-string action pointer was aliased")
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #7060, which taught `ResponsesToolMessageActionStruct` to decode bare-string actions (e.g. `image_generation_call`'s `"generate"`) into `ResponsesToolCallActionStr`. The Framework streaming accumulator's `deepCopyResponsesMessage` still copies only the object action variants, so a message carrying a bare-string action comes out of the copy with an all-nil action struct, and `MarshalJSON` on that copy fails with `responses tool message action struct is empty`. Anything consuming the accumulated stream through the Framework (plugins, aggregated responses) still loses the image-generation item for exactly the requests #7060 fixed on the decode side.

Together with #7060 this completes #5834. Supersedes #5835, which originally carried an independent fix for the decode side.

## Changes

- `framework/streaming/responses.go`: copy `ResponsesToolCallActionStr` in `deepCopyResponsesMessage`. Done by field name via the existing `copyOptionalStringFieldByName` helper (generalised to `any`) so the `framework` module keeps building against its pinned Core release, which predates the field.
- `framework/streaming/responses_test.go`: regression test `TestDeepCopyResponsesMessagePreservesBareStringAction`, asserting the value is preserved and not pointer-aliased. It skips when the pinned Core lacks the field.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Framework (Go)

## How to test

```sh
# Against the local core (field present): must pass.
go work init ./core ./framework
cd framework && go test -race ./streaming/

# Against the pinned released core: framework must build, the new test skips.
cd framework && GOWORK=off go build ./... && \
  GOWORK=off go test ./streaming/ -run TestDeepCopyResponsesMessagePreservesBareStringAction -v
```

Without the `responses.go` change the new test fails with `bare-string action was not preserved`.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #5834
Related: #7060, #5835
