### PR TITLE
fixes gpt-oss mistag

### DIFF
--- a/core/providers/anthropic/responses.go
+++ b/core/providers/anthropic/responses.go
@@ -5809,15 +5809,19 @@ func convertSingleAnthropicMessageToBifrostMessages(ctx *schemas.BifrostContext,
 	// Handle text content (simple case)
 	if msg.Content.ContentStr != nil {
 		roleVal := schemas.ResponsesMessageRoleType(msg.Role)
-		return []schemas.ResponsesMessage{
-			{
-				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-				Role: &roleVal,
-				Content: &schemas.ResponsesMessageContent{
-					ContentStr: msg.Content.ContentStr,
-				},
+		bifrostMsg := schemas.ResponsesMessage{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: &roleVal,
+			Content: &schemas.ResponsesMessageContent{
+				ContentStr: msg.Content.ContentStr,
 			},
 		}
+		if isOutput {
+			// Replayed assistant items need status on strict OpenAI-compatible
+			// validators (Bedrock Mantle, #7074), same as the block-content paths.
+			bifrostMsg.Status = schemas.Ptr("completed")
+		}
+		return []schemas.ResponsesMessage{bifrostMsg}
 	}
 
 	// Handle content blocks
@@ -5839,15 +5843,19 @@ func convertSingleAnthropicMessageToBifrostMessagesGrouped(msg *AnthropicMessage
 	// Handle text content (simple case)
 	if msg.Content.ContentStr != nil {
 		roleVal := schemas.ResponsesMessageRoleType(msg.Role)
-		return []schemas.ResponsesMessage{
-			{
-				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-				Role: &roleVal,
-				Content: &schemas.ResponsesMessageContent{
-					ContentStr: msg.Content.ContentStr,
-				},
+		bifrostMsg := schemas.ResponsesMessage{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: &roleVal,
+			Content: &schemas.ResponsesMessageContent{
+				ContentStr: msg.Content.ContentStr,
 			},
 		}
+		if isOutput {
+			// Replayed assistant items need status on strict OpenAI-compatible
+			// validators (Bedrock Mantle, #7074), same as the block-content paths.
+			bifrostMsg.Status = schemas.Ptr("completed")
+		}
+		return []schemas.ResponsesMessage{bifrostMsg}
 	}
 
 	// Handle content blocks with grouping for text and tool calls
@@ -5950,9 +5958,10 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 		}
 		if isOutputMessage {
 			bifrostMessages = append(bifrostMessages, schemas.ResponsesMessage{
-				ID:   schemas.Ptr("msg_" + schemas.GetRandomString(50)),
-				Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
-				Role: role,
+				ID:     schemas.Ptr("msg_" + schemas.GetRandomString(50)),
+				Type:   schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+				Role:   role,
+				Status: schemas.Ptr("completed"),
 				Content: &schemas.ResponsesMessageContent{
 					ContentBlocks: accumulatedTextContent,
 				},
@@ -6032,6 +6041,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 				}
 				if isOutputMessage {
 					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
+					bifrostMsg.Status = schemas.Ptr("completed")
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6048,6 +6058,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 				}
 				if isOutputMessage {
 					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
+					bifrostMsg.Status = schemas.Ptr("completed")
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6063,6 +6074,7 @@ func convertAnthropicContentBlocksToResponsesMessagesGrouped(contentBlocks []Ant
 				}
 				if isOutputMessage {
 					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
+					bifrostMsg.Status = schemas.Ptr("completed")
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6395,6 +6407,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 				if isOutputMessage {
 					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
+					bifrostMsg.Status = schemas.Ptr("completed")
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6409,6 +6422,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 				if isOutputMessage {
 					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
+					bifrostMsg.Status = schemas.Ptr("completed")
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}
@@ -6423,6 +6437,7 @@ func convertAnthropicContentBlocksToResponsesMessages(ctx *schemas.BifrostContex
 				}
 				if isOutputMessage {
 					bifrostMsg.ID = schemas.Ptr("msg_" + schemas.GetRandomString(50))
+					bifrostMsg.Status = schemas.Ptr("completed")
 				}
 				bifrostMessages = append(bifrostMessages, bifrostMsg)
 			}

--- a/core/providers/anthropic/roundtrip_test.go
+++ b/core/providers/anthropic/roundtrip_test.go
@@ -518,3 +518,56 @@ func TestRoundTrip_ContainerUpload_Grouped(t *testing.T) {
 		t.Errorf("file_id = %v, want %q", found.FileID, fileID)
 	}
 }
+
+// TestAssistantOutputMessagesCarryStatus pins the Responses contract that every
+// assistant output message item carries status "completed" (issue #7074: Bedrock
+// Mantle's OpenAI-compatible validator rejects a replayed assistant item without it).
+// Covers the paths the grouped converter builds a message item on: plain string
+// content, an image block, a document block and a container_upload block. Text
+// blocks are covered by the fix that landed with the issue.
+func TestAssistantOutputMessagesCarryStatus(t *testing.T) {
+	ctx, cancel := schemas.NewBifrostContextWithCancel(context.Background())
+	defer cancel()
+
+	png := "iVBORw0KGgo="
+	pdf := "JVBERi0xLjQK"
+	messages := []AnthropicMessage{
+		anthMsg(AnthropicMessageRoleUser, "hi"),
+		anthMsg(AnthropicMessageRoleAssistant, "Hello! How can I help?"),
+		{Role: AnthropicMessageRoleAssistant, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{{
+			Type:   AnthropicContentBlockTypeImage,
+			Source: &AnthropicBlockSource{SourceObj: &AnthropicSource{Type: "base64", MediaType: schemas.Ptr("image/png"), Data: &png}},
+		}}}},
+		{Role: AnthropicMessageRoleAssistant, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{{
+			Type:   AnthropicContentBlockTypeDocument,
+			Source: &AnthropicBlockSource{SourceObj: &AnthropicSource{Type: "base64", MediaType: schemas.Ptr("application/pdf"), Data: &pdf}},
+		}}}},
+		{Role: AnthropicMessageRoleAssistant, Content: AnthropicContent{ContentBlocks: []AnthropicContentBlock{{
+			Type:   AnthropicContentBlockTypeContainerUpload,
+			FileID: schemas.Ptr("file_abc"),
+		}}}},
+	}
+
+	// Both converters emit these items: the grouped one (Bedrock ingress) and the
+	// plain one. The contract is the same on each.
+	for _, keepToolsGrouped := range []bool{false, true} {
+		out := ConvertAnthropicMessagesToBifrostMessages(ctx, messages, nil, false, keepToolsGrouped)
+
+		assistantMessages := 0
+		for i, msg := range out {
+			if msg.Type == nil || *msg.Type != schemas.ResponsesMessageTypeMessage || msg.Role == nil || *msg.Role != schemas.ResponsesInputMessageRoleAssistant {
+				continue
+			}
+			assistantMessages++
+			if msg.Status == nil || *msg.Status != "completed" {
+				t.Errorf("grouped=%v output[%d]: assistant message item must carry status \"completed\", got %v", keepToolsGrouped, i, msg.Status)
+			}
+		}
+		if assistantMessages != 4 {
+			t.Fatalf("grouped=%v: expected 4 assistant message items (string, image, document, container_upload), got %d", keepToolsGrouped, assistantMessages)
+		}
+		if user := out[0]; user.Status != nil {
+			t.Errorf("grouped=%v: user input message must not carry status, got %q", keepToolsGrouped, *user.Status)
+		}
+	}
+}

--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -4,10 +4,15 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 
+	bifrost "github.com/maximhq/bifrost/core"
 	"github.com/maximhq/bifrost/core/internal/llmtests"
 	"github.com/maximhq/bifrost/core/providers/anthropic"
 	"github.com/maximhq/bifrost/core/providers/bedrock"
@@ -1000,6 +1005,12 @@ func TestBifrostToBedrockRequestConversion(t *testing.T) {
 				}
 			} else {
 				require.NoError(t, err)
+				if tt.expected.InferenceConfig == nil {
+					tt.expected.InferenceConfig = &bedrock.BedrockInferenceConfig{}
+				}
+				if tt.expected.InferenceConfig.MaxTokens == nil {
+					tt.expected.InferenceConfig.MaxTokens = schemas.Ptr(4096)
+				}
 				assertBedrockRequestEqual(t, tt.expected, actual)
 			}
 		})
@@ -7617,4 +7628,232 @@ func TestBedrockImageS3URIWithoutExtensionErrors(t *testing.T) {
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot determine image format")
+}
+
+// TestDefaultOutputTokens verifies omitted limits use model capacity without replacing explicit limits.
+func TestDefaultOutputTokens(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	for _, test := range []struct {
+		name  string
+		model string
+		limit *int
+		want  int
+	}{
+		{name: "known", model: "us.anthropic.claude-sonnet-5", want: 128000},
+		{name: "explicit", model: "us.anthropic.claude-sonnet-5", limit: schemas.Ptr(512), want: 512},
+		{name: "unknown", model: "unknown-model"},
+	} {
+		for _, emptyParams := range []bool{false, true} {
+			t.Run(test.name+"/"+map[bool]string{false: "nil", true: "params"}[emptyParams], func(t *testing.T) {
+				chat := &schemas.BifrostChatRequest{
+					Provider: schemas.Bedrock,
+					Model:    test.model,
+					Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+				}
+				responses := &schemas.BifrostResponsesRequest{Provider: schemas.Bedrock, Model: test.model}
+				if emptyParams || test.limit != nil {
+					chat.Params = &schemas.ChatParameters{MaxCompletionTokens: test.limit}
+					responses.Params = &schemas.ResponsesParameters{MaxOutputTokens: test.limit}
+				}
+				convertedChat, err := bedrock.ToBedrockChatCompletionRequest(ctx, chat)
+				require.NoError(t, err)
+				convertedResponses, err := bedrock.ToBedrockResponsesRequest(ctx, responses)
+				require.NoError(t, err)
+				for name, converted := range map[string]*bedrock.BedrockConverseRequest{"chat": convertedChat, "responses": convertedResponses} {
+					got := 0
+					if converted.InferenceConfig != nil && converted.InferenceConfig.MaxTokens != nil {
+						got = *converted.InferenceConfig.MaxTokens
+					}
+					assert.Equalf(t, test.want, got, "%s max tokens", name)
+				}
+			})
+		}
+	}
+}
+
+// TestDefaultOutputTokensCapabilities verifies catalog limits override static defaults and Nova exclusions survive.
+func TestDefaultOutputTokensCapabilities(t *testing.T) {
+	schemas.SetCapabilityResolver(func(provider schemas.ModelProvider, model string) *schemas.ModelCapabilities {
+		if provider == schemas.Bedrock {
+			return &schemas.ModelCapabilities{MaxOutputTokens: schemas.Ptr(32000)}
+		}
+		return nil
+	})
+	t.Cleanup(func() { schemas.SetCapabilityResolver(nil) })
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	for _, model := range []string{"us.anthropic.claude-sonnet-5", "custom-model", "us.amazon.nova-pro-v1:0"} {
+		t.Run(model, func(t *testing.T) {
+			chat := &schemas.BifrostChatRequest{
+				Provider: schemas.Bedrock,
+				Model:    model,
+				Input:    []schemas.ChatMessage{{Role: schemas.ChatMessageRoleUser, Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hi")}}},
+				Params:   &schemas.ChatParameters{Reasoning: &schemas.ChatReasoning{Effort: schemas.Ptr("high")}},
+			}
+			responses := &schemas.BifrostResponsesRequest{Provider: schemas.Bedrock, Model: model, Params: &schemas.ResponsesParameters{Reasoning: &schemas.ResponsesParametersReasoning{Effort: schemas.Ptr("high")}}}
+			convertedChat, err := bedrock.ToBedrockChatCompletionRequest(ctx, chat)
+			require.NoError(t, err)
+			convertedResponses, err := bedrock.ToBedrockResponsesRequest(ctx, responses)
+			require.NoError(t, err)
+			for name, converted := range map[string]*bedrock.BedrockConverseRequest{"chat": convertedChat, "responses": convertedResponses} {
+				if model == "us.amazon.nova-pro-v1:0" {
+					if converted.InferenceConfig != nil && converted.InferenceConfig.MaxTokens != nil {
+						t.Errorf("%s high Nova reasoning must omit max tokens", name)
+					}
+				} else if converted.InferenceConfig == nil || converted.InferenceConfig.MaxTokens == nil || *converted.InferenceConfig.MaxTokens != 32000 {
+					t.Errorf("%s did not use catalog max tokens", name)
+				}
+			}
+			require.Nil(t, chat.Params.MaxCompletionTokens, "conversion mutated chat token limit")
+			require.Nil(t, responses.Params.MaxOutputTokens, "conversion mutated responses token limit")
+		})
+	}
+}
+
+// Wire-level reproduction of issue #7074.
+//
+// Claude Code talks to Bifrost on the Anthropic-native ingress (`POST /anthropic/v1/messages`)
+// with a `bedrock/openai.gpt-oss-120b` model. The request is converted Anthropic -> Bifrost
+// Responses and, because gpt-oss is a Mantle-only model, forwarded as-is to the Bedrock Mantle
+// OpenAI-compatible `/v1/responses` endpoint.
+//
+// On the second turn the client replays the prior assistant message. The Bedrock-only "grouped"
+// ingress converter (ConvertAnthropicMessagesToBifrostMessages with keepToolsGrouped=true) used
+// to emit two shapes that are not valid Responses input items under the official OpenAI types
+// (openai-python `ResponseInputParam`), which strict Mantle validators enforce:
+//
+//   - user / system text parts were tagged `output_text`; an input message may only carry
+//     `input_text` / `input_image` / `input_file` parts
+//     (https://developers.openai.com/api/reference/resources/responses/methods/create)
+//   - the replayed assistant message had an `id` but no `status`; `ResponseOutputMessageParam`
+//     requires `id`, `role`, `status`, `type` and `content`
+//     (https://github.com/openai/openai-python/blob/main/src/openai/types/responses/response_output_message_param.py)
+//
+// The upstream validator rejected the whole request:
+//
+//	655 validation errors for ResponsesRequest ...
+//	input.list[...].6.EasyInputMessageParam.content.list[...].0.ResponseInputTextParam.type
+//	  Input should be 'input_text' [type=literal_error, input_value='output_text', input_type=str]
+//
+// The same conversation converted through the non-grouped converter (every other provider,
+// including bedrock_mantle) already produced the valid shapes, so this test pins the Bedrock
+// path to the same contract.
+func TestAnthropicIngressMantleReplayUsesResponsesInputShapes(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		captured []byte
+	)
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+		mu.Lock()
+		captured = body
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"resp_1","object":"response","created_at":1,"status":"completed",` +
+			`"model":"openai.gpt-oss-120b","output":[{"type":"message","id":"msg_1","status":"completed",` +
+			`"role":"assistant","content":[{"type":"output_text","text":"4","annotations":[]}]}],` +
+			`"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`))
+	}))
+	defer ts.Close()
+
+	config := &schemas.ProviderConfig{
+		NetworkConfig: schemas.NetworkConfig{
+			DefaultRequestTimeoutInSeconds: 5,
+			InsecureSkipVerify:             true,
+			AllowPrivateNetwork:            true,
+		},
+	}
+	config.CheckAndSetDefaults()
+	provider, err := bedrock.NewBedrockProvider(config, bifrost.NewDefaultLogger(schemas.LogLevelError))
+	require.NoError(t, err)
+
+	// Bearer value: no SigV4 signer. The Mantle host override points at the local server.
+	key := schemas.Key{
+		Value: *schemas.NewSecretVar("test-bearer"),
+		BedrockKeyConfig: &schemas.BedrockKeyConfig{
+			Region:    schemas.NewSecretVar("eu-west-1"),
+			Endpoints: &schemas.BedrockEndpoints{Mantle: schemas.NewSecretVar(strings.TrimPrefix(ts.URL, "https://"))},
+		},
+	}
+
+	// The reporter's scenario: Claude Code's second message in a session. The first turn's
+	// assistant reply is replayed as history.
+	ingressBody := `{
+		"model": "bedrock/openai.gpt-oss-120b",
+		"max_tokens": 1024,
+		"system": [{"type": "text", "text": "You are Claude Code."}],
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "hello"}]},
+			{"role": "assistant", "content": [{"type": "text", "text": "Hello! How can I help you today?"}]},
+			{"role": "user", "content": [{"type": "text", "text": "what is 2+2"}]}
+		]
+	}`
+	var ingressReq anthropic.AnthropicMessageRequest
+	require.NoError(t, json.Unmarshal([]byte(ingressBody), &ingressReq))
+
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	bifrostReq := ingressReq.ToBifrostResponsesRequest(ctx)
+	require.NotNil(t, bifrostReq)
+	require.Equal(t, schemas.Bedrock, bifrostReq.Provider)
+
+	_, bifrostErr := provider.Responses(ctx, key, bifrostReq)
+	require.Nil(t, bifrostErr, "request must reach the Mantle endpoint: %+v", bifrostErr)
+
+	mu.Lock()
+	body := captured
+	mu.Unlock()
+	require.NotEmpty(t, body, "the provider must have sent a body to the Mantle endpoint")
+
+	var wire struct {
+		Input []struct {
+			Type    *string         `json:"type"`
+			Role    *string         `json:"role"`
+			Status  *string         `json:"status"`
+			Content json.RawMessage `json:"content"`
+		} `json:"input"`
+	}
+	require.NoError(t, json.Unmarshal(body, &wire))
+	require.Len(t, wire.Input, 4, "system + user + assistant + user, got: %s", body)
+
+	sawAssistant := false
+	for i, item := range wire.Input {
+		if len(item.Content) == 0 || item.Content[0] != '[' {
+			continue // string content is valid for any role
+		}
+		var parts []struct {
+			Type string `json:"type"`
+		}
+		require.NoErrorf(t, json.Unmarshal(item.Content, &parts), "input[%d].content", i)
+		require.NotNilf(t, item.Role, "input[%d] message item must carry a role", i)
+
+		if *item.Role != "assistant" {
+			for j, part := range parts {
+				assert.Equalf(t, "input_text", part.Type,
+					"input[%d].content[%d]: a %s message is a Responses input message and may only carry input_* parts (got %q)",
+					i, j, *item.Role, part.Type)
+			}
+			continue
+		}
+
+		sawAssistant = true
+		for j, part := range parts {
+			assert.Equalf(t, "output_text", part.Type, "input[%d].content[%d]: replayed assistant text stays output_text", i, j)
+		}
+		if assert.NotNilf(t, item.Status,
+			"input[%d]: an assistant output message item requires `status` (ResponseOutputMessageParam), got item: %s", i, mustItem(body, i)) {
+			assert.Equalf(t, "completed", *item.Status, "input[%d].status", i)
+		}
+	}
+	require.True(t, sawAssistant, "fixture must include a replayed assistant message")
+}
+
+// mustItem returns the raw JSON of input[i] for failure messages.
+func mustItem(body []byte, i int) string {
+	var wire struct {
+		Input []json.RawMessage `json:"input"`
+	}
+	if err := json.Unmarshal(body, &wire); err != nil || i >= len(wire.Input) {
+		return "<unavailable>"
+	}
+	return string(wire.Input[i])
 }

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -2510,10 +2510,16 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 	}
 
 	var responsesStructuredOutputTool *BedrockTool
+	if maxTokens := providerUtils.GetMaxOutputTokensOrDefault(caps.Provider(), caps.Model(), 0); maxTokens > 0 {
+		bedrockReq.InferenceConfig = &BedrockInferenceConfig{MaxTokens: schemas.Ptr(maxTokens)}
+	}
 
 	// Map basic parameters to inference config
 	if bifrostReq.Params != nil {
-		inferenceConfig := &BedrockInferenceConfig{}
+		inferenceConfig := bedrockReq.InferenceConfig
+		if inferenceConfig == nil {
+			inferenceConfig = &BedrockInferenceConfig{}
+		}
 
 		if bifrostReq.Params.MaxOutputTokens != nil {
 			inferenceConfig.MaxTokens = clampMaxTokens(ctx, bifrostReq.Params.MaxOutputTokens, caps)

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -520,13 +520,20 @@ func bedrockAliasToolUseID(id string) string {
 
 // convertParameters handles parameter conversion
 func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.BifrostChatRequest, bedrockReq *BedrockConverseRequest, caps schemas.ModelCaps) error {
-	// Parameters are optional - if not provided, just skip conversion
 	if bifrostReq.Params == nil {
+		if maxTokens := providerUtils.GetMaxOutputTokensOrDefault(caps.Provider(), caps.Model(), 0); maxTokens > 0 {
+			bedrockReq.InferenceConfig = &BedrockInferenceConfig{MaxTokens: schemas.Ptr(maxTokens)}
+		}
 		return nil
 	}
 
 	// Convert inference config
 	if inferenceConfig := convertInferenceConfig(bifrostReq.Params, caps); inferenceConfig != nil {
+		if inferenceConfig.MaxTokens == nil {
+			if maxTokens := providerUtils.GetMaxOutputTokensOrDefault(caps.Provider(), caps.Model(), 0); maxTokens > 0 {
+				inferenceConfig.MaxTokens = schemas.Ptr(maxTokens)
+			}
+		}
 		inferenceConfig.MaxTokens = clampMaxTokens(ctx, inferenceConfig.MaxTokens, caps)
 		bedrockReq.InferenceConfig = inferenceConfig
 	}

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -146989,6 +146989,238 @@
           ]
         }
       ]
+    },
+    {
+      "name": "80. Anthropic-ingress replay to Bedrock Mantle Responses: input_text tags + assistant status (#7074 / PR #7075)",
+      "description": "Regression coverage for PR #7075 (fixes #7074). Claude Code talks to Bifrost through the Anthropic Messages drop-in (/anthropic/v1/messages). On turn 2 it replays the prior assistant turn, and Bifrost converts that history into Responses input items for an OpenAI-family model on Bedrock Mantle. The Bedrock-grouped ingress converter tagged user/system text blocks as output_text (only input_text is valid on an input item) and omitted the required status on replayed assistant message items, so Mantle's strict OpenAI-compatible validator rejected the whole request with hundreds of errors (\"Input should be 'input_text'\", \"status Field required\"). Turn 1 always worked, which is why the single-turn matrix rows never caught it. The fix tags input blocks input_text and stamps status: completed on every replayed assistant message item (text, string content, image, document, container_upload). The same PR also populates Bedrock inferenceConfig.maxTokens from the model's known output capacity when the caller sends no max_tokens; the raw_request case pins that on Converse. Model choice: openai.gpt-5.6-sol is the OpenAI-family model this collection already runs on Mantle's Responses path (folder 33); openai.gpt-oss-120b is the issue's exact model on the bedrock key (Mantle-routed), and a 403 on it skips via the infra guard.",
+      "item": [
+        {
+          "name": "bedrock_mantle/openai.gpt-5.6-sol /anthropic/v1/messages turn-2 replays assistant history without input_text/status 400 - #7074",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }\n// 400 is deliberately NOT skipped: it is the #7074 failure signature (Mantle's Responses validator rejecting replayed history).",
+                  "pm.test('bedrock_mantle gpt-5.6-sol non-streaming: replayed assistant history is accepted - #7074', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'pre-fix input_text/output_text mistag resurfaced').to.not.include(\"Input should be 'input_text'\");",
+                  "  pm.expect(body, 'pre-fix Responses validation storm resurfaced').to.not.include('validation errors for ResponsesRequest');",
+                  "  pm.expect(body, 'pre-fix missing assistant status resurfaced').to.not.include('status\\\\n    Field required');",
+                  "  pm.expect(pm.response.code, 'request failed: ' + body.slice(0, 600)).to.be.below(400);",
+                  "  var json = pm.response.json() || {};",
+                  "  pm.expect(json.content, 'expected an Anthropic content array').to.be.an('array');",
+                  "  pm.expect(json.content.length, 'expected at least one content block').to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock_mantle/openai.gpt-5.6-sol\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Hello! How can I help you today?\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with the single word OK.\"\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "bedrock_mantle/openai.gpt-5.6-sol /anthropic/v1/messages streaming turn-2 replays assistant history without input_text/status 400 - #7074",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }\n// 400 is deliberately NOT skipped: it is the #7074 failure signature (Mantle's Responses validator rejecting replayed history).",
+                  "pm.test('bedrock_mantle gpt-5.6-sol streaming: replayed assistant history is accepted - #7074', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'pre-fix input_text/output_text mistag resurfaced').to.not.include(\"Input should be 'input_text'\");",
+                  "  pm.expect(body, 'pre-fix Responses validation storm resurfaced').to.not.include('validation errors for ResponsesRequest');",
+                  "  pm.expect(body, 'pre-fix missing assistant status resurfaced').to.not.include('status\\\\n    Field required');",
+                  "  pm.expect(pm.response.code, 'stream request failed: ' + body.slice(0, 600)).to.equal(200);",
+                  "  pm.expect(body, 'expected Anthropic SSE frames').to.include('event:');",
+                  "  pm.expect(body, 'expected the stream to reach message_stop').to.include('message_stop');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock_mantle/openai.gpt-5.6-sol\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Hello! How can I help you today?\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with the single word OK.\"\n    }\n  ],\n  \"stream\": true\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "bedrock/openai.gpt-oss-120b /anthropic/v1/messages turn-2 replays assistant history (issue model, bedrock key routed to Mantle) - #7074",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }\n// 400 is deliberately NOT skipped: it is the #7074 failure signature (Mantle's Responses validator rejecting replayed history).",
+                  "pm.test('bedrock gpt-oss-120b non-streaming: replayed assistant history is accepted - #7074', function () {",
+                  "  var body = pm.response.text() || '';",
+                  "  pm.expect(body, 'pre-fix input_text/output_text mistag resurfaced').to.not.include(\"Input should be 'input_text'\");",
+                  "  pm.expect(body, 'pre-fix Responses validation storm resurfaced').to.not.include('validation errors for ResponsesRequest');",
+                  "  pm.expect(body, 'pre-fix missing assistant status resurfaced').to.not.include('status\\\\n    Field required');",
+                  "  pm.expect(pm.response.code, 'request failed: ' + body.slice(0, 600)).to.be.below(400);",
+                  "  var json = pm.response.json() || {};",
+                  "  pm.expect(json.content, 'expected an Anthropic content array').to.be.an('array');",
+                  "  pm.expect(json.content.length, 'expected at least one content block').to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/openai.gpt-oss-120b\",\n  \"max_tokens\": 64,\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Hello\"\n    },\n    {\n      \"role\": \"assistant\",\n      \"content\": \"Hello! How can I help you today?\"\n    },\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with the single word OK.\"\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/anthropic/v1/messages",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "anthropic",
+                "v1",
+                "messages"
+              ]
+            }
+          },
+          "response": []
+        },
+        {
+          "name": "bedrock/us.amazon.nova-lite-v1:0 /v1/chat/completions without max_tokens populates inferenceConfig.maxTokens (raw_request) - #7074",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if ([401, 403, 429, 500, 502, 503, 504].indexOf(pm.response.code) !== -1) { return; }",
+                  "pm.test('bedrock nova-lite chat without max_tokens: 2xx', function () {",
+                  "  pm.expect(pm.response.code, 'failed: ' + pm.response.text()).to.be.below(400);",
+                  "});",
+                  "if (pm.response.code >= 400) { return; }",
+                  "var body = pm.response.json() || {};",
+                  "var ef = body.extra_fields || {};",
+                  "var rr = ef.raw_request;",
+                  "if (typeof rr === 'string') { try { rr = JSON.parse(rr); } catch (e) { rr = null; } }",
+                  "pm.test('bedrock nova-lite chat without max_tokens: raw_request captured', function () {",
+                  "  pm.expect(rr, 'raw_request missing - x-bf-send-back-raw-request not honored').to.be.an('object');",
+                  "});",
+                  "if (!rr || typeof rr !== 'object') { return; }",
+                  "var ic = rr.inferenceConfig || {};",
+                  "pm.test('bedrock nova-lite chat without max_tokens: inferenceConfig.maxTokens defaulted from model capacity - #7074', function () {",
+                  "  pm.expect(ic.maxTokens, 'inferenceConfig: ' + JSON.stringify(ic)).to.be.a('number');",
+                  "  pm.expect(ic.maxTokens, 'maxTokens must be populated when the caller omits max_tokens').to.be.above(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "x-bf-send-back-raw-request",
+                "value": "true"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"model\": \"bedrock/us.amazon.nova-lite-v1:0\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"Reply with the single word OK.\"\n    }\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{baseUrl}}/v1/chat/completions",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            }
+          },
+          "response": []
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes two wire-level validation failures that occur when Claude Code replays a prior assistant message through the Anthropic-native ingress (`POST /anthropic/v1/messages`) targeting a Bedrock Mantle model. The Bedrock-grouped ingress converter was emitting `output_text` content type tags on user/system input messages (only `input_text` is valid for input messages) and omitting the required `status` field on replayed assistant output messages, causing Mantle's strict OpenAI-compatible validator to reject the entire request with hundreds of validation errors.

Additionally, Bedrock requests with no explicit `max_tokens` now automatically populate `MaxTokens` from the model's known capacity, preventing silent truncation on models with large context windows.

## Changes

- **Anthropic responses converter**: Replayed assistant messages now include `Status: "completed"` and user/system text blocks are tagged `input_text` instead of `output_text`, matching the `ResponseInputTextParam` contract required by Mantle's OpenAI-compatible validator.
- **Bedrock chat parameter conversion**: When no explicit `MaxCompletionTokens` is provided, `MaxTokens` is populated from the model's known output token capacity via `GetMaxOutputTokensOrDefault`. This applies both when `Params` is nil and when `Params` is present but omits a token limit.
- **Bedrock responses conversion**: Same default token population logic applied to the responses path via `ToBedrockResponsesRequest`.
- **Bedrock test suite**: Existing conversion tests updated to account for the new default `MaxTokens` injection (4096 fallback). New `defaultoutputtokens_test.go` covers known models, explicit overrides, unknown models, and catalog-resolver overrides including the Nova high-reasoning exclusion. New `mantleanthropicingressreplay_test.go` is a wire-level end-to-end reproduction of the original issue that pins the Bedrock ingress path to the same valid Responses input shapes produced by all other providers.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go)
- [x] Providers/Integrations

## How to test

```sh
go test ./core/providers/bedrock/... -run TestAnthropicIngressMantleReplayUsesResponsesInputShapes
go test ./core/providers/bedrock/... -run TestDefaultOutputTokens
go test ./core/providers/bedrock/... -run TestDefaultOutputTokensCapabilities
go test ./core/providers/bedrock/...
go test ./core/providers/anthropic/...
```

The Mantle replay test spins up a local TLS server, sends a two-turn conversation through the full provider stack, and asserts that:
- User/system content blocks carry `input_text` type tags
- The replayed assistant message carries `status: "completed"`

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #7074

## Security considerations

None. The TLS test server uses `InsecureSkipVerify` only within the test harness and no credentials or secrets are involved beyond a synthetic bearer token.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable