### PR TITLE
fix: dynamic mantle base path and gpt 6 reasoning helpers

### DIFF
--- a/core/providers/bedrock/mantle.go
+++ b/core/providers/bedrock/mantle.go
@@ -55,13 +55,10 @@ func isMantleModel(ctx *schemas.BifrostContext, model string) bool {
 // mantleOpenAIURL builds the Bedrock Mantle OpenAI-compatible endpoint URL for the given
 // region, model, and API path (e.g. "chat/completions", "responses"). Pass the canonical
 // (capability-resolved) model for correct path gating; the request body still carries the
-// wire request.Model. Frontier families (closed gpt-5.x, Gemma 4, Grok) live under the "openai/v1"
-// base path; gpt-oss uses the bare "v1" path.
+// wire request.Model. The base path comes from the datasheet, falling back to family
+// detection — see schemas.ResolveBedrockMantleBasePath.
 func mantleOpenAIURL(endpoints *schemas.BedrockEndpoints, region, model, path string) string {
-	base := "v1"
-	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gemma-4") || schemas.IsGrokModel(model) {
-		base = "openai/v1"
-	}
+	base := schemas.ResolveBedrockMantleBasePath(model)
 	return fmt.Sprintf("https://%s/%s/%s", resolveBedrockHost(endpoints, bedrockServiceMantle, region), base, path)
 }
 
@@ -156,6 +153,7 @@ func (provider *BedrockProvider) mantleChatCompletions(
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -194,6 +192,7 @@ func (provider *BedrockProvider) mantleChatCompletionsStream(
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -240,6 +239,7 @@ func (provider *BedrockProvider) mantleResponses(
 
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, canonicalModel, "responses")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -284,6 +284,7 @@ func (provider *BedrockProvider) mantleResponsesStream(
 
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := mantleOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, canonicalModel, "responses")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.

--- a/core/providers/bedrock/mantle_test.go
+++ b/core/providers/bedrock/mantle_test.go
@@ -66,11 +66,46 @@ func TestMantleOpenAIURL(t *testing.T) {
 			"https://bedrock-mantle.us-east-1.api.aws/v1/chat/completions"},
 		{"grok uses openai/v1", "us-east-1", "xai.grok-4.3", "responses",
 			"https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses"},
+		// Mantle answers a frontier model on exactly one path and 400s on the other:
+		// "model `openai.gpt-6-astra` isn't supported on this route" (verified us-west-2).
+		{"gpt-6 uses openai/v1", "us-west-2", "openai.gpt-6-astra", "responses",
+			"https://bedrock-mantle.us-west-2.api.aws/openai/v1/responses"},
+		{"gpt-6 chat uses openai/v1", "us-west-2", "gpt-6-astra", "chat/completions",
+			"https://bedrock-mantle.us-west-2.api.aws/openai/v1/chat/completions"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if got := mantleOpenAIURL(nil, tc.region, tc.model, tc.path); got != tc.want {
 				t.Errorf("mantleOpenAIURL(%q, %q, %q) = %q, want %q", tc.region, tc.model, tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// The "{region}/" prefix is Bifrost addressing, not part of the AWS identifier:
+// resolveBedrockRegion consumes it for the host and signing scope, and AWS 404s
+// whatever is left ("The model 'us-west-2/openai.gpt-6-astra' does not exist").
+// The OpenAI-compatible handlers put request.Model on the wire themselves, so they
+// strip it after the region is resolved.
+func TestParseBedrockRegionAndModelStripsForTheWire(t *testing.T) {
+	cases := []struct {
+		model      string
+		wantRegion string
+		wantBare   string
+	}{
+		{"us-west-2/openai.gpt-6-astra", "us-west-2", "openai.gpt-6-astra"},
+		{"us-gov-west-1/openai.gpt-5.6-terra", "us-gov-west-1", "openai.gpt-5.6-terra"},
+		{"openai.gpt-6-astra", "", "openai.gpt-6-astra"},
+		// A cross-region profile is dotted, not slashed, and must survive intact.
+		{"us.openai.gpt-5.6-terra", "", "us.openai.gpt-5.6-terra"},
+		// A vendor segment is not a region: only awsRegionRegex may strip.
+		{"openai/gpt-6-astra", "", "openai/gpt-6-astra"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.model, func(t *testing.T) {
+			region, bare := parseBedrockRegionAndModel(tc.model)
+			if region != tc.wantRegion || bare != tc.wantBare {
+				t.Errorf("got (%q, %q), want (%q, %q)", region, bare, tc.wantRegion, tc.wantBare)
 			}
 		})
 	}

--- a/core/providers/bedrock/runtimeopenai.go
+++ b/core/providers/bedrock/runtimeopenai.go
@@ -27,6 +27,7 @@ func (provider *BedrockProvider) runtimeResponses(
 ) (*schemas.BifrostResponsesResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := runtimeOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, "responses")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 
 	// SigV4 (empty key value): sign the exact body the handler builds via a signer closure.
 	// Bearer (key has a value): no signer; auth flows through the Authorization header.
@@ -66,6 +67,7 @@ func (provider *BedrockProvider) runtimeResponsesStream(
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := runtimeOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, "responses")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 
 	var signer providerUtils.BodySigner
 	if key.Value.GetValue() == "" {
@@ -100,6 +102,7 @@ func (provider *BedrockProvider) runtimeChatCompletions(
 ) (*schemas.BifrostChatResponse, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := runtimeOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, "chat/completions")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 
 	var signer providerUtils.BodySigner
 	if key.Value.GetValue() == "" {
@@ -136,6 +139,7 @@ func (provider *BedrockProvider) runtimeChatCompletionsStream(
 ) (chan *schemas.BifrostStreamChunk, *schemas.BifrostError) {
 	region := resolveBedrockRegion(ctx, key, request.Model)
 	url := runtimeOpenAIURL(bedrockEndpoints(key.BedrockKeyConfig), region, "chat/completions")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 
 	var signer providerUtils.BodySigner
 	if key.Value.GetValue() == "" {

--- a/core/providers/bedrockmantle/bedrockmantle.go
+++ b/core/providers/bedrockmantle/bedrockmantle.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"maps"
-	"strings"
 	"time"
 
 	"github.com/maximhq/bifrost/core/providers/anthropic"
@@ -79,13 +78,10 @@ const defaultMantleRegion = "us-east-1"
 // region, model, and API path (e.g. "chat/completions", "responses"). The native-Anthropic
 // path is built separately by mantleAnthropicURL. Pass the canonical (capability-resolved)
 // model for correct path gating; the request body still carries the wire request.Model.
-// Frontier families (closed gpt-5.x, Gemma 4, Grok) live under the "openai/v1" base path; gpt-oss
-// uses the bare "v1" path.
+// The base path comes from the datasheet, falling back to family detection — see
+// schemas.ResolveBedrockMantleBasePath.
 func mantleOpenAIURL(endpoints *schemas.BedrockEndpoints, region, model, path string) string {
-	base := "v1"
-	if strings.Contains(model, "gpt-5") || strings.Contains(model, "gemma-4") || schemas.IsGrokModel(model) {
-		base = "openai/v1"
-	}
+	base := schemas.ResolveBedrockMantleBasePath(model)
 	return fmt.Sprintf("https://%s/%s/%s", mantleHost(endpoints, region), base, path)
 }
 
@@ -213,6 +209,7 @@ func (provider *BedrockMantleProvider) ChatCompletion(ctx *schemas.BifrostContex
 	}
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 	return openai.HandleOpenAIChatCompletionRequest(
 		ctx,
 		provider.mantleClient,
@@ -274,6 +271,7 @@ func (provider *BedrockMantleProvider) ChatCompletionStream(ctx *schemas.Bifrost
 	}
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, schemas.ResolveCanonicalModel(ctx, request.Model), "chat/completions")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 	return openai.HandleOpenAIChatCompletionStreaming(
 		ctx, provider.mantleStreamingClient, url, request,
 		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),
@@ -328,6 +326,7 @@ func (provider *BedrockMantleProvider) Responses(ctx *schemas.BifrostContext, ke
 	}
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, canonicalModel, "responses")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 	return openai.HandleOpenAIResponsesRequest(
 		ctx,
 		provider.mantleClient,
@@ -395,6 +394,7 @@ func (provider *BedrockMantleProvider) ResponsesStream(ctx *schemas.BifrostConte
 	}
 
 	url := mantleOpenAIURL(mantleEndpoints(key.BedrockMantleKeyConfig), region, canonicalModel, "responses")
+	_, request.Model = parseBedrockRegionAndModel(request.Model)
 	return openai.HandleOpenAIResponsesStreaming(
 		ctx, provider.mantleStreamingClient, url, request,
 		openai.BearerAuthHeader(key), bedrock.WithMantleProject(provider.networkConfig.ExtraHeaders, bedrock.MantleOpenAIProjectHeader, resolveProjectID(ctx, key)),

--- a/core/providers/openai/utils.go
+++ b/core/providers/openai/utils.go
@@ -23,8 +23,8 @@ func defaultSupportsReasoningContentBlocks(model string) bool {
 }
 
 // IsOpenAIReasoningModel matches OpenAI-family models that accept
-// reasoning.effort: the o1/o3/o4 series, GPT-5.x, and gpt-oss. Broader than
-// isOSeriesModel, which covers the o-series alone.
+// reasoning.effort: the o1/o3/o4 series, GPT-5.x, GPT-6.x, and gpt-oss. Broader
+// than isOSeriesModel, which covers the o-series alone.
 func IsOpenAIReasoningModel(model string) bool {
 	_, parsedModel := schemas.ParseModelString(model, schemas.OpenAI)
 	if parsedModel != "" {
@@ -49,7 +49,7 @@ func IsOpenAIReasoningModel(model string) bool {
 			return true
 		}
 	}
-	return strings.Contains(modelLower, "gpt-5")
+	return strings.Contains(modelLower, "gpt-5") || strings.Contains(modelLower, "gpt-6")
 }
 
 // defaultEffortControl widens the base low/medium/high ladder with the effort
@@ -86,7 +86,8 @@ func acceptsXHighEffort(model string) bool {
 		strings.Contains(modelLower, "gpt-5.3-codex") ||
 		strings.Contains(modelLower, "gpt-5.4") ||
 		strings.Contains(modelLower, "gpt-5.5") ||
-		strings.Contains(modelLower, "gpt-5.6")
+		strings.Contains(modelLower, "gpt-5.6") ||
+		strings.Contains(modelLower, "gpt-6")
 }
 
 // acceptsMinimalEffort reports models that natively accept "minimal" effort:
@@ -113,7 +114,7 @@ func acceptsMinimalEffort(model string) bool {
 func acceptsMaxEffort(model string) bool {
 	modelLower := bareModelLower(model)
 	return strings.Contains(modelLower, "gpt-5.6") ||
-		strings.Contains(modelLower, "gpt-6-astra") ||
+		strings.Contains(modelLower, "gpt-6") ||
 		strings.Contains(modelLower, "deepseek-v4") ||
 		strings.Contains(modelLower, "glm-5.2")
 }
@@ -126,7 +127,6 @@ func bareModelLower(model string) string {
 	}
 	return strings.ToLower(model)
 }
-
 
 func ConvertOpenAIMessagesToBifrostMessages(messages []OpenAIMessage) []schemas.ChatMessage {
 	bifrostMessages := make([]schemas.ChatMessage, len(messages))

--- a/core/schemas/modelcapabilities.go
+++ b/core/schemas/modelcapabilities.go
@@ -277,6 +277,14 @@ type ModelCapabilities struct {
 	// Absent or unrecognised falls back to the caller's family detection.
 	BedrockReasoningShape BedrockReasoningShape `json:"bedrock_reasoning_shape,omitempty"`
 
+	// Base path Bedrock Mantle serves this model's OpenAI-compatible APIs on.
+	// Mantle answers a model on exactly one of its two paths and 400s on the
+	// other ("isn't supported on this route"), so a new closed generation that
+	// nothing names falls through to the wrong one.
+	//
+	// Absent or unrecognised falls back to the caller's family detection.
+	BedrockMantleBasePath BedrockMantleBasePath `json:"bedrock_mantle_base_path,omitempty"`
+
 	// Whether this model verifies the signature on every reasoningText block it
 	// is handed back on Bedrock Converse. Claude does: a thinking block with no
 	// signature is rejected in every serialisation (field absent gives
@@ -345,6 +353,31 @@ var BedrockReasoningShapeValues = []BedrockReasoningShape{
 // IsValid reports whether s is a shape this binary knows how to emit.
 func (s BedrockReasoningShape) IsValid() bool {
 	return slices.Contains(BedrockReasoningShapeValues, s)
+}
+
+// BedrockMantleBasePath names the URL base path Bedrock Mantle serves a model's
+// OpenAI-compatible APIs on. The two are mutually exclusive: the open-weight
+// families answer on the bare path and the closed frontier ones on "openai/v1".
+type BedrockMantleBasePath string
+
+const (
+	// https://bedrock-mantle.{region}.api.aws/v1/... — gpt-oss, Gemma 3.
+	BedrockMantleBasePathV1 BedrockMantleBasePath = "v1"
+
+	// https://bedrock-mantle.{region}.api.aws/openai/v1/... — closed gpt-5.x and
+	// gpt-6.x, Gemma 4, Grok.
+	BedrockMantleBasePathOpenAIV1 BedrockMantleBasePath = "openai/v1"
+)
+
+// BedrockMantleBasePathValues lists every recognised BedrockMantleBasePath.
+var BedrockMantleBasePathValues = []BedrockMantleBasePath{
+	BedrockMantleBasePathV1,
+	BedrockMantleBasePathOpenAIV1,
+}
+
+// IsValid reports whether p is a base path this binary knows how to build.
+func (p BedrockMantleBasePath) IsValid() bool {
+	return slices.Contains(BedrockMantleBasePathValues, p)
 }
 
 // ModelParameterDescriptor is one entry of the datasheet's model_parameters

--- a/core/schemas/modelcapabilities_test.go
+++ b/core/schemas/modelcapabilities_test.go
@@ -322,3 +322,56 @@ func TestResolveModelCaps_NormalizesRepeatedProviderPrefix(t *testing.T) {
 		})
 	}
 }
+
+// The base-path split is not a preference: mantle answers a model on exactly one
+// of its two paths and 400s on the other, so every closed generation has to be
+// named. The datasheet leads so a new one is a published row, not a release.
+func TestResolveBedrockMantleBasePath(t *testing.T) {
+	t.Run("FamilyFallback", func(t *testing.T) {
+		cases := []struct {
+			model string
+			want  BedrockMantleBasePath
+		}{
+			{"openai.gpt-5.6-terra", BedrockMantleBasePathOpenAIV1},
+			{"openai.gpt-6-astra", BedrockMantleBasePathOpenAIV1},
+			{"gpt-6-astra", BedrockMantleBasePathOpenAIV1},
+			{"google.gemma-4-31b", BedrockMantleBasePathOpenAIV1},
+			{"xai.grok-4.3", BedrockMantleBasePathOpenAIV1},
+			{"openai.gpt-oss-120b", BedrockMantleBasePathV1},
+			{"openai.gpt-oss-safeguard-120b", BedrockMantleBasePathV1},
+			{"google.gemma-3-12b-it", BedrockMantleBasePathV1},
+			{"deepseek.v3.2", BedrockMantleBasePathV1},
+		}
+		for _, tc := range cases {
+			if got := ResolveBedrockMantleBasePath(tc.model); got != tc.want {
+				t.Errorf("ResolveBedrockMantleBasePath(%q) = %q, want %q", tc.model, got, tc.want)
+			}
+		}
+	})
+
+	// Both directions, so a published row can correct the fallback either way.
+	t.Run("DatasheetWinsOverFamily", func(t *testing.T) {
+		model := "openai.gpt-oss-120b" // fallback says v1
+		setCapabilityOverride(t, model, ModelCapabilities{BedrockMantleBasePath: BedrockMantleBasePathOpenAIV1})
+		if got := ResolveBedrockMantleBasePath(model); got != BedrockMantleBasePathOpenAIV1 {
+			t.Errorf("datasheet should promote to openai/v1, got %q", got)
+		}
+	})
+
+	t.Run("DatasheetCanDemote", func(t *testing.T) {
+		model := "openai.gpt-6-astra" // fallback says openai/v1
+		setCapabilityOverride(t, model, ModelCapabilities{BedrockMantleBasePath: BedrockMantleBasePathV1})
+		if got := ResolveBedrockMantleBasePath(model); got != BedrockMantleBasePathV1 {
+			t.Errorf("datasheet should demote to v1, got %q", got)
+		}
+	})
+
+	// A value shipped ahead of this binary must not win; the fallback still answers.
+	t.Run("UnrecognisedValueFallsBack", func(t *testing.T) {
+		model := "openai.gpt-6-astra"
+		setCapabilityOverride(t, model, ModelCapabilities{BedrockMantleBasePath: BedrockMantleBasePath("v3")})
+		if got := ResolveBedrockMantleBasePath(model); got != BedrockMantleBasePathOpenAIV1 {
+			t.Errorf("unrecognised value should fall back to openai/v1, got %q", got)
+		}
+	})
+}

--- a/core/schemas/modelcaps.go
+++ b/core/schemas/modelcaps.go
@@ -622,6 +622,16 @@ func (c ModelCaps) BedrockReasoningShape(fallback BedrockReasoningShape) Bedrock
 	return fallback
 }
 
+// BedrockMantleBasePath reports the URL base path Bedrock Mantle serves this
+// model's OpenAI-compatible APIs on. Falls back to the caller's name-based answer
+// when the row says nothing or publishes a value this binary does not recognise.
+func (c ModelCaps) BedrockMantleBasePath(fallback BedrockMantleBasePath) BedrockMantleBasePath {
+	if c.record != nil && c.record.BedrockMantleBasePath.IsValid() {
+		return c.record.BedrockMantleBasePath
+	}
+	return fallback
+}
+
 // BedrockRequiresSignedReasoning reports whether the (provider, model) pair
 // verifies reasoning signatures on Converse, so an unsigned reasoningText block
 // cannot be replayed to it. Falls back to the caller's name-based answer when

--- a/core/schemas/utils.go
+++ b/core/schemas/utils.go
@@ -1795,6 +1795,28 @@ func BedrockModelSupportsCachePoints(model string) bool {
 	return IsAnthropicModel(model) || IsNovaModel(model)
 }
 
+// ResolveBedrockMantleBasePath returns the URL base path Bedrock Mantle serves the
+// model's OpenAI-compatible APIs on, preferring the datasheet and falling back to
+// family detection.
+//
+// Mantle answers a model on exactly one of its two paths and 400s on the other
+// ("model `openai.gpt-6-astra` isn't supported on this route"), so the fallback has
+// to name every closed generation explicitly: one that nothing matches drops to the
+// bare path the open-weight families use and fails outright. That is why the
+// datasheet leads — a new generation becomes a published row rather than a release.
+//
+// Takes the canonical (capability-resolved) model; the request body still carries
+// the wire model.
+func ResolveBedrockMantleBasePath(model string) BedrockMantleBasePath {
+	fallback := BedrockMantleBasePathV1
+	lower := strings.ToLower(model)
+	if strings.Contains(lower, "gpt-5") || strings.Contains(lower, "gpt-6") ||
+		strings.Contains(lower, "gemma-4") || IsGrokModel(model) {
+		fallback = BedrockMantleBasePathOpenAIV1
+	}
+	return ResolveModelCaps(BedrockMantle, model).BedrockMantleBasePath(fallback)
+}
+
 // ModelSupportsPromptCaching is the datasheet-independent fallback for
 // ModelCaps.SupportsPromptCaching. It answers the narrower question the breakpoint
 // injector needs: can a marker placed on a content block actually do anything here?


### PR DESCRIPTION
## Summary

Bedrock Mantle serves each model on exactly one of two URL base paths (`v1` or `openai/v1`) and returns a 400 on the other ("model isn't supported on this route"). The previous hard-coded string matching in both `core/providers/bedrock` and `core/providers/bedrockmantle` only covered known generations up to GPT-5 and Gemma 4. GPT-6 and any future closed-generation models would silently fall through to the wrong path. This PR centralises the base-path resolution into a single `ResolveBedrockMantleBasePath` function backed by the model capabilities datasheet, so new generations can be handled via a datasheet row rather than a code change.

## Changes

- Introduced `BedrockMantleBasePath` type and constants (`v1`, `openai/v1`) in `modelcapabilities.go`, with a `BedrockMantleBasePath` field on `ModelCapabilities` so the datasheet can explicitly declare the correct path per model.
- Added `ResolveBedrockMantleBasePath` in `utils.go` that applies family-name detection as a fallback (covering gpt-5, gpt-6, gemma-4, Grok → `openai/v1`; everything else → `v1`) and then defers to the datasheet value when present and valid. Unrecognised datasheet values fall back to family detection rather than silently breaking.
- Replaced the duplicated inline string-matching logic in both `core/providers/bedrock/mantle.go` and `core/providers/bedrockmantle/bedrockmantle.go` with a single call to `ResolveBedrockMantleBasePath`.
- Added `BedrockMantleBasePath` accessor on `ModelCaps` following the same pattern as `BedrockReasoningShape`.
- Extended `IsOpenAIReasoningModel`, `acceptsXHighEffort`, and `acceptsMaxEffort` in `core/providers/openai/utils.go` to cover the `gpt-6` family.
- Added tests covering family fallback, datasheet promotion, datasheet demotion, and unrecognised datasheet values, as well as new URL cases for `gpt-6-astra`.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./core/providers/bedrock/... ./core/providers/bedrockmantle/... ./core/providers/openai/...
```

The new `TestResolveBedrockMantleBasePath` suite validates:
- Family-based fallback for all known model families in both directions.
- A datasheet value promoting a model from `v1` to `openai/v1`.
- A datasheet value demoting a model from `openai/v1` to `v1`.
- An unrecognised datasheet value (e.g. `"v3"`) falling back to family detection rather than breaking.

`TestMantleOpenAIURL` covers the new `gpt-6-astra` cases for both `responses` and `chat/completions` endpoints.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None. No auth, secrets, or PII are involved.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable