### PR TITLE
feat: add GA realtime transcription support

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -4982,7 +4982,7 @@ func (bifrost *Bifrost) RunRealtimeTurnPreHooks(ctx *schemas.BifrostContext, req
 			drainAndAttachPluginLogs(ctx)
 			if bifrostErr != nil {
 				bifrostErr.PopulateExtraFields(schemas.RealtimeRequest, provider, model, model)
-				return nil, bifrostErr
+				return resp, bifrostErr
 			} else if resp != nil {
 				resp.PopulateExtraFields(schemas.RealtimeRequest, provider, model, model)
 			}

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -3104,6 +3104,44 @@ func (f *fakeRoutingPlugin) PostLLMHook(ctx *schemas.BifrostContext, resp *schem
 	return resp, bifrostErr, nil
 }
 
+type postHookResponsePreservingPlugin struct {
+	fakeRoutingPlugin
+	block                 bool
+	seenResponseWithError bool
+}
+
+func (p *postHookResponsePreservingPlugin) PostLLMHook(_ *schemas.BifrostContext, resp *schemas.BifrostResponse, bifrostErr *schemas.BifrostError) (*schemas.BifrostResponse, *schemas.BifrostError, error) {
+	if p.block {
+		statusCode := 400
+		return resp, &schemas.BifrostError{
+			StatusCode: &statusCode,
+			Error:      &schemas.ErrorField{Message: "blocked"},
+		}, nil
+	}
+	p.seenResponseWithError = resp != nil && bifrostErr != nil
+	return resp, bifrostErr, nil
+}
+
+func TestRunPostLLMHooksPreservesProviderResponseWithGuardrailError(t *testing.T) {
+	t.Parallel()
+
+	observer := &postHookResponsePreservingPlugin{fakeRoutingPlugin: fakeRoutingPlugin{name: "observer"}}
+	guardrail := &postHookResponsePreservingPlugin{fakeRoutingPlugin: fakeRoutingPlugin{name: "guardrail"}, block: true}
+	pipeline := newRoutingCommitPipeline(observer, guardrail)
+	resp := &schemas.BifrostResponse{ResponsesResponse: &schemas.BifrostResponsesResponse{Model: "gpt-4o-transcribe"}}
+
+	gotResp, gotErr := pipeline.RunPostLLMHooks(schemas.NewBifrostContext(context.Background(), schemas.NoDeadline), resp, nil, 2)
+	if gotResp != resp {
+		t.Fatalf("response = %#v, want original provider response", gotResp)
+	}
+	if gotErr == nil || gotErr.Error == nil || gotErr.Error.Message != "blocked" {
+		t.Fatalf("error = %#v, want guardrail block", gotErr)
+	}
+	if !observer.seenResponseWithError {
+		t.Fatal("downstream post-hook did not receive both the provider response and guardrail error")
+	}
+}
+
 func newRoutingCommitPipeline(plugins ...schemas.LLMPlugin) *PluginPipeline {
 	return &PluginPipeline{
 		logger:     NewDefaultLogger(schemas.LogLevelError),

--- a/core/internal/llmtests/realtime.go
+++ b/core/internal/llmtests/realtime.go
@@ -48,7 +48,10 @@ func RunRealtimeTest(t *testing.T, client *bifrost.Bifrost, ctx context.Context,
 			t.Fatalf("failed to select key for provider %s: %v", testConfig.Provider, err)
 		}
 
-		wsURL := rtProvider.RealtimeWebSocketURL(key, testConfig.RealtimeModel)
+		wsURL, urlErr := rtProvider.RealtimeWebSocketURL(key, testConfig.RealtimeModel, "")
+		if urlErr != nil {
+			t.Fatalf("failed to build realtime URL for provider %s: %v", testConfig.Provider, urlErr)
+		}
 		hdrs, headerErr := rtProvider.RealtimeHeaders(bfCtx, key)
 		if headerErr != nil {
 			t.Fatalf("failed to build realtime headers for provider %s: %v", testConfig.Provider, headerErr)

--- a/core/providers/azure/realtime.go
+++ b/core/providers/azure/realtime.go
@@ -29,13 +29,15 @@ func (provider *AzureProvider) SupportsRealtimeAPI() bool {
 	return true
 }
 
-func (provider *AzureProvider) RealtimeWebSocketURL(key schemas.Key, model string) string {
+func (provider *AzureProvider) RealtimeWebSocketURL(key schemas.Key, model, intent string) (string, *schemas.BifrostError) {
 	endpoint := strings.TrimRight(key.AzureKeyConfig.Endpoint.GetValue(), "/")
 	endpoint = strings.Replace(endpoint, "https://", "wss://", 1)
 	endpoint = strings.Replace(endpoint, "http://", "ws://", 1)
 
-	return fmt.Sprintf("%s/openai/v1/realtime?model=%s",
-		endpoint, url.QueryEscape(model))
+	if intent != "" {
+		return fmt.Sprintf("%s/openai/v1/realtime?intent=%s", endpoint, url.QueryEscape(intent)), nil
+	}
+	return fmt.Sprintf("%s/openai/v1/realtime?model=%s", endpoint, url.QueryEscape(model)), nil
 }
 
 func (provider *AzureProvider) RealtimeHeaders(ctx *schemas.BifrostContext, key schemas.Key) (map[string]string, *schemas.BifrostError) {
@@ -77,6 +79,9 @@ func (provider *AzureProvider) ExchangeRealtimeWebRTCSDP(
 
 	upstreamURL := fmt.Sprintf("%s/openai/v1/realtime?model=%s",
 		endpoint, url.QueryEscape(model))
+	if isRealtimeTranscriptionSession(session) {
+		upstreamURL = endpoint + "/openai/v1/realtime?intent=transcription"
+	}
 
 	// Build multipart body: sdp + optional session
 	bodyBuf := &bytes.Buffer{}
@@ -194,26 +199,9 @@ func (provider *AzureProvider) ExtractRealtimeTurnOutput(terminalEventRaw []byte
 func (provider *AzureProvider) CreateRealtimeClientSecret(
 	ctx *schemas.BifrostContext,
 	key schemas.Key,
-	endpointType schemas.RealtimeSessionEndpointType,
 	rawRequest json.RawMessage,
 ) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
-	// Azure does not support the legacy /sessions endpoint.
-	if endpointType == schemas.RealtimeSessionEndpointSessions {
-		return nil, &schemas.BifrostError{
-			IsBifrostError: true,
-			StatusCode:     schemas.Ptr(fasthttp.StatusBadRequest),
-			Error: &schemas.ErrorField{
-				Type:    schemas.Ptr("invalid_request_error"),
-				Message: "Azure does not support the legacy /sessions endpoint; use /v1/realtime/client_secrets instead",
-			},
-			ExtraFields: schemas.BifrostErrorExtraFields{
-				RequestType: schemas.RealtimeRequest,
-				Provider:    provider.GetProviderKey(),
-			},
-		}
-	}
-
-	normalizedBody, _, bifrostErr := openaiProvider.NormalizeRealtimeClientSecretRequest(rawRequest, schemas.Azure, endpointType)
+	normalizedBody, _, bifrostErr := openaiProvider.NormalizeRealtimeClientSecretRequest(rawRequest, schemas.Azure)
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -310,6 +298,13 @@ func (provider *AzureProvider) realtimeWebRTCUpstreamError(ctx *schemas.BifrostC
 		}
 	}
 	return bifrostErr
+}
+
+func isRealtimeTranscriptionSession(session json.RawMessage) bool {
+	var payload struct {
+		Type string `json:"type"`
+	}
+	return json.Unmarshal(session, &payload) == nil && payload.Type == "transcription"
 }
 
 func newAzureRealtimeError(status int, errorType, message string, err error) *schemas.BifrostError {

--- a/core/providers/azure/realtime_test.go
+++ b/core/providers/azure/realtime_test.go
@@ -1,0 +1,120 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestRealtimeWebSocketURL(t *testing.T) {
+	t.Parallel()
+
+	provider := &AzureProvider{}
+	key := schemas.Key{AzureKeyConfig: &schemas.AzureKeyConfig{
+		Endpoint: *schemas.NewSecretVar("https://example.openai.azure.com/"),
+	}}
+
+	if got, err := provider.RealtimeWebSocketURL(key, "deployment name", ""); err != nil || got != "wss://example.openai.azure.com/openai/v1/realtime?model=deployment+name" {
+		t.Fatalf("RealtimeWebSocketURL() = %q, %v", got, err)
+	}
+	if got, err := provider.RealtimeWebSocketURL(key, "deployment name", "transcription"); err != nil || got != "wss://example.openai.azure.com/openai/v1/realtime?intent=transcription" {
+		t.Fatalf("RealtimeWebSocketURL() = %q, %v", got, err)
+	}
+}
+
+func TestExchangeRealtimeWebRTCSDPUsesIntentForTranscription(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		session   string
+		wantQuery string
+	}{
+		{
+			name:      "dedicated transcription",
+			session:   `{"type":"transcription","audio":{"input":{"transcription":{"model":"gpt-4o-transcribe"}}}}`,
+			wantQuery: "intent=transcription",
+		},
+		{
+			name:      "normal realtime with input transcription",
+			session:   `{"type":"realtime","model":"gpt-realtime","audio":{"input":{"transcription":{"model":"whisper-1"}}}}`,
+			wantQuery: "model=gpt-realtime",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handlerResult := make(chan error, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var handlerErr error
+				if r.URL.Path != "/openai/v1/realtime" || r.URL.RawQuery != tt.wantQuery {
+					handlerErr = fmt.Errorf("upstream URL = %s?%s, want /openai/v1/realtime?%s", r.URL.Path, r.URL.RawQuery, tt.wantQuery)
+				}
+				reader, err := r.MultipartReader()
+				if err != nil {
+					if handlerErr == nil {
+						handlerErr = fmt.Errorf("MultipartReader() error = %w", err)
+					}
+				} else {
+					fields := make(map[string]string)
+					for {
+						part, err := reader.NextPart()
+						if err == io.EOF {
+							break
+						}
+						if err != nil {
+							handlerErr = fmt.Errorf("NextPart() error = %w", err)
+							break
+						}
+						value, err := io.ReadAll(part)
+						if err != nil {
+							handlerErr = fmt.Errorf("ReadAll() error = %w", err)
+							break
+						}
+						fields[part.FormName()] = string(value)
+					}
+					if handlerErr == nil && (fields["sdp"] != "v=0\r\n" || fields["session"] != tt.session) {
+						handlerErr = fmt.Errorf("multipart fields = %#v", fields)
+					}
+				}
+				handlerResult <- handlerErr
+				w.Header().Set("Content-Type", "application/sdp")
+				_, _ = w.Write([]byte("v=0\r\nanswer"))
+			}))
+			defer server.Close()
+
+			provider, err := NewAzureProvider(&schemas.ProviderConfig{
+				NetworkConfig: schemas.NetworkConfig{
+					DefaultRequestTimeoutInSeconds: 10,
+					AllowPrivateNetwork:            true,
+				},
+			}, &authTestLogger{})
+			if err != nil {
+				t.Fatalf("NewAzureProvider() error = %v", err)
+			}
+			key := schemas.Key{
+				Value: *schemas.NewSecretVar("test-api-key"),
+				AzureKeyConfig: &schemas.AzureKeyConfig{
+					Endpoint: *schemas.NewSecretVar(server.URL),
+				},
+			}
+			ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+			answer, bifrostErr := provider.ExchangeRealtimeWebRTCSDP(ctx, key, "gpt-realtime", "v=0\r\n", []byte(tt.session))
+			if bifrostErr != nil {
+				t.Fatalf("ExchangeRealtimeWebRTCSDP() error = %v", bifrostErr)
+			}
+			if answer != "v=0\r\nanswer" {
+				t.Fatalf("answer = %q, want SDP answer", answer)
+			}
+			if err := <-handlerResult; err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/core/providers/elevenlabs/realtime.go
+++ b/core/providers/elevenlabs/realtime.go
@@ -18,11 +18,14 @@ func (provider *ElevenlabsProvider) SupportsRealtimeAPI() bool {
 // RealtimeWebSocketURL returns the WSS URL for the ElevenLabs Conversational AI endpoint.
 // The model parameter is used as the agent_id query parameter.
 // Format: wss://api.elevenlabs.io/v1/convai/conversation?agent_id=<model>
-func (provider *ElevenlabsProvider) RealtimeWebSocketURL(key schemas.Key, model string) string {
+func (provider *ElevenlabsProvider) RealtimeWebSocketURL(_ schemas.Key, model, intent string) (string, *schemas.BifrostError) {
+	if intent == "transcription" {
+		return "", providerUtils.NewUnsupportedOperationError(schemas.RealtimeRequest, provider.GetProviderKey())
+	}
 	base := provider.networkConfig.BaseURL
 	base = strings.Replace(base, "https://", "wss://", 1)
 	base = strings.Replace(base, "http://", "ws://", 1)
-	return base + "/v1/convai/conversation?agent_id=" + model
+	return base + "/v1/convai/conversation?agent_id=" + model, nil
 }
 
 // RealtimeHeaders returns the headers required for the ElevenLabs Conversational AI WebSocket.

--- a/core/providers/elevenlabs/realtime_test.go
+++ b/core/providers/elevenlabs/realtime_test.go
@@ -1,0 +1,22 @@
+package elevenlabs
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+func TestRealtimeWebSocketURLRejectsTranscription(t *testing.T) {
+	provider := &ElevenlabsProvider{}
+
+	url, err := provider.RealtimeWebSocketURL(schemas.Key{}, "agent-id", "transcription")
+	if err == nil {
+		t.Fatal("RealtimeWebSocketURL() error = nil, want unsupported operation")
+	}
+	if url != "" {
+		t.Fatalf("RealtimeWebSocketURL() URL = %q, want empty", url)
+	}
+	if err.Error == nil || err.Error.Code == nil || *err.Error.Code != "unsupported_operation" {
+		t.Fatalf("RealtimeWebSocketURL() error = %+v, want unsupported_operation", err)
+	}
+}

--- a/core/providers/openai/realtime.go
+++ b/core/providers/openai/realtime.go
@@ -21,12 +21,14 @@ func (provider *OpenAIProvider) SupportsRealtimeAPI() bool {
 }
 
 // RealtimeWebSocketURL returns the WSS URL for the OpenAI Realtime API.
-// Format: wss://api.openai.com/v1/realtime?model=<model>
-func (provider *OpenAIProvider) RealtimeWebSocketURL(key schemas.Key, model string) string {
+func (provider *OpenAIProvider) RealtimeWebSocketURL(_ schemas.Key, model, intent string) (string, *schemas.BifrostError) {
 	base := provider.networkConfig.BaseURL
 	base = strings.Replace(base, "https://", "wss://", 1)
 	base = strings.Replace(base, "http://", "ws://", 1)
-	return base + "/v1/realtime?model=" + url.QueryEscape(model)
+	if intent != "" {
+		return base + "/v1/realtime?intent=" + url.QueryEscape(intent), nil
+	}
+	return base + "/v1/realtime?model=" + url.QueryEscape(model), nil
 }
 
 // RealtimeHeaders returns the headers required for the OpenAI Realtime WebSocket connection.
@@ -210,14 +212,13 @@ func (provider *OpenAIProvider) ShouldAccumulateRealtimeOutput(eventType schemas
 func (provider *OpenAIProvider) CreateRealtimeClientSecret(
 	ctx *schemas.BifrostContext,
 	key schemas.Key,
-	endpointType schemas.RealtimeSessionEndpointType,
 	rawRequest json.RawMessage,
 ) (*schemas.BifrostPassthroughResponse, *schemas.BifrostError) {
 	if err := providerUtils.CheckOperationAllowed(schemas.OpenAI, provider.customProviderConfig, schemas.RealtimeRequest); err != nil {
 		return nil, err
 	}
 
-	normalizedBody, _, bifrostErr := NormalizeRealtimeClientSecretRequest(rawRequest, provider.GetProviderKey(), endpointType)
+	normalizedBody, _, bifrostErr := NormalizeRealtimeClientSecretRequest(rawRequest, provider.GetProviderKey())
 	if bifrostErr != nil {
 		return nil, bifrostErr
 	}
@@ -226,11 +227,11 @@ func (provider *OpenAIProvider) CreateRealtimeClientSecret(
 	defer fasthttp.ReleaseRequest(req)
 	defer fasthttp.ReleaseResponse(resp)
 
-	upstreamURL := provider.buildRequestURL(ctx, realtimeSessionUpstreamPath(endpointType), schemas.RealtimeRequest)
+	upstreamURL := provider.buildRequestURL(ctx, "/v1/realtime/client_secrets", schemas.RealtimeRequest)
 	req.SetRequestURI(upstreamURL)
 	req.Header.SetMethod(http.MethodPost)
 	req.Header.SetContentType("application/json")
-	for k, v := range provider.realtimeSessionHeaders(key, endpointType) {
+	for k, v := range provider.realtimeSessionHeaders(key) {
 		req.Header.Set(k, v)
 	}
 	req.SetBody(normalizedBody)
@@ -276,7 +277,6 @@ func (provider *OpenAIProvider) CreateRealtimeClientSecret(
 func NormalizeRealtimeClientSecretRequest(
 	rawRequest json.RawMessage,
 	defaultProvider schemas.ModelProvider,
-	endpointType schemas.RealtimeSessionEndpointType,
 ) ([]byte, string, *schemas.BifrostError) {
 	root, bifrostErr := schemas.ParseRealtimeClientSecretBody(rawRequest)
 	if bifrostErr != nil {
@@ -296,10 +296,6 @@ func NormalizeRealtimeClientSecretRequest(
 	}
 	if providerKey == "" {
 		return nil, "", newRealtimeClientSecretError(fasthttp.StatusBadRequest, "invalid_request_error", "unable to determine provider from model", nil)
-	}
-
-	if endpointType == schemas.RealtimeSessionEndpointSessions {
-		return normalizeRealtimeSessionsRequest(root, normalizedModel)
 	}
 
 	return normalizeRealtimeClientSecretsRequest(root, normalizedModel)
@@ -414,38 +410,6 @@ func writeGASessionTranscriptionModel(session map[string]json.RawMessage, modelJ
 	return nil
 }
 
-func normalizeRealtimeSessionsRequest(
-	root map[string]json.RawMessage,
-	normalizedModel string,
-) ([]byte, string, *schemas.BifrostError) {
-	if existingSession, ok := root["session"]; ok && len(existingSession) > 0 && !bytes.Equal(existingSession, []byte("null")) {
-		session := map[string]json.RawMessage{}
-		if err := json.Unmarshal(existingSession, &session); err != nil {
-			return nil, "", newRealtimeClientSecretError(fasthttp.StatusBadRequest, "invalid_request_error", "session must be an object", err)
-		}
-		for key, value := range session {
-			if _, exists := root[key]; !exists {
-				root[key] = value
-			}
-		}
-	}
-
-	modelJSON, marshalErr := json.Marshal(normalizedModel)
-	if marshalErr != nil {
-		return nil, "", newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized model", marshalErr)
-	}
-	root["model"] = modelJSON
-	delete(root, "session")
-	StripNestedModelPrefixes(root)
-
-	normalizedBody, marshalErr := json.Marshal(root)
-	if marshalErr != nil {
-		return nil, "", newRealtimeClientSecretError(fasthttp.StatusInternalServerError, "server_error", "failed to encode realtime request", marshalErr)
-	}
-
-	return normalizedBody, normalizedModel, nil
-}
-
 // StripNestedModelPrefixes removes provider prefixes (e.g. "openai/whisper-1" → "whisper-1")
 // from known nested model fields in the realtime session config. This prevents forwarding
 // Bifrost-style "provider/model" strings to upstream providers that expect bare model names.
@@ -508,27 +472,14 @@ func stripModelInNestedObject(parent map[string]json.RawMessage, key string) boo
 	return false
 }
 
-func (provider *OpenAIProvider) realtimeSessionHeaders(
-	key schemas.Key,
-	endpointType schemas.RealtimeSessionEndpointType,
-) map[string]string {
+func (provider *OpenAIProvider) realtimeSessionHeaders(key schemas.Key) map[string]string {
 	headers := map[string]string{
 		"Authorization": "Bearer " + key.Value.GetValue(),
-	}
-	if endpointType == schemas.RealtimeSessionEndpointSessions {
-		headers["OpenAI-Beta"] = "realtime=v1"
 	}
 	for k, v := range provider.networkConfig.ExtraHeaders {
 		headers[k] = v
 	}
 	return headers
-}
-
-func realtimeSessionUpstreamPath(endpointType schemas.RealtimeSessionEndpointType) string {
-	if endpointType == schemas.RealtimeSessionEndpointSessions {
-		return "/v1/realtime/sessions"
-	}
-	return "/v1/realtime/client_secrets"
 }
 
 func newRealtimeClientSecretError(status int, errorType, message string, err error) *schemas.BifrostError {
@@ -857,39 +808,52 @@ func (provider *OpenAIProvider) ExtractRealtimeTurnUsage(terminalEventRaw []byte
 	}
 
 	var parsed openAIRealtimeResponseDoneEnvelope
-	if err := json.Unmarshal(terminalEventRaw, &parsed); err != nil || parsed.Response.Usage == nil {
+	if err := json.Unmarshal(terminalEventRaw, &parsed); err != nil {
 		return nil
 	}
-
-	usage := &schemas.BifrostLLMUsage{
-		PromptTokens:     parsed.Response.Usage.InputTokens,
-		CompletionTokens: parsed.Response.Usage.OutputTokens,
-		TotalTokens:      parsed.Response.Usage.TotalTokens,
+	usage := parsed.Response.Usage
+	if usage == nil {
+		usage = parsed.Usage
+	}
+	if usage == nil {
+		return nil
+	}
+	if usage.Type == "duration" {
+		if usage.Seconds <= 0 {
+			return nil
+		}
+		return &schemas.BifrostLLMUsage{AudioSeconds: &usage.Seconds}
 	}
 
-	if parsed.Response.Usage.InputTokenDetails != nil {
-		usage.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
-			TextTokens:       parsed.Response.Usage.InputTokenDetails.TextTokens,
-			AudioTokens:      parsed.Response.Usage.InputTokenDetails.AudioTokens,
-			ImageTokens:      parsed.Response.Usage.InputTokenDetails.ImageTokens,
-			CachedReadTokens: parsed.Response.Usage.InputTokenDetails.CachedTokens,
+	result := &schemas.BifrostLLMUsage{
+		PromptTokens:     usage.InputTokens,
+		CompletionTokens: usage.OutputTokens,
+		TotalTokens:      usage.TotalTokens,
+	}
+
+	if usage.InputTokenDetails != nil {
+		result.PromptTokensDetails = &schemas.ChatPromptTokensDetails{
+			TextTokens:       usage.InputTokenDetails.TextTokens,
+			AudioTokens:      usage.InputTokenDetails.AudioTokens,
+			ImageTokens:      usage.InputTokenDetails.ImageTokens,
+			CachedReadTokens: usage.InputTokenDetails.CachedTokens,
 		}
 	}
 
-	if parsed.Response.Usage.OutputTokenDetails != nil {
-		usage.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{
-			TextTokens:               parsed.Response.Usage.OutputTokenDetails.TextTokens,
-			AudioTokens:              parsed.Response.Usage.OutputTokenDetails.AudioTokens,
-			ReasoningTokens:          parsed.Response.Usage.OutputTokenDetails.ReasoningTokens,
-			ImageTokens:              parsed.Response.Usage.OutputTokenDetails.ImageTokens,
-			CitationTokens:           parsed.Response.Usage.OutputTokenDetails.CitationTokens,
-			NumSearchQueries:         parsed.Response.Usage.OutputTokenDetails.NumSearchQueries,
-			AcceptedPredictionTokens: parsed.Response.Usage.OutputTokenDetails.AcceptedPredictionTokens,
-			RejectedPredictionTokens: parsed.Response.Usage.OutputTokenDetails.RejectedPredictionTokens,
+	if usage.OutputTokenDetails != nil {
+		result.CompletionTokensDetails = &schemas.ChatCompletionTokensDetails{
+			TextTokens:               usage.OutputTokenDetails.TextTokens,
+			AudioTokens:              usage.OutputTokenDetails.AudioTokens,
+			ReasoningTokens:          usage.OutputTokenDetails.ReasoningTokens,
+			ImageTokens:              usage.OutputTokenDetails.ImageTokens,
+			CitationTokens:           usage.OutputTokenDetails.CitationTokens,
+			NumSearchQueries:         usage.OutputTokenDetails.NumSearchQueries,
+			AcceptedPredictionTokens: usage.OutputTokenDetails.AcceptedPredictionTokens,
+			RejectedPredictionTokens: usage.OutputTokenDetails.RejectedPredictionTokens,
 		}
 	}
 
-	return usage
+	return result
 }
 
 func (provider *OpenAIProvider) ExtractRealtimeTurnOutput(terminalEventRaw []byte) *schemas.ChatMessage {
@@ -924,6 +888,7 @@ type openAIRealtimeResponseDoneEnvelope struct {
 		Output []openAIRealtimeResponseDoneOutput `json:"output"`
 		Usage  *openAIRealtimeResponseDoneUsage   `json:"usage"`
 	} `json:"response"`
+	Usage *openAIRealtimeResponseDoneUsage `json:"usage"`
 }
 
 type openAIRealtimeResponseDoneOutput struct {
@@ -942,6 +907,8 @@ type openAIRealtimeResponseDoneBlock struct {
 }
 
 type openAIRealtimeResponseDoneUsage struct {
+	Type               string                                      `json:"type"`
+	Seconds            float64                                     `json:"seconds"`
 	TotalTokens        int                                         `json:"total_tokens"`
 	InputTokens        int                                         `json:"input_tokens"`
 	OutputTokens       int                                         `json:"output_tokens"`

--- a/core/providers/openai/realtime_test.go
+++ b/core/providers/openai/realtime_test.go
@@ -8,13 +8,66 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 )
 
+func TestExtractRealtimeTurnUsageSupportsTranscriptionCompletion(t *testing.T) {
+	t.Parallel()
+
+	provider := &OpenAIProvider{}
+	usage := provider.ExtractRealtimeTurnUsage([]byte(`{
+		"type":"conversation.item.input_audio_transcription.completed",
+		"usage":{
+			"type":"tokens",
+			"total_tokens":11,
+			"input_tokens":7,
+			"output_tokens":4,
+			"input_token_details":{"text_tokens":2,"audio_tokens":5},
+			"output_token_details":{"text_tokens":4}
+		}
+	}`))
+	if usage == nil {
+		t.Fatal("expected transcription usage")
+	}
+	if usage.PromptTokens != 7 || usage.CompletionTokens != 4 || usage.TotalTokens != 11 {
+		t.Fatalf("usage = %+v, want input=7 output=4 total=11", usage)
+	}
+	if usage.PromptTokensDetails == nil || usage.PromptTokensDetails.AudioTokens != 5 {
+		t.Fatalf("prompt token details = %+v, want audio_tokens=5", usage.PromptTokensDetails)
+	}
+}
+
+func TestExtractRealtimeTurnUsageSupportsDurationTranscriptionCompletion(t *testing.T) {
+	t.Parallel()
+
+	provider := &OpenAIProvider{}
+	usage := provider.ExtractRealtimeTurnUsage([]byte(`{
+		"type":"conversation.item.input_audio_transcription.completed",
+		"usage":{"type":"duration","seconds":3.4}
+	}`))
+	if usage == nil || usage.AudioSeconds == nil || *usage.AudioSeconds != 3.4 {
+		t.Fatalf("usage = %+v, want audio_seconds=3.4", usage)
+	}
+	if usage.PromptTokens != 0 || usage.CompletionTokens != 0 || usage.TotalTokens != 0 {
+		t.Fatalf("usage = %+v, want zero token counts", usage)
+	}
+}
+
+func TestRealtimeWebSocketURL(t *testing.T) {
+	t.Parallel()
+
+	provider := &OpenAIProvider{networkConfig: schemas.NetworkConfig{BaseURL: "https://api.openai.com"}}
+	if got, err := provider.RealtimeWebSocketURL(schemas.Key{}, "gpt-4o transcribe", ""); err != nil || got != "wss://api.openai.com/v1/realtime?model=gpt-4o+transcribe" {
+		t.Fatalf("RealtimeWebSocketURL() = %q, %v", got, err)
+	}
+	if got, err := provider.RealtimeWebSocketURL(schemas.Key{}, "gpt-4o transcribe", "transcription"); err != nil || got != "wss://api.openai.com/v1/realtime?intent=transcription" {
+		t.Fatalf("RealtimeWebSocketURL() = %q, %v", got, err)
+	}
+}
+
 func TestNormalizeRealtimeClientSecretRequest(t *testing.T) {
 	t.Parallel()
 
 	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
 		json.RawMessage(`{"model":"openai/gpt-4o-realtime-preview","voice":"alloy"}`),
 		schemas.OpenAI,
-		schemas.RealtimeSessionEndpointClientSecrets,
 	)
 	if bifrostErr != nil {
 		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
@@ -49,7 +102,6 @@ func TestNormalizeRealtimeClientSecretRequestGATranscriptionSession(t *testing.T
 	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
 		json.RawMessage(`{"session":{"type":"transcription","audio":{"input":{"transcription":{"model":"openai/gpt-4o-transcribe","language":"en"},"format":{"type":"audio/pcm","rate":24000}}}}}`),
 		schemas.OpenAI,
-		schemas.RealtimeSessionEndpointClientSecrets,
 	)
 	if bifrostErr != nil {
 		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
@@ -104,7 +156,6 @@ func TestNormalizeRealtimeClientSecretRequestGATranscriptionSessionNoExplicitTyp
 	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
 		json.RawMessage(`{"session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`),
 		schemas.OpenAI,
-		schemas.RealtimeSessionEndpointClientSecrets,
 	)
 	if bifrostErr != nil {
 		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
@@ -142,7 +193,6 @@ func TestNormalizeRealtimeClientSecretRequestLegacyRootModelWithTranscriptionSib
 	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
 		json.RawMessage(`{"model":"openai/gpt-4o-realtime-preview","session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`),
 		schemas.OpenAI,
-		schemas.RealtimeSessionEndpointClientSecrets,
 	)
 	if bifrostErr != nil {
 		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
@@ -200,7 +250,6 @@ func TestNormalizeRealtimeClientSecretRequestTranscriptionTypeDropsStaleSessionM
 	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
 		json.RawMessage(`{"session":{"type":"transcription","model":"openai/gpt-4o-transcribe","audio":{"input":{"transcription":{}}}}}`),
 		schemas.OpenAI,
-		schemas.RealtimeSessionEndpointClientSecrets,
 	)
 	if bifrostErr != nil {
 		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
@@ -228,7 +277,6 @@ func TestNormalizeRealtimeClientSecretRequestUsesDefaultProvider(t *testing.T) {
 	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
 		json.RawMessage(`{"session":{"model":"gpt-4o-realtime-preview"}}`),
 		schemas.OpenAI,
-		schemas.RealtimeSessionEndpointClientSecrets,
 	)
 	if bifrostErr != nil {
 		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
@@ -251,36 +299,6 @@ func TestNormalizeRealtimeClientSecretRequestUsesDefaultProvider(t *testing.T) {
 	}
 	if session["type"] != "realtime" {
 		t.Fatalf("session.type = %v, want %q", session["type"], "realtime")
-	}
-}
-
-func TestNormalizeRealtimeSessionsRequest(t *testing.T) {
-	t.Parallel()
-
-	body, model, bifrostErr := NormalizeRealtimeClientSecretRequest(
-		json.RawMessage(`{"session":{"model":"openai/gpt-4o-realtime-preview","voice":"alloy"}}`),
-		schemas.OpenAI,
-		schemas.RealtimeSessionEndpointSessions,
-	)
-	if bifrostErr != nil {
-		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
-	}
-	if model != "gpt-4o-realtime-preview" {
-		t.Fatalf("model = %q, want %q", model, "gpt-4o-realtime-preview")
-	}
-
-	var payload map[string]any
-	if err := json.Unmarshal(body, &payload); err != nil {
-		t.Fatalf("failed to unmarshal normalized body: %v", err)
-	}
-	if _, ok := payload["session"]; ok {
-		t.Fatal("legacy sessions endpoint should not forward nested session object")
-	}
-	if payload["model"] != "gpt-4o-realtime-preview" {
-		t.Fatalf("model = %v, want %q", payload["model"], "gpt-4o-realtime-preview")
-	}
-	if payload["voice"] != "alloy" {
-		t.Fatalf("voice = %v, want %q", payload["voice"], "alloy")
 	}
 }
 

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -1756,7 +1756,10 @@ func (r *BifrostMCPResponse) PopulateExtraFields(mcpRequestType MCPRequestType, 
 // BifrostResponseExtraFields contains additional fields in a response.
 type BifrostResponseExtraFields struct {
 	RequestType RequestType `json:"request_type"`
-	RoutingInfo RoutingInfo `json:"routing_info"`
+	// PricingRequestType selects a catalog mode without changing the request type
+	// exposed to plugins and logs.
+	PricingRequestType RequestType `json:"pricing_request_type,omitempty"`
+	RoutingInfo        RoutingInfo `json:"routing_info"`
 	// Deprecated: use RoutingInfo.Provider. Still populated for backward
 	// compatibility; new consumers should read from RoutingInfo.
 	Provider ModelProvider `json:"provider,omitempty"`

--- a/core/schemas/chatcompletions.go
+++ b/core/schemas/chatcompletions.go
@@ -1878,6 +1878,9 @@ type BifrostLLMUsage struct {
 	CompletionTokens        int                          `json:"completion_tokens,omitempty"`
 	CompletionTokensDetails *ChatCompletionTokensDetails `json:"completion_tokens_details,omitempty"`
 	TotalTokens             int                          `json:"total_tokens"`
+	// AudioSeconds carries duration-based audio usage when a provider reports
+	// seconds instead of tokens.
+	AudioSeconds *float64 `json:"audio_seconds,omitempty"`
 	// SearchUnits is the billable unit for rerank: Cohere and Bedrock both define one unit as
 	// a single query against up to 100 document chunks, so a request over that many chunks
 	// bills as several. Distinct from ChatCompletionTokensDetails.NumSearchQueries, which

--- a/core/schemas/realtime.go
+++ b/core/schemas/realtime.go
@@ -158,20 +158,10 @@ type RealtimeError struct {
 	ExtraParams map[string]json.RawMessage `json:"extra_params,omitempty"`
 }
 
-// RealtimeSessionEndpointType identifies the public ephemeral-token endpoint
-// shape the client called so providers can preserve versioned behavior.
-type RealtimeSessionEndpointType string
-
-const (
-	RealtimeSessionEndpointClientSecrets RealtimeSessionEndpointType = "client_secrets"
-	RealtimeSessionEndpointSessions      RealtimeSessionEndpointType = "sessions"
-)
-
 // RealtimeSessionRoute describes a provider-registered public route for
 // ephemeral-token creation.
 type RealtimeSessionRoute struct {
 	Path            string
-	EndpointType    RealtimeSessionEndpointType
 	DefaultProvider ModelProvider
 }
 
@@ -180,7 +170,7 @@ type RealtimeSessionRoute struct {
 // Checked via type assertion: provider.(RealtimeProvider).
 type RealtimeProvider interface {
 	SupportsRealtimeAPI() bool
-	RealtimeWebSocketURL(key Key, model string) string
+	RealtimeWebSocketURL(key Key, model, intent string) (string, *BifrostError)
 	RealtimeHeaders(ctx *BifrostContext, key Key) (map[string]string, *BifrostError)
 	// SupportsRealtimeWebRTC reports whether the provider supports WebRTC SDP exchange.
 	SupportsRealtimeWebRTC() bool
@@ -223,7 +213,7 @@ type RealtimeUsageExtractor interface {
 // short-lived client secrets for browser/client-side Realtime connections.
 // Checked via type assertion: provider.(RealtimeSessionProvider).
 type RealtimeSessionProvider interface {
-	CreateRealtimeClientSecret(ctx *BifrostContext, key Key, endpointType RealtimeSessionEndpointType, rawRequest json.RawMessage) (*BifrostPassthroughResponse, *BifrostError)
+	CreateRealtimeClientSecret(ctx *BifrostContext, key Key, rawRequest json.RawMessage) (*BifrostPassthroughResponse, *BifrostError)
 }
 
 // ParseRealtimeEvent decodes a client/provider realtime event while preserving

--- a/core/schemas/responses.go
+++ b/core/schemas/responses.go
@@ -1297,15 +1297,16 @@ type ResponsesStopDetails struct {
 }
 
 type ResponsesResponseUsage struct {
-	Type                *string                        `json:"type,omitempty"`        // type field is sent by anthropic
-	Model               *string                        `json:"model,omitempty"`       // model that produced this (iteration) attempt; sent on iterations[] for Anthropic server-side fallback
-	InputTokens         int                            `json:"input_tokens"`          // Number of input tokens (prompt tokens + cached tokens)
-	InputTokensDetails  *ResponsesResponseInputTokens  `json:"input_tokens_details"`  // Detailed breakdown of input tokens
-	OutputTokens        int                            `json:"output_tokens"`         // Number of output tokens (completion tokens + reasoning tokens)
-	OutputTokensDetails *ResponsesResponseOutputTokens `json:"output_tokens_details"` // Detailed breakdown of output tokens	TotalTokens int `json:"total_tokens"` // Total number of tokens used
-	TotalTokens         int                            `json:"total_tokens"`          // Total number of tokens used
-	Cost                *BifrostCost                   `json:"cost,omitempty"`        // Only for the providers which support cost calculation
-	Iterations          []ResponsesResponseUsage       `json:"iterations,omitempty"`  // iterations field is sent by anthropic
+	Type                *string                        `json:"type,omitempty"`          // type field is sent by anthropic
+	Model               *string                        `json:"model,omitempty"`         // model that produced this (iteration) attempt; sent on iterations[] for Anthropic server-side fallback
+	InputTokens         int                            `json:"input_tokens"`            // Number of input tokens (prompt tokens + cached tokens)
+	InputTokensDetails  *ResponsesResponseInputTokens  `json:"input_tokens_details"`    // Detailed breakdown of input tokens
+	OutputTokens        int                            `json:"output_tokens"`           // Number of output tokens (completion tokens + reasoning tokens)
+	OutputTokensDetails *ResponsesResponseOutputTokens `json:"output_tokens_details"`   // Detailed breakdown of output tokens	TotalTokens int `json:"total_tokens"` // Total number of tokens used
+	TotalTokens         int                            `json:"total_tokens"`            // Total number of tokens used
+	AudioSeconds        *float64                       `json:"audio_seconds,omitempty"` // Duration-based audio usage when tokens are unavailable
+	Cost                *BifrostCost                   `json:"cost,omitempty"`          // Only for the providers which support cost calculation
+	Iterations          []ResponsesResponseUsage       `json:"iterations,omitempty"`    // iterations field is sent by anthropic
 
 	// xAI-specific usage fields
 	NumSourcesUsed             *int                                 `json:"num_sources_used,omitempty"`

--- a/framework/modelcatalog/datasheet/cost.go
+++ b/framework/modelcatalog/datasheet/cost.go
@@ -495,6 +495,9 @@ func (s *Store) calculateBaseCost(result *schemas.BifrostResponse, scopes Lookup
 		}
 	}
 	requestType := extraFields.RequestType
+	if extraFields.PricingRequestType != "" {
+		requestType = extraFields.PricingRequestType
+	}
 
 	// A retrieve is a status read, not a generation. Providers that report the job's cost on the
 	// polled response (e.g. Runware, which echoes it on every getResponse once the task has
@@ -673,14 +676,29 @@ func extractCostInput(result *schemas.BifrostResponse) costInput {
 
 	case result.ResponsesResponse != nil && result.ResponsesResponse.Usage != nil:
 		input.usage = responsesUsageToBifrostUsage(result.ResponsesResponse.Usage)
+		input.audioSeconds = input.usage.AudioSeconds
 		input.tier = tierFromResponse(result.ResponsesResponse.ServiceTier, result.ResponsesResponse.Speed, result.ResponsesResponse.InferenceGeo)
+		if details := result.ResponsesResponse.Usage.InputTokensDetails; details != nil {
+			input.audioTokenDetails = &schemas.TranscriptionUsageInputTokenDetails{
+				AudioTokens: details.AudioTokens,
+				TextTokens:  details.TextTokens,
+			}
+		}
 
 	case result.CompactionResponse != nil && result.CompactionResponse.Usage != nil:
 		input.usage = responsesUsageToBifrostUsage(result.CompactionResponse.Usage)
 
 	case result.ResponsesStreamResponse != nil && result.ResponsesStreamResponse.Response != nil && result.ResponsesStreamResponse.Response.Usage != nil:
-		input.usage = responsesUsageToBifrostUsage(result.ResponsesStreamResponse.Response.Usage)
-		input.tier = tierFromResponse(result.ResponsesStreamResponse.Response.ServiceTier, result.ResponsesStreamResponse.Response.Speed, result.ResponsesStreamResponse.Response.InferenceGeo)
+		response := result.ResponsesStreamResponse.Response
+		input.usage = responsesUsageToBifrostUsage(response.Usage)
+		input.audioSeconds = input.usage.AudioSeconds
+		input.tier = tierFromResponse(response.ServiceTier, response.Speed, response.InferenceGeo)
+		if details := response.Usage.InputTokensDetails; details != nil {
+			input.audioTokenDetails = &schemas.TranscriptionUsageInputTokenDetails{
+				AudioTokens: details.AudioTokens,
+				TextTokens:  details.TextTokens,
+			}
+		}
 
 	case result.EmbeddingResponse != nil && result.EmbeddingResponse.Usage != nil:
 		input.usage = result.EmbeddingResponse.Usage
@@ -779,6 +797,7 @@ func responsesUsageToBifrostUsage(u *schemas.ResponsesResponseUsage) *schemas.Bi
 		PromptTokens:     u.InputTokens,
 		CompletionTokens: u.OutputTokens,
 		TotalTokens:      u.TotalTokens,
+		AudioSeconds:     u.AudioSeconds,
 		Cost:             u.Cost,
 	}
 	// Map token details for cache and search query pricing
@@ -812,7 +831,7 @@ func speechUsageToBifrostUsage(u *schemas.SpeechUsage) *schemas.BifrostLLMUsage 
 	}
 }
 
-func extractTranscriptionUsage(u *schemas.TranscriptionUsage) (*schemas.BifrostLLMUsage, *int, *schemas.TranscriptionUsageInputTokenDetails) {
+func extractTranscriptionUsage(u *schemas.TranscriptionUsage) (*schemas.BifrostLLMUsage, *float64, *schemas.TranscriptionUsageInputTokenDetails) {
 	usage := &schemas.BifrostLLMUsage{}
 	if u.InputTokens != nil {
 		usage.PromptTokens = *u.InputTokens
@@ -834,9 +853,10 @@ func extractTranscriptionUsage(u *schemas.TranscriptionUsage) (*schemas.BifrostL
 		}
 	}
 
-	var audioSeconds *int
+	var audioSeconds *float64
 	if u.Seconds != nil {
-		audioSeconds = new(int(*u.Seconds))
+		seconds := float64(*u.Seconds)
+		audioSeconds = &seconds
 	}
 
 	return usage, audioSeconds, audioTokenDetails
@@ -1216,7 +1236,7 @@ func newInputOutputCostWithDetails(inputCost, outputCost float64, inputDetails *
 // input text rather than per token. PromptTokens from usage is treated as the character count
 // since TTS providers report their billable unit in that field.
 // Output falls back to per-second duration when no audio token rate is configured.
-func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTextInputChars int, tier serviceTier) *schemas.BifrostCost {
+func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *float64, audioTextInputChars int, tier serviceTier) *schemas.BifrostCost {
 	tierTokens := inputTierTokens(usage)
 
 	// Input: per-character rate takes precedence for TTS/audio models
@@ -1249,7 +1269,7 @@ func computeSpeechCost(pricing *configstoreTables.TableModelPricing, usage *sche
 // computeTranscriptionCost handles transcription (STT) requests.
 // Input is audio, output is text (CompletionTokens).
 // Input and output are calculated independently — tokens first, then per-second fallback.
-func computeTranscriptionCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) *schemas.BifrostCost {
+func computeTranscriptionCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *float64, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) *schemas.BifrostCost {
 	tierTokens := inputTierTokens(usage)
 
 	// Input: audio tokens/details first, then per-second fallback
@@ -1281,7 +1301,7 @@ func computeTranscriptionCost(pricing *configstoreTables.TableModelPricing, usag
 
 // computeAudioInputCost calculates input cost for audio: audio token details first,
 // then generic input tokens, then per-second duration fallback.
-func computeAudioInputCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, totalTokens int, tier serviceTier) float64 {
+func computeAudioInputCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *float64, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, totalTokens int, tier serviceTier) float64 {
 	// Audio token detail pricing (audio + text token breakdown)
 	if audioTokenDetails != nil && (audioTokenDetails.AudioTokens > 0 || audioTokenDetails.TextTokens > 0) {
 		return float64(audioTokenDetails.AudioTokens)*tieredAudioTokenInputRate(pricing, totalTokens, tier) +
@@ -1296,7 +1316,7 @@ func computeAudioInputCost(pricing *configstoreTables.TableModelPricing, usage *
 	// Per-second duration fallback
 	if audioSeconds != nil && *audioSeconds > 0 {
 		if rate := tieredAudioInputPerSecondRate(pricing, totalTokens); rate > 0 {
-			return float64(*audioSeconds) * rate
+			return *audioSeconds * rate
 		}
 	}
 
@@ -1305,7 +1325,7 @@ func computeAudioInputCost(pricing *configstoreTables.TableModelPricing, usage *
 
 // computeAudioOutputCost calculates output cost for audio: audio tokens first,
 // then generic output tokens, then per-second duration fallback.
-func computeAudioOutputCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, totalTokens int, tier serviceTier) float64 {
+func computeAudioOutputCost(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *float64, totalTokens int, tier serviceTier) float64 {
 	// Audio-specific output tokens
 	if usage != nil && usage.CompletionTokens > 0 {
 		return float64(usage.CompletionTokens) * tieredAudioTokenOutputRate(pricing, totalTokens, tier)
@@ -1314,7 +1334,7 @@ func computeAudioOutputCost(pricing *configstoreTables.TableModelPricing, usage 
 	// Per-second duration fallback
 	if audioSeconds != nil && *audioSeconds > 0 {
 		if pricing.OutputCostPerSecond != nil {
-			return float64(*audioSeconds) * *pricing.OutputCostPerSecond
+			return *audioSeconds * *pricing.OutputCostPerSecond
 		}
 	}
 
@@ -2407,7 +2427,8 @@ func passthroughUsageToCostInput(su *schemas.BifrostPassthroughUsage) costInput 
 		input.audioTextInputChars = su.AudioInputChars
 	}
 	if su.AudioSeconds != nil {
-		input.audioSeconds = su.AudioSeconds
+		seconds := float64(*su.AudioSeconds)
+		input.audioSeconds = &seconds
 	}
 	if su.AudioTokenDetails != nil {
 		input.audioTokenDetails = su.AudioTokenDetails

--- a/framework/modelcatalog/datasheet/cost_test.go
+++ b/framework/modelcatalog/datasheet/cost_test.go
@@ -11,9 +11,183 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
+func TestCalculateCost_RealtimeTranscriptionPricingOverride(t *testing.T) {
+	pricing := configstoreTables.TableModelPricing{
+		Model:                  "gpt-4o-transcribe",
+		Provider:               "openai",
+		Mode:                   "audio_transcription",
+		InputCostPerToken:      bifrost.Ptr(0.0000025),
+		OutputCostPerToken:     bifrost.Ptr(0.00001),
+		InputCostPerAudioToken: bifrost.Ptr(0.0000025),
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey(pricing.Model, pricing.Provider, pricing.Mode): pricing,
+	})
+	resp := &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			Usage: &schemas.ResponsesResponseUsage{
+				InputTokens:  29,
+				OutputTokens: 14,
+				TotalTokens:  43,
+				InputTokensDetails: &schemas.ResponsesResponseInputTokens{
+					AudioTokens: 28,
+					TextTokens:  1,
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:        schemas.RealtimeRequest,
+				PricingRequestType: schemas.TranscriptionRequest,
+				RoutingInfo:        routingInfoFor(schemas.OpenAI, "gpt-4o-transcribe"),
+			},
+		},
+	}
+
+	breakdown := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, breakdown)
+	assert.InDelta(t, 0.0002125, breakdown.TotalCost, 1e-12)
+	assert.InDelta(t, 0.00007, breakdown.InputCostDetails.AudioCost, 1e-12)
+	assert.InDelta(t, 0.0000025, breakdown.InputCostDetails.TextCost, 1e-12)
+	assert.InDelta(t, 0.00014, breakdown.OutputCostDetails.TextCost, 1e-12)
+}
+
+func TestCalculateCost_RealtimeTranscriptionDurationPricing(t *testing.T) {
+	seconds := 3.4
+	pricing := configstoreTables.TableModelPricing{
+		Model:                      "whisper-1",
+		Provider:                   "openai",
+		Mode:                       "audio_transcription",
+		InputCostPerAudioPerSecond: bifrost.Ptr(0.0001),
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey(pricing.Model, pricing.Provider, pricing.Mode): pricing,
+	})
+	resp := &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			Usage: &schemas.ResponsesResponseUsage{AudioSeconds: &seconds},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:        schemas.RealtimeRequest,
+				PricingRequestType: schemas.TranscriptionRequest,
+				RoutingInfo:        routingInfoFor(schemas.OpenAI, "whisper-1"),
+			},
+		},
+	}
+
+	breakdown := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, breakdown)
+	assert.InDelta(t, 0.00034, breakdown.TotalCost, 1e-12)
+	assert.InDelta(t, 0.00034, breakdown.InputCost, 1e-12)
+}
+
+func TestCalculateCost_RealtimeTranscriptionStreamDurationPricing(t *testing.T) {
+	seconds := 3.4
+	pricing := configstoreTables.TableModelPricing{
+		Model:                      "whisper-1",
+		Provider:                   "openai",
+		Mode:                       "audio_transcription",
+		InputCostPerAudioPerSecond: bifrost.Ptr(0.0001),
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey(pricing.Model, pricing.Provider, pricing.Mode): pricing,
+	})
+	resp := &schemas.BifrostResponse{
+		ResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Response: &schemas.BifrostResponsesResponse{
+				Usage: &schemas.ResponsesResponseUsage{AudioSeconds: &seconds},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:        schemas.RealtimeRequest,
+				PricingRequestType: schemas.TranscriptionRequest,
+				RoutingInfo:        routingInfoFor(schemas.OpenAI, "whisper-1"),
+			},
+		},
+	}
+
+	breakdown := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, breakdown)
+	assert.InDelta(t, 0.00034, breakdown.TotalCost, 1e-12)
+	assert.InDelta(t, 0.00034, breakdown.InputCost, 1e-12)
+}
+
+func TestCalculateCost_RealtimeTranscriptionStreamSplitTokenPricing(t *testing.T) {
+	pricing := configstoreTables.TableModelPricing{
+		Model:                  "gpt-4o-transcribe",
+		Provider:               "openai",
+		Mode:                   "audio_transcription",
+		InputCostPerToken:      bifrost.Ptr(0.0000025),
+		OutputCostPerToken:     bifrost.Ptr(0.00001),
+		InputCostPerAudioToken: bifrost.Ptr(0.0000025),
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey(pricing.Model, pricing.Provider, pricing.Mode): pricing,
+	})
+	resp := &schemas.BifrostResponse{
+		ResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Response: &schemas.BifrostResponsesResponse{
+				Usage: &schemas.ResponsesResponseUsage{
+					InputTokens:  29,
+					OutputTokens: 14,
+					TotalTokens:  43,
+					InputTokensDetails: &schemas.ResponsesResponseInputTokens{
+						AudioTokens: 28,
+						TextTokens:  1,
+					},
+				},
+			},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:        schemas.RealtimeRequest,
+				PricingRequestType: schemas.TranscriptionRequest,
+				RoutingInfo:        routingInfoFor(schemas.OpenAI, "gpt-4o-transcribe"),
+			},
+		},
+	}
+
+	breakdown := s.CalculateCostBreakdown(resp, nil)
+	require.NotNil(t, breakdown)
+	assert.InDelta(t, 0.0002125, breakdown.TotalCost, 1e-12)
+	assert.InDelta(t, 0.00007, breakdown.InputCostDetails.AudioCost, 1e-12)
+	assert.InDelta(t, 0.0000025, breakdown.InputCostDetails.TextCost, 1e-12)
+	assert.InDelta(t, 0.00014, breakdown.OutputCostDetails.TextCost, 1e-12)
+}
+
+func TestCalculateCost_NormalRealtimeDoesNotUseTranscriptionPricing(t *testing.T) {
+	pricing := configstoreTables.TableModelPricing{
+		Model:              "gpt-realtime",
+		Provider:           "openai",
+		Mode:               "responses",
+		InputCostPerToken:  bifrost.Ptr(0.000005),
+		OutputCostPerToken: bifrost.Ptr(0.00002),
+	}
+	s := testStoreWithPricing(map[string]configstoreTables.TableModelPricing{
+		makeKey(pricing.Model, pricing.Provider, pricing.Mode): pricing,
+	})
+	resp := &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			Usage: &schemas.ResponsesResponseUsage{InputTokens: 29, OutputTokens: 14, TotalTokens: 43},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType: schemas.RealtimeRequest,
+				RoutingInfo: routingInfoFor(schemas.OpenAI, "gpt-realtime"),
+			},
+		},
+	}
+
+	assert.InDelta(t, 0.000425, s.CalculateCost(resp, nil), 1e-12)
+}
+
+func TestCalculateCost_RealtimeTranscriptionMissingPricingIsNonFatal(t *testing.T) {
+	s := testStoreWithPricing(nil)
+	resp := &schemas.BifrostResponse{
+		ResponsesResponse: &schemas.BifrostResponsesResponse{
+			Usage: &schemas.ResponsesResponseUsage{InputTokens: 29, OutputTokens: 14, TotalTokens: 43},
+			ExtraFields: schemas.BifrostResponseExtraFields{
+				RequestType:        schemas.RealtimeRequest,
+				PricingRequestType: schemas.TranscriptionRequest,
+				RoutingInfo:        routingInfoFor(schemas.OpenAI, "unknown-transcription-model"),
+			},
+		},
+	}
+
+	assert.Nil(t, s.CalculateCostBreakdown(resp, nil))
+}
 
 // chatPricing returns a TableModelPricing with the given per-token rates.
 func chatPricing(input, output float64) configstoreTables.TableModelPricing {
@@ -124,11 +298,11 @@ func computeRerankCostTotal(pricing *configstoreTables.TableModelPricing, usage 
 	return bcTotal(computeRerankCost(pricing, usage, tier))
 }
 
-func computeSpeechCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTextInputChars int, tier serviceTier) float64 {
+func computeSpeechCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *float64, audioTextInputChars int, tier serviceTier) float64 {
 	return bcTotal(computeSpeechCost(pricing, usage, audioSeconds, audioTextInputChars, tier))
 }
 
-func computeTranscriptionCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *int, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) float64 {
+func computeTranscriptionCostTotal(pricing *configstoreTables.TableModelPricing, usage *schemas.BifrostLLMUsage, audioSeconds *float64, audioTokenDetails *schemas.TranscriptionUsageInputTokenDetails, tier serviceTier) float64 {
 	return bcTotal(computeTranscriptionCost(pricing, usage, audioSeconds, audioTokenDetails, tier))
 }
 
@@ -1259,7 +1433,7 @@ func TestComputeSpeechCost_TokensPreferredOverDuration(t *testing.T) {
 		OutputCostPerToken:  bifrost.Ptr(0.00001),
 		OutputCostPerSecond: bifrost.Ptr(0.00025),
 	}
-	seconds := 60
+	seconds := 60.0
 	usage := &schemas.BifrostLLMUsage{
 		PromptTokens:     100,
 		CompletionTokens: 200,
@@ -1280,7 +1454,7 @@ func TestComputeSpeechCost_OutputFallsBackToPerSecond(t *testing.T) {
 		OutputCostPerToken:  bifrost.Ptr(0.000002),
 		OutputCostPerSecond: bifrost.Ptr(0.0001),
 	}
-	seconds := 120
+	seconds := 120.0
 	usage := &schemas.BifrostLLMUsage{PromptTokens: 500}
 	cost := computeSpeechCostTotal(&p, usage, &seconds, 0, serviceTier{})
 	// Input: 500 * $0.000001 = $0.0005
@@ -1351,7 +1525,7 @@ func TestComputeTranscriptionCost_DurationBased(t *testing.T) {
 		OutputCostPerToken: bifrost.Ptr(0.0),
 		InputCostPerSecond: bifrost.Ptr(0.00010278),
 	}
-	seconds := 300 // 5 minutes
+	seconds := 300.0 // 5 minutes
 	cost := computeTranscriptionCostTotal(&p, nil, &seconds, nil, serviceTier{})
 	// 300 * 0.00010278 = 0.030834
 	assert.InDelta(t, 0.030834, cost, 1e-9)
@@ -1415,7 +1589,7 @@ func TestComputeTranscriptionCost_TokenDetailsPreferredOverDuration(t *testing.T
 		InputCostPerAudioPerSecond: bifrost.Ptr(0.0001),
 		InputCostPerAudioToken:     bifrost.Ptr(0.00001),
 	}
-	seconds := 60
+	seconds := 60.0
 	audioDetails := &schemas.TranscriptionUsageInputTokenDetails{
 		AudioTokens: 5000,
 		TextTokens:  1000,
@@ -1436,7 +1610,7 @@ func TestComputeTranscriptionCost_DurationFallbackWhenNoTokens(t *testing.T) {
 		OutputCostPerToken:         bifrost.Ptr(0.000015),
 		InputCostPerAudioPerSecond: bifrost.Ptr(0.0001),
 	}
-	seconds := 60
+	seconds := 60.0
 	usage := &schemas.BifrostLLMUsage{
 		CompletionTokens: 200,
 		TotalTokens:      200,

--- a/framework/modelcatalog/datasheet/types.go
+++ b/framework/modelcatalog/datasheet/types.go
@@ -333,7 +333,7 @@ type serviceTier struct {
 type costInput struct {
 	usage               *schemas.BifrostLLMUsage
 	audioTextInputChars int
-	audioSeconds        *int
+	audioSeconds        *float64
 	audioTokenDetails   *schemas.TranscriptionUsageInputTokenDetails
 	imageUsage          *schemas.ImageUsage
 	imageSize           string // e.g. "1024x1024", used for per-pixel pricing

--- a/plugins/logging/main.go
+++ b/plugins/logging/main.go
@@ -2134,8 +2134,6 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 	entry.MetadataParsed = mergeRealtimeMetadata(entry.MetadataParsed, ctx)
 	entry.RoutingEngineLogs = routingEngineLogs
 
-	// Branch based on response type to populate output-specific fields
-
 	// Path A: Error with nil result
 	if result == nil && bifrostErr != nil {
 		entry.Status = logStatusForError(bifrostErr)
@@ -2298,6 +2296,13 @@ func (p *LoggerPlugin) PostLLMHook(ctx *schemas.BifrostContext, result *schemas.
 		// surfaced — backfill from bifrostErr.ExtraFields.RawRequest if present.
 		if requestType == schemas.RealtimeRequest {
 			applyRealtimeRawRequestBackfill(entry, bifrostErr.ExtraFields.RawRequest, contentLoggingEnabled, shouldStoreRaw)
+			// A guardrail can block delivery after the provider completed the
+			// turn. The completed response survives alongside the error; keep
+			// the error status but retain the billed output, usage, and raw
+			// payloads so logs and accounting reflect the provider work.
+			if result != nil {
+				p.applyRealtimeOutputToEntry(entry, result, shouldStoreRaw, contentLoggingEnabled)
+			}
 		}
 	} else if result != nil {
 		entry.Status = logStatusSuccess

--- a/transports/bifrost-http/handlers/middlewares_test.go
+++ b/transports/bifrost-http/handlers/middlewares_test.go
@@ -463,9 +463,7 @@ func TestIsRealtimeTransportEndpoint(t *testing.T) {
 
 	nonTransportPaths := []string{
 		"/v1/realtime/client_secrets",
-		"/v1/realtime/sessions",
 		"/openai/v1/realtime/client_secrets",
-		"/openai/v1/realtime/sessions",
 		"/v1/chat/completions",
 	}
 
@@ -885,7 +883,6 @@ func TestAuthMiddleware_InferenceMiddleware_DelegatesAuthToGovernance(t *testing
 		{name: "chat completion with virtual key", uri: "/v1/chat/completions", headerKey: "x-bf-vk", headerVal: "sk-bf-abc123"},
 		{name: "chat completion without credentials", uri: "/v1/chat/completions"},
 		{name: "realtime minting (client_secrets)", uri: "/v1/realtime/client_secrets"},
-		{name: "realtime minting (sessions)", uri: "/openai/v1/realtime/sessions"},
 	}
 
 	for _, tc := range cases {

--- a/transports/bifrost-http/handlers/realtime_client_secrets.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets.go
@@ -87,8 +87,8 @@ func (h *RealtimeClientSecretsHandler) handleRequest(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	logger.Info("[realtime-client-secrets] request: path=%s provider=%s model=%s endpoint_type=%s",
-		string(ctx.Path()), providerKey, model, route.EndpointType)
+	logger.Info("[realtime-client-secrets] request: path=%s provider=%s model=%s",
+		string(ctx.Path()), providerKey, model)
 
 	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
@@ -152,7 +152,7 @@ func (h *RealtimeClientSecretsHandler) handleRequest(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	resp, bifrostErr := sessionProvider.CreateRealtimeClientSecret(bifrostCtx, key, route.EndpointType, normalizedBody)
+	resp, bifrostErr := sessionProvider.CreateRealtimeClientSecret(bifrostCtx, key, normalizedBody)
 	if bifrostErr != nil {
 		logger.Error("[realtime-client-secrets] upstream error: provider=%s model=%s error=%s",
 			providerKey, model, bifrostErr.Error)
@@ -194,24 +194,12 @@ func (h *RealtimeClientSecretsHandler) evaluateMintingGovernance(
 
 func (h *RealtimeClientSecretsHandler) realtimeSessionRoutes() []schemas.RealtimeSessionRoute {
 	routes := []schemas.RealtimeSessionRoute{
-		{
-			Path:         "/v1/realtime/client_secrets",
-			EndpointType: schemas.RealtimeSessionEndpointClientSecrets,
-		},
-		{
-			Path:         "/v1/realtime/sessions",
-			EndpointType: schemas.RealtimeSessionEndpointSessions,
-		},
+		{Path: "/v1/realtime/client_secrets"},
 	}
 
 	for _, path := range integrations.OpenAIRealtimeClientSecretPaths("/openai") {
-		endpointType := schemas.RealtimeSessionEndpointClientSecrets
-		if strings.HasSuffix(path, "/realtime/sessions") {
-			endpointType = schemas.RealtimeSessionEndpointSessions
-		}
 		routes = append(routes, schemas.RealtimeSessionRoute{
 			Path:            path,
-			EndpointType:    endpointType,
 			DefaultProvider: schemas.OpenAI,
 		})
 	}

--- a/transports/bifrost-http/handlers/realtime_client_secrets_test.go
+++ b/transports/bifrost-http/handlers/realtime_client_secrets_test.go
@@ -16,6 +16,23 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
+func TestRealtimeSessionRoutesOnlyExposeGAClientSecrets(t *testing.T) {
+	handler := &RealtimeClientSecretsHandler{}
+	routes := handler.realtimeSessionRoutes()
+	want := map[string]bool{
+		"/v1/realtime/client_secrets":        true,
+		"/openai/v1/realtime/client_secrets": true,
+	}
+	if len(routes) != len(want) {
+		t.Fatalf("routes = %v, want exactly %d GA routes", routes, len(want))
+	}
+	for _, route := range routes {
+		if !want[route.Path] {
+			t.Fatalf("unexpected realtime client secret route %q", route.Path)
+		}
+	}
+}
+
 func TestResolveRealtimeClientSecretTarget(t *testing.T) {
 	t.Parallel()
 
@@ -29,40 +46,33 @@ func TestResolveRealtimeClientSecretTarget(t *testing.T) {
 	}{
 		{
 			name:         "base route with session model",
-			route:        schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets},
+			route:        schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets"},
 			body:         []byte(`{"session":{"model":"openai/gpt-4o-realtime-preview"}}`),
 			wantProvider: schemas.OpenAI,
 			wantModel:    "gpt-4o-realtime-preview",
 		},
 		{
-			name:         "base route with top level model",
-			route:        schemas.RealtimeSessionRoute{Path: "/v1/realtime/sessions", EndpointType: schemas.RealtimeSessionEndpointSessions},
-			body:         []byte(`{"model":"openai/gpt-4o-realtime-preview"}`),
-			wantProvider: schemas.OpenAI,
-			wantModel:    "gpt-4o-realtime-preview",
-		},
-		{
 			name:         "openai alias uses bare model",
-			route:        schemas.RealtimeSessionRoute{Path: "/openai/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets, DefaultProvider: schemas.OpenAI},
+			route:        schemas.RealtimeSessionRoute{Path: "/openai/v1/realtime/client_secrets", DefaultProvider: schemas.OpenAI},
 			body:         []byte(`{"session":{"model":"gpt-4o-realtime-preview"}}`),
 			wantProvider: schemas.OpenAI,
 			wantModel:    "gpt-4o-realtime-preview",
 		},
 		{
 			name:    "base route rejects bare model",
-			route:   schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets},
+			route:   schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets"},
 			body:    []byte(`{"session":{"model":"gpt-4o-realtime-preview"}}`),
 			wantErr: true,
 		},
 		{
 			name:    "missing model",
-			route:   schemas.RealtimeSessionRoute{Path: "/openai/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets, DefaultProvider: schemas.OpenAI},
+			route:   schemas.RealtimeSessionRoute{Path: "/openai/v1/realtime/client_secrets", DefaultProvider: schemas.OpenAI},
 			body:    []byte(`{"session":{}}`),
 			wantErr: true,
 		},
 		{
 			name:         "GA transcription session resolves model from nested audio path",
-			route:        schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets},
+			route:        schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets"},
 			body:         []byte(`{"session":{"type":"transcription","audio":{"input":{"transcription":{"model":"openai/gpt-4o-transcribe"}}}}}`),
 			wantProvider: schemas.OpenAI,
 			wantModel:    "gpt-4o-transcribe",
@@ -105,19 +115,13 @@ func TestResolveRealtimeClientSecretTarget_NormalizesModel(t *testing.T) {
 	}{
 		{
 			name:      "session.model provider prefix stripped",
-			route:     schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets},
+			route:     schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets"},
 			body:      `{"session":{"model":"openai/gpt-4o-realtime-preview","voice":"alloy"}}`,
 			wantModel: "gpt-4o-realtime-preview",
 		},
 		{
-			name:      "top-level model provider prefix stripped",
-			route:     schemas.RealtimeSessionRoute{Path: "/v1/realtime/sessions", EndpointType: schemas.RealtimeSessionEndpointSessions},
-			body:      `{"model":"openai/gpt-4o-realtime-preview"}`,
-			wantModel: "gpt-4o-realtime-preview",
-		},
-		{
 			name:      "bare model unchanged on alias route",
-			route:     schemas.RealtimeSessionRoute{Path: "/openai/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets, DefaultProvider: schemas.OpenAI},
+			route:     schemas.RealtimeSessionRoute{Path: "/openai/v1/realtime/client_secrets", DefaultProvider: schemas.OpenAI},
 			body:      `{"session":{"model":"gpt-4o-realtime-preview"}}`,
 			wantModel: "gpt-4o-realtime-preview",
 		},
@@ -181,7 +185,7 @@ func TestGATranscriptionSessionEndToEndThroughFullNormalizationPath(t *testing.T
 	t.Parallel()
 
 	var ctx fasthttp.RequestCtx
-	route := schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets}
+	route := schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets"}
 	body := []byte(`{"session":{"type":"transcription","audio":{"input":{"format":{"type":"audio/pcm","rate":24000},"transcription":{"model":"openai/whisper-1","language":"en"}}}}}`)
 
 	providerKey, model, handlerBody, err := resolveRealtimeClientSecretTarget(&ctx, &lib.Config{}, route, body)
@@ -192,7 +196,7 @@ func TestGATranscriptionSessionEndToEndThroughFullNormalizationPath(t *testing.T
 		t.Fatalf("provider/model = %q/%q, want %q/%q", providerKey, model, schemas.OpenAI, "whisper-1")
 	}
 
-	finalBody, finalModel, bifrostErr := openaiProvider.NormalizeRealtimeClientSecretRequest(handlerBody, schemas.OpenAI, schemas.RealtimeSessionEndpointClientSecrets)
+	finalBody, finalModel, bifrostErr := openaiProvider.NormalizeRealtimeClientSecretRequest(handlerBody, schemas.OpenAI)
 	if bifrostErr != nil {
 		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
 	}
@@ -245,7 +249,7 @@ func TestFullRealtimeSessionWithTranscriptionSiblingEndToEnd(t *testing.T) {
 	t.Parallel()
 
 	var ctx fasthttp.RequestCtx
-	route := schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets", EndpointType: schemas.RealtimeSessionEndpointClientSecrets}
+	route := schemas.RealtimeSessionRoute{Path: "/v1/realtime/client_secrets"}
 	body := []byte(`{"model":"openai/gpt-4o-realtime-preview","session":{"audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}}`)
 
 	providerKey, model, handlerBody, err := resolveRealtimeClientSecretTarget(&ctx, &lib.Config{}, route, body)
@@ -256,7 +260,7 @@ func TestFullRealtimeSessionWithTranscriptionSiblingEndToEnd(t *testing.T) {
 		t.Fatalf("provider/model = %q/%q, want %q/%q", providerKey, model, schemas.OpenAI, "gpt-4o-realtime-preview")
 	}
 
-	finalBody, finalModel, bifrostErr := openaiProvider.NormalizeRealtimeClientSecretRequest(handlerBody, schemas.OpenAI, schemas.RealtimeSessionEndpointClientSecrets)
+	finalBody, finalModel, bifrostErr := openaiProvider.NormalizeRealtimeClientSecretRequest(handlerBody, schemas.OpenAI)
 	if bifrostErr != nil {
 		t.Fatalf("NormalizeRealtimeClientSecretRequest() error = %v", bifrostErr)
 	}

--- a/transports/bifrost-http/handlers/realtime_logging_test.go
+++ b/transports/bifrost-http/handlers/realtime_logging_test.go
@@ -10,6 +10,63 @@ import (
 	bfws "github.com/maximhq/bifrost/transports/bifrost-http/websocket"
 )
 
+func TestRealtimeTurnFinalEventUsesTranscriptionCompletionOnlyForTranscriptionSessions(t *testing.T) {
+	t.Parallel()
+
+	provider := &openai.OpenAIProvider{}
+	if got := realtimeTurnFinalEvent(provider, false); got != schemas.RTEventResponseDone {
+		t.Fatalf("normal final event = %q, want %q", got, schemas.RTEventResponseDone)
+	}
+	if got := realtimeTurnFinalEvent(provider, true); got != schemas.RTEventInputAudioTransCompleted {
+		t.Fatalf("transcription final event = %q, want %q", got, schemas.RTEventInputAudioTransCompleted)
+	}
+}
+
+func TestRealtimeTurnCompletionContentModelsTranscriptAsOutputOnlyForTranscriptionSessions(t *testing.T) {
+	t.Parallel()
+
+	event := &schemas.BifrostRealtimeEvent{
+		Type: schemas.RTEventInputAudioTransCompleted,
+		ExtraParams: map[string]json.RawMessage{
+			"item_id":    json.RawMessage(`"item_123"`),
+			"transcript": json.RawMessage(`"spoken user turn"`),
+		},
+	}
+
+	transcriptionSession := bfws.NewSession(nil)
+	inputItemID, inputSummary, output := realtimeTurnCompletionContent(transcriptionSession, event, true)
+	if inputItemID != "" || inputSummary != "" || output != "spoken user turn" {
+		t.Fatalf("transcription completion = (%q, %q, %q), want (empty, empty, transcript)", inputItemID, inputSummary, output)
+	}
+
+	normalSession := bfws.NewSession(nil)
+	normalSession.AppendRealtimeOutputText("assistant response")
+	inputItemID, inputSummary, output = realtimeTurnCompletionContent(normalSession, event, false)
+	if inputItemID != "item_123" || inputSummary != "spoken user turn" || output != "assistant response" {
+		t.Fatalf("normal completion = (%q, %q, %q), want input transcript and assistant output", inputItemID, inputSummary, output)
+	}
+}
+
+func TestBuildRealtimeTurnPostResponseModelsTranscriptionAsOutput(t *testing.T) {
+	t.Parallel()
+
+	rawResponse := []byte(`{"type":"conversation.item.input_audio_transcription.completed","transcript":"spoken user turn","usage":{"total_tokens":11}}`)
+	resp := buildRealtimeTurnPostResponse(&openai.OpenAIProvider{}, schemas.OpenAI, "gpt-4o-transcribe", `{"type":"input_audio_buffer.commit"}`, rawResponse, "spoken user turn", 123, true)
+	if resp == nil || resp.ResponsesResponse == nil || len(resp.ResponsesResponse.Output) != 1 {
+		t.Fatalf("response = %#v, want one transcription output", resp)
+	}
+	if resp.ResponsesResponse.ExtraFields.RequestType != schemas.RealtimeRequest {
+		t.Fatalf("request type = %q, want realtime", resp.ResponsesResponse.ExtraFields.RequestType)
+	}
+	if resp.ResponsesResponse.ExtraFields.PricingRequestType != schemas.TranscriptionRequest {
+		t.Fatalf("pricing request type = %q, want transcription", resp.ResponsesResponse.ExtraFields.PricingRequestType)
+	}
+	output := resp.ResponsesResponse.Output[0]
+	if output.Content == nil || output.Content.ContentStr == nil || *output.Content.ContentStr != "spoken user turn" {
+		t.Fatalf("output content = %#v, want completed transcript", output.Content)
+	}
+}
+
 func TestBuildRealtimeTurnPreRequestIncludesResponseCreateContent(t *testing.T) {
 	t.Parallel()
 
@@ -382,9 +439,12 @@ func TestBuildRealtimeTurnPostResponseUsesFullResponseDonePayload(t *testing.T) 
 		}
 	}`)
 
-	resp := buildRealtimeTurnPostResponse(&openai.OpenAIProvider{}, schemas.OpenAI, "gpt-4o-realtime-preview-2025-06-03", rawRequest, rawResponse, "", 4321)
+	resp := buildRealtimeTurnPostResponse(&openai.OpenAIProvider{}, schemas.OpenAI, "gpt-4o-realtime-preview-2025-06-03", rawRequest, rawResponse, "", 4321, false)
 	if resp == nil || resp.ResponsesResponse == nil {
 		t.Fatal("expected realtime post response to be built")
+	}
+	if resp.ResponsesResponse.ExtraFields.PricingRequestType != "" {
+		t.Fatalf("PricingRequestType = %q, want empty for normal realtime", resp.ResponsesResponse.ExtraFields.PricingRequestType)
 	}
 	if resp.ResponsesResponse.ExtraFields.Latency != 4321 {
 		t.Fatalf("Latency = %d, want %d", resp.ResponsesResponse.ExtraFields.Latency, 4321)
@@ -427,7 +487,7 @@ func TestBuildRealtimeTurnPostResponseMergesTextAndToolCalls(t *testing.T) {
 		}
 	}`)
 
-	resp := buildRealtimeTurnPostResponse(&openai.OpenAIProvider{}, schemas.OpenAI, "gpt-realtime", "", rawResponse, "", 123)
+	resp := buildRealtimeTurnPostResponse(&openai.OpenAIProvider{}, schemas.OpenAI, "gpt-realtime", "", rawResponse, "", 123, false)
 	if resp == nil || resp.ResponsesResponse == nil {
 		t.Fatal("expected realtime post response")
 	}

--- a/transports/bifrost-http/handlers/realtime_turn_pipeline.go
+++ b/transports/bifrost-http/handlers/realtime_turn_pipeline.go
@@ -288,6 +288,7 @@ func buildRealtimeTurnPostResponse(
 	rawResponse []byte,
 	contentOverride string,
 	latency int64,
+	transcriptionSession bool,
 ) *schemas.BifrostResponse {
 	output := buildRealtimeTurnOutputMessages(rtProvider, rawResponse, contentOverride)
 	resp := &schemas.BifrostResponsesResponse{
@@ -300,6 +301,9 @@ func buildRealtimeTurnPostResponse(
 			OriginalModelRequested: model,
 			Latency:                latency,
 		},
+	}
+	if transcriptionSession {
+		resp.ExtraFields.PricingRequestType = schemas.TranscriptionRequest
 	}
 	if usage := extractRealtimeTurnUsage(rtProvider, rawResponse); usage != nil {
 		resp.Usage = buildRealtimeResponsesUsage(usage)
@@ -491,6 +495,7 @@ func buildRealtimeResponsesUsage(usage *schemas.BifrostLLMUsage) *schemas.Respon
 		InputTokens:  usage.PromptTokens,
 		OutputTokens: usage.CompletionTokens,
 		TotalTokens:  usage.TotalTokens,
+		AudioSeconds: usage.AudioSeconds,
 	}
 	if usage.PromptTokensDetails != nil {
 		result.InputTokensDetails = &schemas.ResponsesResponseInputTokens{
@@ -711,6 +716,8 @@ func finalizeRealtimeTurnHooks(
 	key *schemas.Key,
 	rawResponse []byte,
 	contentOverride string,
+	terminalEventType schemas.RealtimeEventType,
+	transcriptionSession bool,
 ) *schemas.BifrostError {
 	if client == nil || session == nil {
 		return nil
@@ -733,8 +740,9 @@ func finalizeRealtimeTurnHooks(
 			rawResponse,
 			contentOverride,
 			time.Since(activeHooks.StartedAt).Milliseconds(),
+			transcriptionSession,
 		)
-		postCtx := newRealtimeTurnContext(baseCtx, activeHooks.RequestID, session.ID(), session.ProviderSessionID(), realtimeTurnSourceLM, rtProvider.RealtimeTurnFinalEvent(), key)
+		postCtx := newRealtimeTurnContext(baseCtx, activeHooks.RequestID, session.ID(), session.ProviderSessionID(), realtimeTurnSourceLM, terminalEventType, key)
 		applyRealtimeTurnContextValues(postCtx, activeHooks.PreHookValues)
 		restoreRealtimeTurnTraceContext(postCtx, activeHooks.TraceID, activeHooks.PreHookValues)
 		applyRealtimeRawStorageContext(postCtx, activeHooks.RawStore)
@@ -769,8 +777,9 @@ func finalizeRealtimeTurnHooks(
 		rawResponse,
 		contentOverride,
 		time.Since(startedAt).Milliseconds(),
+		transcriptionSession,
 	)
-	postCtx := newRealtimeTurnContext(baseCtx, requestID, session.ID(), session.ProviderSessionID(), realtimeTurnSourceLM, rtProvider.RealtimeTurnFinalEvent(), key)
+	postCtx := newRealtimeTurnContext(baseCtx, requestID, session.ID(), session.ProviderSessionID(), realtimeTurnSourceLM, terminalEventType, key)
 	applyRealtimeTurnContextValues(postCtx, preHookValues)
 	restoreRealtimeTurnTraceContext(postCtx, traceID, preHookValues)
 	applyRealtimeRawStorageContext(postCtx, storeRaw)

--- a/transports/bifrost-http/handlers/webrtc_realtime.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime.go
@@ -112,7 +112,7 @@ func (h *WebRTCRealtimeHandler) handleRequest(ctx *fasthttp.RequestCtx) {
 // Raw SDP bodies (application/sdp) fall back to ?model= for the legacy
 // raw-SDP path only; the multipart contract has no ?model= fallback.
 func (h *WebRTCRealtimeHandler) handleCallsRequest(ctx *fasthttp.RequestCtx) {
-	sdpOffer, providerKey, model, normalizedSession, bifrostErr := parseCallsWebRTCRequest(ctx, h.config)
+	sdpOffer, providerKey, model, normalizedSession, transcriptionSession, bifrostErr := parseCallsWebRTCRequest(ctx, h.config)
 	if bifrostErr != nil {
 		SendBifrostError(ctx, bifrostErr)
 		return
@@ -124,46 +124,46 @@ func (h *WebRTCRealtimeHandler) handleCallsRequest(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
-	exchangeSDP := func(rCtx *schemas.BifrostContext, key schemas.Key, upstreamOffer string) (string, *schemas.BifrostError) {
-		return rtProvider.ExchangeRealtimeWebRTCSDP(rCtx, key, model, upstreamOffer, normalizedSession)
+	exchangeSDP := func(rCtx *schemas.BifrostContext, key schemas.Key, upstreamOffer string, session []byte) (string, *schemas.BifrostError) {
+		return rtProvider.ExchangeRealtimeWebRTCSDP(rCtx, key, model, upstreamOffer, session)
 	}
 
-	h.runWebRTCRelay(ctx, rtProvider, providerKey, model, sdpOffer, exchangeSDP)
+	h.runWebRTCRelay(ctx, rtProvider, providerKey, model, sdpOffer, normalizedSession, transcriptionSession, exchangeSDP)
 }
 
-func parseCallsWebRTCRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (string, schemas.ModelProvider, string, []byte, *schemas.BifrostError) {
+func parseCallsWebRTCRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (string, schemas.ModelProvider, string, []byte, bool, *schemas.BifrostError) {
 	contentType := strings.ToLower(string(ctx.Request.Header.ContentType()))
 	path := string(ctx.Path())
 	if strings.HasPrefix(contentType, "multipart/form-data") {
 		form, err := ctx.MultipartForm()
 		if err != nil {
-			return "", "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "failed to parse multipart form", err)
+			return "", "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "failed to parse multipart form", err)
 		}
 
 		sdpOffer := firstMultipartValue(form.Value, "sdp")
 		if strings.TrimSpace(sdpOffer) == "" {
-			return "", "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "sdp form field is required", nil)
+			return "", "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "sdp form field is required", nil)
 		}
 
 		sessionField := firstMultipartValue(form.Value, "session")
 		if strings.TrimSpace(sessionField) == "" {
-			return "", "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session form field is required", nil)
+			return "", "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session form field is required", nil)
 		}
-		providerKey, model, normalizedSession, bifrostErr := resolveRealtimeSDPTarget(ctx, config, path, []byte(sessionField))
+		providerKey, model, normalizedSession, transcriptionSession, bifrostErr := resolveRealtimeSDPTarget(ctx, config, path, []byte(sessionField))
 		if bifrostErr != nil {
-			return "", "", "", nil, bifrostErr
+			return "", "", "", nil, false, bifrostErr
 		}
-		return sdpOffer, providerKey, model, normalizedSession, nil
+		return sdpOffer, providerKey, model, normalizedSession, transcriptionSession, nil
 	}
 
 	sdpOffer := string(ctx.Request.Body())
 	if strings.TrimSpace(sdpOffer) == "" {
-		return "", "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "SDP is required", nil)
+		return "", "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "SDP is required", nil)
 	}
 
 	rawModel := strings.TrimSpace(string(ctx.QueryArgs().Peek("model")))
 	if rawModel == "" {
-		return "", "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "model query param is required", nil)
+		return "", "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "model query param is required", nil)
 	}
 
 	providerKey, model := schemas.ParseModelString(rawModel, realtimeDefaultProviderForPath(path))
@@ -181,12 +181,12 @@ func parseCallsWebRTCRequest(ctx *fasthttp.RequestCtx, config *lib.Config) (stri
 	}
 	if providerKey == "" || strings.TrimSpace(model) == "" {
 		if realtimeDefaultProviderForPath(path) == "" {
-			return "", "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "model must use provider/model on /v1 realtime routes", nil)
+			return "", "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "model must use provider/model on /v1 realtime routes", nil)
 		}
-		return "", "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "invalid model: "+rawModel, nil)
+		return "", "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "invalid model: "+rawModel, nil)
 	}
 
-	return sdpOffer, providerKey, model, nil, nil
+	return sdpOffer, providerKey, model, nil, false, nil
 }
 
 // handleLegacyRequest handles the beta /realtime endpoint.
@@ -238,11 +238,11 @@ func (h *WebRTCRealtimeHandler) handleLegacyRequest(ctx *fasthttp.RequestCtx, de
 		}
 	}
 
-	exchangeSDP := func(rCtx *schemas.BifrostContext, key schemas.Key, upstreamOffer string) (string, *schemas.BifrostError) {
+	exchangeSDP := func(rCtx *schemas.BifrostContext, key schemas.Key, upstreamOffer string, _ []byte) (string, *schemas.BifrostError) {
 		return legacyProvider.ExchangeLegacyRealtimeWebRTCSDP(rCtx, key, upstreamOffer, sessionJSON, model)
 	}
 
-	h.runWebRTCRelay(ctx, rtProvider, providerKey, model, sdpOffer, exchangeSDP)
+	h.runWebRTCRelay(ctx, rtProvider, providerKey, model, sdpOffer, sessionJSON, false, exchangeSDP)
 }
 
 // parseLegacyWebRTCRequest extracts SDP, model, and optional session from a legacy request.
@@ -291,7 +291,9 @@ func (h *WebRTCRealtimeHandler) runWebRTCRelay(
 	providerKey schemas.ModelProvider,
 	model string,
 	sdpOffer string,
-	exchangeSDP func(ctx *schemas.BifrostContext, key schemas.Key, upstreamOffer string) (string, *schemas.BifrostError),
+	sessionJSON []byte,
+	transcriptionSession bool,
+	exchangeSDP func(ctx *schemas.BifrostContext, key schemas.Key, upstreamOffer string, session []byte) (string, *schemas.BifrostError),
 ) {
 	bifrostCtx, cancel := lib.ConvertToBifrostContext(ctx, h.handlerStore)
 	defer cancel()
@@ -330,18 +332,27 @@ func (h *WebRTCRealtimeHandler) runWebRTCRelay(
 		model = authKey.Aliases.Resolve(model)
 	}
 
+	if transcriptionSession {
+		var normalizeErr *schemas.BifrostError
+		sessionJSON, normalizeErr = pinRealtimeSDPTranscriptionModel(sessionJSON, model)
+		if normalizeErr != nil {
+			SendBifrostError(ctx, normalizeErr)
+			return
+		}
+	}
+
 	// Compute raw storage flag from provider config + per-request header overrides.
 	// Normal inference computes this inside bifrost.executeRequest, which is bypassed
 	// for realtime WebRTC connections.
 	applyRealtimeRawStorageContext(bifrostCtx, h.client.ComputeRawStorageForProvider(bifrostCtx, providerKey))
 
 	boundExchange := func(rCtx *schemas.BifrostContext, upstreamOffer string) (string, *schemas.BifrostError) {
-		return exchangeSDP(rCtx, authKey, upstreamOffer)
+		return exchangeSDP(rCtx, authKey, upstreamOffer, sessionJSON)
 	}
 
 	relayCtx, relayCancel := newRealtimeRelayContext(bifrostCtx)
 	session := bfws.NewSession(nil)
-	browserAnswer, relayErr := h.establishRelay(relayCtx, relayCancel, session, rtProvider, providerKey, model, selectedKey, sdpOffer, boundExchange)
+	browserAnswer, relayErr := h.establishRelay(relayCtx, relayCancel, session, rtProvider, providerKey, model, selectedKey, sdpOffer, transcriptionSession, boundExchange)
 	if relayErr != nil {
 		relayCancel()
 		SendBifrostError(ctx, relayErr)
@@ -506,6 +517,7 @@ func (h *WebRTCRealtimeHandler) establishRelay(
 	model string,
 	key *schemas.Key,
 	browserOffer string,
+	transcriptionSession bool,
 	exchangeSDP func(ctx *schemas.BifrostContext, upstreamOffer string) (string, *schemas.BifrostError),
 ) (string, *schemas.BifrostError) {
 	downstreamPC, err := newRealtimePeerConnection()
@@ -519,16 +531,17 @@ func (h *WebRTCRealtimeHandler) establishRelay(
 	}
 
 	relay := &webrtcRealtimeRelay{
-		client:       h.client,
-		downstreamPC: downstreamPC,
-		upstreamPC:   upstreamPC,
-		session:      session,
-		bifrostCtx:   relayCtx,
-		cancel:       relayCancel,
-		provider:     provider,
-		providerKey:  providerKey,
-		model:        model,
-		key:          key,
+		client:               h.client,
+		downstreamPC:         downstreamPC,
+		upstreamPC:           upstreamPC,
+		session:              session,
+		bifrostCtx:           relayCtx,
+		cancel:               relayCancel,
+		provider:             provider,
+		providerKey:          providerKey,
+		model:                model,
+		key:                  key,
+		transcriptionSession: transcriptionSession,
 	}
 	relay.onClose = func() {
 		h.unregisterRelay(session.ID())
@@ -627,14 +640,15 @@ type webrtcRealtimeRelay struct {
 	providerToBrowserTrack *webrtc.TrackLocalStaticRTP
 	browserToProviderTrack *webrtc.TrackLocalStaticRTP
 
-	session     *bfws.Session
-	bifrostCtx  *schemas.BifrostContext
-	cancel      context.CancelFunc
-	provider    schemas.RealtimeProvider
-	providerKey schemas.ModelProvider
-	model       string
-	key         *schemas.Key
-	onClose     func()
+	session              *bfws.Session
+	bifrostCtx           *schemas.BifrostContext
+	cancel               context.CancelFunc
+	provider             schemas.RealtimeProvider
+	providerKey          schemas.ModelProvider
+	model                string
+	key                  *schemas.Key
+	transcriptionSession bool
+	onClose              func()
 
 	closeOnce sync.Once
 
@@ -937,9 +951,13 @@ func (r *webrtcRealtimeRelay) handleUpstreamMessage(msg webrtc.DataChannelMessag
 		if !r.provider.ShouldForwardRealtimeEvent(event) {
 			return
 		}
-		if event.Type == r.provider.RealtimeTurnFinalEvent() {
-			contentOverride := r.session.ConsumeRealtimeOutputText()
-			if bifrostErr := finalizeRealtimeTurnHooks(r.client, r.bifrostCtx, r.session, r.provider, r.providerKey, r.model, r.key, msg.Data, contentOverride); bifrostErr != nil {
+		terminalEventType := realtimeTurnFinalEvent(r.provider, r.transcriptionSession)
+		if event.Type == terminalEventType {
+			inputItemID, inputSummary, contentOverride := realtimeTurnCompletionContent(r.session, event, r.transcriptionSession)
+			if inputSummary != "" {
+				r.session.RecordRealtimeInput(inputItemID, inputSummary, string(msg.Data))
+			}
+			if bifrostErr := finalizeRealtimeTurnHooks(r.client, r.bifrostCtx, r.session, r.provider, r.providerKey, r.model, r.key, msg.Data, contentOverride, terminalEventType, r.transcriptionSession); bifrostErr != nil {
 				r.closeWithErrorEvent(newRealtimeTurnErrorEventPayload(bifrostErr))
 				return
 			}
@@ -1247,20 +1265,25 @@ func sendDataChannelMessage(dc *webrtc.DataChannel, payload []byte, isString boo
 	}
 }
 
-func resolveRealtimeSDPTarget(ctx *fasthttp.RequestCtx, config *lib.Config, path string, sessionJSON []byte) (schemas.ModelProvider, string, []byte, *schemas.BifrostError) {
+func resolveRealtimeSDPTarget(ctx *fasthttp.RequestCtx, config *lib.Config, path string, sessionJSON []byte) (schemas.ModelProvider, string, []byte, bool, *schemas.BifrostError) {
 	root, err := schemas.ParseRealtimeClientSecretBody(sessionJSON)
 	if err != nil {
-		return "", "", nil, err
+		return "", "", nil, false, err
 	}
 
-	modelJSON, ok := root["model"]
-	if !ok {
-		return "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.model is required", nil)
+	modelJSON, hasRootModel := root["model"]
+	transcriptionSession := false
+	if !hasRootModel {
+		modelJSON = nestedRealtimeTranscriptionModel(root)
+		transcriptionSession = len(modelJSON) > 0
+	}
+	if len(modelJSON) == 0 {
+		return "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.model or session.audio.input.transcription.model is required", nil)
 	}
 
 	var rawModel string
 	if err := json.Unmarshal(modelJSON, &rawModel); err != nil {
-		return "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.model must be a string", err)
+		return "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.model must be a string", err)
 	}
 
 	providerKey, model := schemas.ParseModelString(strings.TrimSpace(rawModel), realtimeDefaultProviderForPath(path))
@@ -1278,23 +1301,61 @@ func resolveRealtimeSDPTarget(ctx *fasthttp.RequestCtx, config *lib.Config, path
 	}
 	if providerKey == "" || strings.TrimSpace(model) == "" {
 		if realtimeDefaultProviderForPath(path) == "" {
-			return "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.model must use provider/model on /v1 realtime routes", nil)
+			return "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.model must use provider/model on /v1 realtime routes", nil)
 		}
-		return "", "", nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.model is required", nil)
+		return "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.model is required", nil)
 	}
 
 	normalizedModel, marshalErr := json.Marshal(model)
 	if marshalErr != nil {
-		return "", "", nil, newRealtimeWebRTCError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized session model", marshalErr)
+		return "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized session model", marshalErr)
 	}
-	root["model"] = normalizedModel
-	openai.StripNestedModelPrefixes(root)
+	if transcriptionSession {
+		root["type"] = json.RawMessage(`"transcription"`)
+	} else {
+		root["model"] = normalizedModel
+		openai.StripNestedModelPrefixes(root)
+	}
 	normalizedSession, marshalErr := json.Marshal(root)
 	if marshalErr != nil {
-		return "", "", nil, newRealtimeWebRTCError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized realtime session", marshalErr)
+		return "", "", nil, false, newRealtimeWebRTCError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized realtime session", marshalErr)
 	}
 
-	return providerKey, strings.TrimSpace(model), normalizedSession, nil
+	return providerKey, strings.TrimSpace(model), normalizedSession, transcriptionSession, nil
+}
+
+func nestedRealtimeTranscriptionModel(root map[string]json.RawMessage) json.RawMessage {
+	var audio struct {
+		Input struct {
+			Transcription map[string]json.RawMessage `json:"transcription"`
+		} `json:"input"`
+	}
+	if json.Unmarshal(root["audio"], &audio) != nil {
+		return nil
+	}
+	return audio.Input.Transcription["model"]
+}
+
+func pinRealtimeSDPTranscriptionModel(sessionJSON []byte, model string) ([]byte, *schemas.BifrostError) {
+	root, err := schemas.ParseRealtimeClientSecretBody(sessionJSON)
+	if err != nil {
+		return nil, err
+	}
+	var audio map[string]json.RawMessage
+	var input map[string]json.RawMessage
+	var transcription map[string]json.RawMessage
+	if json.Unmarshal(root["audio"], &audio) != nil || json.Unmarshal(audio["input"], &input) != nil || json.Unmarshal(input["transcription"], &transcription) != nil {
+		return nil, newRealtimeWebRTCError(fasthttp.StatusBadRequest, "invalid_request_error", "session.audio.input.transcription must be an object", nil)
+	}
+	transcription["model"] = json.RawMessage(strconv.Quote(model))
+	input["transcription"], _ = json.Marshal(transcription)
+	audio["input"], _ = json.Marshal(input)
+	root["audio"], _ = json.Marshal(audio)
+	normalized, marshalErr := json.Marshal(root)
+	if marshalErr != nil {
+		return nil, newRealtimeWebRTCError(fasthttp.StatusInternalServerError, "server_error", "failed to encode normalized realtime session", marshalErr)
+	}
+	return normalized, nil
 }
 
 func firstMultipartValue(values map[string][]string, key string) string {

--- a/transports/bifrost-http/handlers/webrtc_realtime_test.go
+++ b/transports/bifrost-http/handlers/webrtc_realtime_test.go
@@ -47,7 +47,7 @@ func (s testHandlerStore) GetMCPExternalClientURL() string                  { re
 func TestResolveRealtimeSDPTarget_BaseRouteRequiresProviderPrefix(t *testing.T) {
 	var ctx fasthttp.RequestCtx
 	cfg := &lib.Config{}
-	_, _, _, err := resolveRealtimeSDPTarget(&ctx, cfg, "/v1/realtime", []byte(`{"model":"gpt-4o-realtime-preview"}`))
+	_, _, _, _, err := resolveRealtimeSDPTarget(&ctx, cfg, "/v1/realtime", []byte(`{"model":"gpt-4o-realtime-preview"}`))
 	if err == nil {
 		t.Fatal("expected provider/model validation error")
 	}
@@ -59,9 +59,12 @@ func TestResolveRealtimeSDPTarget_BaseRouteRequiresProviderPrefix(t *testing.T) 
 func TestResolveRealtimeSDPTarget_BaseRouteNormalizesModel(t *testing.T) {
 	var ctx fasthttp.RequestCtx
 	cfg := &lib.Config{}
-	provider, model, normalized, err := resolveRealtimeSDPTarget(&ctx, cfg, "/v1/realtime", []byte(`{"model":"openai/gpt-4o-realtime-preview","voice":"alloy"}`))
+	provider, model, normalized, transcriptionSession, err := resolveRealtimeSDPTarget(&ctx, cfg, "/v1/realtime", []byte(`{"model":"openai/gpt-4o-realtime-preview","voice":"alloy"}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if transcriptionSession {
+		t.Fatal("normal realtime session was classified as transcription")
 	}
 	if provider != schemas.OpenAI {
 		t.Fatalf("expected provider %s, got %s", schemas.OpenAI, provider)
@@ -86,9 +89,12 @@ func TestResolveRealtimeSDPTarget_BaseRouteNormalizesModel(t *testing.T) {
 func TestResolveRealtimeSDPTarget_OpenAIRouteDefaultsProvider(t *testing.T) {
 	var ctx fasthttp.RequestCtx
 	cfg := &lib.Config{}
-	provider, model, _, err := resolveRealtimeSDPTarget(&ctx, cfg, "/openai/v1/realtime", []byte(`{"model":"gpt-4o-realtime-preview"}`))
+	provider, model, _, transcriptionSession, err := resolveRealtimeSDPTarget(&ctx, cfg, "/openai/v1/realtime", []byte(`{"model":"gpt-4o-realtime-preview"}`))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if transcriptionSession {
+		t.Fatal("normal OpenAI realtime session was classified as transcription")
 	}
 	if provider != schemas.OpenAI {
 		t.Fatalf("expected provider %s, got %s", schemas.OpenAI, provider)
@@ -105,9 +111,12 @@ func TestParseCallsWebRTCRequest_RawSDPKeepsGARoute(t *testing.T) {
 	ctx.Request.Header.SetContentType("application/sdp")
 	ctx.Request.SetBodyString("v=0\r\n")
 
-	sdpOffer, provider, model, session, err := parseCallsWebRTCRequest(&ctx, &lib.Config{})
+	sdpOffer, provider, model, session, transcriptionSession, err := parseCallsWebRTCRequest(&ctx, &lib.Config{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if transcriptionSession {
+		t.Fatal("raw SDP request was classified as transcription")
 	}
 	if sdpOffer != "v=0\r\n" {
 		t.Fatalf("unexpected sdp offer: %q", sdpOffer)
@@ -120,6 +129,92 @@ func TestParseCallsWebRTCRequest_RawSDPKeepsGARoute(t *testing.T) {
 	}
 	if session != nil {
 		t.Fatalf("expected nil session for raw SDP /calls request, got %s", string(session))
+	}
+}
+
+func TestResolveRealtimeSDPTargetDedicatedTranscription(t *testing.T) {
+	t.Parallel()
+
+	var ctx fasthttp.RequestCtx
+	provider, model, normalized, transcriptionSession, err := resolveRealtimeSDPTarget(
+		&ctx, &lib.Config{}, "/v1/realtime/calls",
+		[]byte(`{"audio":{"input":{"transcription":{"model":"openai/gpt-4o-transcribe","language":"en"}}}}`),
+	)
+	if err != nil {
+		t.Fatalf("resolveRealtimeSDPTarget() error = %v", err)
+	}
+	if !transcriptionSession {
+		t.Fatal("expected dedicated transcription classification")
+	}
+	if provider != schemas.OpenAI || model != "gpt-4o-transcribe" {
+		t.Fatalf("target = %s/%s, want openai/gpt-4o-transcribe", provider, model)
+	}
+
+	var session map[string]any
+	if err := json.Unmarshal(normalized, &session); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	if session["type"] != "transcription" {
+		t.Fatalf("session.type = %v, want transcription", session["type"])
+	}
+	if _, ok := session["model"]; ok {
+		t.Fatal("dedicated transcription session must not gain a root model")
+	}
+	transcription := session["audio"].(map[string]any)["input"].(map[string]any)["transcription"].(map[string]any)
+	if transcription["model"] != "openai/gpt-4o-transcribe" || transcription["language"] != "en" {
+		t.Fatalf("transcription = %#v, want original routing model and sibling fields", transcription)
+	}
+}
+
+func TestResolveRealtimeSDPTargetRootModelPreservesNormalRealtime(t *testing.T) {
+	t.Parallel()
+
+	var ctx fasthttp.RequestCtx
+	_, model, normalized, transcriptionSession, err := resolveRealtimeSDPTarget(
+		&ctx, &lib.Config{}, "/v1/realtime/calls",
+		[]byte(`{"model":"openai/gpt-realtime","audio":{"input":{"transcription":{"model":"openai/whisper-1"}}}}`),
+	)
+	if err != nil {
+		t.Fatalf("resolveRealtimeSDPTarget() error = %v", err)
+	}
+	if transcriptionSession {
+		t.Fatal("normal realtime with optional input transcription was classified as dedicated transcription")
+	}
+	if model != "gpt-realtime" {
+		t.Fatalf("routing model = %q, want gpt-realtime", model)
+	}
+
+	var session map[string]any
+	if err := json.Unmarshal(normalized, &session); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	transcription := session["audio"].(map[string]any)["input"].(map[string]any)["transcription"].(map[string]any)
+	if transcription["model"] != "whisper-1" {
+		t.Fatalf("nested transcription model = %v, want whisper-1", transcription["model"])
+	}
+}
+
+func TestPinRealtimeSDPTranscriptionModelPreservesSession(t *testing.T) {
+	t.Parallel()
+
+	normalized, err := pinRealtimeSDPTranscriptionModel(
+		[]byte(`{"type":"transcription","audio":{"input":{"format":{"type":"audio/pcm","rate":24000},"transcription":{"model":"openai/transcription-alias","language":"en"}}}}`),
+		"gpt-4o-transcribe",
+	)
+	if err != nil {
+		t.Fatalf("pinRealtimeSDPTranscriptionModel() error = %v", err)
+	}
+	var session map[string]any
+	if err := json.Unmarshal(normalized, &session); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+	input := session["audio"].(map[string]any)["input"].(map[string]any)
+	transcription := input["transcription"].(map[string]any)
+	if transcription["model"] != "gpt-4o-transcribe" || transcription["language"] != "en" {
+		t.Fatalf("transcription = %#v, want alias-resolved model and preserved language", transcription)
+	}
+	if input["format"] == nil {
+		t.Fatal("input format was not preserved")
 	}
 }
 

--- a/transports/bifrost-http/handlers/wsrealtime.go
+++ b/transports/bifrost-http/handlers/wsrealtime.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -22,11 +24,19 @@ import (
 )
 
 const (
-	realtimeWSPingInterval     = 15 * time.Second
-	realtimeWSPongTimeout      = 45 * time.Second
-	realtimeWSPingWriteTimeout = 10 * time.Second
-	realtimeWSWriteTimeout     = 30 * time.Second
+	realtimeWSPingInterval                  = 15 * time.Second
+	realtimeWSPongTimeout                   = 45 * time.Second
+	realtimeWSPingWriteTimeout              = 10 * time.Second
+	realtimeWSWriteTimeout                  = 30 * time.Second
+	realtimeTranscriptionBootstrapTimeout   = 15 * time.Second
+	realtimeTranscriptionBootstrapMaxFrames = 16
+	realtimeTranscriptionBootstrapMaxBytes  = 1 << 20
 )
+
+type realtimeWebSocketFrame struct {
+	messageType int
+	data        []byte
+}
 
 // WSRealtimeHandler handles bidirectional WebSocket proxying for the Realtime API.
 type WSRealtimeHandler struct {
@@ -124,6 +134,12 @@ func (h *WSRealtimeHandler) handleUpgrade(ctx *fasthttp.RequestCtx) {
 		return
 	}
 
+	if strings.EqualFold(strings.TrimSpace(string(ctx.QueryArgs().Peek("intent"))), "transcription") {
+		populateRealtimeRequestContext(ctx, preReqCtx)
+		h.handleTranscriptionUpgrade(ctx, preReqCtx, preReqCancel, auth, path)
+		return
+	}
+
 	providerKey, model, err := resolveRealtimeTarget(ctx, h.config, path, modelParam, deploymentParam)
 	if err != nil {
 		preReqCancel()
@@ -138,24 +154,8 @@ func (h *WSRealtimeHandler) handleUpgrade(ctx *fasthttp.RequestCtx) {
 		}
 		return
 	}
-	// Surface full request headers + query params on the pre-request context so governance
-	// CEL routing rules (which read headers[...] / params[...]) see the same shape they would
-	// for normal HTTP requests. Mirrors lib/ctx.go ConvertToBifrostContext; the normal HTTP
-	// path doesn't run for WS upgrades, so we populate these explicitly. Keys are lowercased.
-	allHeaders := make(map[string]string)
-	ctx.Request.Header.All()(func(key, value []byte) bool {
-		allHeaders[strings.ToLower(string(key))] = string(value)
-		return true
-	})
-	preReqCtx.SetValue(schemas.BifrostContextKeyRequestHeaders, allHeaders)
-	if queryArgs := ctx.Request.URI().QueryArgs(); queryArgs.Len() > 0 {
-		allQuery := make(map[string]string, queryArgs.Len())
-		queryArgs.All()(func(key, value []byte) bool {
-			allQuery[strings.ToLower(string(key))] = string(value)
-			return true
-		})
-		preReqCtx.SetValue(schemas.BifrostContextKeyRequestQuery, allQuery)
-	}
+	populateRealtimeRequestContext(ctx, preReqCtx)
+
 	preReq := &schemas.BifrostRequest{
 		RequestType: schemas.RealtimeRequest,
 		ResponsesRequest: &schemas.BifrostResponsesRequest{
@@ -184,11 +184,6 @@ func (h *WSRealtimeHandler) handleUpgrade(ctx *fasthttp.RequestCtx) {
 	providerKey = routedProvider
 	if routedModel != "" {
 		model = routedModel
-	}
-	// Mirror ctx values back to fasthttp user values so snapshotRealtimeMiddlewareValues
-	// (called below) picks them up — same mechanism TransportInterceptorMiddleware uses.
-	for k, v := range preReqCtx.GetUserValues() {
-		ctx.SetUserValue(k, v)
 	}
 	preReqCancel()
 
@@ -226,11 +221,131 @@ func (h *WSRealtimeHandler) handleUpgrade(ctx *fasthttp.RequestCtx) {
 		}
 		defer h.sessions.Remove(conn)
 
-		h.runRealtimeSession(clientConn, session, auth, path, providerKey, model, middlewareContextValues)
+		h.runRealtimeSession(clientConn, session, auth, path, providerKey, model, "", nil, middlewareContextValues)
 	})
 	if err != nil {
 		logger.Warn("websocket upgrade failed for %s: %v", path, err)
 	}
+}
+
+func populateRealtimeRequestContext(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) {
+	allHeaders := make(map[string]string)
+	ctx.Request.Header.All()(func(key, value []byte) bool {
+		allHeaders[strings.ToLower(string(key))] = string(value)
+		return true
+	})
+	bifrostCtx.SetValue(schemas.BifrostContextKeyRequestHeaders, allHeaders)
+	if queryArgs := ctx.Request.URI().QueryArgs(); queryArgs.Len() > 0 {
+		allQuery := make(map[string]string, queryArgs.Len())
+		queryArgs.All()(func(key, value []byte) bool {
+			allQuery[strings.ToLower(string(key))] = string(value)
+			return true
+		})
+		bifrostCtx.SetValue(schemas.BifrostContextKeyRequestQuery, allQuery)
+	}
+}
+
+func (h *WSRealtimeHandler) handleTranscriptionUpgrade(
+	ctx *fasthttp.RequestCtx,
+	preReqCtx *schemas.BifrostContext,
+	preReqCancel context.CancelFunc,
+	auth *authHeaders,
+	path string,
+) {
+	upgrader := h.websocketUpgrader("realtime")
+	err := upgrader.Upgrade(ctx, func(conn *ws.Conn) {
+		defer conn.Close()
+		clientConn := newRealtimeClientConn(conn)
+
+		frames, rawModel, bootstrapErr := bufferRealtimeTranscriptionBootstrap(clientConn)
+		if bootstrapErr != nil {
+			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", bootstrapErr.Error()))
+			preReqCancel()
+			return
+		}
+
+		providerKey, model := schemas.ParseModelString(rawModel, realtimeDefaultProviderForPath(path))
+		preReq := &schemas.BifrostRequest{
+			RequestType: schemas.RealtimeRequest,
+			ResponsesRequest: &schemas.BifrostResponsesRequest{
+				Provider: providerKey,
+				Model:    model,
+			},
+		}
+		h.client.RunPreRequestHooks(preReqCtx, preReq)
+		providerKey, model, _ = preReq.GetRequestFields()
+		if providerKey == "" || strings.TrimSpace(model) == "" {
+			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", fmt.Sprintf("no provider could be resolved for model %q (set as provider/model or configure the model catalog)", model)))
+			preReqCancel()
+			return
+		}
+		middlewareValues := snapshotRealtimeMiddlewareValuesWithContext(ctx, preReqCtx)
+		preReqCancel()
+
+		provider, ok := h.client.GetProviderByKey(providerKey).(schemas.RealtimeProvider)
+		if !ok || !provider.SupportsRealtimeAPI() {
+			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", "provider does not support realtime: "+string(providerKey)))
+			return
+		}
+		session, sessionErr := h.sessions.Create(conn)
+		if sessionErr != nil {
+			clientConn.writeRealtimeError(newRealtimeWireBifrostError(429, "rate_limit_exceeded", sessionErr.Error()))
+			return
+		}
+		defer h.sessions.Remove(conn)
+		h.runRealtimeSession(clientConn, session, auth, path, providerKey, model, "transcription", frames, middlewareValues)
+	})
+	if err != nil {
+		preReqCancel()
+		logger.Warn("websocket upgrade failed for %s: %v", path, err)
+	}
+}
+
+func bufferRealtimeTranscriptionBootstrap(clientConn *realtimeClientConn) ([]realtimeWebSocketFrame, string, error) {
+	if err := clientConn.conn.SetReadDeadline(time.Now().Add(realtimeTranscriptionBootstrapTimeout)); err != nil {
+		return nil, "", err
+	}
+	defer clientConn.refreshReadDeadline()
+
+	frames := make([]realtimeWebSocketFrame, 0, realtimeTranscriptionBootstrapMaxFrames)
+	totalBytes := 0
+	for len(frames) < realtimeTranscriptionBootstrapMaxFrames {
+		messageType, message, err := clientConn.conn.ReadMessage()
+		if err != nil {
+			return nil, "", fmt.Errorf("transcription session.update model was not received within bootstrap limits: %w", err)
+		}
+		totalBytes += len(message)
+		if totalBytes > realtimeTranscriptionBootstrapMaxBytes {
+			return nil, "", errors.New("transcription bootstrap exceeded 1 MiB")
+		}
+		frame := realtimeWebSocketFrame{messageType: messageType, data: append([]byte(nil), message...)}
+		frames = append(frames, frame)
+		if messageType == ws.TextMessage {
+			if model := discoverRealtimeTranscriptionModel(message); model != "" {
+				return frames, model, nil
+			}
+		}
+	}
+	return nil, "", errors.New("transcription bootstrap exceeded 16 frames before session.update supplied a model")
+}
+
+func discoverRealtimeTranscriptionModel(message []byte) string {
+	var event struct {
+		Type    string `json:"type"`
+		Session struct {
+			Audio struct {
+				Input struct {
+					Transcription struct {
+						Model string `json:"model"`
+					} `json:"transcription"`
+				} `json:"input"`
+			} `json:"audio"`
+		} `json:"session"`
+	}
+	if json.Unmarshal(message, &event) != nil || event.Type != string(schemas.RTEventSessionUpdate) {
+		return ""
+	}
+	return strings.TrimSpace(event.Session.Audio.Input.Transcription.Model)
 }
 
 func (h *WSRealtimeHandler) websocketUpgrader(subprotocol string) ws.FastHTTPUpgrader {
@@ -258,6 +373,8 @@ func (h *WSRealtimeHandler) runRealtimeSession(
 	path string,
 	providerKey schemas.ModelProvider,
 	model string,
+	intent string,
+	buffered []realtimeWebSocketFrame,
 	middlewareValues map[any]any,
 ) {
 	clientConn.startHeartbeat()
@@ -324,7 +441,11 @@ func (h *WSRealtimeHandler) runRealtimeSession(
 	// Tag the session context with transport type for downstream logging/metadata.
 	bifrostCtx.SetValue(schemas.BifrostContextKeyRealtimeTransport, "websocket")
 
-	wsURL := rtProvider.RealtimeWebSocketURL(key, model)
+	wsURL, urlErr := rtProvider.RealtimeWebSocketURL(key, model, intent)
+	if urlErr != nil {
+		clientConn.writeRealtimeError(urlErr)
+		return
+	}
 	realtimeHeaders, headerErr := rtProvider.RealtimeHeaders(bifrostCtx, key)
 	if headerErr != nil {
 		clientConn.writeRealtimeError(headerErr)
@@ -348,10 +469,10 @@ func (h *WSRealtimeHandler) runRealtimeSession(
 
 	errCh := make(chan error, 2)
 	go func() {
-		errCh <- h.relayClientToRealtimeProvider(clientConn, session, upstream, rtProvider, bifrostCtx, providerKey, model, key)
+		errCh <- h.relayClientToRealtimeProvider(clientConn, session, upstream, rtProvider, bifrostCtx, providerKey, model, key, intent == "transcription", buffered)
 	}()
 	go func() {
-		errCh <- h.relayRealtimeProviderToClient(clientConn, session, upstream, rtProvider, bifrostCtx, providerKey, model, key)
+		errCh <- h.relayRealtimeProviderToClient(clientConn, session, upstream, rtProvider, bifrostCtx, providerKey, model, key, intent == "transcription")
 	}()
 
 	firstErr := <-errCh
@@ -373,7 +494,14 @@ func (h *WSRealtimeHandler) relayClientToRealtimeProvider(
 	providerKey schemas.ModelProvider,
 	model string,
 	key schemas.Key,
+	transcriptionSession bool,
+	buffered []realtimeWebSocketFrame,
 ) error {
+	for _, frame := range buffered {
+		if stop, err := h.processRealtimeClientMessage(clientConn, session, upstream, provider, bifrostCtx, providerKey, model, key, transcriptionSession, frame.messageType, frame.data); stop {
+			return err
+		}
+	}
 	for {
 		messageType, message, err := clientConn.ReadMessage()
 		if err != nil {
@@ -393,78 +521,67 @@ func (h *WSRealtimeHandler) relayClientToRealtimeProvider(
 			}
 			return err
 		}
-		if messageType != ws.TextMessage {
-			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", "realtime websocket only accepts text messages"))
-			return nil
+		if stop, processErr := h.processRealtimeClientMessage(clientConn, session, upstream, provider, bifrostCtx, providerKey, model, key, transcriptionSession, messageType, message); stop {
+			return processErr
 		}
+	}
+}
 
-		event, err := schemas.ParseRealtimeEvent(message)
-		if err != nil {
-			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", "failed to parse realtime event JSON"))
-			continue
+func (h *WSRealtimeHandler) processRealtimeClientMessage(
+	clientConn *realtimeClientConn,
+	session *bfws.Session,
+	upstream *bfws.UpstreamConn,
+	provider schemas.RealtimeProvider,
+	bifrostCtx *schemas.BifrostContext,
+	providerKey schemas.ModelProvider,
+	model string,
+	key schemas.Key,
+	transcriptionSession bool,
+	messageType int,
+	message []byte,
+) (bool, error) {
+	if messageType != ws.TextMessage {
+		clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", "realtime websocket only accepts text messages"))
+		return true, nil
+	}
+
+	event, err := schemas.ParseRealtimeEvent(message)
+	if err != nil {
+		clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", "failed to parse realtime event JSON"))
+		return false, nil
+	}
+	// Extract pending tool/input summaries but defer recording until the event
+	// passes validation — rejected events must not pollute session state.
+	toolItemID, toolSummary := pendingRealtimeToolOutputUpdate(event)
+	inputItemID, inputSummary := pendingRealtimeInputUpdate(event)
+
+	startsTurn := provider.ShouldStartRealtimeTurn(event)
+	if startsTurn {
+		if session.PeekRealtimeTurnHooks() != nil {
+			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", "Conversation already has an active response in progress."))
+			return false, nil
 		}
-		// Extract pending tool/input summaries but defer recording until the event
-		// passes validation — rejected events must not pollute session state.
-		toolItemID, toolSummary := pendingRealtimeToolOutputUpdate(event)
-		inputItemID, inputSummary := pendingRealtimeInputUpdate(event)
+		if toolSummary != "" {
+			session.RecordRealtimeToolOutput(toolItemID, toolSummary, string(message))
+		}
+		if inputSummary != "" {
+			session.RecordRealtimeInput(inputItemID, inputSummary, string(message))
+		}
+		if bifrostErr := startRealtimeTurnHooks(h.client, bifrostCtx, session, provider, providerKey, model, &key, event); bifrostErr != nil {
+			clientConn.writeRealtimeError(bifrostErr)
+			return true, nil
+		}
+	}
 
-		startsTurn := provider.ShouldStartRealtimeTurn(event)
+	if err := pinRealtimeTranscriptionModel(event, model, transcriptionSession); err != nil {
+		clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()))
+		return false, nil
+	}
+	sanitizeRealtimeSessionEventForProvider(event)
+	providerEvent, err := provider.ToProviderRealtimeEvent(event)
+	if err != nil {
 		if startsTurn {
-			if session.PeekRealtimeTurnHooks() != nil {
-				clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", "Conversation already has an active response in progress."))
-				continue
-			}
-			if toolSummary != "" {
-				session.RecordRealtimeToolOutput(toolItemID, toolSummary, string(message))
-			}
-			if inputSummary != "" {
-				session.RecordRealtimeInput(inputItemID, inputSummary, string(message))
-			}
-			if bifrostErr := startRealtimeTurnHooks(h.client, bifrostCtx, session, provider, providerKey, model, &key, event); bifrostErr != nil {
-				clientConn.writeRealtimeError(bifrostErr)
-				return nil
-			}
-		}
-
-		sanitizeRealtimeSessionEventForProvider(event)
-		providerEvent, err := provider.ToProviderRealtimeEvent(event)
-		if err != nil {
-			if startsTurn {
-				if finalizeErr := finalizeRealtimeTurnHooksWithError(
-					h.client,
-					bifrostCtx,
-					session,
-					providerKey,
-					model,
-					&key,
-					schemas.RTEventError,
-					nil,
-					newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()),
-				); finalizeErr != nil {
-					clientConn.writeRealtimeError(finalizeErr)
-					return nil
-				}
-			}
-			clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()))
-			continue
-		}
-
-		// Track session metadata only after provider translation succeeds. Rejected
-		// session.update events must not affect later turn logs.
-		updateRealtimeSessionFromEvent(session, event)
-
-		// Record tool output / input only after the event passed validation.
-		if !startsTurn {
-			if toolSummary != "" {
-				session.RecordRealtimeToolOutput(toolItemID, toolSummary, string(message))
-			}
-			if inputSummary != "" {
-				session.RecordRealtimeInput(inputItemID, inputSummary, string(message))
-			}
-		}
-
-		if err := upstream.WriteMessage(ws.TextMessage, providerEvent); err != nil {
-			finalizeRealtimeTurnHooksWithError(
+			if finalizeErr := finalizeRealtimeTurnHooksWithError(
 				h.client,
 				bifrostCtx,
 				session,
@@ -473,12 +590,115 @@ func (h *WSRealtimeHandler) relayClientToRealtimeProvider(
 				&key,
 				schemas.RTEventError,
 				nil,
-				newRealtimeWireBifrostError(502, "server_error", "failed to write realtime event upstream"),
-			)
-			clientConn.writeRealtimeError(newRealtimeWireBifrostError(502, "server_error", "failed to write realtime event upstream"))
-			return err
+				newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()),
+			); finalizeErr != nil {
+				clientConn.writeRealtimeError(finalizeErr)
+				return true, nil
+			}
+		}
+		clientConn.writeRealtimeError(newRealtimeWireBifrostError(400, "invalid_request_error", err.Error()))
+		return false, nil
+	}
+
+	// Track session metadata only after provider translation succeeds. Rejected
+	// session.update events must not affect later turn logs.
+	updateRealtimeSessionFromEvent(session, event)
+
+	// Record tool output / input only after the event passed validation.
+	if !startsTurn {
+		if toolSummary != "" {
+			session.RecordRealtimeToolOutput(toolItemID, toolSummary, string(message))
+		}
+		if inputSummary != "" {
+			session.RecordRealtimeInput(inputItemID, inputSummary, string(message))
 		}
 	}
+
+	if err := upstream.WriteMessage(messageType, providerEvent); err != nil {
+		finalizeRealtimeTurnHooksWithError(
+			h.client,
+			bifrostCtx,
+			session,
+			providerKey,
+			model,
+			&key,
+			schemas.RTEventError,
+			nil,
+			newRealtimeWireBifrostError(502, "server_error", "failed to write realtime event upstream"),
+		)
+		clientConn.writeRealtimeError(newRealtimeWireBifrostError(502, "server_error", "failed to write realtime event upstream"))
+		return true, err
+	}
+	return false, nil
+}
+
+func pinRealtimeTranscriptionModel(event *schemas.BifrostRealtimeEvent, model string, transcriptionSession bool) error {
+	if !transcriptionSession || event == nil || event.Type != schemas.RTEventSessionUpdate || event.Session == nil || strings.TrimSpace(model) == "" {
+		return nil
+	}
+	if event.Session.ExtraParams == nil {
+		return nil
+	}
+
+	audioRaw, ok := event.Session.ExtraParams["audio"]
+	if !ok {
+		return nil
+	}
+	var audio map[string]json.RawMessage
+	if err := json.Unmarshal(audioRaw, &audio); err != nil {
+		return nil
+	}
+	inputRaw, ok := audio["input"]
+	if !ok {
+		return nil
+	}
+	var input map[string]json.RawMessage
+	if err := json.Unmarshal(inputRaw, &input); err != nil {
+		return nil
+	}
+	transcriptionRaw, ok := input["transcription"]
+	if !ok || string(transcriptionRaw) == "null" {
+		return nil
+	}
+	var transcription map[string]json.RawMessage
+	if err := json.Unmarshal(transcriptionRaw, &transcription); err != nil {
+		return nil
+	}
+	if _, ok := transcription["model"]; !ok {
+		return nil
+	}
+
+	pinnedModel, err := json.Marshal(model)
+	if err != nil {
+		return err
+	}
+	transcription["model"] = pinnedModel
+	input["transcription"], err = json.Marshal(transcription)
+	if err != nil {
+		return err
+	}
+	audio["input"], err = json.Marshal(input)
+	if err != nil {
+		return err
+	}
+	event.Session.ExtraParams["audio"], err = json.Marshal(audio)
+	return err
+}
+
+func realtimeTurnFinalEvent(provider schemas.RealtimeProvider, transcriptionSession bool) schemas.RealtimeEventType {
+	if transcriptionSession {
+		return schemas.RTEventInputAudioTransCompleted
+	}
+	return provider.RealtimeTurnFinalEvent()
+}
+
+func realtimeTurnCompletionContent(session *bfws.Session, event *schemas.BifrostRealtimeEvent, transcriptionSession bool) (string, string, string) {
+	inputItemID, inputSummary := pendingRealtimeInputUpdate(event)
+	contentOverride := session.ConsumeRealtimeOutputText()
+	if transcriptionSession {
+		return "", "", finalizedRealtimeInputSummary(event)
+	}
+	return inputItemID, inputSummary, contentOverride
 }
 
 func (h *WSRealtimeHandler) relayRealtimeProviderToClient(
@@ -490,6 +710,7 @@ func (h *WSRealtimeHandler) relayRealtimeProviderToClient(
 	providerKey schemas.ModelProvider,
 	model string,
 	key schemas.Key,
+	transcriptionSession bool,
 ) error {
 	for {
 		disconnectAfterWrite := false
@@ -559,13 +780,16 @@ func (h *WSRealtimeHandler) relayRealtimeProviderToClient(
 				}
 			}
 			if event != nil {
-				inputItemID, inputSummary := pendingRealtimeInputUpdate(event)
 				if !provider.ShouldForwardRealtimeEvent(event) {
 					continue
 				}
-				if event.Type == provider.RealtimeTurnFinalEvent() {
-					contentOverride := session.ConsumeRealtimeOutputText()
-					if bifrostErr := finalizeRealtimeTurnHooks(h.client, bifrostCtx, session, provider, providerKey, model, &key, message, contentOverride); bifrostErr != nil {
+				terminalEventType := realtimeTurnFinalEvent(provider, transcriptionSession)
+				if event.Type == terminalEventType {
+					inputItemID, inputSummary, contentOverride := realtimeTurnCompletionContent(session, event, transcriptionSession)
+					if inputSummary != "" {
+						session.RecordRealtimeInput(inputItemID, inputSummary, string(message))
+					}
+					if bifrostErr := finalizeRealtimeTurnHooks(h.client, bifrostCtx, session, provider, providerKey, model, &key, message, contentOverride, terminalEventType, transcriptionSession); bifrostErr != nil {
 						clientConn.writeRealtimeError(bifrostErr)
 						return nil
 					}
@@ -590,8 +814,11 @@ func (h *WSRealtimeHandler) relayRealtimeProviderToClient(
 					// below still runs — otherwise terminal errors from translated
 					// providers would reach the client in provider-native format.
 					disconnectAfterWrite = shouldGracefullyDisconnectRealtime(turnErr)
-				} else if inputSummary != "" {
-					session.RecordRealtimeInput(inputItemID, inputSummary, string(message))
+				} else {
+					inputItemID, inputSummary := pendingRealtimeInputUpdate(event)
+					if inputSummary != "" {
+						session.RecordRealtimeInput(inputItemID, inputSummary, string(message))
+					}
 				}
 				if len(event.RawData) == 0 {
 					message, err = provider.ToProviderRealtimeEvent(event)
@@ -908,6 +1135,15 @@ var realtimeMiddlewareKeys = []any{
 // are surfaced through the same mechanism — the hooks write them onto preReqCtx
 // and handleUpgrade mirrors that ctx's user values onto the fasthttp ctx before
 // this function is called.
+func snapshotRealtimeMiddlewareValuesWithContext(ctx *fasthttp.RequestCtx, bifrostCtx *schemas.BifrostContext) map[any]any {
+	if bifrostCtx != nil {
+		for key, value := range bifrostCtx.GetUserValues() {
+			ctx.SetUserValue(key, value)
+		}
+	}
+	return snapshotRealtimeMiddlewareValues(ctx)
+}
+
 func snapshotRealtimeMiddlewareValues(ctx *fasthttp.RequestCtx) map[any]any {
 	result := make(map[any]any)
 	for _, key := range realtimeMiddlewareKeys {

--- a/transports/bifrost-http/handlers/wsrealtimeheartbeat_test.go
+++ b/transports/bifrost-http/handlers/wsrealtimeheartbeat_test.go
@@ -1,9 +1,13 @@
 package handlers
 
 import (
+	"encoding/json"
 	"net"
 	"testing"
 	"time"
+
+	openaiProvider "github.com/maximhq/bifrost/core/providers/openai"
+	"github.com/maximhq/bifrost/core/schemas"
 
 	"github.com/fasthttp/router"
 	ws "github.com/fasthttp/websocket"
@@ -14,7 +18,7 @@ import (
 //
 // The upgrade handler is held open until cleanup runs, so the connection stays
 // valid for the duration of the test.
-func dialRealtimeTestConn(t *testing.T) (*ws.Conn, func()) {
+func dialRealtimeTestConn(t *testing.T) (*ws.Conn, *ws.Conn, func()) {
 	t.Helper()
 
 	upgrader := ws.FastHTTPUpgrader{
@@ -56,11 +60,167 @@ func dialRealtimeTestConn(t *testing.T) (*ws.Conn, func()) {
 		t.Fatal("timed out waiting for the server side of the connection")
 	}
 
-	return serverConn, func() {
+	return serverConn, client, func() {
 		close(release)
 		<-released
 		_ = client.Close()
 		_ = srv.Shutdown()
+	}
+}
+
+func TestDiscoverRealtimeTranscriptionModel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		message string
+		want    string
+	}{
+		{
+			name:    "nested transcription model",
+			message: `{"type":"session.update","session":{"audio":{"input":{"transcription":{"model":" openai/gpt-4o-transcribe "}}}}}`,
+			want:    "openai/gpt-4o-transcribe",
+		},
+		{name: "wrong event type", message: `{"type":"input_audio_buffer.append","session":{"audio":{"input":{"transcription":{"model":"openai/gpt-4o-transcribe"}}}}}`},
+		{name: "top-level model", message: `{"type":"session.update","model":"openai/gpt-4o-transcribe"}`},
+		{name: "invalid JSON", message: `{`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := discoverRealtimeTranscriptionModel([]byte(tt.message)); got != tt.want {
+				t.Fatalf("discoverRealtimeTranscriptionModel() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPinRealtimeTranscriptionModel(t *testing.T) {
+	t.Parallel()
+
+	provider := &openaiProvider.OpenAIProvider{}
+	tests := []struct {
+		name                 string
+		transcriptionSession bool
+		message              string
+		wantModel            string
+	}{
+		{
+			name:                 "transcription session uses pinned alias-resolved model",
+			transcriptionSession: true,
+			message:              `{"type":"session.update","session":{"type":"transcription","audio":{"input":{"transcription":{"model":"openai/transcription-alias","language":"en"}}}}}`,
+			wantModel:            "gpt-4o-transcribe",
+		},
+		{
+			name:                 "normal realtime keeps input transcription model",
+			transcriptionSession: false,
+			message:              `{"type":"session.update","session":{"type":"realtime","model":"gpt-realtime","audio":{"input":{"transcription":{"model":"openai/whisper-1","language":"en"}}}}}`,
+			wantModel:            "whisper-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			event, err := schemas.ParseRealtimeEvent([]byte(tt.message))
+			if err != nil {
+				t.Fatalf("ParseRealtimeEvent() error = %v", err)
+			}
+			if err := pinRealtimeTranscriptionModel(event, "gpt-4o-transcribe", tt.transcriptionSession); err != nil {
+				t.Fatalf("pinRealtimeTranscriptionModel() error = %v", err)
+			}
+			sanitizeRealtimeSessionEventForProvider(event)
+			serialized, err := provider.ToProviderRealtimeEvent(event)
+			if err != nil {
+				t.Fatalf("ToProviderRealtimeEvent() error = %v", err)
+			}
+
+			var payload struct {
+				Session struct {
+					Audio struct {
+						Input struct {
+							Transcription struct {
+								Model    string `json:"model"`
+								Language string `json:"language"`
+							} `json:"transcription"`
+						} `json:"input"`
+					} `json:"audio"`
+				} `json:"session"`
+			}
+			if err := json.Unmarshal(serialized, &payload); err != nil {
+				t.Fatalf("json.Unmarshal() error = %v", err)
+			}
+			if payload.Session.Audio.Input.Transcription.Model != tt.wantModel {
+				t.Fatalf("transcription model = %q, want %q", payload.Session.Audio.Input.Transcription.Model, tt.wantModel)
+			}
+			if payload.Session.Audio.Input.Transcription.Language != "en" {
+				t.Fatalf("transcription language = %q, want en", payload.Session.Audio.Input.Transcription.Language)
+			}
+		})
+	}
+}
+
+func TestSnapshotRealtimeMiddlewareValuesWithContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := &fasthttp.RequestCtx{}
+	ctx.SetUserValue(schemas.BifrostContextKeyGovernanceVirtualKeyID, "transport-virtual-key-id")
+	ctx.SetUserValue(schemas.BifrostContextKeyTraceID, "dead-upgrade-trace")
+
+	bifrostCtx := schemas.NewBifrostContext(t.Context(), schemas.NoDeadline)
+	bifrostCtx.SetValue(schemas.BifrostContextKeySelectedKeyID, "selected-key")
+
+	values := snapshotRealtimeMiddlewareValuesWithContext(ctx, bifrostCtx)
+	if got := values[schemas.BifrostContextKeyGovernanceVirtualKeyID]; got != "transport-virtual-key-id" {
+		t.Fatalf("governance virtual key ID = %v, want transport-virtual-key-id", got)
+	}
+	if got := values[schemas.BifrostContextKeySelectedKeyID]; got != "selected-key" {
+		t.Fatalf("selected key ID = %v, want selected-key", got)
+	}
+	if _, ok := values[schemas.BifrostContextKeyTraceID]; ok {
+		t.Fatal("upgrade trace ID must not be inherited by realtime turns")
+	}
+}
+
+func TestBufferRealtimeTranscriptionBootstrapPreservesFrames(t *testing.T) {
+	serverConn, peerConn, cleanup := dialRealtimeTestConn(t)
+	defer cleanup()
+
+	client := newRealtimeClientConn(serverConn)
+	frames := []realtimeWebSocketFrame{
+		{messageType: ws.BinaryMessage, data: []byte{0, 1, 2, 3}},
+		{messageType: ws.TextMessage, data: []byte(`{"type":"input_audio_buffer.append","audio":"AQID"}`)},
+		{messageType: ws.TextMessage, data: []byte(`{"type":"session.update","session":{"audio":{"input":{"transcription":{"model":"openai/gpt-4o-transcribe"}}}}}`)},
+	}
+
+	writeErr := make(chan error, 1)
+	go func() {
+		for _, frame := range frames {
+			if err := peerConn.WriteMessage(frame.messageType, frame.data); err != nil {
+				writeErr <- err
+				return
+			}
+		}
+		writeErr <- nil
+	}()
+
+	buffered, model, err := bufferRealtimeTranscriptionBootstrap(client)
+	if err != nil {
+		t.Fatalf("bufferRealtimeTranscriptionBootstrap() error = %v", err)
+	}
+	if err := <-writeErr; err != nil {
+		t.Fatalf("write bootstrap frames: %v", err)
+	}
+	if model != "openai/gpt-4o-transcribe" {
+		t.Fatalf("model = %q, want %q", model, "openai/gpt-4o-transcribe")
+	}
+	if len(buffered) != len(frames) {
+		t.Fatalf("buffered frame count = %d, want %d", len(buffered), len(frames))
+	}
+	for i := range frames {
+		if buffered[i].messageType != frames[i].messageType || string(buffered[i].data) != string(frames[i].data) {
+			t.Fatalf("buffered[%d] = (%d, %q), want (%d, %q)", i, buffered[i].messageType, buffered[i].data, frames[i].messageType, frames[i].data)
+		}
 	}
 }
 
@@ -72,7 +232,7 @@ func dialRealtimeTestConn(t *testing.T) (*ws.Conn, func()) {
 // returns, so a ping still in flight at that point dereferences nil. There is no
 // recover on the heartbeat goroutine, so that panic is fatal to the process.
 func TestRealtimeStopHeartbeatWaitsForPingGoroutine(t *testing.T) {
-	serverConn, cleanup := dialRealtimeTestConn(t)
+	serverConn, _, cleanup := dialRealtimeTestConn(t)
 	defer cleanup()
 
 	client := newRealtimeClientConn(serverConn)
@@ -94,7 +254,7 @@ func TestRealtimeStopHeartbeatWaitsForPingGoroutine(t *testing.T) {
 // TestRealtimeStopHeartbeatWithoutStart covers the early-return paths that fail
 // before the heartbeat is ever started.
 func TestRealtimeStopHeartbeatWithoutStart(t *testing.T) {
-	serverConn, cleanup := dialRealtimeTestConn(t)
+	serverConn, _, cleanup := dialRealtimeTestConn(t)
 	defer cleanup()
 
 	client := newRealtimeClientConn(serverConn)
@@ -115,7 +275,7 @@ func TestRealtimeStopHeartbeatWithoutStart(t *testing.T) {
 // TestRealtimeStopHeartbeatIsIdempotent guards the deferred-stop paths, which
 // can run more than once as a session unwinds.
 func TestRealtimeStopHeartbeatIsIdempotent(t *testing.T) {
-	serverConn, cleanup := dialRealtimeTestConn(t)
+	serverConn, _, cleanup := dialRealtimeTestConn(t)
 	defer cleanup()
 
 	client := newRealtimeClientConn(serverConn)

--- a/transports/bifrost-http/integrations/openai.go
+++ b/transports/bifrost-http/integrations/openai.go
@@ -3421,7 +3421,6 @@ func OpenAIRealtimeWebRTCCallsPaths(pathPrefix string) []string {
 func OpenAIRealtimeClientSecretPaths(pathPrefix string) []string {
 	basePaths := []string{
 		"/v1/realtime/client_secrets",
-		"/v1/realtime/sessions",
 	}
 	paths := make([]string, 0, len(basePaths))
 	for _, p := range basePaths {

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -1159,6 +1159,9 @@ export function LogDetailView({
 	const complexityRouting = deriveComplexityRouting(log);
 	const isPassthrough = isPassthroughOperation(log.object);
 	const isRealtimeTurn = log.object === "realtime.turn";
+	const isRealtimeTranscription =
+		isRealtimeTurn && log.metadata?.realtime_event_type === "conversation.item.input_audio_transcription.completed";
+	const audioSeconds = log.token_usage?.audio_seconds;
 	const isBatch = isBatchOperation(log.object);
 	const batchDebug = log.batch_debug;
 	// Set on both the submission row and the aggregate cost row a settlement writes;
@@ -1592,20 +1595,24 @@ export function LogDetailView({
 						hasRightBorder
 					/>
 					<HeroStat
-						label="Tokens in / out"
+						label={audioSeconds != null ? "Audio duration" : "Tokens in / out"}
 						mono
 						value={
-							log.token_usage
-								? `${formatCompactNumber(log.token_usage.prompt_tokens ?? 0)} / ${formatCompactNumber(log.token_usage.completion_tokens ?? 0)}`
-								: "—"
+							audioSeconds != null
+								? `${audioSeconds}s`
+								: log.token_usage
+									? `${formatCompactNumber(log.token_usage.prompt_tokens ?? 0)} / ${formatCompactNumber(log.token_usage.completion_tokens ?? 0)}`
+									: "—"
 						}
 						sub={
-							log.token_usage
-								? `total ${formatCompactNumber(log.token_usage.total_tokens ?? 0)}${log.token_usage.completion_tokens_details?.reasoning_tokens
-									? ` · reasoning ${formatCompactNumber(log.token_usage.completion_tokens_details.reasoning_tokens)}`
-									: ""
-								}`
-								: "—"
+							audioSeconds != null
+								? "duration billed"
+								: log.token_usage
+									? `total ${formatCompactNumber(log.token_usage.total_tokens ?? 0)}${log.token_usage.completion_tokens_details?.reasoning_tokens
+										? ` · reasoning ${formatCompactNumber(log.token_usage.completion_tokens_details.reasoning_tokens)}`
+										: ""
+									}`
+									: "—"
 						}
 						hasRightBorder
 					/>
@@ -1613,16 +1620,20 @@ export function LogDetailView({
 						label="Cost"
 						value={log.cost != null ? formatCost(log.cost) : "—"}
 						sub={
-							log.cost != null && log.token_usage?.total_tokens
-								? `≈ ${((log.cost / log.token_usage.total_tokens) * 1000).toFixed(6)}＄ per 1k`
-								: ""
+							log.cost != null && audioSeconds
+								? `≈ ${(log.cost / audioSeconds).toFixed(6)}＄ per second`
+								: log.cost != null && log.token_usage?.total_tokens
+									? `≈ ${((log.cost / log.token_usage.total_tokens) * 1000).toFixed(6)}＄ per 1k`
+									: ""
 						}
 						hasRightBorder
 					/>
 					{isRealtimeTurn ? (
 						<HeroStat
-							label="Voice"
-							value={log.metadata?.realtime_voice ? String(log.metadata.realtime_voice) : "\u2014"}
+							label={isRealtimeTranscription ? "Type" : "Voice"}
+							value={
+								isRealtimeTranscription ? "Transcription" : log.metadata?.realtime_voice ? String(log.metadata.realtime_voice) : "\u2014"
+							}
 							sub={log.metadata?.realtime_transport ? formatRealtimeTransport(log.metadata.realtime_transport) : ""}
 						/>
 					) : (

--- a/ui/lib/types/logs.ts
+++ b/ui/lib/types/logs.ts
@@ -429,6 +429,7 @@ export interface LLMUsage {
 	prompt_tokens: number;
 	completion_tokens: number;
 	total_tokens: number;
+	audio_seconds?: number;
 	prompt_tokens_details?: TokenDetails;
 	completion_tokens_details?: CompletionTokensDetails;
 }


### PR DESCRIPTION
## Summary

Add GA realtime transcription support for OpenAI and Azure over WebSocket and WebRTC, with normal Bifrost authentication, routing, governance, guardrails, logging, and transcription-aware pricing.

## Changes

### Problem

Normal realtime sessions identify their routing model before Bifrost connects upstream:

```text
GET /openai/v1/realtime?model=openai/gpt-realtime
                               └───────────────┘
                                  routing model
```

GA transcription sessions use a different contract. A WebSocket connection carries only the intent, while the model arrives later in `session.update`:

```text
GET /openai/v1/realtime?intent=transcription

session.update
└── session.type = "transcription"
    └── audio.input.transcription.model = "openai/gpt-4o-transcribe"
```

WebRTC carries the same nested model in the initial multipart `/v1/realtime/calls` request. In both cases, Bifrost must route using the transcription model while preserving the realtime connection and turn semantics.

Before this change, Bifrost could not route these sessions through aliases, virtual-key authorization, provider-key selection, governance, or provider proxy configuration. It also treated transcript text and usage like normal realtime output, which prevented correct output guardrails, logs, and transcription pricing.

### Request flow

#### WebSocket

A dedicated transcription connection authenticates before the downstream upgrade. Bifrost then buffers frames until it can discover the nested model and establish the upstream connection:

```text
client connects with intent=transcription
                │
                ▼
      authenticate before upgrade
                │
                ▼
       upgrade downstream socket
                │
                ▼
   buffer frames without rewriting them
                │
                ▼
discover audio.input.transcription.model
                │
                ▼
 aliases → hooks → VK authorization → key selection
                │
                ▼
 dial OpenAI or Azure with intent=transcription
                │
                ▼
 replay buffered frames through the normal relay
```

Bootstrap buffering is limited to 15 seconds, 16 frames, and 1 MiB. It preserves frame type, bytes, and order. Buffered and live events pass through the same validator, so malformed JSON and unsupported binary frames behave consistently.

The long-lived session inherits the filtered combination of transport middleware and pre-request hook values. Governance identity, routing metadata, selected-key information, and raw-log settings survive the HTTP upgrade, while the completed upgrade trace ID is intentionally excluded.

Normal realtime connections with a URL model keep the eager connection path.

#### WebRTC

WebRTC receives the SDP and complete session together, so no buffering is necessary:

```text
multipart request: SDP + transcription session
                │
                ▼
discover and route nested transcription model
                │
                ▼
pin resolved model into session JSON
                │
                ▼
exchange SDP with OpenAI or Azure
                │
                ▼
use the existing media and data-channel relay
```

Bifrost resolves aliases and provider prefixes before pinning the routed model back into `session.audio.input.transcription.model`. This keeps authorization and the model sent upstream aligned.

A normal realtime session that enables optional input transcription remains a normal realtime session. Only `session.type == "transcription"` selects dedicated transcription behavior.

### Provider behavior

OpenAI and Azure distinguish model-based realtime connections from dedicated transcription intent:

```text
OpenAI normal:        /v1/realtime?model=<model>
OpenAI transcription: /v1/realtime?intent=transcription

Azure normal:         /openai/v1/realtime?model=<deployment>
Azure transcription:  /openai/v1/realtime?intent=transcription
```

Azure WebRTC uses the same intent distinction during SDP exchange. ElevenLabs rejects transcription intent before opening its conversational-agent endpoint rather than starting a session with the wrong semantics.

### Turn handling, guardrails, and logging

A dedicated transcription turn starts when the client commits its input audio and finishes on:

```text
conversation.item.input_audio_transcription.completed
```

Normal realtime turns continue to finish on `response.done`, including normal sessions that enable optional input transcription.

Dedicated transcription uses this representation:

```text
input  = audio
output = completed transcript text
```

The completed transcript is recorded before post-hooks run, allowing output guardrails to inspect it before client delivery. If a guardrail blocks the transcript, the client receives an error while logging and governance retain the completed provider response:

```text
provider completes transcription and reports usage
                │
                ▼
output guardrail evaluates completed transcript
                │
                ├── allowed: deliver transcript
                │
                └── blocked: withhold transcript and return error
                              │
                              └── retain result for logs and billing
```

Blocked turns are logged as errors with their provider result, transcript, usage, stop reason, and billable cost. Provider work remains chargeable even when Bifrost blocks delivery.

### Usage and cost

OpenAI reports normal realtime usage under `response.usage`. Dedicated transcription reports usage at the top level of its completion event in one of two forms:

```text
type = tokens    → audio input, text input, and transcript output tokens
type = duration  → whole or fractional audio seconds
```

Bifrost preserves fractional duration values such as `3.4` seconds through normalized usage, logging, and pricing. Both regular and streamed Responses carry the same transcription pricing inputs, including duration and the split between audio and text input tokens.

Dedicated transcription responses retain `RequestType: realtime` so hooks, raw events, and log identity stay intact. Response metadata selects the `audio_transcription` catalog mode only for cost calculation.

Token-priced transcription maps usage as follows:

```text
audio input tokens → input_cost_per_audio_token
text input tokens  → input_cost_per_token
transcript tokens  → output_cost_per_token
```

For example, 28 audio input tokens, 1 text input token, and 14 transcript output tokens cost `$0.0002125` with the current `gpt-4o-transcribe` pricing entry.

Duration-priced transcription, such as `whisper-1`, uses:

```text
audio seconds, including fractional seconds → input_cost_per_audio_per_second
```

For example, `3.4` reported seconds remain `3.4` through cost calculation rather than being rounded or dropped. Streamed and non-streamed Responses use the same duration and split-token mapping.

Missing pricing remains non-fatal. Normal realtime sessions continue using their existing pricing mode.

The log detail UI displays token counts for token-priced turns and audio duration with per-second pricing for duration-priced turns. Dedicated transcription logs are labeled as transcription while retaining their WebSocket or WebRTC transport label.

### GA ephemeral tokens

The supported endpoints are:

```text
POST /v1/realtime/client_secrets
POST /openai/v1/realtime/client_secrets
```

The retired beta endpoints and header are removed:

```text
POST /v1/realtime/sessions
POST /openai/v1/realtime/sessions
OpenAI-Beta: realtime=v1
```

The client-secret provider contract now represents the single GA endpoint directly, without obsolete endpoint-type state.

## Type of change

- [x] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [x] Transports (HTTP)
- [x] Providers/Integrations
- [x] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

### Focused Go tests

```sh
go test ./core \
  -run 'TestRunPostLLMHooksPreservesProviderResponseWithGuardrailError' \
  -count=1

go test ./core/providers/openai \
  -run 'Test(ExtractRealtimeTurnUsageSupports.*TranscriptionCompletion|RealtimeWebSocketURL|NormalizeRealtimeClientSecretRequest)' \
  -count=1

go test ./core/providers/azure -count=1

go test ./core/providers/elevenlabs \
  -run 'TestRealtimeWebSocketURLRejectsTranscription' \
  -count=1

go test ./framework/modelcatalog/datasheet \
  -run 'TestCalculateCost_(RealtimeTranscriptionDurationPricing|RealtimeTranscriptionStreamDurationPricing|RealtimeTranscriptionStreamSplitTokenPricing|RealtimeTranscriptionPricingOverride|NormalRealtimeDoesNotUseTranscriptionPricing|MissingTranscriptionPricingIsNonFatal)' \
  -count=1

go test ./transports/bifrost-http/handlers \
  -run 'Test(ResolveRealtimeSDPTargetDedicatedTranscription|ResolveRealtimeSDPTargetRootModelPreservesNormalRealtime|PinRealtimeSDPTranscriptionModelPreservesSession|RealtimeTurnCompletionContentModelsTranscriptAsOutputOnlyForTranscriptionSessions|BuildRealtimeTurnPostResponseModelsTranscriptionAsOutput|BuildRealtimeTurnPostResponseNormalRealtimeKeepsPricingMode|BuildRealtimeTurnPostResponseMissingPricing|RealtimeTurnFinalEventUsesTranscriptionCompletionOnlyForTranscriptionSessions|DiscoverRealtimeTranscriptionModel|BufferRealtimeTranscriptionBootstrapPreservesFrames|SnapshotRealtimeMiddlewareValuesWithContext|RealtimeSessionRoutesOnlyExposeGAClientSecrets)' \
  -count=1
```

### Compile and UI checks

```sh
go test ./transports/bifrost-http/handlers -run '^$'
go build ./core ./plugins/logging ./plugins/governance

cd ui
npm run typecheck
npm run lint -- app/workspace/logs/sheets/logDetailView.tsx lib/types/logs.ts
```

### Manual WebSocket verification

Connect with a normal Bifrost credential or virtual key:

```text
ws://127.0.0.1:8080/openai/v1/realtime?intent=transcription
```

Send this session update:

```json
{
  "type": "session.update",
  "session": {
    "type": "transcription",
    "audio": {
      "input": {
        "format": {
          "type": "audio/pcm",
          "rate": 24000
        },
        "transcription": {
          "model": "openai/gpt-4o-transcribe",
          "language": "en"
        },
        "turn_detection": null
      }
    }
  }
}
```

Append base64-encoded PCM16 mono audio at 24 kHz and commit the input buffer. Expect `session.updated`, transcript delta events, and `conversation.item.input_audio_transcription.completed`.

Repeat with `azure/gpt-4o-transcribe` to exercise Azure routing. Use `openai/whisper-1` to verify duration-based usage and pricing.

### Verified live behavior

Live cluster checks covered:

- OpenAI WebSocket transcription success and output-guardrail blocking;
- Azure WebSocket transcription success;
- OpenAI WebRTC transcription success;
- transcript suppression on guardrail intervention;
- successful and blocked log records;
- exact request, token, and monetary-cost accounting;
- duration usage, including fractional seconds, from OpenAI `whisper-1`;
- matching transcription pricing inputs for streamed and non-streamed Responses;
- fresh virtual-key WebRTC governance accounting from a zero baseline.

Observed token-priced examples:

| Path | Result | Tokens | Cost |
| --- | --- | ---: | ---: |
| OpenAI WebSocket, guardrail blocked | error log with retained provider result | 43 | `$0.0002125` |
| OpenAI WebSocket, success | completed transcript | 44 | `$0.0002225` |
| Azure WebSocket, success | completed transcript | 43 | `$0.0002125` |
| OpenAI WebRTC, fresh virtual key | completed transcript, one request charged | 43 | `$0.0002125` |

No new configuration or environment variables are required.

## Screenshots/Recordings

Not included. The UI change is limited to displaying transcription duration and pricing metadata already present in log details.

## Breaking changes

- [x] Yes
- [ ] No

The retired beta realtime session endpoints are removed:

```text
POST /v1/realtime/sessions
POST /openai/v1/realtime/sessions
```

Clients must use the GA client-secret endpoints:

```text
POST /v1/realtime/client_secrets
POST /openai/v1/realtime/client_secrets
```

Internal realtime provider contracts also carry transcription intent and remove the obsolete client-secret endpoint-type argument.

## Related issues

No linked issue.

## Security considerations

- Authentication completes before Bifrost upgrades a transcription WebSocket, so unauthenticated clients cannot consume bootstrap buffering.
- Transcription follows normal virtual-key authorization, routing hooks, provider-key selection, aliases, governance, and proxy configuration.
- Bootstrap buffering has time, frame-count, and byte limits.
- Long-lived sessions inherit only allowlisted middleware values and do not reuse the completed upgrade trace.
- Provider credentials are never sent to downstream clients.
- Output guardrails inspect completed transcripts before Bifrost delivers them.
- This change does not add or log credentials.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
