### PR TITLE
fix(bedrock): guardrail config dropped on retry

### DIFF
--- a/core/providers/bedrock/bedrock_test.go
+++ b/core/providers/bedrock/bedrock_test.go
@@ -7595,3 +7595,90 @@ func TestBedrockImageS3URIWithoutExtensionErrors(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot determine image format")
 }
+
+// TestGuardrailConfigSurvivesReconversion guards against the request converter
+// consuming the caller's ExtraParams map.
+//
+// applyBedrockExtraParams deletes the keys it promotes to typed fields. When the
+// converter aliased bifrostReq.Params.ExtraParams instead of copying it, those deletes
+// mutated the caller's request. core re-runs the converter on every retry and fallback
+// attempt against the same BifrostChatRequest, so the second attempt saw no
+// guardrailConfig at all and reached Bedrock unguarded - with no error raised anywhere.
+func TestGuardrailConfigSurvivesReconversion(t *testing.T) {
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+
+	newChatRequest := func() *schemas.BifrostChatRequest {
+		return &schemas.BifrostChatRequest{
+			Provider: schemas.Bedrock,
+			Model:    "anthropic.claude-3-5-sonnet-v2",
+			Input: []schemas.ChatMessage{
+				{
+					Role:    schemas.ChatMessageRoleUser,
+					Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("Hello")},
+				},
+			},
+			Params: &schemas.ChatParameters{
+				ExtraParams: map[string]interface{}{
+					"guardrailConfig": map[string]interface{}{
+						"guardrailIdentifier": "test-guardrail-id",
+						"guardrailVersion":    "DRAFT",
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("chat completion path", func(t *testing.T) {
+		req := newChatRequest()
+
+		first, err := bedrock.ToBedrockChatCompletionRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, first.GuardrailConfig, "first attempt must carry the guardrail")
+
+		// The caller's map must be untouched, or any retry loses the guardrail.
+		require.Contains(t, req.Params.ExtraParams, "guardrailConfig",
+			"converting must not delete guardrailConfig from the caller's ExtraParams")
+
+		// Simulate a retry: core converts the same request object again.
+		second, err := bedrock.ToBedrockChatCompletionRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, second.GuardrailConfig,
+			"a retried request must still reach Bedrock with its guardrail attached")
+		assert.Equal(t, first.GuardrailConfig.GuardrailIdentifier, second.GuardrailConfig.GuardrailIdentifier)
+		assert.Equal(t, first.GuardrailConfig.GuardrailVersion, second.GuardrailConfig.GuardrailVersion)
+	})
+
+	t.Run("responses path", func(t *testing.T) {
+		chat := newChatRequest()
+		req := &schemas.BifrostResponsesRequest{
+			Provider: schemas.Bedrock,
+			Model:    chat.Model,
+			Params: &schemas.ResponsesParameters{
+				ExtraParams: map[string]interface{}{
+					"guardrailConfig": map[string]interface{}{
+						"guardrailIdentifier": "test-guardrail-id",
+						"guardrailVersion":    "DRAFT",
+					},
+				},
+			},
+			Input: []schemas.ResponsesMessage{
+				{
+					Role:    schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+					Content: &schemas.ResponsesMessageContent{ContentStr: schemas.Ptr("Hello")},
+				},
+			},
+		}
+
+		first, err := bedrock.ToBedrockResponsesRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, first.GuardrailConfig, "first attempt must carry the guardrail")
+
+		require.Contains(t, req.Params.ExtraParams, "guardrailConfig",
+			"converting must not delete guardrailConfig from the caller's ExtraParams")
+
+		second, err := bedrock.ToBedrockResponsesRequest(ctx, req)
+		require.NoError(t, err)
+		require.NotNil(t, second.GuardrailConfig,
+			"a retried request must still reach Bedrock with its guardrail attached")
+	})
+}

--- a/core/providers/bedrock/responses.go
+++ b/core/providers/bedrock/responses.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -2712,7 +2713,10 @@ func ToBedrockResponsesRequest(ctx *schemas.BifrostContext, bifrostReq *schemas.
 			}
 		}
 		if bifrostReq.Params.ExtraParams != nil {
-			bedrockReq.ExtraParams = bifrostReq.Params.ExtraParams
+			// Cloned for the same reason as convertChatParameters: the deletes below and
+			// in applyBedrockExtraParams would otherwise strip keys from the caller's map,
+			// which core re-converts on every retry and fallback attempt.
+			bedrockReq.ExtraParams = maps.Clone(bifrostReq.Params.ExtraParams)
 			if stop, ok := schemas.SafeExtractStringSlice(bifrostReq.Params.ExtraParams["stop"]); ok {
 				delete(bedrockReq.ExtraParams, "stop")
 				// GLM models on Bedrock reject the stopSequences field.

--- a/core/providers/bedrock/utils.go
+++ b/core/providers/bedrock/utils.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"mime"
 	"net/url"
 	"path/filepath"
@@ -813,9 +814,14 @@ func convertChatParameters(ctx *schemas.BifrostContext, bifrostReq *schemas.Bifr
 			Type: mapBifrostServiceTierToBedrock(*bifrostReq.Params.ServiceTier),
 		}
 	}
-	// Add extra parameters
+	// Add extra parameters.
+	// Cloned, not aliased: applyBedrockExtraParams consumes the keys it promotes to typed
+	// fields, and deleting from the caller's map would strip them from the request itself.
+	// core re-runs this converter on every retry and fallback attempt against the same
+	// BifrostChatRequest, so aliasing meant a retried request reached Bedrock with no
+	// guardrailConfig at all - silently unguarded, with no error anywhere.
 	if len(bifrostReq.Params.ExtraParams) > 0 {
-		bedrockReq.ExtraParams = bifrostReq.Params.ExtraParams
+		bedrockReq.ExtraParams = maps.Clone(bifrostReq.Params.ExtraParams)
 		applyBedrockExtraParams(bedrockReq.ExtraParams, bedrockReq)
 		if len(bedrockReq.ExtraParams) == 0 {
 			bedrockReq.ExtraParams = nil


### PR DESCRIPTION
## Summary

When `applyBedrockExtraParams` promotes keys like `guardrailConfig` to typed fields on the Bedrock request, it deletes those keys from the map. Because the converter was aliasing `bifrostReq.Params.ExtraParams` directly rather than copying it, those deletes mutated the caller's original request. Since core re-runs the converter on every retry and fallback attempt against the same `BifrostChatRequest`, any subsequent attempt saw no `guardrailConfig` and reached Bedrock silently unguarded — with no error raised anywhere.

## Changes

- `convertChatParameters` in `utils.go` now clones `bifrostReq.Params.ExtraParams` via `maps.Clone` before assigning it to `bedrockReq.ExtraParams`, preventing `applyBedrockExtraParams` from mutating the caller's map.
- `ToBedrockResponsesRequest` in `responses.go` applies the same clone for the same reason, since it also deletes keys (e.g. `stop`) from the extra params map.
- A regression test `TestGuardrailConfigSurvivesReconversion` is added covering both the chat completion and responses paths, asserting that the caller's `ExtraParams` map is untouched after conversion and that a simulated retry produces a request with the guardrail still attached.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/bedrock/... -run TestGuardrailConfigSurvivesReconversion -v
```

The test simulates two consecutive conversions of the same `BifrostChatRequest` and `BifrostResponsesRequest` (as core does on retry), asserting that `guardrailConfig` is present on both the first and second converted requests, and that the original `ExtraParams` map is not modified.

## Screenshots/Recordings

N/A

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

N/A

## Security considerations

Without this fix, guardrails configured via `guardrailConfig` in `ExtraParams` were silently dropped on any retry or fallback attempt, meaning requests could reach Bedrock without the intended guardrail applied. This fix ensures guardrails are consistently enforced across all attempts.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable