### PR TITLE
docs(logging): clarify `CountRecalcTargets` matview staleness and `Total` approximation

### DIFF
--- a/docs/architecture/framework/model-catalog.mdx
+++ b/docs/architecture/framework/model-catalog.mdx
@@ -67,6 +67,14 @@ It integrates with semantic caching to provide accurate cost calculations:
 
 The system automatically applies different pricing rates for high-token contexts, reflecting real provider pricing models. Two tiers are supported: above 128k tokens and above 200k tokens, with the higher tier taking precedence when both are configured.
 
+### **6. Time-of-Day Pricing**
+
+Models can declare recurring weekly peak windows (`peak_hours`) and a discount (`off_peak_cost_multiplier`) that scales every usage-based charge outside them — DeepSeek's V4 lineup, for instance, bills at half rate outside Monday-Friday `01:00-04:00` and `06:00-10:00` UTC.
+
+The mechanism is generic: nothing in the cost engine names a provider, so any model whose datasheet row carries the two fields is priced this way. Base rates are the peak prices and the multiplier only ever scales downward, so a row with an incomplete or unparseable schedule bills at the full rate rather than under-billing. Flat per-request and per-query fees are excluded from the discount.
+
+Peak vs off-peak is decided by the request's **start time**, carried on `LookupScopes.BilledAt`, so pricing is deterministic and a stream crossing a boundary bills entirely at its start-time rate.
+
 ## Configuration
 
 The `ModelCatalog` can be configured during initialization by passing a `Config` struct.
@@ -206,6 +214,10 @@ type PricingEntry struct {
     InputCostPerQuery             *float64 `json:"input_cost_per_query,omitempty"`
     CodeInterpreterCostPerSession *float64 `json:"code_interpreter_cost_per_session,omitempty"`
     CostPerRequest                *float64 `json:"cost_per_request,omitempty"`
+
+    // Costs - Time of day
+    OffPeakCostMultiplier *float64           `json:"off_peak_cost_multiplier,omitempty"`
+    PeakHours             *PeakHoursSchedule `json:"peak_hours,omitempty"`
 }
 ```
 

--- a/docs/openapi/openapi.json
+++ b/docs/openapi/openapi.json
@@ -113234,6 +113234,70 @@
           "annotation_cost_per_page": {
             "type": "number",
             "minimum": 0
+          },
+          "off_peak_cost_multiplier": {
+            "type": "number",
+            "exclusiveMinimum": 0,
+            "maximum": 1,
+            "description": "Multiplier applied to every usage-based charge when the request falls outside the windows declared in peak_hours. Every other rate on this object is the peak (higher) price, so this can only scale downward — e.g. 0.5 for a 50% off-peak discount. Flat per-request and per-query fees are not discounted. A discount applies only when the RESOLVED pricing row carries both this field and peak_hours. A patch may supply one and inherit the other from the model's datasheet entry, so setting this alone still discounts when the datasheet already declares a schedule; it bills at peak only when neither source provides one.\n"
+          },
+          "peak_hours": {
+            "type": "object",
+            "description": "Recurring weekly windows during which the model is billed at its peak (base) rates. Any instant outside every window is off-peak and is discounted by off_peak_cost_multiplier. Peak vs off-peak is decided by the request's start time, so a stream crossing a boundary bills entirely at its start-time rate.\n",
+            "properties": {
+              "timezone": {
+                "type": "string",
+                "description": "IANA location name (e.g. \"UTC\", \"Asia/Shanghai\"). Empty means UTC.",
+                "example": "UTC"
+              },
+              "windows": {
+                "type": "array",
+                "description": "At least one window is required. A schedule with no usable window cannot be evaluated, and an unevaluable schedule bills at peak, so an empty list would silently discard the discount rather than make every instant off-peak.\n",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "days": {
+                      "type": "array",
+                      "description": "Weekdays the window applies to, 0 = Sunday through 6 = Saturday. For a window that wraps past midnight, this is the weekday the window starts on. At least one is required, for the same reason windows itself is.\n",
+                      "minItems": 1,
+                      "items": {
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 6
+                      },
+                      "example": [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5
+                      ]
+                    },
+                    "start": {
+                      "type": "string",
+                      "description": "Window start as \"HH:MM\" in the schedule's timezone (inclusive).",
+                      "pattern": "^([01][0-9]|2[0-3]):[0-5][0-9]$",
+                      "example": "01:00"
+                    },
+                    "end": {
+                      "type": "string",
+                      "description": "Window end as \"HH:MM\" in the schedule's timezone (exclusive). A value less than or equal to start wraps past midnight. \"24:00\" is accepted as an end-of-day marker.\n",
+                      "pattern": "^(([01][0-9]|2[0-3]):[0-5][0-9]|24:00)$",
+                      "example": "04:00"
+                    }
+                  },
+                  "required": [
+                    "days",
+                    "start",
+                    "end"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "windows"
+            ]
           }
         }
       },

--- a/docs/openapi/schemas/management/governance.yaml
+++ b/docs/openapi/schemas/management/governance.yaml
@@ -2151,6 +2151,77 @@ PricingPatch:
     annotation_cost_per_page:
       type: number
       minimum: 0
+    # Costs - Time of day
+    off_peak_cost_multiplier:
+      type: number
+      exclusiveMinimum: 0
+      maximum: 1
+      description: >
+        Multiplier applied to every usage-based charge when the request falls
+        outside the windows declared in peak_hours. Every other rate on this
+        object is the peak (higher) price, so this can only scale downward —
+        e.g. 0.5 for a 50% off-peak discount. Flat per-request and per-query
+        fees are not discounted. A discount applies only when the RESOLVED
+        pricing row carries both this field and peak_hours. A patch may supply
+        one and inherit the other from the model's datasheet entry, so setting
+        this alone still discounts when the datasheet already declares a
+        schedule; it bills at peak only when neither source provides one.
+    peak_hours:
+      type: object
+      description: >
+        Recurring weekly windows during which the model is billed at its peak
+        (base) rates. Any instant outside every window is off-peak and is
+        discounted by off_peak_cost_multiplier. Peak vs off-peak is decided by
+        the request's start time, so a stream crossing a boundary bills
+        entirely at its start-time rate.
+      properties:
+        timezone:
+          type: string
+          description: IANA location name (e.g. "UTC", "Asia/Shanghai"). Empty means UTC.
+          example: UTC
+        windows:
+          type: array
+          description: >
+            At least one window is required. A schedule with no usable window
+            cannot be evaluated, and an unevaluable schedule bills at peak, so
+            an empty list would silently discard the discount rather than make
+            every instant off-peak.
+          minItems: 1
+          items:
+            type: object
+            properties:
+              days:
+                type: array
+                description: >
+                  Weekdays the window applies to, 0 = Sunday through
+                  6 = Saturday. For a window that wraps past midnight, this is
+                  the weekday the window starts on. At least one is required,
+                  for the same reason windows itself is.
+                minItems: 1
+                items:
+                  type: integer
+                  minimum: 0
+                  maximum: 6
+                example: [1, 2, 3, 4, 5]
+              start:
+                type: string
+                description: Window start as "HH:MM" in the schedule's timezone (inclusive).
+                pattern: '^([01][0-9]|2[0-3]):[0-5][0-9]$'
+                example: "01:00"
+              end:
+                type: string
+                description: >
+                  Window end as "HH:MM" in the schedule's timezone (exclusive).
+                  A value less than or equal to start wraps past midnight.
+                  "24:00" is accepted as an end-of-day marker.
+                pattern: '^(([01][0-9]|2[0-3]):[0-5][0-9]|24:00)$'
+                example: "04:00"
+            required:
+              - days
+              - start
+              - end
+      required:
+        - windows
 
 PricingOverride:
   type: object

--- a/docs/providers/custom-pricing.mdx
+++ b/docs/providers/custom-pricing.mdx
@@ -447,6 +447,47 @@ The resolution-banded video rates are matched on the short edge of the generated
 | `ocr_cost_per_page` | Cost per page processed by OCR |
 | `annotation_cost_per_page` | Cost per annotated page |
 
+### Time-of-day costs
+
+Some providers bill the same model at different rates depending on when the request is made. DeepSeek, for example, charges half its normal rate outside a set of published peak windows.
+
+| Field | Description |
+|-------|-------------|
+| `off_peak_cost_multiplier` | Multiplier applied to every usage-based charge when the request falls outside `peak_hours`. Must be greater than `0` and at most `1` |
+| `peak_hours` | The recurring weekly windows during which the model is billed at its base rates |
+
+Three rules govern how this works:
+
+- **Base rates are the peak rates.** Every other cost field is the higher, peak-hour price, and `off_peak_cost_multiplier` discounts downward from it. A row that carries a schedule but no multiplier — or whose schedule cannot be evaluated — bills at the full base rate rather than silently under-billing.
+- **Both fields are required on the resolved row.** A multiplier with no schedule has no way to know when to apply, and a schedule with no multiplier has nothing to apply. An override may set one and inherit the other from the model's datasheet entry, so setting the multiplier alone still discounts when the datasheet already declares a schedule. It bills at the base rate only when neither the override nor the datasheet supplies the missing half.
+- **Flat fees are not discounted.** `cost_per_request`, `input_cost_per_query`, and `search_context_cost_per_query` are per-request and per-query charges rather than usage charges, so they are billed in full at any hour.
+
+`peak_hours` takes a timezone and a list of windows:
+
+```json
+{
+  "off_peak_cost_multiplier": 0.5,
+  "peak_hours": {
+    "timezone": "UTC",
+    "windows": [
+      { "days": [1, 2, 3, 4, 5], "start": "01:00", "end": "04:00" },
+      { "days": [1, 2, 3, 4, 5], "start": "06:00", "end": "10:00" }
+    ]
+  }
+}
+```
+
+- `timezone` is an IANA location name. Leave it empty for UTC.
+- `days` are weekday numbers, `0` = Sunday through `6` = Saturday.
+- `start` and `end` are `"HH:MM"` in the schedule's own timezone, covering the half-open interval `[start, end)` — a window ending at `04:00` does not include `04:00` itself, so adjacent windows never double-count.
+- An `end` less than or equal to `start` wraps past midnight. In that case `days` names the weekday the window *starts* on, so `Mon 22:00-02:00` also covers Tuesday's small hours.
+
+<Info>
+Peak vs off-peak is decided by the **request's start time**, not its completion time. This keeps pricing deterministic and reproducible, and makes streaming and non-streaming requests agree. A long stream that crosses a window boundary bills entirely at its start-time rate.
+</Info>
+
+The override UI exposes `off_peak_cost_multiplier` as a numeric field. `peak_hours` is a schedule object rather than a number, so it is edited through the API or the JSON patch editor; an existing schedule is preserved when you edit an override's other fields in the UI.
+
 ---
 
 ## Examples
@@ -498,6 +539,34 @@ Override costs for a specific image model at global scope:
   "pattern": "dall-e-3",
   "request_types": ["image_generation"],
   "pricing_patch": "{\"output_cost_per_image_high_quality\":0.04,\"output_cost_per_image_medium_quality\":0.02}"
+}
+```
+
+### Halving costs outside peak hours
+
+Mirrors DeepSeek's published schedule: base rates are the peak prices, and everything outside Monday-Friday `01:00-04:00` and `06:00-10:00` UTC bills at half.
+
+```json
+{
+  "name": "DeepSeek peak/off-peak",
+  "scope_kind": "provider",
+  "provider_id": "deepseek",
+  "match_type": "wildcard",
+  "pattern": "deepseek-v4*",
+  "request_types": ["chat_completion"],
+  "pricing_patch": {
+    "input_cost_per_token": 0.00000044,
+    "cache_read_input_token_cost": 0.000000014,
+    "output_cost_per_token": 0.00000132,
+    "off_peak_cost_multiplier": 0.5,
+    "peak_hours": {
+      "timezone": "UTC",
+      "windows": [
+        { "days": [1, 2, 3, 4, 5], "start": "01:00", "end": "04:00" },
+        { "days": [1, 2, 3, 4, 5], "start": "06:00", "end": "10:00" }
+      ]
+    }
+  }
 }
 ```
 

--- a/docs/providers/supported-providers/deepseek.mdx
+++ b/docs/providers/supported-providers/deepseek.mdx
@@ -256,6 +256,13 @@ Lists available models from DeepSeek through `/models`.
 
 ## Caveats
 
+<Accordion title="Peak / Off-Peak Pricing">
+**Severity**: Medium
+**Behavior**: DeepSeek bills the V4 models at two different rates depending on the time of day. Peak is Monday-Friday `01:00-04:00` and `06:00-10:00` UTC; every other hour, weekends included, is off-peak at half the peak rate, across cache-hit input, cache-miss input, and output alike
+**Impact**: Bifrost prices this through the generic time-of-day fields (`off_peak_cost_multiplier` and `peak_hours`) on the model's pricing row. If those fields are absent from the pricing datasheet in use, DeepSeek requests bill at the peak rate around the clock, overstating cost for most of the week — set them with a [custom pricing override](/providers/custom-pricing#time-of-day-costs) to correct it. Peak vs off-peak is decided by the request's start time, so a stream crossing a boundary bills entirely at its start-time rate
+**Code**: `offPeakMultiplier` and `scaleUsageCost` in `framework/modelcatalog/datasheet/cost.go`
+</Accordion>
+
 <Accordion title="Default Base URL">
 **Severity**: Low
 **Behavior**: DeepSeek defaults to `https://api.deepseek.com`

--- a/framework/jobaccounting/pricingscopes_test.go
+++ b/framework/jobaccounting/pricingscopes_test.go
@@ -1,0 +1,37 @@
+package jobaccounting
+
+import (
+	"testing"
+	"time"
+
+	"github.com/maximhq/bifrost/framework/logstore"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestPricingScopesForLog_CarriesBilledAt guards the one pricing input a
+// reprice cannot re-derive from anywhere else. Without BilledAt the time-of-day
+// engine falls back to the wall clock, so a model on a peak/off-peak schedule
+// reprices to a different cost on every pass.
+func TestPricingScopesForLog_CarriesBilledAt(t *testing.T) {
+	vk := "vk-1"
+	userID := "user-1"
+	ts := time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC)
+
+	scopes := PricingScopesForLog(&logstore.Log{
+		Timestamp:     ts,
+		Provider:      "deepseek",
+		SelectedKeyID: "key-1",
+		VirtualKeyID:  &vk,
+		UserID:        &userID,
+	})
+
+	assert.Equal(t, ts, scopes.BilledAt)
+	assert.Equal(t, "deepseek", scopes.Provider)
+	assert.Equal(t, "key-1", scopes.SelectedKeyID)
+	assert.Equal(t, vk, scopes.VirtualKeyID)
+	assert.Equal(t, userID, scopes.UserID)
+}
+
+func TestPricingScopesForLog_NilEntry(t *testing.T) {
+	assert.True(t, PricingScopesForLog(nil).BilledAt.IsZero())
+}

--- a/framework/jobaccounting/types.go
+++ b/framework/jobaccounting/types.go
@@ -382,5 +382,13 @@ func PricingScopesForLog(entry *logstore.Log) modelcatalog.PricingLookupScopes {
 		SelectedKeyID: entry.SelectedKeyID,
 		VirtualKeyID:  virtualKeyID,
 		UserID:        userID,
+		// Pin time-of-day pricing to the row's own Timestamp so a reprice charges
+		// the same rate the row was settled at. For an aggregate batch or video
+		// row that instant is settlement time, since buildAggregateLog stamps
+		// Timestamp from JobRequest.Now, which is also what the initial
+		// settlement priced against. Leaving this unset made every reprice
+		// resolve peak vs off-peak against whenever the sweeper happened to run,
+		// so the same row yielded a different cost on each pass.
+		BilledAt: entry.Timestamp,
 	}
 }

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/maximhq/bifrost/core/schemas"
 	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
@@ -247,6 +249,10 @@ func (s *Store) computeGuardrailJudgeCost(call schemas.BifrostGuardrailJudgeCall
 	judgeScopes := LookupScopes{Provider: string(call.JudgeProvider)}
 	if scopes != nil {
 		judgeScopes.VirtualKeyID = scopes.VirtualKeyID
+		// The judge call is part of the same request, so it prices against the
+		// same instant. Dropping this would silently fall back to wall-clock
+		// time-of-day pricing for judge calls only.
+		judgeScopes.BilledAt = scopes.BilledAt
 	}
 
 	usage := &schemas.BifrostLLMUsage{
@@ -636,9 +642,20 @@ func (s *Store) computeCostFromInput(input costInput, routingInfo schemas.Routin
 		return nil
 	}
 
+	// Time-of-day pricing: providers that discount outside declared peak windows
+	// (e.g. DeepSeek's 50% off-peak rate) scale every usage-based charge by a
+	// flat multiplier. Applied here rather than inside each compute*Cost so one
+	// branch covers every modality. It lands after computeTextCost's
+	// inference_geo multiplier, so the two compose multiplicatively.
+	if m, ok := offPeakMultiplier(pricing, scopes.BilledAt); ok {
+		scaleUsageCost(cost, m)
+	}
+
 	// Flat per-request surcharge, billed once on top of usage-based cost whenever
 	// the resolved pricing row carries one. It maps to no token category, so it
 	// folds into the input side (InputCostDetails.RequestCost) and the total.
+	// Deliberately added after the off-peak scaling: a flat per-request fee is
+	// not a usage charge and is not discounted.
 	if pricing.CostPerRequest != nil {
 		if cost == nil {
 			cost = &schemas.BifrostCost{}
@@ -2432,4 +2449,195 @@ func passthroughUsageToCostInput(su *schemas.BifrostPassthroughUsage) costInput 
 		}
 	}
 	return input
+}
+
+// ---------------------------------------------------------------------------
+// Time-of-day (peak / off-peak) pricing
+// ---------------------------------------------------------------------------
+
+// peakHoursLocations caches resolved IANA locations. time.LoadLocation hits the
+// filesystem (or the embedded tzdata) on every call, which is far too expensive
+// to repeat per priced request. A nil value memoizes a failed lookup so a bad
+// timezone string is not retried forever.
+var peakHoursLocations sync.Map // string -> *time.Location
+
+// peakHoursLocation resolves a schedule's timezone. An empty name means UTC.
+// An unknown name returns nil, which callers must treat as "cannot evaluate".
+func peakHoursLocation(name string) *time.Location {
+	if name == "" {
+		return time.UTC
+	}
+	if cached, ok := peakHoursLocations.Load(name); ok {
+		loc, _ := cached.(*time.Location)
+		return loc
+	}
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		peakHoursLocations.Store(name, (*time.Location)(nil))
+		return nil
+	}
+	peakHoursLocations.Store(name, loc)
+	return loc
+}
+
+// parseClockMinutes parses an "HH:MM" wall-clock string into minutes since
+// midnight. Returns false for anything malformed or out of range. "24:00" is
+// accepted as an end-of-day marker so a window can span a full day.
+func parseClockMinutes(v string) (int, bool) {
+	hh, mm, ok := strings.Cut(v, ":")
+	if !ok {
+		return 0, false
+	}
+	h, err := strconv.Atoi(hh)
+	if err != nil || h < 0 || h > 24 {
+		return 0, false
+	}
+	m, err := strconv.Atoi(mm)
+	if err != nil || m < 0 || m > 59 {
+		return 0, false
+	}
+	if h == 24 && m != 0 {
+		return 0, false
+	}
+	return h*60 + m, true
+}
+
+// isWithinPeakWindows reports whether at falls inside any window of sched, and
+// whether the schedule could be evaluated at all. A schedule that cannot be
+// evaluated — no windows, unknown timezone, every window malformed — returns
+// ok=false, and callers bill at peak. That direction matters: base rates are
+// the peak (higher) prices, so failing closed over-bills rather than handing
+// out a discount that was never configured.
+func isWithinPeakWindows(sched *PeakHoursSchedule, at time.Time) (peak bool, ok bool) {
+	if sched == nil || len(sched.Windows) == 0 {
+		return false, false
+	}
+	loc := peakHoursLocation(sched.Timezone)
+	if loc == nil {
+		return false, false
+	}
+
+	local := at.In(loc)
+	weekday := int(local.Weekday())
+	minutes := local.Hour()*60 + local.Minute()
+
+	// A window that wraps past midnight is also matched against the previous
+	// day: 22:00-02:00 on Monday still covers Tuesday 01:00.
+	prevWeekday := (weekday + 6) % 7
+	prevMinutes := minutes + 24*60
+
+	valid := false
+	for _, w := range sched.Windows {
+		start, startOK := parseClockMinutes(w.Start)
+		end, endOK := parseClockMinutes(w.End)
+		if !startOK || !endOK || len(w.Days) == 0 {
+			continue
+		}
+		wrapped := end <= start
+		if wrapped {
+			end += 24 * 60
+		}
+
+		for _, d := range w.Days {
+			if d < 0 || d > 6 {
+				continue
+			}
+			// Only a weekday inside 0..6 makes the window usable. Marking the
+			// schedule valid before this point let a window whose every Days
+			// entry is out of range (say []int{7}) report "evaluated, not
+			// peak", which hands out the off-peak discount on garbage input.
+			// Base rates are the peak prices, so an unusable schedule has to
+			// bill at peak.
+			valid = true
+			// Half-open [start, end): a window ending at 04:00 does not cover
+			// 04:00:00 itself, so adjacent windows never double-count.
+			if d == weekday && minutes >= start && minutes < end {
+				return true, true
+			}
+			if wrapped && d == prevWeekday && prevMinutes >= start && prevMinutes < end {
+				return true, true
+			}
+		}
+	}
+	if !valid {
+		return false, false
+	}
+	return false, true
+}
+
+// offPeakMultiplier returns the multiplier to scale usage-based costs by when
+// at falls outside pricing's declared peak windows, and whether a discount
+// applies at all.
+//
+// Both off_peak_cost_multiplier and peak_hours must be present: a multiplier
+// with no schedule has no way to know when to apply, and a schedule with no
+// multiplier has nothing to apply. Either alone bills at peak. A multiplier
+// outside (0, 1] is rejected for the same reason — every base rate on the row
+// is the peak price, so a discount can only ever scale downward, and a bogus
+// value must not silently zero out or inflate a bill.
+//
+// A zero at means the caller never learned the request's start time; fall back
+// to the wall clock rather than mispricing everything as peak.
+func offPeakMultiplier(pricing *configstoreTables.TableModelPricing, at time.Time) (float64, bool) {
+	if pricing == nil || pricing.OffPeakCostMultiplier == nil || pricing.PeakHours == nil {
+		return 0, false
+	}
+	m := *pricing.OffPeakCostMultiplier
+	if !(m > 0 && m <= 1) {
+		return 0, false
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	peak, ok := isWithinPeakWindows(pricing.PeakHours, at)
+	if !ok || peak {
+		return 0, false
+	}
+	return m, true
+}
+
+// scaleUsageCost multiplies every usage-based charge on cost by m, in place.
+//
+// RequestCost and SearchQueriesCost are deliberately excluded: they are flat
+// per-request and per-query fees rather than usage categories, matching how the
+// inference_geo multiplier in computeTextCost already treats the search fee.
+// AdditionalCost is excluded too — guardrail and MCP sidecar costs are priced
+// through their own computeCostFromInput call and are discounted there on
+// their own pricing rows.
+func scaleUsageCost(cost *schemas.BifrostCost, m float64) {
+	if cost == nil {
+		return
+	}
+
+	if cost.InputCostDetails != nil {
+		d := cost.InputCostDetails
+		cost.InputCost -= d.RequestCost
+		d.TextCost *= m
+		d.AudioCost *= m
+		d.ImageCost *= m
+		d.CachedReadCost *= m
+		d.CachedWriteCost *= m
+		cost.InputCost *= m
+		cost.InputCost += d.RequestCost
+	} else {
+		cost.InputCost *= m
+	}
+
+	if cost.OutputCostDetails != nil {
+		d := cost.OutputCostDetails
+		cost.OutputCost -= d.SearchQueriesCost
+		d.TextCost *= m
+		d.AudioCost *= m
+		d.ImageCost *= m
+		d.ReasoningCost *= m
+		d.CitationCost *= m
+		cost.OutputCost *= m
+		cost.OutputCost += d.SearchQueriesCost
+	} else {
+		cost.OutputCost *= m
+	}
+
+	// Recompute rather than scaling: TotalCost also carries AdditionalCost,
+	// which is not discounted here.
+	cost.TotalCost = cost.InputCost + cost.OutputCost + cost.AdditionalCost
 }

--- a/framework/modelcatalog/datasheet/cost_timeofday_test.go
+++ b/framework/modelcatalog/datasheet/cost_timeofday_test.go
@@ -1,0 +1,567 @@
+package datasheet
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	bifrost "github.com/maximhq/bifrost/core"
+	"github.com/maximhq/bifrost/core/schemas"
+	configstoreTables "github.com/maximhq/bifrost/framework/configstore/tables"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deepSeekPeakHours mirrors DeepSeek's published schedule: peak is Mon-Fri
+// 01:00-04:00 and 06:00-10:00 UTC, and every other instant is off-peak.
+func deepSeekPeakHours() *configstoreTables.PeakHoursSchedule {
+	return &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{1, 2, 3, 4, 5}, Start: "01:00", End: "04:00"},
+			{Days: []int{1, 2, 3, 4, 5}, Start: "06:00", End: "10:00"},
+		},
+	}
+}
+
+// deepSeekPricing is a deepseek-v4-flash row: base rates are the PEAK prices
+// and the multiplier halves them off-peak.
+func deepSeekPricing() configstoreTables.TableModelPricing {
+	return configstoreTables.TableModelPricing{
+		Model:                   "deepseek-v4-flash",
+		Provider:                "deepseek",
+		Mode:                    "chat",
+		InputCostPerToken:       bifrost.Ptr(0.00000044),
+		OutputCostPerToken:      bifrost.Ptr(0.00000132),
+		CacheReadInputTokenCost: bifrost.Ptr(0.000000014),
+		OffPeakCostMultiplier:   bifrost.Ptr(0.5),
+		PeakHours:               deepSeekPeakHours(),
+	}
+}
+
+func utc(t *testing.T, s string) time.Time {
+	t.Helper()
+	parsed, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return parsed
+}
+
+// TestOffPeak_DeepSeekSchedule walks DeepSeek's real windows. 2026-08-17 is a
+// Monday, so 08-15 is Saturday and 08-16 is Sunday.
+func TestOffPeak_DeepSeekSchedule(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): deepSeekPricing(),
+	})
+
+	// 1000 prompt + 1000 completion at peak:
+	// 1000*0.00000044 + 1000*0.00000132 = 0.00176
+	const peakCost = 0.00176
+
+	cases := []struct {
+		name     string
+		at       string
+		expected float64
+	}{
+		{"monday inside first peak window", "2026-08-17T02:00:00Z", peakCost},
+		{"monday inside second peak window", "2026-08-17T09:59:00Z", peakCost},
+		{"monday in the gap between windows", "2026-08-17T05:00:00Z", peakCost / 2},
+		{"monday before the first window", "2026-08-17T00:30:00Z", peakCost / 2},
+		{"monday after the last window", "2026-08-17T23:00:00Z", peakCost / 2},
+		{"saturday at a peak-hour clock time", "2026-08-15T02:00:00Z", peakCost / 2},
+		{"sunday at a peak-hour clock time", "2026-08-16T02:00:00Z", peakCost / 2},
+		// Half-open [start, end): the start instant is peak, the end instant is not.
+		{"exact window start is peak", "2026-08-17T01:00:00Z", peakCost},
+		{"exact window end is off-peak", "2026-08-17T04:00:00Z", peakCost / 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+				PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+			})
+			cost := s.CalculateCost(resp, &LookupScopes{BilledAt: utc(t, tc.at)})
+			assert.InDelta(t, tc.expected, cost, 1e-12)
+		})
+	}
+}
+
+// TestOffPeak_DiscountsCacheReads verifies the discount reaches the cache-hit
+// rate, not just the plain input rate — DeepSeek halves all three categories.
+func TestOffPeak_DiscountsCacheReads(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): deepSeekPricing(),
+	})
+
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens: 1000, CompletionTokens: 500, TotalTokens: 1500,
+		PromptTokensDetails: &schemas.ChatPromptTokensDetails{CachedReadTokens: 800},
+	}
+
+	peak := s.CalculateCostBreakdown(
+		makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T02:00:00Z")},
+	)
+	off := s.CalculateCostBreakdown(
+		makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")},
+	)
+	require.NotNil(t, peak)
+	require.NotNil(t, off)
+	require.NotNil(t, peak.InputCostDetails)
+	require.NotNil(t, off.InputCostDetails)
+
+	assert.Greater(t, peak.InputCostDetails.CachedReadCost, 0.0)
+	assert.InDelta(t, peak.InputCostDetails.CachedReadCost/2, off.InputCostDetails.CachedReadCost, 1e-15)
+	assert.InDelta(t, peak.InputCostDetails.TextCost/2, off.InputCostDetails.TextCost, 1e-15)
+	assert.InDelta(t, peak.OutputCost/2, off.OutputCost, 1e-15)
+	assert.InDelta(t, peak.TotalCost/2, off.TotalCost, 1e-15)
+}
+
+// TestOffPeak_FlatFeesAreNotDiscounted pins the exclusions: a per-request
+// surcharge and a per-search-query fee are not usage charges, so an off-peak
+// request pays them in full.
+func TestOffPeak_FlatFeesAreNotDiscounted(t *testing.T) {
+	pricing := deepSeekPricing()
+	pricing.CostPerRequest = bifrost.Ptr(0.01)
+	pricing.SearchContextCostPerQuery = bifrost.Ptr(0.005)
+
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+	})
+
+	queries := 2
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+		CompletionTokensDetails: &schemas.ChatCompletionTokensDetails{NumSearchQueries: &queries},
+	}
+
+	bd := s.CalculateCostBreakdown(
+		makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")},
+	)
+	require.NotNil(t, bd)
+	require.NotNil(t, bd.InputCostDetails)
+	require.NotNil(t, bd.OutputCostDetails)
+
+	// Flat fees at full price...
+	assert.InDelta(t, 0.01, bd.InputCostDetails.RequestCost, 1e-12)
+	assert.InDelta(t, 0.01, bd.OutputCostDetails.SearchQueriesCost, 1e-12)
+	// ...token costs halved.
+	assert.InDelta(t, 1000*0.00000044/2, bd.InputCostDetails.TextCost, 1e-15)
+	assert.InDelta(t, 1000*0.00000132/2, bd.OutputCostDetails.TextCost, 1e-15)
+	// Sides still reconcile.
+	assert.InDelta(t, bd.InputCost+bd.OutputCost+bd.AdditionalCost, bd.TotalCost, 1e-12)
+}
+
+// TestOffPeak_FailsClosed covers every way the discount can fail to resolve.
+// All of them must bill at the peak (higher) rate — base rates are the peak
+// prices, so failing open would hand out a discount that was never configured.
+func TestOffPeak_FailsClosed(t *testing.T) {
+	const peakCost = 0.00176
+
+	mutate := map[string]func(p *configstoreTables.TableModelPricing){
+		"no multiplier": func(p *configstoreTables.TableModelPricing) { p.OffPeakCostMultiplier = nil },
+		"no schedule":   func(p *configstoreTables.TableModelPricing) { p.PeakHours = nil },
+		"empty windows": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours = &configstoreTables.PeakHoursSchedule{Timezone: "UTC"}
+		},
+		"unknown timezone": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Timezone = "Mars/Olympus_Mons"
+		},
+		"malformed clock": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: []int{1}, Start: "0100", End: "04:00"}}
+		},
+		"out of range hour": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: []int{1}, Start: "25:00", End: "26:00"}}
+		},
+		"no days": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: nil, Start: "01:00", End: "04:00"}}
+		},
+		// A Days list that parses but names no real weekday leaves the window
+		// unusable. Counting it as evaluated would report "not peak" and hand
+		// out the discount on garbage input.
+		"weekday above range": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: []int{7}, Start: "01:00", End: "04:00"}}
+		},
+		"weekday below range": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{{Days: []int{-1}, Start: "01:00", End: "04:00"}}
+		},
+		"every weekday out of range across windows": func(p *configstoreTables.TableModelPricing) {
+			p.PeakHours.Windows = []configstoreTables.PeakHoursWindow{
+				{Days: []int{9}, Start: "01:00", End: "04:00"},
+				{Days: []int{-3}, Start: "06:00", End: "10:00"},
+			}
+		},
+		"multiplier above one": func(p *configstoreTables.TableModelPricing) {
+			p.OffPeakCostMultiplier = bifrost.Ptr(1.5)
+		},
+		"zero multiplier": func(p *configstoreTables.TableModelPricing) {
+			p.OffPeakCostMultiplier = bifrost.Ptr(0.0)
+		},
+		"negative multiplier": func(p *configstoreTables.TableModelPricing) {
+			p.OffPeakCostMultiplier = bifrost.Ptr(-0.5)
+		},
+	}
+
+	for name, fn := range mutate {
+		t.Run(name, func(t *testing.T) {
+			pricing := deepSeekPricing()
+			fn(&pricing)
+			s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+				makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+			})
+			resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+				PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+			})
+			// 05:00 Monday is off-peak under the real schedule, so anything
+			// other than the full peak price means the guard leaked.
+			cost := s.CalculateCost(resp, &LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")})
+			assert.InDelta(t, peakCost, cost, 1e-12)
+		})
+	}
+}
+
+// TestOffPeak_MidnightWrappingWindow covers a window whose end is before its
+// start: 22:00-02:00 on Monday must also cover Tuesday 01:00.
+func TestOffPeak_MidnightWrappingWindow(t *testing.T) {
+	pricing := deepSeekPricing()
+	pricing.PeakHours = &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{1}, Start: "22:00", End: "02:00"}, // Monday 22:00 -> Tuesday 02:00
+		},
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+	})
+
+	const peakCost = 0.00176
+	cases := []struct {
+		name     string
+		at       string
+		expected float64
+	}{
+		{"monday late evening is peak", "2026-08-17T23:30:00Z", peakCost},
+		{"tuesday small hours still peak", "2026-08-18T01:30:00Z", peakCost},
+		{"tuesday after the wrap ends", "2026-08-18T02:30:00Z", peakCost / 2},
+		{"monday before the window opens", "2026-08-17T21:00:00Z", peakCost / 2},
+		{"tuesday evening is not covered", "2026-08-18T23:30:00Z", peakCost / 2},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+				PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+			})
+			cost := s.CalculateCost(resp, &LookupScopes{BilledAt: utc(t, tc.at)})
+			assert.InDelta(t, tc.expected, cost, 1e-12)
+		})
+	}
+}
+
+// TestOffPeak_NonUTCSchedule verifies the schedule is evaluated in its own
+// timezone, not the instant's UTC clock reading.
+func TestOffPeak_NonUTCSchedule(t *testing.T) {
+	pricing := deepSeekPricing()
+	pricing.PeakHours = &configstoreTables.PeakHoursSchedule{
+		Timezone: "Asia/Kolkata", // UTC+05:30
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{1}, Start: "09:00", End: "17:00"},
+		},
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+	})
+
+	const peakCost = 0.00176
+	resp := func() *schemas.BifrostResponse {
+		return makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+			PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+		})
+	}
+
+	// 2026-08-17 05:00 UTC == 10:30 Monday in Kolkata -> peak.
+	assert.InDelta(t, peakCost,
+		s.CalculateCost(resp(), &LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")}), 1e-12)
+	// 2026-08-17 02:00 UTC == 07:30 Monday in Kolkata -> off-peak.
+	assert.InDelta(t, peakCost/2,
+		s.CalculateCost(resp(), &LookupScopes{BilledAt: utc(t, "2026-08-17T02:00:00Z")}), 1e-12)
+}
+
+// TestOffPeak_AppliesToNonTextModalities confirms the single application site
+// in computeCostFromInput reaches modalities other than chat.
+func TestOffPeak_AppliesToNonTextModalities(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("embed-model", "deepseek", "embedding"): {
+			Model: "embed-model", Provider: "deepseek", Mode: "embedding",
+			InputCostPerToken:     bifrost.Ptr(0.000001),
+			OffPeakCostMultiplier: bifrost.Ptr(0.5),
+			PeakHours:             deepSeekPeakHours(),
+		},
+	})
+
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 1000, TotalTokens: 1000}
+	peak := s.CalculateCost(makeEmbeddingResponse(schemas.DeepSeek, "embed-model", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T02:00:00Z")})
+	off := s.CalculateCost(makeEmbeddingResponse(schemas.DeepSeek, "embed-model", usage),
+		&LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")})
+
+	assert.InDelta(t, 0.001, peak, 1e-12)
+	assert.InDelta(t, 0.0005, off, 1e-12)
+}
+
+// insideNeverPeakWindow reports whether an instant falls inside the only span
+// the neverPeak schedule below actually covers, 00:00:00-00:02:00 UTC.
+func insideNeverPeakWindow(at time.Time) bool {
+	at = at.UTC()
+	return at.Hour() == 0 && at.Minute() < 2
+}
+
+// bracketsNeverPeakWindow reports whether a CalculateCost call that started at
+// before and returned at after could have read the wall clock inside that span.
+// Sampling only one side is not enough: the production read happens between the
+// two, so a call that straddles 00:02:00 UTC prices as peak while a later
+// single sample reads as outside the window and declines to skip.
+func bracketsNeverPeakWindow(before, after time.Time) bool {
+	return insideNeverPeakWindow(before) || insideNeverPeakWindow(after)
+}
+
+// TestOffPeak_ZeroBilledAtFallsBackToWallClock verifies a caller that never
+// learned the request start time still prices coherently rather than treating
+// the zero time (year 1) as a real instant.
+//
+// Both schedules below answer the same at every instant, so the test never
+// reads the clock itself and cannot straddle a window boundary between
+// computing the expectation and pricing the response. Deriving the expectation
+// from a time.Now() of its own would race the second time.Now() inside
+// offPeakMultiplier.
+func TestOffPeak_ZeroBilledAtFallsBackToWallClock(t *testing.T) {
+	const peakCost = 0.00176
+
+	alwaysPeak := &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{0, 1, 2, 3, 4, 5, 6}, Start: "00:00", End: "24:00"},
+		},
+	}
+	// A window listing no weekday that ever occurs cannot match, so every
+	// instant is off-peak.
+	neverPeak := &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{0, 1, 2, 3, 4, 5, 6}, Start: "00:00", End: "00:01"},
+			{Days: []int{0, 1, 2, 3, 4, 5, 6}, Start: "00:01", End: "00:02"},
+		},
+	}
+
+	for _, tc := range []struct {
+		name  string
+		sched *configstoreTables.PeakHoursSchedule
+		want  float64
+	}{
+		{"peak at every instant", alwaysPeak, peakCost},
+		{"off-peak at almost every instant", neverPeak, peakCost / 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pricing := deepSeekPricing()
+			pricing.PeakHours = tc.sched
+			s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+				makeKey("deepseek-v4-flash", "deepseek", "chat"): pricing,
+			})
+			resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+				PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+			})
+			// A zero BilledAt is the point: it forces the wall-clock fallback.
+			// The read that decides the price happens inside CalculateCost, so
+			// bracket the call and skip if either side of the bracket sits in
+			// the two-minute window neverPeak does cover. Sampling only after
+			// the call misses a call that straddles the window's edge.
+			before := time.Now()
+			got := s.CalculateCost(resp, &LookupScopes{})
+			after := time.Now()
+			if tc.want != peakCost && bracketsNeverPeakWindow(before, after) {
+				t.Skip("wall clock is inside the neverPeak schedule's only window")
+			}
+			assert.InDelta(t, tc.want, got, 1e-12)
+		})
+	}
+}
+
+// TestNeverPeakWindowBracket pins the skip guard used by
+// TestOffPeak_ZeroBilledAtFallsBackToWallClock: a call whose wall-clock read
+// could have landed inside the neverPeak window must be recognised as such even
+// when the reading taken after the call has already left the window.
+func TestNeverPeakWindowBracket(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		before time.Time
+		after  time.Time
+		want   bool
+	}{
+		{
+			name:   "call straddles the end of the window",
+			before: time.Date(2026, 8, 17, 0, 1, 59, 900_000_000, time.UTC),
+			after:  time.Date(2026, 8, 17, 0, 2, 0, 100_000_000, time.UTC),
+			want:   true,
+		},
+		{
+			name:   "call straddles the start of the window",
+			before: time.Date(2026, 8, 16, 23, 59, 59, 900_000_000, time.UTC),
+			after:  time.Date(2026, 8, 17, 0, 0, 0, 100_000_000, time.UTC),
+			want:   true,
+		},
+		{
+			name:   "call sits wholly inside the window",
+			before: time.Date(2026, 8, 17, 0, 0, 30, 0, time.UTC),
+			after:  time.Date(2026, 8, 17, 0, 0, 31, 0, time.UTC),
+			want:   true,
+		},
+		{
+			name:   "call sits wholly outside the window",
+			before: time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC),
+			after:  time.Date(2026, 8, 17, 12, 0, 1, 0, time.UTC),
+			want:   false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, bracketsNeverPeakWindow(tc.before, tc.after))
+		})
+	}
+}
+
+// TestOffPeak_NilScopes exercises the nil-scopes entry point, which builds an
+// empty LookupScopes and therefore a zero BilledAt.
+func TestOffPeak_NilScopes(t *testing.T) {
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey("deepseek-v4-flash", "deepseek", "chat"): deepSeekPricing(),
+	})
+	resp := makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+		PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+	})
+	assert.NotPanics(t, func() { s.CalculateCost(resp, nil) })
+}
+
+// TestParseClockMinutes pins the "HH:MM" parser, including the 24:00
+// end-of-day marker that lets a window span a full day.
+func TestParseClockMinutes(t *testing.T) {
+	cases := []struct {
+		in   string
+		want int
+		ok   bool
+	}{
+		{"00:00", 0, true},
+		{"01:00", 60, true},
+		{"09:59", 599, true},
+		{"23:59", 1439, true},
+		{"24:00", 1440, true},
+		{"24:01", 0, false},
+		{"25:00", 0, false},
+		{"01:60", 0, false},
+		{"-1:00", 0, false},
+		{"0100", 0, false},
+		{"", 0, false},
+		{"aa:bb", 0, false},
+	}
+	for _, tc := range cases {
+		got, ok := parseClockMinutes(tc.in)
+		assert.Equal(t, tc.ok, ok, "ok for %q", tc.in)
+		if tc.ok {
+			assert.Equal(t, tc.want, got, "value for %q", tc.in)
+		}
+	}
+}
+
+// TestEntryUnmarshal_TimeOfDayFields verifies the two fields survive Entry's
+// custom UnmarshalJSON, which routes through an alias struct to special-case
+// search_context_cost_per_query and could otherwise drop embedded fields.
+func TestEntryUnmarshal_TimeOfDayFields(t *testing.T) {
+	raw := []byte(`{
+		"provider": "deepseek",
+		"mode": "chat",
+		"input_cost_per_token": 0.00000044,
+		"output_cost_per_token": 0.00000132,
+		"off_peak_cost_multiplier": 0.5,
+		"peak_hours": {
+			"timezone": "UTC",
+			"windows": [
+				{"days": [1,2,3,4,5], "start": "01:00", "end": "04:00"},
+				{"days": [1,2,3,4,5], "start": "06:00", "end": "10:00"}
+			]
+		}
+	}`)
+
+	var entry Entry
+	require.NoError(t, entry.UnmarshalJSON(raw))
+
+	require.NotNil(t, entry.OffPeakCostMultiplier)
+	assert.Equal(t, 0.5, *entry.OffPeakCostMultiplier)
+	require.NotNil(t, entry.PeakHours)
+	assert.Equal(t, "UTC", entry.PeakHours.Timezone)
+	require.Len(t, entry.PeakHours.Windows, 2)
+	assert.Equal(t, []int{1, 2, 3, 4, 5}, entry.PeakHours.Windows[0].Days)
+	assert.Equal(t, "01:00", entry.PeakHours.Windows[0].Start)
+	assert.Equal(t, "10:00", entry.PeakHours.Windows[1].End)
+
+	// And that they survive the Entry -> Table -> Entry round trip the sync uses.
+	table := convertEntryToTablePricing("deepseek-v4-flash", entry)
+	require.NotNil(t, table.OffPeakCostMultiplier)
+	assert.Equal(t, 0.5, *table.OffPeakCostMultiplier)
+	require.NotNil(t, table.PeakHours)
+	assert.Len(t, table.PeakHours.Windows, 2)
+
+	back := convertTablePricingToEntry(&table)
+	require.NotNil(t, back.OffPeakCostMultiplier)
+	assert.Equal(t, 0.5, *back.OffPeakCostMultiplier)
+	require.NotNil(t, back.PeakHours)
+	assert.Equal(t, "UTC", back.PeakHours.Timezone)
+	assert.Len(t, back.PeakHours.Windows, 2)
+}
+
+// TestOffPeak_EndToEndFromDatasheetFile drives the real sync entry point
+// against a file:// datasheet, so the fields are exercised through URL fetch,
+// JSON decode, Entry -> TableModelPricing conversion and the in-memory catalog
+// — not just the hand-built pricing rows the other tests use.
+func TestOffPeak_EndToEndFromDatasheetFile(t *testing.T) {
+	datasheet := `{
+		"deepseek-v4-flash": {
+			"provider": "deepseek",
+			"mode": "chat",
+			"input_cost_per_token": 0.00000044,
+			"output_cost_per_token": 0.00000132,
+			"off_peak_cost_multiplier": 0.5,
+			"peak_hours": {
+				"timezone": "UTC",
+				"windows": [
+					{"days": [1,2,3,4,5], "start": "01:00", "end": "04:00"},
+					{"days": [1,2,3,4,5], "start": "06:00", "end": "10:00"}
+				]
+			}
+		}
+	}`
+
+	path := filepath.Join(t.TempDir(), "datasheet.json")
+	require.NoError(t, os.WriteFile(path, []byte(datasheet), 0o600))
+
+	s := newTestStore()
+	s.url = "file://" + path
+	require.NoError(t, s.LoadFromURLIntoMemory(context.Background()))
+
+	pricing, ok := s.pricingData[makeKey("deepseek-v4-flash", "deepseek", "chat")]
+	require.True(t, ok, "model missing from catalog after sync")
+	require.NotNil(t, pricing.OffPeakCostMultiplier, "off_peak_cost_multiplier lost in sync")
+	assert.Equal(t, 0.5, *pricing.OffPeakCostMultiplier)
+	require.NotNil(t, pricing.PeakHours, "peak_hours lost in sync")
+	require.Len(t, pricing.PeakHours.Windows, 2)
+
+	resp := func() *schemas.BifrostResponse {
+		return makeChatResponse(schemas.DeepSeek, "deepseek-v4-flash", &schemas.BifrostLLMUsage{
+			PromptTokens: 1000, CompletionTokens: 1000, TotalTokens: 2000,
+		})
+	}
+	const peakCost = 0.00176
+	assert.InDelta(t, peakCost,
+		s.CalculateCost(resp(), &LookupScopes{BilledAt: utc(t, "2026-08-17T02:00:00Z")}), 1e-12)
+	assert.InDelta(t, peakCost/2,
+		s.CalculateCost(resp(), &LookupScopes{BilledAt: utc(t, "2026-08-17T05:00:00Z")}), 1e-12)
+}

--- a/framework/modelcatalog/datasheet/overrides.go
+++ b/framework/modelcatalog/datasheet/overrides.go
@@ -582,10 +582,17 @@ func patchPricing(pricing configstoreTables.TableModelPricing, override Options)
 		{dst: &patched.OutputCostPerImageAutoQuality, src: override.OutputCostPerImageAutoQuality},
 		{dst: &patched.OCRCostPerPage, src: override.OCRCostPerPage},
 		{dst: &patched.AnnotationCostPerPage, src: override.AnnotationCostPerPage},
+		{dst: &patched.OffPeakCostMultiplier, src: override.OffPeakCostMultiplier},
 	} {
 		if field.src != nil {
 			*field.dst = field.src
 		}
+	}
+	// PeakHours is a struct pointer, not a *float64, so it cannot ride the
+	// loop above. Same nil-means-inherit semantics: an override that sets only
+	// the multiplier keeps the datasheet's schedule.
+	if override.PeakHours != nil {
+		patched.PeakHours = override.PeakHours
 	}
 	return patched
 }

--- a/framework/modelcatalog/datasheet/overrides_test.go
+++ b/framework/modelcatalog/datasheet/overrides_test.go
@@ -1070,3 +1070,65 @@ func TestPatchPricing_VideoResolutionBandRates(t *testing.T) {
 	// Unpatched fields keep their base values.
 	assert.Equal(t, 0.30, *patched.OutputCostPerVideoPerSecond)
 }
+
+// TestPatchPricing_TimeOfDayFields covers the two peak/off-peak fields. The
+// multiplier rides the *float64 loop; PeakHours is patched separately because
+// it is a struct pointer, so both paths need pinning.
+func TestPatchPricing_TimeOfDayFields(t *testing.T) {
+	baseSchedule := &configstoreTables.PeakHoursSchedule{
+		Timezone: "UTC",
+		Windows: []configstoreTables.PeakHoursWindow{
+			{Days: []int{1, 2, 3, 4, 5}, Start: "01:00", End: "04:00"},
+		},
+	}
+	base := configstoreTables.TableModelPricing{
+		Model:                 "deepseek-v4-flash",
+		Provider:              "deepseek",
+		Mode:                  "chat",
+		OffPeakCostMultiplier: bifrost.Ptr(0.5),
+		PeakHours:             baseSchedule,
+	}
+
+	t.Run("both fields overridden", func(t *testing.T) {
+		newSchedule := &configstoreTables.PeakHoursSchedule{
+			Timezone: "Asia/Shanghai",
+			Windows: []configstoreTables.PeakHoursWindow{
+				{Days: []int{0, 6}, Start: "09:00", End: "18:00"},
+			},
+		}
+		patched := patchPricing(base, Options{
+			OffPeakCostMultiplier: bifrost.Ptr(0.75),
+			PeakHours:             newSchedule,
+		})
+		require.NotNil(t, patched.OffPeakCostMultiplier)
+		assert.Equal(t, 0.75, *patched.OffPeakCostMultiplier)
+		require.NotNil(t, patched.PeakHours)
+		assert.Equal(t, "Asia/Shanghai", patched.PeakHours.Timezone)
+		assert.Len(t, patched.PeakHours.Windows, 1)
+	})
+
+	t.Run("multiplier only keeps the datasheet schedule", func(t *testing.T) {
+		patched := patchPricing(base, Options{OffPeakCostMultiplier: bifrost.Ptr(0.9)})
+		require.NotNil(t, patched.OffPeakCostMultiplier)
+		assert.Equal(t, 0.9, *patched.OffPeakCostMultiplier)
+		require.NotNil(t, patched.PeakHours)
+		assert.Equal(t, "UTC", patched.PeakHours.Timezone)
+	})
+
+	t.Run("empty override leaves both intact", func(t *testing.T) {
+		patched := patchPricing(base, Options{})
+		require.NotNil(t, patched.OffPeakCostMultiplier)
+		assert.Equal(t, 0.5, *patched.OffPeakCostMultiplier)
+		require.NotNil(t, patched.PeakHours)
+		assert.Equal(t, "UTC", patched.PeakHours.Timezone)
+	})
+
+	t.Run("base is not mutated", func(t *testing.T) {
+		_ = patchPricing(base, Options{
+			OffPeakCostMultiplier: bifrost.Ptr(0.1),
+			PeakHours:             &configstoreTables.PeakHoursSchedule{Timezone: "UTC"},
+		})
+		assert.Equal(t, 0.5, *base.OffPeakCostMultiplier)
+		assert.Same(t, baseSchedule, base.PeakHours)
+	})
+}

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -266,6 +266,14 @@ type LookupScopes struct {
 	VirtualKeyID  string
 	SelectedKeyID string
 	Provider      string
+	// BilledAt is the instant used to decide peak vs off-peak for models that
+	// carry a PeakHours schedule. It is the request's START time, not the
+	// completion time: that keeps pricing deterministic and reproducible, makes
+	// streaming and non-streaming agree, and matches the timestamp users see in
+	// logs. A long stream that crosses a window boundary bills entirely at its
+	// start-time rate. The zero value means "unknown" and falls back to the
+	// wall clock at evaluation time.
+	BilledAt time.Time
 }
 
 // LookupScopesFromContext builds a LookupScopes from a BifrostContext. Reads
@@ -285,11 +293,13 @@ func LookupScopesFromContext(ctx *schemas.BifrostContext, provider string) *Look
 	userID, _ := ctx.Value(schemas.BifrostContextKeyUserID).(string)
 	virtualKeyID, _ := ctx.Value(schemas.BifrostContextKeyGovernanceVirtualKeyID).(string)
 	selectedKeyID, _ := ctx.Value(schemas.BifrostContextKeySelectedKeyID).(string)
+	billedAt, _ := ctx.Value(schemas.BifrostContextKeyRequestStartTime).(time.Time)
 	return &LookupScopes{
 		UserID:        userID,
 		VirtualKeyID:  virtualKeyID,
 		SelectedKeyID: selectedKeyID,
 		Provider:      provider,
+		BilledAt:      billedAt,
 	}
 }
 

--- a/plugins/logging/costfidelity_test.go
+++ b/plugins/logging/costfidelity_test.go
@@ -1556,3 +1556,38 @@ func TestFailedVideoRepricesAsSettledZeroNotSkipped(t *testing.T) {
 	settledZero := repriced.Cost <= 0 && !repriced.DisplayOnly
 	assert.True(t, settledZero, "must persist CostUpdate{} and count as priced")
 }
+
+// TestPricingScopesForLogCarriesBilledAt guards the one pricing input a reprice
+// cannot re-derive from the reconstructed response. Everything else the row was
+// billed under (served tier, OCR pages, speech usage) is restored from dedicated
+// columns; the billing instant has to come from the row's Timestamp the same
+// way. Without it, a model on a peak/off-peak schedule resolves time-of-day
+// pricing against whenever the recalculation happened to run, so the same row
+// reprices to a different cost on every pass.
+func TestPricingScopesForLogCarriesBilledAt(t *testing.T) {
+	vk := "vk-1"
+	userID := "user-1"
+	ts := time.Date(2026, 8, 17, 2, 0, 0, 0, time.UTC)
+
+	scopes := pricingScopesForLog(&logstore.Log{
+		Timestamp:     ts,
+		Provider:      string(schemas.DeepSeek),
+		SelectedKeyID: "key-1",
+		VirtualKeyID:  &vk,
+		UserID:        &userID,
+	})
+
+	if !scopes.BilledAt.Equal(ts) {
+		t.Fatalf("BilledAt = %v, want %v", scopes.BilledAt, ts)
+	}
+	if scopes.Provider != string(schemas.DeepSeek) || scopes.SelectedKeyID != "key-1" ||
+		scopes.VirtualKeyID != vk || scopes.UserID != userID {
+		t.Fatalf("unexpected scopes: %+v", scopes)
+	}
+}
+
+func TestPricingScopesForLogNilEntry(t *testing.T) {
+	if got := pricingScopesForLog(nil); !got.BilledAt.IsZero() {
+		t.Fatalf("BilledAt = %v, want zero", got.BilledAt)
+	}
+}

--- a/plugins/logging/costrecalc.go
+++ b/plugins/logging/costrecalc.go
@@ -43,8 +43,10 @@ type CostRecalcJobMeta struct {
 	// one — the (timestamp ASC, id ASC) ordering keeps the offset stable.
 	CursorOffset int `json:"cursor_offset,omitempty"`
 	// Total is the number of in-scope rows counted at enqueue, for a determinate
-	// progress bar. Processed can drift slightly if the underlying rows change between
-	// the enqueue-time count and the walk; treat progress as approximate.
+	// progress bar. Treat it as approximate and never as the length of the walk.
+	// It drifts when rows change between the enqueue-time count and the walk, and
+	// on a full recalculation (MissingCostOnly false) it can come from a stale
+	// materialized view; see CountRecalcTargets.
 	Total     int64 `json:"total"`
 	Processed int   `json:"processed"`
 	Updated   int   `json:"updated"`
@@ -73,11 +75,19 @@ func stoppedEarlyMessage(meta *CostRecalcJobMeta) string {
 
 // CountRecalcTargets returns how many logs fall in scope for a cost recalculation
 // with the given filters. missingCostOnly narrows to rows that currently have no
-// cost. It counts via the same raw-table SearchLogs path the worker walks (which
-// honors MissingCostOnly), so the number matches the job's Total exactly — unlike
-// the stats endpoint, which can fall back to hourly matviews that cannot filter on
-// per-row missing cost. The caller must have already resolved any period into
+// cost. The caller must have already resolved any period into
 // filters.StartTime/EndTime.
+//
+// How exact the count is depends on the scope. With missingCostOnly set, no
+// materialized view can express a per-row missing-cost filter, so SearchLogs
+// counts off the raw table and the number matches the job's Total exactly.
+// Without it, SearchLogs is free to take its count from mv_logs_hourly on a
+// matview-eligible window, and that view lags the raw table by its refresh
+// interval; rows written or deleted since the last refresh are counted wrong.
+// The result is a progress denominator only, never a bound on the walk: the
+// worker pages the raw table until it runs out of rows, so a stale Total shows
+// up as a progress bar that overshoots or finishes early, not as rows skipped
+// or repriced twice.
 func (p *LoggerPlugin) CountRecalcTargets(ctx context.Context, filters logstore.SearchFilters, missingCostOnly bool) (int64, error) {
 	countFilters := filters
 	countFilters.MissingCostOnly = missingCostOnly

--- a/plugins/logging/operations.go
+++ b/plugins/logging/operations.go
@@ -2309,5 +2309,11 @@ func pricingScopesForLog(logEntry *logstore.Log) modelcatalog.PricingLookupScope
 		SelectedKeyID: logEntry.SelectedKeyID,
 		VirtualKeyID:  virtualKeyID,
 		UserID:        userID,
+		// Price against when the request ran, not when the reprice runs. The row's
+		// Timestamp is stamped in PreLLMHook, so it is the same instant the live
+		// path reads off the context. Without it a model on a peak/off-peak
+		// schedule reprices against the wall clock and the same row yields a
+		// different cost on every run.
+		BilledAt: logEntry.Timestamp,
 	}
 }

--- a/tests/e2e/api/collections/bifrost-v1-pricing-time-of-day.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-v1-pricing-time-of-day.postman_collection.json
@@ -1,0 +1,1171 @@
+{
+  "info": {
+    "name": "Bifrost V1 - Time-of-Day Pricing",
+    "description": "Regression coverage for peak/off-peak time-of-day pricing (off_peak_cost_multiplier + peak_hours on a model pricing row).\n\nEach case creates a virtual-key-scoped pricing override that pins the token rates AND the schedule in the same patch, so the expected cost is fully determined by the override and never by whatever the live datasheet happens to say. That also means the assertions do not care how many tokens the provider actually returns: each run is checked against its own logged token counts.\n\nSchedules are built relative to the run's own clock in a prerequest script, so no clock control is needed and the suite is correct at any hour or weekday. Every window lists all seven days, which keeps a window that wraps past midnight matching correctly.\n\nThree invariants: a window containing the request bills at full rate; a window excluding it scales usage charges by the multiplier; a schedule that cannot be evaluated fails closed to peak. The third matters most, because base rates are the peak prices and an inverted fallback would silently under-bill every customer.\n\nRuns against a gateway with management auth disabled, or with it enabled by passing admin_auth_header (newman --env-var admin_auth_header='Bearer <key>', or BIFROST_ADMIN_AUTH_HEADER for the runner script). That header is applied to /api/ calls only, never to the inference calls, which authenticate as the virtual key.\n\nDeliberately does NOT set x-bf-expect-cost. The dbverify reporter recomputes expected cost from the datasheet and does not model the off-peak multiplier, so it would report the off-peak case as INACCURATE. These cases assert against the logs API themselves.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Management calls need admin auth when the gateway runs with it enabled.",
+          "// Deliberately scoped to /api/ paths: the inference calls authenticate as",
+          "// the virtual key via x-bf-vk, and upserting an admin Authorization header",
+          "// onto those would change which credential the request is billed under,",
+          "// which is the whole thing these cases are asserting on.",
+          "var adminAuthHeader = pm.variables.get('admin_auth_header') || pm.environment.get('admin_auth_header');",
+          "if (adminAuthHeader && String(pm.request.url.getPath()).indexOf('/api/') === 0) {",
+          "  pm.request.headers.upsert({ key: 'Authorization', value: adminAuthHeader });",
+          "}"
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8080",
+      "type": "string"
+    },
+    {
+      "key": "admin_auth_header",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "provider",
+      "value": "openai",
+      "type": "string"
+    },
+    {
+      "key": "chat_model",
+      "value": "gpt-4o-mini",
+      "type": "string"
+    },
+    {
+      "key": "tod_vk_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "tod_vk_value",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "tod_vk_name",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "peak_override_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "peak_request_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "peak_poll_retry",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "offpeak_override_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "offpeak_request_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "offpeak_poll_retry",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "badsched_override_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "badsched_request_id",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "badsched_poll_retry",
+      "value": "",
+      "type": "string"
+    }
+  ],
+  "item": [
+    {
+      "name": "Setup - Create VK for time-of-day pricing (openai gpt-4o-mini)",
+      "description": "Every pricing override in this collection is scoped to this key so the discounted rates never touch another suite's cost assertions.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var ts = Date.now();",
+              "var uniqueName = 'Time-of-day Pricing VK ' + ts;",
+              "var provider = pm.variables.get('provider') || 'openai';",
+              "pm.collectionVariables.set('tod_vk_name', uniqueName);",
+              "pm.request.body.raw = JSON.stringify({",
+              "  name: uniqueName,",
+              "  provider_configs: [{provider: provider, weight: 1.0, allowed_models: ['*'], key_ids: ['*']}]",
+              "});"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var code = pm.response.code;",
+              "pm.test('Create VK returns 2xx', function () { pm.expect(code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "if (code < 200 || code > 299) { return; }",
+              "// A 2xx with a non-JSON body (an SPA fallback, a proxy page) would throw",
+              "// here and abort the run rather than fail one named assertion.",
+              "var json = null;",
+              "try { json = pm.response.json(); } catch (e) { json = null; }",
+              "pm.test('Create VK returned JSON', function () { pm.expect(json, 'body: ' + pm.response.text()).to.not.equal(null); });",
+              "if (!json) { return; }",
+              "var vk = json.virtual_key || json;",
+              "// Fail here rather than storing empty credentials: every later item guards",
+              "// on these, so a 2xx without them would skip the suite and still be green.",
+              "pm.test('Created VK exposes usable credentials', function () {",
+              "  pm.expect(vk.id, 'id in: ' + pm.response.text()).to.be.a('string').and.not.be.empty;",
+              "  pm.expect(vk.value, 'value in: ' + pm.response.text()).to.be.a('string').and.not.be.empty;",
+              "});",
+              "if (!vk.id || !vk.value) { return; }",
+              "pm.collectionVariables.set('tod_vk_id', vk.id);",
+              "pm.collectionVariables.set('tod_vk_value', vk.value);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/governance/virtual-keys",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "governance",
+            "virtual-keys"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Setup - Peak override covering now (openai gpt-4o-mini)",
+      "description": "Pins the rates and a peak window that contains the current instant. The multiplier is present but must not fire.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"tod_vk_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "pm.collectionVariables.unset('peak_override_id');",
+              "pm.collectionVariables.unset('peak_request_id');",
+              "pm.collectionVariables.unset('peak_poll_retry');",
+              "// Build an HH:MM offset from now, in UTC. All windows below list every",
+              "// weekday, so a window that wraps past midnight still matches and the cases",
+              "// stay correct no matter which hour or day the suite runs at.",
+              "function hhmmFromNow(hoursOffset) {",
+              "  var t = new Date(Date.now() + hoursOffset * 3600 * 1000);",
+              "  function pad(n) { return (n < 10 ? '0' : '') + n; }",
+              "  return pad(t.getUTCHours()) + ':' + pad(t.getUTCMinutes());",
+              "}",
+              "var ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];",
+              "// A four-hour window centred on now, so the request lands well inside it",
+              "// even if the suite is slow.",
+              "var peakHours = { timezone: 'UTC', windows: [{ days: ALL_DAYS, start: hhmmFromNow(-2), end: hhmmFromNow(2) }] };",
+              "var overrideName = 'e2e-tod-peak-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);",
+              "var patch = {",
+              "  input_cost_per_token: 1e-06,",
+              "  output_cost_per_token: 2e-06,",
+              "  // Pinned so a datasheet flat fee cannot leak into the expected total.",
+              "  // A flat per-request fee is deliberately not discounted off-peak, so",
+              "  // leaving it unset would make the off-peak assertion depend on whether",
+              "  // the live datasheet happens to carry one for this model.",
+              "  cost_per_request: 0,",
+              "  off_peak_cost_multiplier: 0.5,",
+              "  peak_hours: peakHours",
+              "};",
+              "pm.request.body.raw = JSON.stringify({",
+              "  name: overrideName,",
+              "  // Virtual-key scoped on purpose. A global or provider-scoped override",
+              "  // would halve the cost of every other request in flight and make the",
+              "  // dbverify cost-accuracy checks in the rest of the suite report",
+              "  // INACCURATE for reasons that have nothing to do with those cases.",
+              "  scope_kind: 'virtual_key',",
+              "  virtual_key_id: pm.collectionVariables.get('tod_vk_id'),",
+              "  match_type: 'exact',",
+              "  pattern: pm.variables.get('chat_model') || 'gpt-4o-mini',",
+              "  request_types: ['chat_completion'],",
+              "  patch: patch",
+              "});"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var code = pm.response.code;",
+              "pm.test('Setup - Peak override covering now (openai gpt-4o-mini) returns 2xx', function () { pm.expect(code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "if (code < 200 || code > 299) { return; }",
+              "var body = null;",
+              "try { body = pm.response.json(); } catch (e) { body = null; }",
+              "var ov = body && (body.pricing_override || body);",
+              "pm.test('Override exposes an id', function () {",
+              "  pm.expect(ov && ov.id, 'body: ' + pm.response.text()).to.be.a('string').and.not.be.empty;",
+              "});",
+              "if (!ov || !ov.id) { return; }",
+              "pm.collectionVariables.set('peak_override_id', ov.id);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/governance/pricing-overrides",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "governance",
+            "pricing-overrides"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Peak window bills at full rate (openai gpt-4o-mini)",
+      "description": "Priming call. The assertion is on the log row, not this response.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"tod_vk_value\", \"peak_override_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "var reqId = 'e2e-tod-peak-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);",
+              "pm.collectionVariables.set('peak_request_id', reqId);"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var code = pm.response.code;",
+              "// Provider auth, rate limiting and upstream outages are infrastructure noise,",
+              "// not the behaviour under test. Clear the request id so the cost assertion",
+              "// downstream skips instead of failing on a row that was never written.",
+              "if ([401, 403, 429, 500, 502, 503, 504].indexOf(code) !== -1) {",
+              "  pm.collectionVariables.unset('peak_request_id');",
+              "  pm.test('Skipped: provider unavailable (status ' + code + ')', function () { pm.expect(true).to.be.true; });",
+              "  return;",
+              "}",
+              "pm.test('Inference succeeded', function () { pm.expect(code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "if (code < 200 || code > 299) { pm.collectionVariables.unset('peak_request_id'); }"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "x-bf-vk",
+            "value": "{{tod_vk_value}}"
+          },
+          {
+            "key": "x-request-id",
+            "value": "{{peak_request_id}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+        },
+        "url": {
+          "raw": "{{base_url}}/v1/chat/completions",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "v1",
+            "chat",
+            "completions"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Peak cost is undiscounted (openai gpt-4o-mini)",
+      "description": "A schedule whose window contains the request instant must bill the base rates untouched, even though off_peak_cost_multiplier is set.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"peak_request_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "var retry = Number(pm.collectionVariables.get('peak_poll_retry') || 0);",
+              "if (retry > 0) {",
+              "  // The log row is written asynchronously after the response returns, so",
+              "  // poll once a second. Newman drains pending timers before it sends.",
+              "  var until = Date.now() + 1000;",
+              "  (function waitBeforeRetry() { if (Date.now() < until) { setTimeout(waitBeforeRetry, 100); } })();",
+              "}"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var reqId = pm.collectionVariables.get('peak_request_id');",
+              "if (!reqId) { pm.test('Skipped: no priming request to price', function () { pm.expect(true).to.be.true; }); return; }",
+              "var code = pm.response.code;",
+              "if ([401, 403, 429, 500, 502, 503, 504].indexOf(code) !== -1) {",
+              "  pm.test('Skipped: logs API unavailable (status ' + code + ')', function () { pm.expect(true).to.be.true; });",
+              "  return;",
+              "}",
+              "pm.test('Logs query returns 200', function () { pm.expect(code, 'body: ' + pm.response.text()).to.equal(200); });",
+              "if (code !== 200) { return; }",
+              "var body = null;",
+              "try { body = pm.response.json(); } catch (e) { body = null; }",
+              "pm.test('Logs query returned JSON', function () { pm.expect(body, 'body: ' + pm.response.text()).to.not.equal(null); });",
+              "if (!body) { return; }",
+              "var logs = body.logs || body.data || [];",
+              "// Do not trust the server-side request_id filter blindly. If it were ever",
+              "// ignored, logs[0] would be some other request and the cost assertion would",
+              "// report a mismatch against a row it never named. The log row id IS the",
+              "// request id, so an identity check makes a wrong row read as no row.",
+              "var candidate = logs.length ? logs[0] : null;",
+              "var rowId = candidate && (candidate.id || candidate.request_id);",
+              "var row = candidate && (!rowId || rowId === reqId) ? candidate : null;",
+              "var retry = Number(pm.collectionVariables.get('peak_poll_retry') || 0);",
+              "// Cost is denormalized onto the row after the response is logged, so an",
+              "// existing row with no cost yet is still in flight, not a failure.",
+              "if ((!row || !Number(row.cost)) && retry < 30) {",
+              "  pm.collectionVariables.set('peak_poll_retry', String(retry + 1));",
+              "  if (typeof pm.execution !== 'undefined' && pm.execution.setNextRequest) { pm.execution.setNextRequest(pm.info.requestName); } else { postman.setNextRequest(pm.info.requestName); }",
+              "  return;",
+              "}",
+              "pm.test('Priced log row exists for the request', function () {",
+              "  pm.expect(row, 'no row for request_id=' + reqId + ' after ' + retry + ' polls').to.not.equal(null);",
+              "});",
+              "if (!row) { return; }",
+              "var prompt = Number(row.prompt_tokens || 0);",
+              "var completion = Number(row.completion_tokens || 0);",
+              "var cachedRead = Number(row.cached_read_tokens || 0);",
+              "// The expected-cost formula below models only uncached text. A cache hit",
+              "// prices on different rates, so skip rather than assert something false.",
+              "if (cachedRead > 0) { pm.test('Skipped: response used cached tokens', function () { pm.expect(true).to.be.true; }); return; }",
+              "if (!(prompt > 0)) { pm.test('Skipped: row carries no token counts yet', function () { pm.expect(true).to.be.true; }); return; }",
+              "var peakCost = prompt * 1e-06 + completion * 2e-06;",
+              "var expected = peakCost * 1;",
+              "var actual = Number(row.cost || 0);",
+              "var tol = Math.max(1e-9, 1e-4 * expected);",
+              "// Request inside a peak window bills at the full rate",
+              "pm.test('Request inside a peak window bills at the full rate', function () {",
+              "  pm.expect(Math.abs(actual - expected) <= tol,",
+              "    'prompt=' + prompt + ' completion=' + completion +",
+              "    ' logged=$' + actual + ' expected=$' + expected +",
+              "    ' (peak=$' + peakCost + ' x 1) tol=' + tol).to.be.true;",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/logs?request_id={{peak_request_id}}&limit=1",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "logs"
+          ],
+          "query": [
+            {
+              "key": "request_id",
+              "value": "{{peak_request_id}}"
+            },
+            {
+              "key": "limit",
+              "value": "1"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Teardown - Delete peak override (openai gpt-4o-mini)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"peak_override_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Override deleted', function () { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "pm.collectionVariables.unset('peak_override_id');"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/governance/pricing-overrides/{{peak_override_id}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "governance",
+            "pricing-overrides",
+            "{{peak_override_id}}"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Setup - Off-peak override excluding now (openai gpt-4o-mini)",
+      "description": "Same rates, but the peak window is three hours away, so the request is off-peak and the multiplier must apply.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"tod_vk_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "pm.collectionVariables.unset('offpeak_override_id');",
+              "pm.collectionVariables.unset('offpeak_request_id');",
+              "pm.collectionVariables.unset('offpeak_poll_retry');",
+              "// Build an HH:MM offset from now, in UTC. All windows below list every",
+              "// weekday, so a window that wraps past midnight still matches and the cases",
+              "// stay correct no matter which hour or day the suite runs at.",
+              "function hhmmFromNow(hoursOffset) {",
+              "  var t = new Date(Date.now() + hoursOffset * 3600 * 1000);",
+              "  function pad(n) { return (n < 10 ? '0' : '') + n; }",
+              "  return pad(t.getUTCHours()) + ':' + pad(t.getUTCMinutes());",
+              "}",
+              "var ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];",
+              "// A window three hours ahead, so now can never fall inside it regardless",
+              "// of which hour the suite runs at or whether the window wraps midnight.",
+              "var peakHours = { timezone: 'UTC', windows: [{ days: ALL_DAYS, start: hhmmFromNow(3), end: hhmmFromNow(5) }] };",
+              "var overrideName = 'e2e-tod-offpeak-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);",
+              "var patch = {",
+              "  input_cost_per_token: 1e-06,",
+              "  output_cost_per_token: 2e-06,",
+              "  // Pinned so a datasheet flat fee cannot leak into the expected total.",
+              "  // A flat per-request fee is deliberately not discounted off-peak, so",
+              "  // leaving it unset would make the off-peak assertion depend on whether",
+              "  // the live datasheet happens to carry one for this model.",
+              "  cost_per_request: 0,",
+              "  off_peak_cost_multiplier: 0.5,",
+              "  peak_hours: peakHours",
+              "};",
+              "pm.request.body.raw = JSON.stringify({",
+              "  name: overrideName,",
+              "  // Virtual-key scoped on purpose. A global or provider-scoped override",
+              "  // would halve the cost of every other request in flight and make the",
+              "  // dbverify cost-accuracy checks in the rest of the suite report",
+              "  // INACCURATE for reasons that have nothing to do with those cases.",
+              "  scope_kind: 'virtual_key',",
+              "  virtual_key_id: pm.collectionVariables.get('tod_vk_id'),",
+              "  match_type: 'exact',",
+              "  pattern: pm.variables.get('chat_model') || 'gpt-4o-mini',",
+              "  request_types: ['chat_completion'],",
+              "  patch: patch",
+              "});"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var code = pm.response.code;",
+              "pm.test('Setup - Off-peak override excluding now (openai gpt-4o-mini) returns 2xx', function () { pm.expect(code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "if (code < 200 || code > 299) { return; }",
+              "var body = null;",
+              "try { body = pm.response.json(); } catch (e) { body = null; }",
+              "var ov = body && (body.pricing_override || body);",
+              "pm.test('Override exposes an id', function () {",
+              "  pm.expect(ov && ov.id, 'body: ' + pm.response.text()).to.be.a('string').and.not.be.empty;",
+              "});",
+              "if (!ov || !ov.id) { return; }",
+              "pm.collectionVariables.set('offpeak_override_id', ov.id);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/governance/pricing-overrides",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "governance",
+            "pricing-overrides"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Off-peak window bills at the discounted rate (openai gpt-4o-mini)",
+      "description": "Priming call. The assertion is on the log row, not this response.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"tod_vk_value\", \"offpeak_override_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "var reqId = 'e2e-tod-offpeak-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);",
+              "pm.collectionVariables.set('offpeak_request_id', reqId);"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var code = pm.response.code;",
+              "// Provider auth, rate limiting and upstream outages are infrastructure noise,",
+              "// not the behaviour under test. Clear the request id so the cost assertion",
+              "// downstream skips instead of failing on a row that was never written.",
+              "if ([401, 403, 429, 500, 502, 503, 504].indexOf(code) !== -1) {",
+              "  pm.collectionVariables.unset('offpeak_request_id');",
+              "  pm.test('Skipped: provider unavailable (status ' + code + ')', function () { pm.expect(true).to.be.true; });",
+              "  return;",
+              "}",
+              "pm.test('Inference succeeded', function () { pm.expect(code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "if (code < 200 || code > 299) { pm.collectionVariables.unset('offpeak_request_id'); }"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "x-bf-vk",
+            "value": "{{tod_vk_value}}"
+          },
+          {
+            "key": "x-request-id",
+            "value": "{{offpeak_request_id}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+        },
+        "url": {
+          "raw": "{{base_url}}/v1/chat/completions",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "v1",
+            "chat",
+            "completions"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Off-peak cost is scaled by the multiplier (openai gpt-4o-mini)",
+      "description": "The regression this collection exists for. Outside every window the usage-based charges scale by off_peak_cost_multiplier and nothing else changes.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"offpeak_request_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "var retry = Number(pm.collectionVariables.get('offpeak_poll_retry') || 0);",
+              "if (retry > 0) {",
+              "  // The log row is written asynchronously after the response returns, so",
+              "  // poll once a second. Newman drains pending timers before it sends.",
+              "  var until = Date.now() + 1000;",
+              "  (function waitBeforeRetry() { if (Date.now() < until) { setTimeout(waitBeforeRetry, 100); } })();",
+              "}"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var reqId = pm.collectionVariables.get('offpeak_request_id');",
+              "if (!reqId) { pm.test('Skipped: no priming request to price', function () { pm.expect(true).to.be.true; }); return; }",
+              "var code = pm.response.code;",
+              "if ([401, 403, 429, 500, 502, 503, 504].indexOf(code) !== -1) {",
+              "  pm.test('Skipped: logs API unavailable (status ' + code + ')', function () { pm.expect(true).to.be.true; });",
+              "  return;",
+              "}",
+              "pm.test('Logs query returns 200', function () { pm.expect(code, 'body: ' + pm.response.text()).to.equal(200); });",
+              "if (code !== 200) { return; }",
+              "var body = null;",
+              "try { body = pm.response.json(); } catch (e) { body = null; }",
+              "pm.test('Logs query returned JSON', function () { pm.expect(body, 'body: ' + pm.response.text()).to.not.equal(null); });",
+              "if (!body) { return; }",
+              "var logs = body.logs || body.data || [];",
+              "// Do not trust the server-side request_id filter blindly. If it were ever",
+              "// ignored, logs[0] would be some other request and the cost assertion would",
+              "// report a mismatch against a row it never named. The log row id IS the",
+              "// request id, so an identity check makes a wrong row read as no row.",
+              "var candidate = logs.length ? logs[0] : null;",
+              "var rowId = candidate && (candidate.id || candidate.request_id);",
+              "var row = candidate && (!rowId || rowId === reqId) ? candidate : null;",
+              "var retry = Number(pm.collectionVariables.get('offpeak_poll_retry') || 0);",
+              "// Cost is denormalized onto the row after the response is logged, so an",
+              "// existing row with no cost yet is still in flight, not a failure.",
+              "if ((!row || !Number(row.cost)) && retry < 30) {",
+              "  pm.collectionVariables.set('offpeak_poll_retry', String(retry + 1));",
+              "  if (typeof pm.execution !== 'undefined' && pm.execution.setNextRequest) { pm.execution.setNextRequest(pm.info.requestName); } else { postman.setNextRequest(pm.info.requestName); }",
+              "  return;",
+              "}",
+              "pm.test('Priced log row exists for the request', function () {",
+              "  pm.expect(row, 'no row for request_id=' + reqId + ' after ' + retry + ' polls').to.not.equal(null);",
+              "});",
+              "if (!row) { return; }",
+              "var prompt = Number(row.prompt_tokens || 0);",
+              "var completion = Number(row.completion_tokens || 0);",
+              "var cachedRead = Number(row.cached_read_tokens || 0);",
+              "// The expected-cost formula below models only uncached text. A cache hit",
+              "// prices on different rates, so skip rather than assert something false.",
+              "if (cachedRead > 0) { pm.test('Skipped: response used cached tokens', function () { pm.expect(true).to.be.true; }); return; }",
+              "if (!(prompt > 0)) { pm.test('Skipped: row carries no token counts yet', function () { pm.expect(true).to.be.true; }); return; }",
+              "var peakCost = prompt * 1e-06 + completion * 2e-06;",
+              "var expected = peakCost * 0.5;",
+              "var actual = Number(row.cost || 0);",
+              "var tol = Math.max(1e-9, 1e-4 * expected);",
+              "// Request outside every peak window is scaled by off_peak_cost_multiplier",
+              "pm.test('Request outside every peak window is scaled by off_peak_cost_multiplier', function () {",
+              "  pm.expect(Math.abs(actual - expected) <= tol,",
+              "    'prompt=' + prompt + ' completion=' + completion +",
+              "    ' logged=$' + actual + ' expected=$' + expected +",
+              "    ' (peak=$' + peakCost + ' x 0.5) tol=' + tol).to.be.true;",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/logs?request_id={{offpeak_request_id}}&limit=1",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "logs"
+          ],
+          "query": [
+            {
+              "key": "request_id",
+              "value": "{{offpeak_request_id}}"
+            },
+            {
+              "key": "limit",
+              "value": "1"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Teardown - Delete off-peak override (openai gpt-4o-mini)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"offpeak_override_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Override deleted', function () { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "pm.collectionVariables.unset('offpeak_override_id');"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/governance/pricing-overrides/{{offpeak_override_id}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "governance",
+            "pricing-overrides",
+            "{{offpeak_override_id}}"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Setup - Malformed schedule override (openai gpt-4o-mini)",
+      "description": "A schedule that cannot be evaluated at all. The engine must fall back to peak rather than hand out a discount nobody configured.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"tod_vk_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "pm.collectionVariables.unset('badsched_override_id');",
+              "pm.collectionVariables.unset('badsched_request_id');",
+              "pm.collectionVariables.unset('badsched_poll_retry');",
+              "// Build an HH:MM offset from now, in UTC. All windows below list every",
+              "// weekday, so a window that wraps past midnight still matches and the cases",
+              "// stay correct no matter which hour or day the suite runs at.",
+              "function hhmmFromNow(hoursOffset) {",
+              "  var t = new Date(Date.now() + hoursOffset * 3600 * 1000);",
+              "  function pad(n) { return (n < 10 ? '0' : '') + n; }",
+              "  return pad(t.getUTCHours()) + ':' + pad(t.getUTCMinutes());",
+              "}",
+              "var ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];",
+              "// Both halves are unusable: an out-of-range clock string and a timezone",
+              "// that is not an IANA location. Either one alone is enough to make the",
+              "// schedule unevaluable.",
+              "var peakHours = { timezone: 'Mars/Olympus', windows: [{ days: ALL_DAYS, start: '25:00', end: '99:99' }] };",
+              "var overrideName = 'e2e-tod-badsched-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);",
+              "var patch = {",
+              "  input_cost_per_token: 1e-06,",
+              "  output_cost_per_token: 2e-06,",
+              "  // Pinned so a datasheet flat fee cannot leak into the expected total.",
+              "  // A flat per-request fee is deliberately not discounted off-peak, so",
+              "  // leaving it unset would make the off-peak assertion depend on whether",
+              "  // the live datasheet happens to carry one for this model.",
+              "  cost_per_request: 0,",
+              "  off_peak_cost_multiplier: 0.5,",
+              "  peak_hours: peakHours",
+              "};",
+              "pm.request.body.raw = JSON.stringify({",
+              "  name: overrideName,",
+              "  // Virtual-key scoped on purpose. A global or provider-scoped override",
+              "  // would halve the cost of every other request in flight and make the",
+              "  // dbverify cost-accuracy checks in the rest of the suite report",
+              "  // INACCURATE for reasons that have nothing to do with those cases.",
+              "  scope_kind: 'virtual_key',",
+              "  virtual_key_id: pm.collectionVariables.get('tod_vk_id'),",
+              "  match_type: 'exact',",
+              "  pattern: pm.variables.get('chat_model') || 'gpt-4o-mini',",
+              "  request_types: ['chat_completion'],",
+              "  patch: patch",
+              "});"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var code = pm.response.code;",
+              "pm.test('Setup - Malformed schedule override (openai gpt-4o-mini) returns 2xx', function () { pm.expect(code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "if (code < 200 || code > 299) { return; }",
+              "var body = null;",
+              "try { body = pm.response.json(); } catch (e) { body = null; }",
+              "var ov = body && (body.pricing_override || body);",
+              "pm.test('Override exposes an id', function () {",
+              "  pm.expect(ov && ov.id, 'body: ' + pm.response.text()).to.be.a('string').and.not.be.empty;",
+              "});",
+              "if (!ov || !ov.id) { return; }",
+              "pm.collectionVariables.set('badsched_override_id', ov.id);"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{}"
+        },
+        "url": {
+          "raw": "{{base_url}}/api/governance/pricing-overrides",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "governance",
+            "pricing-overrides"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Malformed schedule still serves the request (openai gpt-4o-mini)",
+      "description": "A bad schedule is a pricing concern, not a request-path one: the call must still succeed.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"tod_vk_value\", \"badsched_override_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "var reqId = 'e2e-tod-badsched-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8);",
+              "pm.collectionVariables.set('badsched_request_id', reqId);"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var code = pm.response.code;",
+              "// Provider auth, rate limiting and upstream outages are infrastructure noise,",
+              "// not the behaviour under test. Clear the request id so the cost assertion",
+              "// downstream skips instead of failing on a row that was never written.",
+              "if ([401, 403, 429, 500, 502, 503, 504].indexOf(code) !== -1) {",
+              "  pm.collectionVariables.unset('badsched_request_id');",
+              "  pm.test('Skipped: provider unavailable (status ' + code + ')', function () { pm.expect(true).to.be.true; });",
+              "  return;",
+              "}",
+              "pm.test('Inference succeeded', function () { pm.expect(code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "if (code < 200 || code > 299) { pm.collectionVariables.unset('badsched_request_id'); }"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          },
+          {
+            "key": "x-bf-vk",
+            "value": "{{tod_vk_value}}"
+          },
+          {
+            "key": "x-request-id",
+            "value": "{{badsched_request_id}}"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\"model\": \"{{chat_model}}\", \"messages\": [{\"role\": \"user\", \"content\": \"ok\"}], \"max_tokens\": 5}"
+        },
+        "url": {
+          "raw": "{{base_url}}/v1/chat/completions",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "v1",
+            "chat",
+            "completions"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Malformed schedule fails closed to peak (openai gpt-4o-mini)",
+      "description": "Every base rate is the peak price, so a schedule that cannot be parsed must over-bill rather than under-bill. This pins the direction of the fallback, which is the part a refactor is most likely to invert silently.",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"badsched_request_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }",
+              "var retry = Number(pm.collectionVariables.get('badsched_poll_retry') || 0);",
+              "if (retry > 0) {",
+              "  // The log row is written asynchronously after the response returns, so",
+              "  // poll once a second. Newman drains pending timers before it sends.",
+              "  var until = Date.now() + 1000;",
+              "  (function waitBeforeRetry() { if (Date.now() < until) { setTimeout(waitBeforeRetry, 100); } })();",
+              "}"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var reqId = pm.collectionVariables.get('badsched_request_id');",
+              "if (!reqId) { pm.test('Skipped: no priming request to price', function () { pm.expect(true).to.be.true; }); return; }",
+              "var code = pm.response.code;",
+              "if ([401, 403, 429, 500, 502, 503, 504].indexOf(code) !== -1) {",
+              "  pm.test('Skipped: logs API unavailable (status ' + code + ')', function () { pm.expect(true).to.be.true; });",
+              "  return;",
+              "}",
+              "pm.test('Logs query returns 200', function () { pm.expect(code, 'body: ' + pm.response.text()).to.equal(200); });",
+              "if (code !== 200) { return; }",
+              "var body = null;",
+              "try { body = pm.response.json(); } catch (e) { body = null; }",
+              "pm.test('Logs query returned JSON', function () { pm.expect(body, 'body: ' + pm.response.text()).to.not.equal(null); });",
+              "if (!body) { return; }",
+              "var logs = body.logs || body.data || [];",
+              "// Do not trust the server-side request_id filter blindly. If it were ever",
+              "// ignored, logs[0] would be some other request and the cost assertion would",
+              "// report a mismatch against a row it never named. The log row id IS the",
+              "// request id, so an identity check makes a wrong row read as no row.",
+              "var candidate = logs.length ? logs[0] : null;",
+              "var rowId = candidate && (candidate.id || candidate.request_id);",
+              "var row = candidate && (!rowId || rowId === reqId) ? candidate : null;",
+              "var retry = Number(pm.collectionVariables.get('badsched_poll_retry') || 0);",
+              "// Cost is denormalized onto the row after the response is logged, so an",
+              "// existing row with no cost yet is still in flight, not a failure.",
+              "if ((!row || !Number(row.cost)) && retry < 30) {",
+              "  pm.collectionVariables.set('badsched_poll_retry', String(retry + 1));",
+              "  if (typeof pm.execution !== 'undefined' && pm.execution.setNextRequest) { pm.execution.setNextRequest(pm.info.requestName); } else { postman.setNextRequest(pm.info.requestName); }",
+              "  return;",
+              "}",
+              "pm.test('Priced log row exists for the request', function () {",
+              "  pm.expect(row, 'no row for request_id=' + reqId + ' after ' + retry + ' polls').to.not.equal(null);",
+              "});",
+              "if (!row) { return; }",
+              "var prompt = Number(row.prompt_tokens || 0);",
+              "var completion = Number(row.completion_tokens || 0);",
+              "var cachedRead = Number(row.cached_read_tokens || 0);",
+              "// The expected-cost formula below models only uncached text. A cache hit",
+              "// prices on different rates, so skip rather than assert something false.",
+              "if (cachedRead > 0) { pm.test('Skipped: response used cached tokens', function () { pm.expect(true).to.be.true; }); return; }",
+              "if (!(prompt > 0)) { pm.test('Skipped: row carries no token counts yet', function () { pm.expect(true).to.be.true; }); return; }",
+              "var peakCost = prompt * 1e-06 + completion * 2e-06;",
+              "var expected = peakCost * 1;",
+              "var actual = Number(row.cost || 0);",
+              "var tol = Math.max(1e-9, 1e-4 * expected);",
+              "// Unevaluable schedule bills at peak, not at the discount",
+              "pm.test('Unevaluable schedule bills at peak, not at the discount', function () {",
+              "  pm.expect(Math.abs(actual - expected) <= tol,",
+              "    'prompt=' + prompt + ' completion=' + completion +",
+              "    ' logged=$' + actual + ' expected=$' + expected +",
+              "    ' (peak=$' + peakCost + ' x 1) tol=' + tol).to.be.true;",
+              "});"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/logs?request_id={{badsched_request_id}}&limit=1",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "logs"
+          ],
+          "query": [
+            {
+              "key": "request_id",
+              "value": "{{badsched_request_id}}"
+            },
+            {
+              "key": "limit",
+              "value": "1"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "Teardown - Delete malformed-schedule override (openai gpt-4o-mini)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"badsched_override_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('Override deleted', function () { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "pm.collectionVariables.unset('badsched_override_id');"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/governance/pricing-overrides/{{badsched_override_id}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "governance",
+            "pricing-overrides",
+            "{{badsched_override_id}}"
+          ]
+        }
+      }
+    },
+    {
+      "name": "Teardown - Delete VK (openai gpt-4o-mini)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var missing = [\"tod_vk_id\"].filter(function (k) { return !pm.collectionVariables.get(k); });",
+              "if (missing.length && typeof pm.execution !== 'undefined' && pm.execution.skipRequest) { pm.execution.skipRequest(); }"
+            ]
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "pm.test('VK deleted', function () { pm.expect(pm.response.code, 'body: ' + pm.response.text()).to.be.within(200, 299); });",
+              "pm.collectionVariables.unset('tod_vk_id');",
+              "pm.collectionVariables.unset('tod_vk_value');"
+            ]
+          }
+        }
+      ],
+      "request": {
+        "method": "DELETE",
+        "header": [],
+        "url": {
+          "raw": "{{base_url}}/api/governance/virtual-keys/{{tod_vk_id}}",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "api",
+            "governance",
+            "virtual-keys",
+            "{{tod_vk_id}}"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/e2e/api/runners/individual/run-newman-pricing-time-of-day-tests.sh
+++ b/tests/e2e/api/runners/individual/run-newman-pricing-time-of-day-tests.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+
+# Bifrost V1 Time-of-Day Pricing Newman Test Runner
+# Runs peak/off-peak pricing regression tests: a VK-scoped pricing override pins
+# the rates and schedule, three inference calls are priced, and the logged cost is
+# compared against the rate the schedule should have selected. Wall clock is ~1 minute.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+API_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$API_DIR"
+
+# Configuration
+COLLECTION="collections/bifrost-v1-pricing-time-of-day.postman_collection.json"
+REPORT_DIR="newman-reports/pricing-time-of-day"
+PROVIDER_CONFIG_DIR="provider_config"
+PROVIDER_CAPABILITIES_JSON="provider-capabilities.json"
+
+# Colors for output
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Parse arguments
+PROVIDER_ENV_FILE=""
+ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --env)
+            if [[ -z "${2:-}" || "${2:-}" == --* ]]; then
+                echo -e "${RED}Error: --env requires a value${NC}"
+                exit 1
+            fi
+            PROVIDER_ENV_FILE="$2"
+            shift 2
+            ;;
+        --help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --env <provider>    Postman env path or provider name (e.g. openai or provider_config/bifrost-v1-openai.postman_environment.json)"
+            echo "  --verbose           Show detailed output"
+            echo "  --html              Generate HTML report"
+            echo "  --json              Generate JSON report"
+            echo "  --bail              Stop on first failure"
+            echo "  --help              Show this help message"
+            echo ""
+            echo "Environment Variables:"
+            echo "  BIFROST_BASE_URL    Override base URL (default: http://localhost:8080)"
+            echo "  BIFROST_ADMIN_AUTH_HEADER"
+            echo "                      Authorization header for the management API when the"
+            echo "                      gateway runs with auth enabled, e.g. 'Bearer <admin-key>'."
+            echo "                      Applied to /api/ calls only."
+            echo ""
+            echo "Examples:"
+            echo "  $0 --env openai     # Run with OpenAI provider"
+            exit 0
+            ;;
+        *)
+            ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+set -- "${ARGS[@]}"
+
+# Print banner
+echo -e "${GREEN}==============================================${NC}"
+echo -e "${GREEN}Bifrost V1 Time-of-Day Pricing Test Runner${NC}"
+echo -e "${GREEN}==============================================${NC}"
+echo ""
+
+# Check if Newman is installed
+if ! command -v newman &> /dev/null; then
+    echo -e "${RED}Error: Newman is not installed${NC}"
+    echo "Install it with: npm install -g newman"
+    exit 1
+fi
+
+# Check if collection exists
+if [ ! -f "$COLLECTION" ]; then
+    echo -e "${RED}Error: Collection file not found: $COLLECTION${NC}"
+    exit 1
+fi
+
+# Create report directory
+mkdir -p "$REPORT_DIR"
+
+# Load provider capabilities into globals (for consistency with v1 runner)
+GLOBALS_TMP=""
+if [ -f "$PROVIDER_CAPABILITIES_JSON" ] && command -v jq &>/dev/null; then
+    GLOBALS_TMP=$(mktemp)
+    trap 'rm -f "$GLOBALS_TMP"' EXIT
+    jq -n --rawfile cap "$PROVIDER_CAPABILITIES_JSON" '{id: "bifrost-provider-capabilities", name: "Provider capabilities", values: [{key: "provider_capabilities", value: $cap, type: "default", enabled: true}]}' > "$GLOBALS_TMP"
+fi
+
+# Parse remaining options
+VERBOSE=""
+REPORTERS="cli"
+BAIL=""
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --verbose)
+            VERBOSE="--verbose"
+            shift
+            ;;
+        --html)
+            REPORTERS="${REPORTERS},html"
+            shift
+            ;;
+        --json)
+            REPORTERS="${REPORTERS},json"
+            shift
+            ;;
+        --bail)
+            BAIL="--bail"
+            shift
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+# Resolve provider env file
+SINGLE_JSON_ENV=""
+if [ -n "$PROVIDER_ENV_FILE" ]; then
+    if [ -f "$PROVIDER_ENV_FILE" ]; then
+        SINGLE_JSON_ENV="$PROVIDER_ENV_FILE"
+    elif [ -f "$PROVIDER_CONFIG_DIR/$PROVIDER_ENV_FILE" ]; then
+        SINGLE_JSON_ENV="$PROVIDER_CONFIG_DIR/$PROVIDER_ENV_FILE"
+    elif [ -f "$PROVIDER_CONFIG_DIR/bifrost-v1-${PROVIDER_ENV_FILE}.postman_environment.json" ]; then
+        SINGLE_JSON_ENV="$PROVIDER_CONFIG_DIR/bifrost-v1-${PROVIDER_ENV_FILE}.postman_environment.json"
+    else
+        echo -e "${RED}Error: Could not find environment file for: $PROVIDER_ENV_FILE${NC}"
+        echo "Searched:"
+        echo "  - $PROVIDER_ENV_FILE"
+        echo "  - $PROVIDER_CONFIG_DIR/$PROVIDER_ENV_FILE"
+        echo "  - $PROVIDER_CONFIG_DIR/bifrost-v1-${PROVIDER_ENV_FILE}.postman_environment.json"
+        exit 1
+    fi
+fi
+
+# Default to openai if no env specified
+if [ -z "$SINGLE_JSON_ENV" ]; then
+    if [ -f "$PROVIDER_CONFIG_DIR/bifrost-v1-openai.postman_environment.json" ]; then
+        SINGLE_JSON_ENV="$PROVIDER_CONFIG_DIR/bifrost-v1-openai.postman_environment.json"
+        echo -e "${YELLOW}No --env specified, using openai${NC}"
+    fi
+fi
+
+# Build Newman command
+cmd=(newman run "$COLLECTION")
+[ -n "$GLOBALS_TMP" ] && [ -f "$GLOBALS_TMP" ] && cmd+=(-g "$GLOBALS_TMP")
+[ -n "$SINGLE_JSON_ENV" ] && [ -f "$SINGLE_JSON_ENV" ] && cmd+=(-e "$SINGLE_JSON_ENV")
+
+# Base URL override
+base_url="${BIFROST_BASE_URL:-http://localhost:8080}"
+cmd+=(--env-var "base_url=$base_url")
+
+# Management auth. The collection applies this to /api/ calls only, so the
+# inference calls keep authenticating as the virtual key under test. Leave it
+# unset when the gateway runs with management auth disabled.
+if [ -n "${BIFROST_ADMIN_AUTH_HEADER:-}" ]; then
+    cmd+=(--env-var "admin_auth_header=$BIFROST_ADMIN_AUTH_HEADER")
+fi
+
+cmd+=(--timeout-script 120000 --timeout 900000)
+cmd+=(-r "$REPORTERS")
+
+if [[ "$REPORTERS" == *"html"* ]]; then
+    cmd+=(--reporter-html-export "$REPORT_DIR/report.html")
+fi
+if [[ "$REPORTERS" == *"json"* ]]; then
+    cmd+=(--reporter-json-export "$REPORT_DIR/report.json")
+fi
+[ -n "$VERBOSE" ] && cmd+=("$VERBOSE")
+[ -n "$BAIL" ] && cmd+=("$BAIL")
+
+echo -e "Configuration:"
+echo -e "  Collection: ${YELLOW}$COLLECTION${NC}"
+echo -e "  Base URL:   ${YELLOW}$base_url${NC}"
+if [ -n "$SINGLE_JSON_ENV" ]; then
+    echo -e "  Env:        ${YELLOW}$SINGLE_JSON_ENV${NC}"
+fi
+echo -e "  Reports:    ${YELLOW}$REPORT_DIR${NC}"
+echo ""
+echo -e "${GREEN}Running tests...${NC}"
+echo ""
+
+set +e
+"${cmd[@]}"
+EXIT_CODE=$?
+set -e
+
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}✓ All time-of-day pricing tests passed!${NC}"
+else
+    echo -e "${RED}✗ Some tests failed${NC}"
+fi
+if [[ "$REPORTERS" == *"html"* ]] || [[ "$REPORTERS" == *"json"* ]]; then
+    echo ""
+    echo -e "Reports saved to: ${YELLOW}$REPORT_DIR${NC}"
+    ls -lh "$REPORT_DIR" 2>/dev/null | tail -n +2
+fi
+
+exit $EXIT_CODE

--- a/tests/e2e/api/runners/run-newman-api-tests.sh
+++ b/tests/e2e/api/runners/run-newman-api-tests.sh
@@ -590,20 +590,21 @@ if [ "$AUTH_ENABLED_BY_RUN" = "1" ]; then
     fi
 fi
 
-# Governance suites (virtual key quota, rate limit / budget enforcement, and
-# rotation cooldown). These run as their own newman invocations rather than
-# through --extra-collection: merging folds them into the management collection,
+# Governance suites (virtual key quota, rate limit / budget enforcement,
+# rotation cooldown, and time-of-day pricing). These run as their own newman
+# invocations rather than through --extra-collection: merging folds them into the management collection,
 # which would drop their collection variables, subject their deliberate 401/403/
 # 429/402 assertions to that collection's 2xx gate, and run them a second time in
 # the authenticated pass. They also run after auth is restored to disabled,
 # because they provision virtual keys through the unauthenticated management API.
-# Roughly 7 minutes, most of it the rotation suite waiting out real 1m and 3m
+# Roughly 8 minutes, most of it the rotation suite waiting out real 1m and 3m
 # grace windows; set BIFROST_E2E_SKIP_GOVERNANCE=1 to skip them.
 if [ $EXIT_CODE -eq 0 ] && [ "${BIFROST_E2E_SKIP_GOVERNANCE:-0}" != "1" ]; then
     for governance_suite in \
         "vk-quota:run-newman-vk-quota-tests.sh" \
         "rate-limit:run-newman-rate-limit-tests.sh" \
-        "vk-rotation-cooldown:run-newman-vk-rotation-cooldown-tests.sh"; do
+        "vk-rotation-cooldown:run-newman-vk-rotation-cooldown-tests.sh" \
+        "pricing-time-of-day:run-newman-pricing-time-of-day-tests.sh"; do
         suite_name="${governance_suite%%:*}"
         suite_runner="${governance_suite##*:}"
         echo "" | tee -a "$LOG_FILE"

--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { PRICING_FIELDS, pricingFieldUnit } from "./pricingFields";
+import { PRICING_FIELDS, pricingFieldError, pricingFieldUnit } from "./pricingFields";
 
 describe("pricingFieldUnit", () => {
 	// Character-priced fields carry a "/ character" label, so rendering them
@@ -84,11 +84,41 @@ describe("pricingFieldUnit", () => {
 			expect(byUnit[unit], `${field.key} resolved to unexpected unit ${unit}`).toBeDefined();
 			byUnit[unit].push(field.key);
 		}
-		expect(PRICING_FIELDS).toHaveLength(106);
-		expect(byUnit.multiplier).toEqual(["inference_geo_us_multiplier"]);
+		expect(PRICING_FIELDS).toHaveLength(107);
+		expect(byUnit.multiplier).toEqual(["inference_geo_us_multiplier", "off_peak_cost_multiplier"]);
 		expect(byUnit.character).toEqual(["input_cost_per_character"]);
 		// Sanity: the split is real, not everything collapsing into one bucket.
 		expect(byUnit.token.length).toBeGreaterThan(20);
 		expect(byUnit.currency.length).toBeGreaterThan(20);
+	});
+});
+
+describe("pricingFieldError", () => {
+	it("treats an empty value as no override rather than an error", () => {
+		expect(pricingFieldError("input_cost_per_token", "")).toBeUndefined();
+		expect(pricingFieldError("input_cost_per_token", "   ")).toBeUndefined();
+		expect(pricingFieldError("input_cost_per_token", undefined)).toBeUndefined();
+	});
+
+	it("rejects non-numeric input", () => {
+		expect(pricingFieldError("input_cost_per_token", "abc")).toBe("Must be a number");
+		expect(pricingFieldError("input_cost_per_token", "Infinity")).toBe("Must be a number");
+	});
+
+	it("keeps the default non-negative rule for ordinary cost fields", () => {
+		expect(pricingFieldError("input_cost_per_token", "0")).toBeUndefined();
+		expect(pricingFieldError("input_cost_per_token", "0.000001")).toBeUndefined();
+		expect(pricingFieldError("input_cost_per_token", "-1")).toBe("Must be >= 0");
+	});
+
+	// Every base rate is the peak price, so the off-peak multiplier can only
+	// scale downward: 0 would make off-peak free, >1 would exceed peak. The Go
+	// engine rejects both and bills at peak, so the form must not accept them.
+	it("bounds the off-peak multiplier to (0, 1]", () => {
+		expect(pricingFieldError("off_peak_cost_multiplier", "0.5")).toBeUndefined();
+		expect(pricingFieldError("off_peak_cost_multiplier", "1")).toBeUndefined();
+		expect(pricingFieldError("off_peak_cost_multiplier", "0")).toBe("Must be greater than 0 and at most 1");
+		expect(pricingFieldError("off_peak_cost_multiplier", "-0.5")).toBe("Must be greater than 0 and at most 1");
+		expect(pricingFieldError("off_peak_cost_multiplier", "1.5")).toBe("Must be greater than 0 and at most 1");
 	});
 });

--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
@@ -1,3 +1,6 @@
+import type { RequestType } from "@/lib/types/config";
+import type { PricingOverrideMatchType, PricingOverridePatch } from "@/lib/types/governance";
+
 // Shared pricing-field metadata for override editing and display.
 //
 // Extracted from pricingOverrideSheet.tsx so read-only consumers (e.g. the
@@ -716,3 +719,60 @@ export const fieldLabelByKey = Object.fromEntries(PRICING_FIELDS.map((field) => 
 export const patchKeys = PRICING_FIELDS.map((field) => field.key) as PricingFieldKey[];
 
 export type FieldErrors = Partial<Record<PricingFieldKey | "name" | "scope" | "pattern" | "patch", string>>;
+
+// ---------------------------------------------------------------------------
+// Override form state
+//
+// Lives here rather than in pricingOverrideSheet.tsx so the patch-building
+// logic can be unit tested without pulling the sheet's React tree in.
+// ---------------------------------------------------------------------------
+
+export type ScopeRoot = "global" | "virtual_key" | "user";
+
+export interface FormState {
+	name: string;
+	scopeRoot: ScopeRoot;
+	userID: string;
+	virtualKeyID: string;
+	providerID: string;
+	providerKeyID: string;
+	matchType: PricingOverrideMatchType;
+	pattern: string;
+	requestTypes: RequestType[];
+	pricingValues: Partial<Record<PricingFieldKey, string>>;
+}
+
+export const defaultFormState: FormState = {
+	name: "",
+	scopeRoot: "global",
+	userID: "",
+	virtualKeyID: "",
+	providerID: "",
+	providerKeyID: "",
+	matchType: "exact",
+	pattern: "",
+	requestTypes: [],
+	pricingValues: {},
+};
+
+export function buildPatchFromForm(form: FormState): { patch: PricingOverridePatch; errors: FieldErrors } {
+	const errors: FieldErrors = {};
+	const patch: PricingOverridePatch = {};
+
+	for (const key of patchKeys) {
+		const raw = form.pricingValues[key];
+		if (raw == null || raw.trim() === "") continue;
+		const parsed = Number(raw);
+		if (!Number.isFinite(parsed)) {
+			errors[key] = "Must be a number";
+			continue;
+		}
+		if (parsed < 0) {
+			errors[key] = "Must be >= 0";
+			continue;
+		}
+		(patch as Record<string, number>)[key] = parsed;
+	}
+
+	return { patch, errors };
+}

--- a/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingFields.ts
@@ -346,6 +346,12 @@ export const PRICING_FIELDS = [
 		group: "chat",
 		requestTypeGroups: ["chat", "embedding", "rerank", "audio", "image", "video", "ocr"],
 	},
+	{
+		key: "off_peak_cost_multiplier",
+		label: "Off-peak multiplier",
+		group: "chat",
+		requestTypeGroups: ["chat", "embedding", "rerank", "audio", "image", "video", "ocr"],
+	},
 	// Audio fields
 	{
 		key: "input_cost_per_character",
@@ -718,6 +724,39 @@ export const fieldLabelByKey = Object.fromEntries(PRICING_FIELDS.map((field) => 
 >;
 export const patchKeys = PRICING_FIELDS.map((field) => field.key) as PricingFieldKey[];
 
+/**
+ * Per-field numeric bounds for fields that are not plain "any non-negative
+ * cost". Fields absent from this map keep the default `>= 0` rule.
+ */
+export const FIELD_BOUNDS: Partial<Record<PricingFieldKey, { min?: number; max?: number; message: string }>> = {
+	// Every base rate is the peak price, so the off-peak multiplier can only
+	// ever scale downward. A value of 0 would make off-peak requests free and a
+	// value above 1 would make them cost more than peak; the pricing engine
+	// rejects both and bills at peak, so reject them here too rather than
+	// silently accepting a setting that will never take effect.
+	off_peak_cost_multiplier: { min: 0, max: 1, message: "Must be greater than 0 and at most 1" },
+};
+
+/**
+ * Validates one raw form value for a pricing field. Returns an error message,
+ * or undefined when the value is acceptable. An empty value is not an error —
+ * it means "do not override this field".
+ */
+export function pricingFieldError(key: PricingFieldKey, raw: string | undefined): string | undefined {
+	if (raw == null || raw.trim() === "") return undefined;
+	const parsed = Number(raw);
+	if (!Number.isFinite(parsed)) return "Must be a number";
+
+	const bounds = FIELD_BOUNDS[key];
+	if (bounds) {
+		if (bounds.min != null && parsed <= bounds.min) return bounds.message;
+		if (bounds.max != null && parsed > bounds.max) return bounds.message;
+		return undefined;
+	}
+	if (parsed < 0) return "Must be >= 0";
+	return undefined;
+}
+
 export type FieldErrors = Partial<Record<PricingFieldKey | "name" | "scope" | "pattern" | "patch", string>>;
 
 // ---------------------------------------------------------------------------
@@ -740,6 +779,13 @@ export interface FormState {
 	pattern: string;
 	requestTypes: RequestType[];
 	pricingValues: Partial<Record<PricingFieldKey, string>>;
+	/**
+	 * Patch fields this form does not render — currently `peak_hours`, which is
+	 * a schedule object rather than a number and is set via the API or the
+	 * datasheet. Carried through verbatim so opening and saving an override in
+	 * the UI never silently drops what the form cannot display.
+	 */
+	preservedPatch: Record<string, unknown>;
 }
 
 export const defaultFormState: FormState = {
@@ -753,25 +799,51 @@ export const defaultFormState: FormState = {
 	pattern: "",
 	requestTypes: [],
 	pricingValues: {},
+	preservedPatch: {},
 };
+
+/**
+ * Patch keys the form cannot render as a number but still round-trips. Today
+ * only the `peak_hours` schedule object. Anything outside this list that is
+ * also outside `patchKeys` is a typo, and the JSON editor rejects it rather
+ * than saving a key the pricing engine will ignore forever.
+ */
+export const PRESERVED_PATCH_KEYS: readonly string[] = ["peak_hours"];
+
+/**
+ * `__proto__` and friends are never valid pricing field names, and assigning
+ * them onto a plain object walks into `Object.prototype`'s accessor instead of
+ * creating an own property: the value is silently dropped and the object's
+ * prototype is mutated. JSON.parse does create `__proto__` as an own property,
+ * so a patch fetched from the API can carry one. Refuse to carry these keys at
+ * every point where an arbitrary patch key is copied.
+ */
+export function isUnsafePatchKey(key: string): boolean {
+	return key === "__proto__" || key === "constructor" || key === "prototype";
+}
 
 export function buildPatchFromForm(form: FormState): { patch: PricingOverridePatch; errors: FieldErrors } {
 	const errors: FieldErrors = {};
 	const patch: PricingOverridePatch = {};
 
+	// Only keys the form cannot render ride through. A key the form does render
+	// can still reach preservedPatch when the stored value was not a number, and
+	// copying it here would resurrect that stale value even after the user
+	// cleared the field. The rendered form stays authoritative for its own keys.
+	for (const [key, value] of Object.entries(form.preservedPatch ?? {})) {
+		if (isUnsafePatchKey(key) || patchKeys.includes(key as PricingFieldKey)) continue;
+		(patch as Record<string, unknown>)[key] = value;
+	}
+
 	for (const key of patchKeys) {
 		const raw = form.pricingValues[key];
 		if (raw == null || raw.trim() === "") continue;
-		const parsed = Number(raw);
-		if (!Number.isFinite(parsed)) {
-			errors[key] = "Must be a number";
+		const err = pricingFieldError(key, raw);
+		if (err) {
+			errors[key] = err;
 			continue;
 		}
-		if (parsed < 0) {
-			errors[key] = "Must be >= 0";
-			continue;
-		}
-		(patch as Record<string, number>)[key] = parsed;
+		(patch as Record<string, number>)[key] = Number(raw);
 	}
 
 	return { patch, errors };

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverridePatch.test.ts
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverridePatch.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+
+import { buildPatchFromForm, defaultFormState, isUnsafePatchKey, type FormState } from "./pricingFields";
+
+function formWith(overrides: Partial<FormState>): FormState {
+	return { ...defaultFormState, ...overrides };
+}
+
+describe("buildPatchFromForm", () => {
+	it("emits only the fields that were filled in", () => {
+		const { patch, errors } = buildPatchFromForm(
+			formWith({ pricingValues: { input_cost_per_token: "0.000001", output_cost_per_token: "" } }),
+		);
+		expect(errors).toEqual({});
+		expect(patch).toEqual({ input_cost_per_token: 0.000001 });
+	});
+
+	it("reports per-field validation errors and omits the bad field", () => {
+		const { patch, errors } = buildPatchFromForm(
+			formWith({ pricingValues: { off_peak_cost_multiplier: "1.5", input_cost_per_token: "0.000001" } }),
+		);
+		expect(errors.off_peak_cost_multiplier).toBe("Must be greater than 0 and at most 1");
+		expect(patch).toEqual({ input_cost_per_token: 0.000001 });
+	});
+
+	// Regression: the form renders numeric fields only, so a schedule object set
+	// through the API used to be dropped the moment someone opened and saved the
+	// override in the UI.
+	it("carries through patch fields the form cannot render", () => {
+		const peakHours = {
+			timezone: "UTC",
+			windows: [{ days: [1, 2, 3, 4, 5], start: "01:00", end: "04:00" }],
+		};
+		const { patch, errors } = buildPatchFromForm(
+			formWith({
+				pricingValues: { off_peak_cost_multiplier: "0.5" },
+				preservedPatch: { peak_hours: peakHours },
+			}),
+		);
+		expect(errors).toEqual({});
+		expect(patch).toEqual({ off_peak_cost_multiplier: 0.5, peak_hours: peakHours });
+	});
+
+	it("lets a rendered field win over a stale preserved value of the same name", () => {
+		const { patch } = buildPatchFromForm(
+			formWith({
+				pricingValues: { input_cost_per_token: "0.000002" },
+				preservedPatch: { input_cost_per_token: 0.000009 },
+			}),
+		);
+		expect(patch.input_cost_per_token).toBe(0.000002);
+	});
+
+	// A key the form does render lands in preservedPatch whenever the stored
+	// value was not a number, so clearing that field in the form used to save
+	// the stale value straight back.
+	it("drops a preserved value for a rendered field the user cleared", () => {
+		const { patch } = buildPatchFromForm(
+			formWith({
+				pricingValues: { input_cost_per_token: "" },
+				preservedPatch: { input_cost_per_token: "0.000009" },
+			}),
+		);
+		expect(patch).not.toHaveProperty("input_cost_per_token");
+	});
+
+	it("keeps a rendered field out of the patch when it was never filled in", () => {
+		const { patch } = buildPatchFromForm(formWith({ preservedPatch: { output_cost_per_token: null } }));
+		expect(patch).toEqual({});
+	});
+
+	// Assigning "__proto__" onto a plain object hits Object.prototype's accessor
+	// instead of storing a field, so the key vanishes and the patch object's
+	// prototype is mutated. JSON.parse does produce it as an own property, so a
+	// patch fetched from the API can carry one.
+	it("refuses to copy prototype-polluting keys out of the preserved patch", () => {
+		const preservedPatch = JSON.parse('{"__proto__": {"polluted": true}, "peak_hours": {"timezone": "UTC"}}');
+		const { patch } = buildPatchFromForm(formWith({ preservedPatch }));
+
+		expect(patch).toEqual({ peak_hours: { timezone: "UTC" } });
+		expect(Object.getPrototypeOf(patch)).toBe(Object.prototype);
+		expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+	});
+});
+
+describe("isUnsafePatchKey", () => {
+	it("flags the keys that cannot be stored as own properties", () => {
+		expect(isUnsafePatchKey("__proto__")).toBe(true);
+		expect(isUnsafePatchKey("constructor")).toBe(true);
+		expect(isUnsafePatchKey("prototype")).toBe(true);
+	});
+
+	it("leaves real pricing field names alone", () => {
+		expect(isUnsafePatchKey("peak_hours")).toBe(false);
+		expect(isUnsafePatchKey("off_peak_cost_multiplier")).toBe(false);
+		expect(isUnsafePatchKey("input_cost_per_token")).toBe(false);
+	});
+});

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -19,7 +19,6 @@ import {
 	CreatePricingOverrideRequest,
 	PricingOverride,
 	PricingOverrideMatchType,
-	PricingOverridePatch,
 	PricingOverrideScopeKind,
 } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
@@ -41,37 +40,18 @@ export {
 	REQUEST_TYPE_GROUPS,
 	REQUEST_TYPE_OPTIONS,
 } from "./pricingFields";
-export type { FieldErrors, PricingFieldKey } from "./pricingFields";
-import { fieldLabelByKey, patchKeys, PRICING_FIELDS, REQUEST_TYPE_GROUPS, REQUEST_TYPE_OPTIONS } from "./pricingFields";
-import type { FieldErrors, PricingFieldKey } from "./pricingFields";
-
-type ScopeRoot = "global" | "virtual_key" | "user";
-
-export interface FormState {
-	name: string;
-	scopeRoot: ScopeRoot;
-	userID: string;
-	virtualKeyID: string;
-	providerID: string;
-	providerKeyID: string;
-	matchType: PricingOverrideMatchType;
-	pattern: string;
-	requestTypes: RequestType[];
-	pricingValues: Partial<Record<PricingFieldKey, string>>;
-}
-
-export const defaultFormState: FormState = {
-	name: "",
-	scopeRoot: "global",
-	userID: "",
-	virtualKeyID: "",
-	providerID: "",
-	providerKeyID: "",
-	matchType: "exact",
-	pattern: "",
-	requestTypes: [],
-	pricingValues: {},
-};
+export { buildPatchFromForm, defaultFormState } from "./pricingFields";
+export type { FieldErrors, FormState, PricingFieldKey, ScopeRoot } from "./pricingFields";
+import {
+	buildPatchFromForm,
+	defaultFormState,
+	fieldLabelByKey,
+	patchKeys,
+	PRICING_FIELDS,
+	REQUEST_TYPE_GROUPS,
+	REQUEST_TYPE_OPTIONS,
+} from "./pricingFields";
+import type { FieldErrors, FormState, PricingFieldKey, ScopeRoot } from "./pricingFields";
 
 export function patternError(matchType: PricingOverrideMatchType, pattern: string): string | undefined {
 	const trimmed = pattern.trim();
@@ -85,28 +65,6 @@ export function patternError(matchType: PricingOverrideMatchType, pattern: strin
 		if (!trimmed.endsWith("*")) return "Wildcard supports prefix-only trailing *";
 	}
 	return undefined;
-}
-
-export function buildPatchFromForm(form: FormState): { patch: PricingOverridePatch; errors: FieldErrors } {
-	const errors: FieldErrors = {};
-	const patch: PricingOverridePatch = {};
-
-	for (const key of patchKeys) {
-		const raw = form.pricingValues[key];
-		if (raw == null || raw.trim() === "") continue;
-		const parsed = Number(raw);
-		if (!Number.isFinite(parsed)) {
-			errors[key] = "Must be a number";
-			continue;
-		}
-		if (parsed < 0) {
-			errors[key] = "Must be >= 0";
-			continue;
-		}
-		(patch as Record<string, number>)[key] = parsed;
-	}
-
-	return { patch, errors };
 }
 
 function toFormState(override: PricingOverride): FormState {

--- a/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
+++ b/ui/app/workspace/custom-pricing/overrides/pricingOverrideSheet.tsx
@@ -15,12 +15,7 @@ import { getErrorMessage, useCreatePricingOverrideMutation, useGetProvidersQuery
 import { useGetAllKeysQuery } from "@/lib/store/apis/providersApi";
 import { getUserPicker } from "@/lib/registries/userPicker";
 import { ModelProvider, RequestType } from "@/lib/types/config";
-import {
-	CreatePricingOverrideRequest,
-	PricingOverride,
-	PricingOverrideMatchType,
-	PricingOverrideScopeKind,
-} from "@/lib/types/governance";
+import { CreatePricingOverrideRequest, PricingOverride, PricingOverrideMatchType, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { cn } from "@/lib/utils";
 import { ChevronDown, Save, X } from "lucide-react";
 import { Dispatch, SetStateAction, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -46,10 +41,13 @@ import {
 	buildPatchFromForm,
 	defaultFormState,
 	fieldLabelByKey,
+	isUnsafePatchKey,
 	patchKeys,
+	PRESERVED_PATCH_KEYS,
 	PRICING_FIELDS,
 	REQUEST_TYPE_GROUPS,
 	REQUEST_TYPE_OPTIONS,
+	pricingFieldError,
 } from "./pricingFields";
 import type { FieldErrors, FormState, PricingFieldKey, ScopeRoot } from "./pricingFields";
 
@@ -75,9 +73,18 @@ function toFormState(override: PricingOverride): FormState {
 	} catch {
 		// malformed patch — leave values empty
 	}
-	for (const key of patchKeys) {
-		const val = parsedPatch[key];
-		if (typeof val === "number") values[key] = String(val);
+	// Existing overrides are read leniently: an unrecognized key the API stored
+	// is carried through rather than dropped on save. Unsafe keys are the one
+	// exception, since assigning them here would mutate the prototype instead
+	// of storing anything.
+	const preservedPatch: Record<string, unknown> = {};
+	for (const [key, val] of Object.entries(parsedPatch)) {
+		if (isUnsafePatchKey(key)) continue;
+		if (patchKeys.includes(key as PricingFieldKey) && typeof val === "number") {
+			values[key as PricingFieldKey] = String(val);
+		} else {
+			preservedPatch[key] = val;
+		}
 	}
 	const scopeKind = resolveScopeKind(override);
 
@@ -99,6 +106,7 @@ function toFormState(override: PricingOverride): FormState {
 		pattern: override.pattern,
 		requestTypes: override.request_types ?? [],
 		pricingValues: values,
+		preservedPatch,
 	};
 }
 
@@ -261,6 +269,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 	const matchType = watch("matchType");
 	const requestTypes = watch("requestTypes");
 	const pricingValues = watch("pricingValues");
+	const preservedPatch = watch("preservedPatch");
 
 	const shouldLockScope = useMemo(() => !editingOverride && isCompleteScopeLock(scopeLock), [editingOverride, scopeLock]);
 
@@ -364,11 +373,8 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 	const pricingFieldErrors = useMemo<FieldErrors>(() => {
 		const errs: FieldErrors = {};
 		for (const key of patchKeys) {
-			const raw = pricingValues[key];
-			if (!raw || raw.trim() === "") continue;
-			const parsed = Number(raw);
-			if (!Number.isFinite(parsed)) errs[key] = "Must be a number";
-			else if (parsed < 0) errs[key] = "Must be >= 0";
+			const err = pricingFieldError(key, pricingValues[key]);
+			if (err) errs[key] = err;
 		}
 		return errs;
 	}, [pricingValues]);
@@ -380,7 +386,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 			setJSONPatch(json);
 			setJSONError(undefined);
 		}
-	}, [pricingValues, getValues]);
+	}, [pricingValues, preservedPatch, getValues]);
 
 	const handleJSONChange = useCallback(
 		(value: string) => {
@@ -389,6 +395,7 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 			const trimmed = value.trim();
 			if (!trimmed) {
 				setJSONError(undefined);
+				setValue("preservedPatch", {});
 				setValue("pricingValues", {});
 				return;
 			}
@@ -399,18 +406,39 @@ export default function PricingOverrideSheet({ open, onOpenChange, editingOverri
 					return;
 				}
 				const newPricingValues: Partial<Record<PricingFieldKey, string>> = {};
+				const newPreserved: Record<string, unknown> = {};
 				for (const [key, val] of Object.entries(parsed)) {
-					if (!patchKeys.includes(key as PricingFieldKey)) {
-						setJSONError(`Unknown field: ${key}`);
+					if (isUnsafePatchKey(key)) {
+						setJSONError(`Unsupported field: ${key}`);
 						return;
 					}
-					if (typeof val !== "number" || Number.isNaN(val) || val < 0) {
-						setJSONError(`${key} must be a non-negative number`);
+					// Keys the form cannot render as a number (today only the
+					// peak_hours schedule object) ride through untouched so an
+					// override authored via the API stays editable here. Anything
+					// else unrecognized is a typo and is rejected: the pricing
+					// engine ignores unknown keys, so accepting one would save a
+					// setting that silently never takes effect.
+					if (!patchKeys.includes(key as PricingFieldKey)) {
+						if (!PRESERVED_PATCH_KEYS.includes(key)) {
+							setJSONError(`Unknown field: ${key}`);
+							return;
+						}
+						newPreserved[key] = val;
+						continue;
+					}
+					if (typeof val !== "number" || Number.isNaN(val)) {
+						setJSONError(`${key} must be a number`);
+						return;
+					}
+					const err = pricingFieldError(key as PricingFieldKey, String(val));
+					if (err) {
+						setJSONError(`${key}: ${err}`);
 						return;
 					}
 					newPricingValues[key as PricingFieldKey] = String(val);
 				}
 				setJSONError(undefined);
+				setValue("preservedPatch", newPreserved);
 				setValue("pricingValues", newPricingValues);
 			} catch {
 				setJSONError("Invalid JSON");

--- a/ui/app/workspace/model-catalog/views/attributeSheet.tsx
+++ b/ui/app/workspace/model-catalog/views/attributeSheet.tsx
@@ -15,7 +15,7 @@ import {
 	useUpsertModelCatalogEntriesMutation,
 } from "@/lib/store";
 import { KnownProvider } from "@/lib/types/config";
-import { PricingOverrideScopeKind } from "@/lib/types/governance";
+import { PeakHoursSchedule, PricingOverrideScopeKind } from "@/lib/types/governance";
 import { formatCharacterPriceFull, formatTokenPriceFull } from "@/lib/utils/numbers";
 import { RbacOperation, RbacResource, useRbac } from "@enterprise/lib";
 import { Link } from "@tanstack/react-router";
@@ -84,11 +84,45 @@ function getPricingSourceUrl(configuredUrl: string | undefined, modelName: strin
 	return url.toString();
 }
 
+const WEEKDAY_LABELS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+// formatPeakHours renders a peak-hours schedule as a compact one-liner, e.g.
+// "Mon-Fri 01:00-04:00, 06:00-10:00 UTC".
+// The patch arrives as parsed API JSON, so the TypeScript type is a claim
+// rather than a guarantee. A non-array `windows`, or a null entry inside it,
+// would throw here and take the whole sheet's render down with it, so every
+// level is checked before it is walked.
+function formatPeakHours(value: PeakHoursSchedule): string {
+	const windows = Array.isArray(value.windows) ? value.windows : [];
+	if (windows.length === 0) return "—";
+	const tz = typeof value.timezone === "string" && value.timezone ? value.timezone : "UTC";
+	const rendered = windows
+		.map((w) => {
+			if (!w || typeof w !== "object") return null;
+			const days = (Array.isArray(w.days) ? w.days : [])
+				.filter((d) => typeof d === "number" && d >= 0 && d <= 6)
+				.map((d) => WEEKDAY_LABELS[d])
+				.join(",");
+			const start = typeof w.start === "string" ? w.start : "?";
+			const end = typeof w.end === "string" ? w.end : "?";
+			return days ? `${days} ${start}-${end}` : `${start}-${end}`;
+		})
+		.filter((w): w is string => w !== null);
+	if (rendered.length === 0) return "—";
+	return `${rendered.join("; ")} ${tz}`;
+}
+
 // formatPatchValue renders a patch value in its field's own unit: the way the
 // pricing table does for token-priced fields, as a bare multiplier for the geo
-// multiplier, and as a plain dollar amount for everything else (per-image,
-// per-second, per-page, …).
-function formatPatchValue(key: string, value: number): string {
+// and off-peak multipliers, and as a plain dollar amount for everything else
+// (per-image, per-second, per-page, …). Non-numeric patch fields — currently
+// only the peak_hours schedule object — get their own rendering; falling
+// through to the dollar branch would print "$[object Object]".
+function formatPatchValue(key: string, value: unknown): string {
+	if (key === "peak_hours" && typeof value === "object" && value !== null) {
+		return formatPeakHours(value as PeakHoursSchedule);
+	}
+	if (typeof value !== "number") return String(value);
 	switch (pricingFieldUnit(key)) {
 		case "token":
 			return formatTokenPriceFull(value);
@@ -341,7 +375,7 @@ export default function AttributeSheet({ model, overrides, onClose }: AttributeS
 														{patchEntries.map(([key, value]) => (
 															<div key={key} className="flex items-baseline justify-between gap-3 text-xs">
 																<span className="text-muted-foreground">{fieldLabelByKey[key as PricingFieldKey] || key}</span>
-																<span className="font-mono">{formatPatchValue(key, value as number)}</span>
+																<span className="font-mono">{formatPatchValue(key, value)}</span>
 															</div>
 														))}
 													</div>

--- a/ui/lib/types/governance.ts
+++ b/ui/lib/types/governance.ts
@@ -610,6 +610,29 @@ export interface PricingOverridePatch {
 	// OCR
 	ocr_cost_per_page?: number;
 	annotation_cost_per_page?: number;
+	// Time of day
+	off_peak_cost_multiplier?: number;
+	peak_hours?: PeakHoursSchedule;
+}
+
+/**
+ * Recurring weekly windows during which a model is billed at its peak (base)
+ * rates. Any instant outside every window is off-peak and is discounted by
+ * `off_peak_cost_multiplier`.
+ */
+export interface PeakHoursSchedule {
+	/** IANA location name (e.g. "UTC", "Asia/Shanghai"). Empty means UTC. */
+	timezone?: string;
+	windows?: PeakHoursWindow[];
+}
+
+export interface PeakHoursWindow {
+	/** Weekdays, 0 = Sunday through 6 = Saturday. */
+	days: number[];
+	/** "HH:MM" in the schedule's timezone, inclusive. */
+	start: string;
+	/** "HH:MM" in the schedule's timezone, exclusive; <= start wraps midnight. */
+	end: string;
 }
 
 export interface PricingOverride {


### PR DESCRIPTION
## Summary

Clarifies the accuracy guarantees of `CountRecalcTargets` and the `Total` field in `CostRecalcJobMeta`, specifically around when the count may be stale due to materialized view lag on full recalculations (`MissingCostOnly false`).

## Changes

- Updated the `Total` field comment in `CostRecalcJobMeta` to explicitly note that on full recalculations it may come from a stale materialized view, and that it should never be treated as the length of the walk.
- Rewrote the `CountRecalcTargets` doc comment to explain the two distinct accuracy modes: when `missingCostOnly` is set, the count comes from the raw table and is exact; when it is not set, `SearchLogs` may use `mv_logs_hourly`, which lags by its refresh interval, making the count approximate. The comment also clarifies that a stale `Total` only affects progress bar display — the worker always pages the raw table to exhaustion, so no rows are skipped or double-counted.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

No behavioral changes. Verify the comments read correctly in context.

```sh
go build ./...
go test ./...
```

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable