### PR TITLE
feat(redaction): surface literal regions and service URLs in plaintext via `RedactedIfSecret`

### DIFF
--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -286,6 +286,22 @@ func (e *SecretVar) Redacted() *SecretVar {
 	return &SecretVar{Val: prefix + middle + suffix, ref: e.ref, SecretType: e.SecretType}
 }
 
+// RedactedIfSecret returns a copy holding the literal value when the SecretVar
+// is plain text, and a Redacted copy when it is env/vault-backed. Use it for
+// fields that are identifiers or network addresses rather than credentials — a
+// region or a service URL is not worth hiding, but the resolved contents of a
+// secret reference still are. Like Redacted it always returns a fresh pointer,
+// so a redacted API response never aliases the live config.
+func (e *SecretVar) RedactedIfSecret() *SecretVar {
+	if e == nil {
+		return nil
+	}
+	if e.IsFromSecret() {
+		return e.Redacted()
+	}
+	return e.Clone()
+}
+
 // FullyRedacted returns a copy of the SecretVar with Val replaced by a fixed placeholder
 // so no substring of the original value is exposed. Use for API responses where
 // Redacted is unsafe (e.g. literal proxy passwords). secretRef and secretType are

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -811,3 +811,67 @@ func TestSecretVar_MarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestSecretVar_RedactedIfSecret(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var ev *SecretVar
+		if got := ev.RedactedIfSecret(); got != nil {
+			t.Fatalf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("literal value is surfaced in plaintext", func(t *testing.T) {
+		for _, val := range []string{"", "us-east-1", "https://vllm.internal.example.com:8000"} {
+			e := &SecretVar{Val: val, SecretType: SecretTypePlainText}
+			got := e.RedactedIfSecret()
+			if got.GetValue() != val {
+				t.Errorf("RedactedIfSecret().GetValue() = %q, want %q", got.GetValue(), val)
+			}
+		}
+	})
+
+	t.Run("env-backed value is masked and keeps its reference", func(t *testing.T) {
+		e := &SecretVar{Val: "us-east-1", ref: "env.AWS_REGION", SecretType: SecretTypeEnv}
+		got := e.RedactedIfSecret()
+		if got.GetValue() == "us-east-1" {
+			t.Error("RedactedIfSecret() surfaced the resolved value of an env reference")
+		}
+		if !got.IsRedacted() {
+			t.Errorf("RedactedIfSecret().IsRedacted() = false for %q", got.GetValue())
+		}
+		if got.GetRawRef() != "env.AWS_REGION" {
+			t.Errorf("RedactedIfSecret().GetRawRef() = %q, want %q", got.GetRawRef(), "env.AWS_REGION")
+		}
+	})
+
+	t.Run("vault-backed value is masked and keeps its reference", func(t *testing.T) {
+		e := &SecretVar{Val: "https://mcp.internal.example.com/mcp", ref: "vault.bifrost/mcp-url", SecretType: SecretTypeVault}
+		got := e.RedactedIfSecret()
+		if got.GetValue() == e.Val {
+			t.Error("RedactedIfSecret() surfaced the resolved value of a vault reference")
+		}
+		if got.GetRawRef() != "vault.bifrost/mcp-url" {
+			t.Errorf("RedactedIfSecret().GetRawRef() = %q, want %q", got.GetRawRef(), "vault.bifrost/mcp-url")
+		}
+	})
+
+	t.Run("returns a fresh pointer so callers cannot reach the original", func(t *testing.T) {
+		e := &SecretVar{Val: "us-east-1", SecretType: SecretTypePlainText}
+		got := e.RedactedIfSecret()
+		if got == e {
+			t.Fatal("RedactedIfSecret() aliased the original SecretVar")
+		}
+		got.Val = "eu-west-1"
+		if e.Val != "us-east-1" {
+			t.Errorf("mutating the copy changed the original to %q", e.Val)
+		}
+	})
+
+	t.Run("does not mutate the original", func(t *testing.T) {
+		e := &SecretVar{Val: "actual-secret-value", ref: "env.SOME_URL", SecretType: SecretTypeEnv}
+		_ = e.RedactedIfSecret()
+		if e.Val != "actual-secret-value" {
+			t.Errorf("original Val mutated to %q", e.Val)
+		}
+	})
+}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -584,11 +584,8 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		// Redact Azure key config if present
 		if key.AzureKeyConfig != nil {
 			azureConfig := &schemas.AzureKeyConfig{}
-			if key.AzureKeyConfig.Endpoint.IsFromSecret() {
-				azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.Redacted()
-			} else {
-				azureConfig.Endpoint = key.AzureKeyConfig.Endpoint
-			}
+			// The endpoint is a hostname, not a credential — surface it in plaintext.
+			azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.RedactedIfSecret()
 			if key.AzureKeyConfig.ClientID != nil {
 				azureConfig.ClientID = key.AzureKeyConfig.ClientID.Redacted()
 			}
@@ -609,7 +606,8 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			vertexConfig := &schemas.VertexKeyConfig{}
 			vertexConfig.ProjectID = *key.VertexKeyConfig.ProjectID.Redacted()
 			vertexConfig.ProjectNumber = *key.VertexKeyConfig.ProjectNumber.Redacted()
-			vertexConfig.Region = *key.VertexKeyConfig.Region.Redacted()
+			// The region is a public identifier, not a credential — surface it in plaintext.
+			vertexConfig.Region = *key.VertexKeyConfig.Region.RedactedIfSecret()
 			vertexConfig.AuthCredentials = *key.VertexKeyConfig.AuthCredentials.Redacted()
 			vertexConfig.ForceSingleRegion = key.VertexKeyConfig.ForceSingleRegion
 			redactedConfig.Keys[i].VertexKeyConfig = vertexConfig
@@ -623,8 +621,9 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			if key.BedrockKeyConfig.SessionToken != nil {
 				bedrockConfig.SessionToken = key.BedrockKeyConfig.SessionToken.Redacted()
 			}
+			// The region is a public identifier, not a credential — surface it in plaintext.
 			if key.BedrockKeyConfig.Region != nil {
-				bedrockConfig.Region = key.BedrockKeyConfig.Region.Redacted()
+				bedrockConfig.Region = key.BedrockKeyConfig.Region.RedactedIfSecret()
 			}
 			if key.BedrockKeyConfig.ARN != nil {
 				bedrockConfig.ARN = key.BedrockKeyConfig.ARN.Redacted()
@@ -664,8 +663,9 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			if key.BedrockMantleKeyConfig.SessionToken != nil {
 				mantleConfig.SessionToken = key.BedrockMantleKeyConfig.SessionToken.Redacted()
 			}
+			// The region is a public identifier, not a credential — surface it in plaintext.
 			if key.BedrockMantleKeyConfig.Region != nil {
-				mantleConfig.Region = key.BedrockMantleKeyConfig.Region.Redacted()
+				mantleConfig.Region = key.BedrockMantleKeyConfig.Region.RedactedIfSecret()
 			}
 			if key.BedrockMantleKeyConfig.RoleARN != nil {
 				mantleConfig.RoleARN = key.BedrockMantleKeyConfig.RoleARN.Redacted()
@@ -691,7 +691,8 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			vllmConfig := &schemas.VLLMKeyConfig{
 				ModelName: key.VLLMKeyConfig.ModelName,
 			}
-			vllmConfig.URL = *key.VLLMKeyConfig.URL.Redacted()
+			// The URL is a service address, not a credential — surface it in plaintext.
+			vllmConfig.URL = *key.VLLMKeyConfig.URL.RedactedIfSecret()
 			redactedConfig.Keys[i].VLLMKeyConfig = vllmConfig
 		}
 
@@ -704,13 +705,15 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 
 		if key.OllamaKeyConfig != nil {
 			ollamaConfig := &schemas.OllamaKeyConfig{}
-			ollamaConfig.URL = *key.OllamaKeyConfig.URL.Redacted()
+			// The URL is a service address, not a credential — surface it in plaintext.
+			ollamaConfig.URL = *key.OllamaKeyConfig.URL.RedactedIfSecret()
 			redactedConfig.Keys[i].OllamaKeyConfig = ollamaConfig
 		}
 
 		if key.SGLKeyConfig != nil {
 			sglConfig := &schemas.SGLKeyConfig{}
-			sglConfig.URL = *key.SGLKeyConfig.URL.Redacted()
+			// The URL is a service address, not a credential — surface it in plaintext.
+			sglConfig.URL = *key.SGLKeyConfig.URL.RedactedIfSecret()
 			redactedConfig.Keys[i].SGLKeyConfig = sglConfig
 		}
 
@@ -722,11 +725,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			}
 			// The workspace URL is a hostname, not a credential — surface it in
 			// plaintext so the UI can round-trip it, mirroring the Azure endpoint.
-			if key.DatabricksKeyConfig.WorkspaceURL.IsFromSecret() {
-				databricksConfig.WorkspaceURL = *key.DatabricksKeyConfig.WorkspaceURL.Redacted()
-			} else {
-				databricksConfig.WorkspaceURL = key.DatabricksKeyConfig.WorkspaceURL
-			}
+			databricksConfig.WorkspaceURL = *key.DatabricksKeyConfig.WorkspaceURL.RedactedIfSecret()
 			if key.DatabricksKeyConfig.ClientID != nil {
 				databricksConfig.ClientID = key.DatabricksKeyConfig.ClientID.Redacted()
 			}

--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -228,3 +228,97 @@ func TestProviderConfig_Redacted_FullJSONHasNoLeakedEnvSecrets(t *testing.T) {
 			"env var reference %q missing from redacted JSON output", ref)
 	}
 }
+
+// TestProviderConfig_Redacted_SurfacesLiteralIdentifiers pins the rule that a
+// region or a self-hosted service URL is an identifier, not a credential: when
+// it is stored as a literal it must read back verbatim so the update form shows
+// something an operator can actually read.
+func TestProviderConfig_Redacted_SurfacesLiteralIdentifiers(t *testing.T) {
+	config := ProviderConfig{
+		Keys: []schemas.Key{{
+			ID:    "k1",
+			Name:  "test",
+			Value: schemas.SecretVar{Val: ""},
+			VertexKeyConfig: &schemas.VertexKeyConfig{
+				Region: *schemas.NewSecretVar("us-central1"),
+			},
+			BedrockKeyConfig: &schemas.BedrockKeyConfig{
+				AccessKey: schemas.SecretVar{Val: ""},
+				SecretKey: schemas.SecretVar{Val: ""},
+				Region:    schemas.NewSecretVar("us-east-1"),
+			},
+			BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{
+				AccessKey: schemas.SecretVar{Val: ""},
+				SecretKey: schemas.SecretVar{Val: ""},
+				Region:    schemas.NewSecretVar("us-east-1"),
+			},
+			VLLMKeyConfig: &schemas.VLLMKeyConfig{
+				URL: *schemas.NewSecretVar("http://vllm.internal.example.com:8000"),
+			},
+			OllamaKeyConfig: &schemas.OllamaKeyConfig{
+				URL: *schemas.NewSecretVar("http://ollama.internal.example.com:11434"),
+			},
+			SGLKeyConfig: &schemas.SGLKeyConfig{
+				URL: *schemas.NewSecretVar("http://sgl.internal.example.com:30000"),
+			},
+		}},
+	}
+
+	redacted := config.Redacted()
+	require.NotNil(t, redacted)
+	require.Len(t, redacted.Keys, 1)
+	key := redacted.Keys[0]
+
+	assert.Equal(t, "us-central1", key.VertexKeyConfig.Region.GetValue())
+	assert.Equal(t, "us-east-1", key.BedrockKeyConfig.Region.GetValue())
+	assert.Equal(t, "us-east-1", key.BedrockMantleKeyConfig.Region.GetValue())
+	assert.Equal(t, "http://vllm.internal.example.com:8000", key.VLLMKeyConfig.URL.GetValue())
+	assert.Equal(t, "http://ollama.internal.example.com:11434", key.OllamaKeyConfig.URL.GetValue())
+	assert.Equal(t, "http://sgl.internal.example.com:30000", key.SGLKeyConfig.URL.GetValue())
+
+	// The redacted copy must not alias the live config: these are pointer
+	// fields, and an API response handing out the live SecretVar would let a
+	// caller edit the running configuration.
+	assert.NotSame(t, config.Keys[0].BedrockKeyConfig.Region, key.BedrockKeyConfig.Region)
+	assert.NotSame(t, config.Keys[0].BedrockMantleKeyConfig.Region, key.BedrockMantleKeyConfig.Region)
+}
+
+// TestProviderConfig_Redacted_MasksSecretBackedIdentifiers is the other half of
+// the rule: an operator who deliberately sourced a region or URL from env/vault
+// still gets the resolved value masked, with the reference intact for the UI.
+func TestProviderConfig_Redacted_MasksSecretBackedIdentifiers(t *testing.T) {
+	t.Setenv("LEAK_TEST_REGION", "ap-southeast-2")
+	t.Setenv("LEAK_TEST_VLLM_URL", "http://vllm-secret.internal.example.com:8000")
+
+	config := ProviderConfig{
+		Keys: []schemas.Key{{
+			ID:    "k1",
+			Name:  "test",
+			Value: schemas.SecretVar{Val: ""},
+			BedrockKeyConfig: &schemas.BedrockKeyConfig{
+				AccessKey: schemas.SecretVar{Val: ""},
+				SecretKey: schemas.SecretVar{Val: ""},
+				Region:    schemas.NewSecretVar("env.LEAK_TEST_REGION"),
+			},
+			VLLMKeyConfig: &schemas.VLLMKeyConfig{
+				URL: *schemas.NewSecretVar("env.LEAK_TEST_VLLM_URL"),
+			},
+		}},
+	}
+	require.Equal(t, "ap-southeast-2", config.Keys[0].BedrockKeyConfig.Region.GetValue(),
+		"setup: region should resolve from the environment")
+
+	redacted := config.Redacted()
+	data, err := json.Marshal(redacted)
+	require.NoError(t, err)
+	jsonStr := string(data)
+
+	for _, secret := range []string{"ap-southeast-2", "vllm-secret.internal.example.com"} {
+		assert.NotContains(t, jsonStr, secret,
+			"resolved env value %q leaked into redacted JSON output", secret)
+	}
+	for _, ref := range []string{"env.LEAK_TEST_REGION", "env.LEAK_TEST_VLLM_URL"} {
+		assert.Contains(t, jsonStr, ref,
+			"env var reference %q missing from redacted JSON output", ref)
+	}
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -6905,7 +6905,8 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 			}
 			if key.AzureKeyConfig != nil {
 				cfg := *key.AzureKeyConfig // safe copy
-				cfg.Endpoint = *cfg.Endpoint.Redacted()
+				// The endpoint is a hostname, not a credential — surface it in plaintext.
+				cfg.Endpoint = *cfg.Endpoint.RedactedIfSecret()
 				cfg.ClientID = cfg.ClientID.Redacted()
 				cfg.ClientSecret = cfg.ClientSecret.Redacted()
 				cfg.TenantID = cfg.TenantID.Redacted()
@@ -6916,7 +6917,8 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 				cfg.ARN = key.BedrockKeyConfig.ARN.Redacted()
 				cfg.AccessKey = *cfg.AccessKey.Redacted()
 				cfg.ExternalID = cfg.ExternalID.Redacted()
-				cfg.Region = cfg.Region.Redacted()
+				// The region is a public identifier, not a credential — surface it in plaintext.
+				cfg.Region = cfg.Region.RedactedIfSecret()
 				cfg.RoleARN = cfg.RoleARN.Redacted()
 				cfg.RoleSessionName = cfg.RoleSessionName.Redacted()
 				cfg.SecretKey = *cfg.SecretKey.Redacted()
@@ -6928,7 +6930,8 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 				cfg.AccessKey = *cfg.AccessKey.Redacted()
 				cfg.SecretKey = *cfg.SecretKey.Redacted()
 				cfg.SessionToken = cfg.SessionToken.Redacted()
-				cfg.Region = cfg.Region.Redacted()
+				// The region is a public identifier, not a credential — surface it in plaintext.
+				cfg.Region = cfg.Region.RedactedIfSecret()
 				cfg.RoleARN = cfg.RoleARN.Redacted()
 				cfg.ExternalID = cfg.ExternalID.Redacted()
 				cfg.RoleSessionName = cfg.RoleSessionName.Redacted()
@@ -6938,7 +6941,8 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 				cfg := *key.VertexKeyConfig // safe copy
 				cfg.ProjectID = *cfg.ProjectID.Redacted()
 				cfg.ProjectNumber = *cfg.ProjectNumber.Redacted()
-				cfg.Region = *cfg.Region.Redacted()
+				// The region is a public identifier, not a credential — surface it in plaintext.
+				cfg.Region = *cfg.Region.RedactedIfSecret()
 				cfg.AuthCredentials = *cfg.AuthCredentials.Redacted()
 				configStoreKey.VertexKeyConfig = &cfg
 			}
@@ -6947,23 +6951,27 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 			}
 			if key.VLLMKeyConfig != nil {
 				cfg := *key.VLLMKeyConfig // safe copy
-				cfg.URL = *cfg.URL.Redacted()
+				// The URL is a service address, not a credential — surface it in plaintext.
+				cfg.URL = *cfg.URL.RedactedIfSecret()
 				configStoreKey.VLLMKeyConfig = &cfg
 			}
 			if key.OllamaKeyConfig != nil {
 				cfg := *key.OllamaKeyConfig // safe copy
-				cfg.URL = *cfg.URL.Redacted()
+				// The URL is a service address, not a credential — surface it in plaintext.
+				cfg.URL = *cfg.URL.RedactedIfSecret()
 				configStoreKey.OllamaKeyConfig = &cfg
 			}
 			if key.SGLKeyConfig != nil {
 				cfg := *key.SGLKeyConfig // safe copy
-				cfg.URL = *cfg.URL.Redacted()
+				// The URL is a service address, not a credential — surface it in plaintext.
+				cfg.URL = *cfg.URL.RedactedIfSecret()
 				configStoreKey.SGLKeyConfig = &cfg
 			}
 
 			if key.DatabricksKeyConfig != nil {
 				cfg := *key.DatabricksKeyConfig // safe copy
-				cfg.WorkspaceURL = *cfg.WorkspaceURL.Redacted()
+				// The workspace URL is a hostname, not a credential — surface it in plaintext.
+				cfg.WorkspaceURL = *cfg.WorkspaceURL.RedactedIfSecret()
 				cfg.ClientID = cfg.ClientID.Redacted()
 				cfg.ClientSecret = cfg.ClientSecret.Redacted()
 				configStoreKey.DatabricksKeyConfig = &cfg
@@ -7351,15 +7359,19 @@ func (c *Config) EnableMCPClient(ctx context.Context, id string) error {
 }
 
 // RedactMCPClientConfig creates a redacted copy of a MCPClientConfig configuration.
-// Connection strings and headers are redacted for safe external exposure.
+// Credentials — headers, OAuth client secrets and the TLS CA cert — are redacted
+// for safe external exposure.
 func (c *Config) RedactMCPClientConfig(config *schemas.MCPClientConfig) *schemas.MCPClientConfig {
 	// Create an actual copy of the struct (not just a pointer copy)
 	// This prevents modifying the original config when redacting
 	configCopy := *config
 
-	// Redact connection string if present
+	// The connection string is a server address, not a credential — surface it
+	// in plaintext so operators can see which host a client points at. Anything
+	// secret about the connection lives in Headers or the OAuth block below,
+	// which stay redacted.
 	if config.ConnectionString != nil {
-		configCopy.ConnectionString = config.ConnectionString.Redacted()
+		configCopy.ConnectionString = config.ConnectionString.RedactedIfSecret()
 	}
 
 	// Redact Header values if present

--- a/transports/bifrost-http/lib/mcpredaction_test.go
+++ b/transports/bifrost-http/lib/mcpredaction_test.go
@@ -1,0 +1,84 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRedactMCPClientConfig_SurfacesLiteralConnectionString pins the security
+// boundary of the MCP redaction: the connection string is a server address and
+// reads back verbatim, while everything that actually authenticates the
+// connection stays masked.
+func TestRedactMCPClientConfig_SurfacesLiteralConnectionString(t *testing.T) {
+	c := &Config{}
+
+	config := &schemas.MCPClientConfig{
+		ID:                "mcp-1",
+		Name:              "self",
+		ConnectionType:    schemas.MCPConnectionTypeHTTP,
+		ConnectionString:  schemas.NewSecretVar("https://mcp.internal.example.com/mcp"),
+		OauthClientID:     schemas.NewSecretVar("oauth-client-id-value"),
+		OauthClientSecret: schemas.NewSecretVar("oauth-client-secret-value"),
+		Headers: map[string]schemas.SecretVar{
+			"Authorization": *schemas.NewSecretVar("Bearer super-secret-token"),
+		},
+		TokenExchange: &schemas.MCPTokenExchangeConfig{
+			Audience:     "api://example",
+			ClientID:     schemas.NewSecretVar("exchange-client-id-value"),
+			ClientSecret: schemas.NewSecretVar("exchange-client-secret-value"),
+		},
+		TLSConfig: &schemas.MCPTLSConfig{
+			CACertPEM: schemas.NewSecretVar("-----BEGIN CERTIFICATE-----secret-pem-body-----END CERTIFICATE-----"),
+		},
+	}
+
+	redacted := c.RedactMCPClientConfig(config)
+	require.NotNil(t, redacted)
+
+	assert.Equal(t, "https://mcp.internal.example.com/mcp", redacted.ConnectionString.GetValue(),
+		"the connection target is an address, not a credential")
+
+	// Everything below is a credential and must not survive the round-trip.
+	assert.True(t, redacted.OauthClientID.IsRedacted(), "oauth_client_id leaked")
+	assert.True(t, redacted.OauthClientSecret.IsRedacted(), "oauth_client_secret leaked")
+	redactedHeader := redacted.Headers["Authorization"]
+	assert.NotContains(t, redactedHeader.GetValue(), "super-secret-token", "header value leaked")
+	assert.True(t, redacted.TokenExchange.ClientID.IsRedacted(), "token_exchange.client_id leaked")
+	assert.True(t, redacted.TokenExchange.ClientSecret.IsRedacted(), "token_exchange.client_secret leaked")
+	assert.NotContains(t, redacted.TLSConfig.CACertPEM.GetValue(), "secret-pem-body",
+		"tls_config.ca_cert_pem leaked")
+
+	// The live config must be untouched — the runtime dials from it.
+	liveHeader := config.Headers["Authorization"]
+	assert.Equal(t, "Bearer super-secret-token", liveHeader.GetValue())
+	assert.Equal(t, "oauth-client-secret-value", config.OauthClientSecret.GetValue())
+	assert.NotSame(t, config.ConnectionString, redacted.ConnectionString,
+		"redacted copy must not alias the live connection string")
+}
+
+// TestRedactMCPClientConfig_MasksSecretBackedConnectionString covers the other
+// half: a connection string sourced from env/vault keeps its resolved value
+// hidden and its reference intact for the UI to render.
+func TestRedactMCPClientConfig_MasksSecretBackedConnectionString(t *testing.T) {
+	t.Setenv("MCP_REDACTION_TEST_URL", "https://mcp-secret.internal.example.com/mcp")
+
+	c := &Config{}
+	connectionString := schemas.NewSecretVar("env.MCP_REDACTION_TEST_URL")
+	require.Equal(t, "https://mcp-secret.internal.example.com/mcp", connectionString.GetValue(),
+		"setup: connection string should resolve from the environment")
+
+	redacted := c.RedactMCPClientConfig(&schemas.MCPClientConfig{
+		ID:               "mcp-1",
+		Name:             "self",
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: connectionString,
+	})
+
+	assert.NotContains(t, redacted.ConnectionString.GetValue(), "mcp-secret.internal.example.com",
+		"resolved env value leaked through connection_string")
+	assert.Equal(t, "env.MCP_REDACTION_TEST_URL", redacted.ConnectionString.GetRawRef(),
+		"secret ref must be preserved so the UI can show it")
+}


### PR DESCRIPTION
## Summary

Regions and service URLs (Azure endpoint, Vertex/Bedrock/Bedrock-Mantle region, vLLM/Ollama/SGL/Databricks URL, MCP connection string) were being unconditionally redacted in API responses, making them unreadable in the UI. These fields are public identifiers, not credentials. This PR introduces a `RedactedIfSecret` method that surfaces literal values in plaintext while still masking anything sourced from an env var or vault reference.

## Changes

- Added `SecretVar.RedactedIfSecret()`: returns a plain clone when the value is a literal, and delegates to `Redacted()` when the value is env/vault-backed. Always returns a fresh pointer so the redacted copy never aliases the live config.
- Replaced unconditional `Redacted()` calls on non-credential fields (regions, endpoints, service URLs, MCP connection strings) with `RedactedIfSecret()` across `ProviderConfig.Redacted()`, `Config.GetAllKeys()`, and `Config.RedactMCPClientConfig()`.
- Removed the now-redundant `IsFromSecret()` guard blocks that previously tried to replicate this logic inline for the Azure endpoint and Databricks workspace URL.
- Added unit tests for `RedactedIfSecret` covering nil receiver, literal passthrough, env/vault masking, pointer isolation, and mutation safety.
- Added integration-level redaction tests pinning that literal identifiers survive redaction verbatim and that env/vault-backed identifiers are masked with their references preserved.
- Added `TestRedactMCPClientConfig_SurfacesLiteralConnectionString` and `TestRedactMCPClientConfig_MasksSecretBackedConnectionString` to cover both halves of the MCP connection string rule.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/schemas/... ./framework/configstore/... ./transports/bifrost-http/lib/...
```

The new tests cover:
- `TestSecretVar_RedactedIfSecret` — unit tests for the new method
- `TestProviderConfig_Redacted_SurfacesLiteralIdentifiers` — literal regions and URLs read back verbatim after redaction
- `TestProviderConfig_Redacted_MasksSecretBackedIdentifiers` — env-backed regions and URLs are masked and their references are preserved
- `TestRedactMCPClientConfig_SurfacesLiteralConnectionString` — MCP connection string is surfaced; credentials remain masked
- `TestRedactMCPClientConfig_MasksSecretBackedConnectionString` — env-backed MCP connection string is masked with its reference intact

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

The change deliberately widens what is visible in redacted API responses, but only for fields that are not credentials. Anything sourced from an env var or vault reference is still masked regardless of field type — `RedactedIfSecret` delegates to `Redacted()` in that path. Actual credentials (API keys, client secrets, auth tokens, TLS CA certs) are unaffected and continue to use `Redacted()` or `FullyRedacted()` directly. The fresh-pointer guarantee ensures no redacted response can alias the live configuration.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable