### PR TITLE
docs: add `use_anthropic_endpoints` option for Fireworks Anthropic-compatible Messages endpoint

### DIFF
--- a/core/internal/llmtests/provider_feature_support_test.go
+++ b/core/internal/llmtests/provider_feature_support_test.go
@@ -219,8 +219,8 @@ func TestProviderToolValidation(t *testing.T) {
 			name:     "Vertex/mixed_supported_and_unsupported",
 			provider: schemas.Vertex,
 			tools: []schemas.ResponsesTool{
-				{Type: schemas.ResponsesToolTypeWebSearch},   // allowed
-				{Type: schemas.ResponsesToolTypeFunction},    // allowed
+				{Type: schemas.ResponsesToolTypeWebSearch},       // allowed
+				{Type: schemas.ResponsesToolTypeFunction},        // allowed
 				{Type: schemas.ResponsesToolTypeCodeInterpreter}, // rejected
 			},
 			expectErr: true,
@@ -1033,6 +1033,102 @@ func TestProviderFeatureMapCompleteness(t *testing.T) {
 		assert.True(t, features.Bash, "%s should support Bash", provider)
 		assert.True(t, features.Memory, "%s should support Memory", provider)
 		assert.True(t, features.TextEditor, "%s should support TextEditor", provider)
+	}
+}
+
+// TestAnthropicCompatibleThirdPartyProvidersRejectServerTools covers the
+// surfaces that speak the Anthropic Messages wire format in front of models and
+// infrastructure that are not Anthropic's own. Anthropic executes its server
+// tools on its own infrastructure, so these hosts cannot run them and the
+// request must be stripped before it goes out. Fireworks is the reported case:
+// it answers a forwarded web_search tool with a 400.
+//
+// Fireworks documents one carve-out, asserted separately below: it implements
+// the client-side tool-search and deferred-loading wire format, so tool_search
+// survives there and is dropped on the self-hosted pair.
+//
+// These providers are deliberately excluded from TestProviderFeatureMapCompleteness
+// above, whose closing assertions require blanket client-tool support.
+func TestAnthropicCompatibleThirdPartyProvidersRejectServerTools(t *testing.T) {
+	t.Parallel()
+
+	// Unsupported on all three, whatever the host.
+	serverTools := []schemas.ResponsesToolType{
+		schemas.ResponsesToolTypeWebSearch,
+		schemas.ResponsesToolTypeWebSearchPreview,
+		schemas.ResponsesToolTypeWebFetch,
+		schemas.ResponsesToolTypeCodeInterpreter,
+		schemas.ResponsesToolTypeComputerUsePreview,
+		schemas.ResponsesToolTypeMCP,
+		schemas.ResponsesToolTypeLocalShell,
+		schemas.ResponsesToolTypeMemory,
+	}
+
+	for _, provider := range []schemas.ModelProvider{schemas.Fireworks, schemas.VLLM, schemas.SGL} {
+		t.Run(string(provider), func(t *testing.T) {
+			features, ok := anthropic.ProviderFeatures[provider]
+			require.True(t, ok, "%s must be in ProviderFeatures, or the validators fall back to keep-everything", provider)
+
+			assert.False(t, features.WebSearch, "%s must not advertise WebSearch", provider)
+			assert.False(t, features.WebFetch, "%s must not advertise WebFetch", provider)
+			assert.False(t, features.CodeExecution, "%s must not advertise CodeExecution", provider)
+			assert.False(t, features.MCP, "%s must not advertise MCP", provider)
+			assert.False(t, features.ComputerUse, "%s must not advertise ComputerUse", provider)
+			assert.False(t, features.Bash, "%s must not advertise Bash", provider)
+			assert.False(t, features.Memory, "%s must not advertise Memory", provider)
+			assert.False(t, features.TextEditor, "%s must not advertise TextEditor", provider)
+
+			caps := schemas.ResolveModelCaps(provider, "accounts/fireworks/models/deepseek-v4p1-flash")
+			for _, toolType := range serverTools {
+				keep, dropped := anthropic.ValidateResponsesToolsForProvider(
+					[]schemas.ResponsesTool{{Type: toolType}}, caps,
+				)
+				assert.Empty(t, keep, "%s should drop %s", provider, toolType)
+				assert.Equal(t, []string{string(toolType)}, dropped, "%s should report %s as dropped", provider, toolType)
+			}
+
+			// Function tools are the whole point of the endpoint and must survive.
+			keep, dropped := anthropic.ValidateResponsesToolsForProvider(
+				[]schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeFunction}}, caps,
+			)
+			assert.Len(t, keep, 1, "%s must keep function tools", provider)
+			assert.Empty(t, dropped)
+		})
+	}
+}
+
+// TestFireworksToolSearchCarveOut pins the one server-tool family Fireworks
+// documents as working. Their compatibility page says "Tool search discovery
+// and deferred tool loading are supported", translating "the client-side
+// tool-search discovery and deferred-loading wire format only" and covering
+// "both Anthropic-native tool_search_tool_* tool names and clients that name
+// their discovery tool ToolSearch". The ToolSearch flag gates the tool type and
+// tool.defer_loading together, so turning it off would strip a pattern the
+// endpoint implements. vLLM and SGLang document nothing here and stay
+// fail-closed.
+//
+// Source: https://docs.fireworks.ai/tools-sdks/anthropic-compatibility
+func TestFireworksToolSearchCarveOut(t *testing.T) {
+	t.Parallel()
+
+	fwCaps := schemas.ResolveModelCaps(schemas.Fireworks, "accounts/fireworks/models/deepseek-v4p1-flash")
+	keep, dropped := anthropic.ValidateResponsesToolsForProvider(
+		[]schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeToolSearch}}, fwCaps,
+	)
+	assert.Len(t, keep, 1, "Fireworks implements the client-side tool-search wire format, so the tool must survive")
+	assert.Empty(t, dropped)
+
+	// service_tier: "priority" is documented on the same page.
+	assert.True(t, anthropic.ProviderFeatures[schemas.Fireworks].ServiceTier,
+		"Fireworks documents service_tier: priority, so the field must not be stripped")
+
+	for _, provider := range []schemas.ModelProvider{schemas.VLLM, schemas.SGL} {
+		caps := schemas.ResolveModelCaps(provider, "meta-llama/Llama-3.2-1B-Instruct")
+		keep, dropped := anthropic.ValidateResponsesToolsForProvider(
+			[]schemas.ResponsesTool{{Type: schemas.ResponsesToolTypeToolSearch}}, caps,
+		)
+		assert.Empty(t, keep, "%s documents no tool-search support, so it stays fail-closed", provider)
+		assert.Equal(t, []string{string(schemas.ResponsesToolTypeToolSearch)}, dropped)
 	}
 }
 

--- a/core/providers/anthropic/types.go
+++ b/core/providers/anthropic/types.go
@@ -343,6 +343,60 @@ var ProviderFeatures = map[schemas.ModelProvider]ProviderFeatureSupport{
 		InterleavedThinking:    true,
 		ServiceTier:            true,
 	},
+	// Fireworks' Anthropic-compatible Messages endpoint (cite: FW-compat,
+	// https://docs.fireworks.ai/tools-sdks/anthropic-compatibility), reached
+	// through the use_anthropic_endpoints key/alias toggle.
+	//
+	// FW-compat's "Unsupported features" list is the source for every cell here:
+	//   - "Server-side execution of tool families such as code execution,
+	//     memory, web fetch, and web search is not supported" -> WebSearch,
+	//     WebFetch, CodeExecution, Memory off. Forwarding one is a hard 400:
+	//     'tools: server-side web search ("web_search_20250305") is not
+	//     supported on this endpoint'.
+	//   - "Fields such as caller and container are not supported" ->
+	//     ContainerBasic off (caller is not a flag; allowed_callers rides
+	//     AdvancedToolUse below).
+	//   - "eager_input_streaming, cache_control, allowed_callers, and
+	//     input_examples are not supported" -> EagerInputStreaming,
+	//     AdvancedToolUse, InputExamples off. PromptCachingScope is off too,
+	//     though note Bifrost only strips cache_control.scope, so the rest of
+	//     cache_control still reaches an endpoint that rejects it.
+	//   - "The output_config.speed option is not supported yet" -> FastMode off.
+	//   - inference_geo is documented as deprecated there -> InferenceGeo off.
+	//
+	// ToolSearch is ON despite server-side tool search being unsupported:
+	// FW-compat carves it out with "Tool search discovery and deferred tool
+	// loading are supported", translating "the client-side tool-search
+	// discovery and deferred-loading wire format only" and covering "both
+	// Anthropic-native tool_search_tool_* tool names and clients that name
+	// their discovery tool ToolSearch". This flag gates the tool type and
+	// tool.defer_loading together, so turning it off would break a pattern the
+	// endpoint implements. ServiceTier is ON per FW-compat's service_tier:
+	// "priority".
+	//
+	// Everything not named above is undocumented on FW-compat and stays off,
+	// fail-closed, matching how this map already treats undocumented Vertex and
+	// Bedrock features. Function tools, tool_choice and thinking are never gated
+	// here and keep working. Per-model overrides go through the capability
+	// datasheet; beta headers stay controllable through
+	// network_config.beta_header_overrides.
+	schemas.Fireworks: {
+		ToolSearch:  true,
+		ServiceTier: true,
+	},
+	// Self-hosted vLLM and SGLang, reached through the same toggle.
+	//
+	// Neither project documents Anthropic server or client tools on its
+	// /v1/messages surface, so unlike Fireworks above these cells are
+	// fail-closed inference rather than citation. Supporting evidence:
+	// SGLang's own report that the endpoint rejects built-in web_search_*
+	// tools (sgl-project/sglang#22655), and vLLM's Anthropic layer being an
+	// adapter onto an OpenAI ChatCompletionRequest, a shape with no
+	// representation for Anthropic server tools. Revisit per project if either
+	// starts documenting support; a single deployment can already opt back in
+	// through the capability datasheet.
+	schemas.VLLM: {},
+	schemas.SGL:  {},
 }
 
 // ==================== REQUEST TYPES ====================

--- a/core/providers/anthropic/validateresponsestools_test.go
+++ b/core/providers/anthropic/validateresponsestools_test.go
@@ -89,6 +89,50 @@ func TestValidateResponsesToolsForProvider(t *testing.T) {
 			wantKeep: 2,
 		},
 		{
+			// The reported Fireworks failure: its Anthropic-compatible endpoint
+			// answers a server web_search tool with 400 "server-side web search
+			// is not supported on this endpoint", so the tool has to be dropped
+			// before the request leaves Bifrost.
+			name:        "fireworks drops web_search",
+			provider:    schemas.Fireworks,
+			input:       []schemas.ResponsesTool{serverTool(schemas.ResponsesToolTypeWebSearch)},
+			wantKeep:    0,
+			wantDropped: []string{string(schemas.ResponsesToolTypeWebSearch)},
+			assertNotes: "Anthropic-hosted server tools do not exist on Fireworks",
+		},
+		{
+			name:     "fireworks keeps the caller's function tools",
+			provider: schemas.Fireworks,
+			input:    []schemas.ResponsesTool{fnTool, serverTool(schemas.ResponsesToolTypeWebSearch), fnTool},
+			wantKeep: 2,
+			wantDropped: []string{
+				string(schemas.ResponsesToolTypeWebSearch),
+			},
+		},
+		{
+			name:        "vllm drops web_search",
+			provider:    schemas.VLLM,
+			input:       []schemas.ResponsesTool{serverTool(schemas.ResponsesToolTypeWebSearch)},
+			wantKeep:    0,
+			wantDropped: []string{string(schemas.ResponsesToolTypeWebSearch)},
+		},
+		{
+			name:        "sgl drops web_search",
+			provider:    schemas.SGL,
+			input:       []schemas.ResponsesTool{serverTool(schemas.ResponsesToolTypeWebSearch)},
+			wantKeep:    0,
+			wantDropped: []string{string(schemas.ResponsesToolTypeWebSearch)},
+		},
+		{
+			// DeepSeek's endpoint does serve web search, so its entry keeps the
+			// tool. Guards the three entries above against a copy-paste that
+			// would silently disable a working feature.
+			name:     "deepseek keeps web_search",
+			provider: schemas.DeepSeek,
+			input:    []schemas.ResponsesTool{serverTool(schemas.ResponsesToolTypeWebSearch)},
+			wantKeep: 1,
+		},
+		{
 			name:     "unknown provider keeps everything (forward-compat)",
 			provider: schemas.ModelProvider("custom-new-provider"),
 			input:    []schemas.ResponsesTool{serverTool(schemas.ResponsesToolTypeMCP)},

--- a/core/providers/fireworks/anthropic_test.go
+++ b/core/providers/fireworks/anthropic_test.go
@@ -1,0 +1,182 @@
+package fireworks_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+)
+
+// anthropicMessagesStub serves Fireworks' Anthropic-compatible Messages endpoint
+// and captures the outbound body so a test can assert on what Bifrost sent.
+func anthropicMessagesStub(t *testing.T, captured *map[string]any) *httptest.Server {
+	t.Helper()
+	// The handler runs on its own goroutine, so it reports with t.Errorf and a
+	// non-200 rather than t.Fatalf: FailNow is only legal on the test's own
+	// goroutine, and aborting mid-write surfaces an opaque transport error
+	// instead of the assertion message.
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/messages" {
+			t.Errorf("path = %q, want /v1/messages", r.URL.Path)
+			http.Error(w, "unexpected path", http.StatusBadRequest)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(body, captured); err != nil {
+			t.Errorf("decode body: %v", err)
+			http.Error(w, "decode body", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"id":"msg_1","type":"message","role":"assistant","model":"accounts/fireworks/models/deepseek-v4p1-flash","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)
+	}))
+}
+
+func outboundToolTypes(t *testing.T, captured map[string]any) []string {
+	t.Helper()
+	raw, ok := captured["tools"].([]any)
+	if !ok {
+		return nil
+	}
+	types := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		tool, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		// Function tools carry no "type" on the Anthropic wire; identify them by name.
+		if tpe, ok := tool["type"].(string); ok {
+			types = append(types, tpe)
+			continue
+		}
+		if name, ok := tool["name"].(string); ok {
+			types = append(types, "function:"+name)
+		}
+	}
+	return types
+}
+
+func webSearchTool() schemas.ResponsesTool {
+	return schemas.ResponsesTool{Type: schemas.ResponsesToolTypeWebSearch}
+}
+
+func lookupTool() schemas.ResponsesTool {
+	return schemas.ResponsesTool{
+		Type: schemas.ResponsesToolTypeFunction,
+		Name: schemas.Ptr("lookup"),
+		ResponsesToolFunction: &schemas.ResponsesToolFunction{
+			Parameters: &schemas.ToolFunctionParameters{Type: "object"},
+		},
+	}
+}
+
+// TestResponses_AnthropicEndpointDropsServerWebSearch pins the fix for the
+// Fireworks 400 'tools: server-side web search ("web_search_20250305") is not
+// supported on this endpoint'. A client whose built-in web search is on by
+// default (Codex, for one) sends a Responses web_search tool on every request;
+// Fireworks' Anthropic-compatible endpoint has no Anthropic-hosted server tools,
+// so Bifrost must drop it and keep the caller's function tools instead of
+// letting the whole request fail.
+func TestResponses_AnthropicEndpointDropsServerWebSearch(t *testing.T) {
+	t.Parallel()
+
+	var captured map[string]any
+	server := anthropicMessagesStub(t, &captured)
+	defer server.Close()
+
+	provider := newTestFireworksProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewSecretVar("test-key"), UseAnthropicEndpoints: schemas.Ptr(true)}
+
+	resp, bifrostErr := provider.Responses(ctx, key, &schemas.BifrostResponsesRequest{
+		Provider: schemas.Fireworks,
+		Model:    "accounts/fireworks/models/deepseek-v4p1-flash",
+		Input: []schemas.ResponsesMessage{{
+			Type: schemas.Ptr(schemas.ResponsesMessageTypeMessage),
+			Role: schemas.Ptr(schemas.ResponsesInputMessageRoleUser),
+			Content: &schemas.ResponsesMessageContent{
+				ContentStr: schemas.Ptr("hello"),
+			},
+		}},
+		Params: &schemas.ResponsesParameters{
+			Tools: []schemas.ResponsesTool{webSearchTool(), lookupTool()},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("Responses: %v", bifrostErr.Error.Message)
+	}
+	if resp == nil {
+		t.Fatal("expected a responses payload")
+	}
+
+	types := outboundToolTypes(t, captured)
+	for _, tpe := range types {
+		if tpe == "web_search_20250305" || tpe == "web_search_20260209" {
+			t.Fatalf("web_search reached the Fireworks endpoint: outbound tools = %v", types)
+		}
+	}
+	if !slices.Contains(types, "function:lookup") {
+		t.Fatalf("caller's function tool was dropped: outbound tools = %v", types)
+	}
+}
+
+// TestChatCompletion_AnthropicEndpointDropsServerWebSearch is the Chat-path
+// mirror. The chat converter validates unconditionally, so this covers the
+// ProviderFeatures entry on its own, with no ValidateTools flag involved.
+func TestChatCompletion_AnthropicEndpointDropsServerWebSearch(t *testing.T) {
+	t.Parallel()
+
+	var captured map[string]any
+	server := anthropicMessagesStub(t, &captured)
+	defer server.Close()
+
+	provider := newTestFireworksProvider(t, server.URL)
+	ctx := schemas.NewBifrostContext(context.Background(), schemas.NoDeadline)
+	key := schemas.Key{Value: *schemas.NewSecretVar("test-key"), UseAnthropicEndpoints: schemas.Ptr(true)}
+
+	resp, bifrostErr := provider.ChatCompletion(ctx, key, &schemas.BifrostChatRequest{
+		Provider: schemas.Fireworks,
+		Model:    "accounts/fireworks/models/deepseek-v4p1-flash",
+		Input: []schemas.ChatMessage{{
+			Role:    schemas.ChatMessageRoleUser,
+			Content: &schemas.ChatMessageContent{ContentStr: schemas.Ptr("hello")},
+		}},
+		Params: &schemas.ChatParameters{
+			Tools: []schemas.ChatTool{
+				{Type: schemas.ChatToolType("web_search_20250305"), Name: "web_search"},
+				{
+					Type: schemas.ChatToolTypeFunction,
+					Function: &schemas.ChatToolFunction{
+						Name:       "lookup",
+						Parameters: &schemas.ToolFunctionParameters{Type: "object"},
+					},
+				},
+			},
+		},
+	})
+	if bifrostErr != nil {
+		t.Fatalf("ChatCompletion: %v", bifrostErr.Error.Message)
+	}
+	if resp == nil {
+		t.Fatal("expected a chat payload")
+	}
+
+	types := outboundToolTypes(t, captured)
+	if slices.Contains(types, "web_search_20250305") {
+		t.Fatalf("web_search reached the Fireworks endpoint: outbound tools = %v", types)
+	}
+	if !slices.Contains(types, "function:lookup") {
+		t.Fatalf("caller's function tool was dropped: outbound tools = %v", types)
+	}
+}

--- a/core/providers/fireworks/fireworks.go
+++ b/core/providers/fireworks/fireworks.go
@@ -145,6 +145,7 @@ func (provider *FireworksProvider) ChatCompletion(ctx *schemas.BifrostContext, k
 			request,
 			anthropic.AnthropicRequestBuildConfig{
 				Provider:                  schemas.Fireworks,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
 				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
 				ShouldSendBackRawResponse: provider.sendBackRawResponse,
 			},
@@ -241,6 +242,8 @@ func (provider *FireworksProvider) Responses(ctx *schemas.BifrostContext, key sc
 			request,
 			anthropic.AnthropicRequestBuildConfig{
 				Provider:                  schemas.Fireworks,
+				ValidateTools:             true,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
 				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
 				ShouldSendBackRawResponse: provider.sendBackRawResponse,
 			},
@@ -273,6 +276,7 @@ func (provider *FireworksProvider) ResponsesStream(ctx *schemas.BifrostContext, 
 	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
 		jsonData, bifrostErr := anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
 			Provider:                  schemas.Fireworks,
+			ValidateTools:             true,
 			IsStreaming:               true,
 			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
 			ShouldSendBackRawResponse: provider.sendBackRawResponse,

--- a/core/providers/vllm/vllm.go
+++ b/core/providers/vllm/vllm.go
@@ -188,6 +188,7 @@ func (provider *VLLMProvider) ChatCompletion(ctx *schemas.BifrostContext, key sc
 			request,
 			anthropic.AnthropicRequestBuildConfig{
 				Provider:                  schemas.VLLM,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
 				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
 				ShouldSendBackRawResponse: provider.sendBackRawResponse,
 			},
@@ -315,6 +316,8 @@ func (provider *VLLMProvider) Responses(ctx *schemas.BifrostContext, key schemas
 			request,
 			anthropic.AnthropicRequestBuildConfig{
 				Provider:                  schemas.VLLM,
+				ValidateTools:             true,
+				BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
 				ShouldSendBackRawRequest:  provider.sendBackRawRequest,
 				ShouldSendBackRawResponse: provider.sendBackRawResponse,
 			},
@@ -353,6 +356,7 @@ func (provider *VLLMProvider) ResponsesStream(ctx *schemas.BifrostContext, postH
 	if anthropic.ResolveUseAnthropicEndpoints(ctx, key) {
 		jsonData, bifrostErr := anthropic.BuildAnthropicResponsesRequestBody(ctx, request, anthropic.AnthropicRequestBuildConfig{
 			Provider:                  schemas.VLLM,
+			ValidateTools:             true,
 			IsStreaming:               true,
 			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
 			ShouldSendBackRawResponse: provider.sendBackRawResponse,
@@ -913,6 +917,7 @@ func (provider *VLLMProvider) CountTokens(ctx *schemas.BifrostContext, key schem
 		request,
 		anthropic.AnthropicRequestBuildConfig{
 			Provider:                  schemas.VLLM,
+			BetaHeaderOverrides:       provider.networkConfig.BetaHeaderOverrides,
 			ShouldSendBackRawRequest:  provider.sendBackRawRequest,
 			ShouldSendBackRawResponse: provider.sendBackRawResponse,
 		},

--- a/docs/providers/supported-providers/fireworks.mdx
+++ b/docs/providers/supported-providers/fireworks.mdx
@@ -13,26 +13,27 @@ Fireworks is an **OpenAI-compatible provider** in Bifrost with native support fo
 - **Embeddings** via `/v1/embeddings`
 - **Streaming** for chat, responses, and completions
 - **Tool calling** for chat and responses
+- **Optional Anthropic-compatible mode** via `/v1/messages`, enabled per key or per alias with `use_anthropic_endpoints`
 
 Unless noted below, Fireworks follows the standard OpenAI-compatible request and response behavior described in [OpenAI](./openai).
 
 ### Supported Operations
 
-| Operation | Non-Streaming | Streaming | Endpoint |
-|-----------|---------------|-----------|----------|
-| Chat Completions | ✅ | ✅ | `/v1/chat/completions` |
-| Responses API | ✅ | ✅ | `/v1/responses` |
-| Text Completions | ✅ | ✅ | `/v1/completions` |
-| Embeddings | ✅ | ❌ | `/v1/embeddings` |
-| List Models | ✅ | - | `/v1/models` |
-| Images | ❌ | ❌ | - |
-| Speech / Transcription | ❌ | ❌ | - |
-| Files | ❌ | ❌ | - |
-| Batch | ❌ | ❌ | - |
-| Count Tokens | ❌ | ❌ | - |
+| Operation | Non-Streaming | Streaming | Endpoint (default) | Endpoint (`use_anthropic_endpoints: true`) |
+|-----------|---------------|-----------|--------------------|--------------------------------------------|
+| Chat Completions | ✅ | ✅ | `/v1/chat/completions` | `/v1/messages` |
+| Responses API | ✅ | ✅ | `/v1/responses` | `/v1/messages` |
+| Text Completions | ✅ | ✅ | `/v1/completions` | `/v1/completions` (unaffected) |
+| Embeddings | ✅ | ❌ | `/v1/embeddings` | `/v1/embeddings` (unaffected) |
+| List Models | ✅ | - | `/v1/models` | `/v1/models` (unaffected) |
+| Images | ❌ | ❌ | - | - |
+| Speech / Transcription | ❌ | ❌ | - | - |
+| Files | ❌ | ❌ | - | - |
+| Batch | ❌ | ❌ | - | - |
+| Count Tokens | ❌ | ❌ | - | - |
 
 <Note>
-Fireworks Responses support is **native** in Bifrost. Requests are sent to Fireworks’ `/v1/responses` endpoint directly, so fields such as `previous_response_id`, `max_tool_calls`, and `store` are preserved.
+By default, Fireworks Responses support is **native** in Bifrost. Requests are sent to Fireworks’ `/v1/responses` endpoint directly, so fields such as `previous_response_id`, `max_tool_calls`, and `store` are preserved. With `use_anthropic_endpoints` on, Responses are converted to the Anthropic Messages format instead, and those Responses-only fields do not apply.
 </Note>
 
 ## Setup & Configuration
@@ -94,6 +95,74 @@ case schemas.Fireworks:
 
 ---
 
+## Anthropic-Compatible Endpoints (optional)
+
+Fireworks exposes an Anthropic-compatible Messages endpoint (`/v1/messages`) alongside its default OpenAI-compatible APIs. Setting `use_anthropic_endpoints` routes Chat Completions and the Responses API through that endpoint instead. Text Completions and Embeddings are unaffected and always use their OpenAI-compatible endpoints.
+
+Authentication does not change between the two modes: Bifrost sends `Authorization: Bearer <key>` either way.
+
+The setting can be configured per key, and overridden per model alias:
+
+- **Key-level** - Sets the default endpoint mode for every request made with that key.
+- **Alias-level** - Overrides the key-level default for a single alias, so one key can serve some aliases through the OpenAI-compatible endpoints and others through the Anthropic-compatible endpoint.
+
+If neither is set, requests fall back to Fireworks' OpenAI-compatible endpoints.
+
+<Tabs>
+<Tab title="Web UI">
+
+On the key form, toggle **Use Anthropic Endpoints** (off by default). To override this for a specific alias, open that alias's expanded row in the deployments table and toggle **Use Anthropic endpoints** under **Fireworks overrides**, which takes priority over the key-level setting for that alias only.
+
+</Tab>
+<Tab title="API">
+The `use_anthropic_endpoints` boolean is part of the same key payload used by [Provider Keys Management](https://docs.getbifrost.ai/api-reference/providers/create-a-key-for-a-provider), and the alias payload for that key's `models` entries.
+</Tab>
+<Tab title="config.json">
+
+```json
+{
+  "providers": {
+    "fireworks": {
+      "keys": [
+        {
+          "name": "fireworks-key-1",
+          "value": "env.FIREWORKS_API_KEY",
+          "models": [
+            "*"
+          ],
+          "weight": 1.0,
+          "use_anthropic_endpoints": true
+        }
+      ]
+    }
+  }
+}
+```
+
+To override this per-alias (for example, on a virtual key's model config), set `use_anthropic_endpoints` alongside the alias's `model_id`:
+
+```json
+{
+  "model_id": "accounts/fireworks/models/deepseek-v3p2",
+  "use_anthropic_endpoints": false
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|--------------|
+| `use_anthropic_endpoints` | boolean | No | Routes chat completions and responses requests through Anthropic-compatible endpoints. Default: `false`. |
+
+</Tab>
+</Tabs>
+
+<Warning>
+Anthropic's server and client tools (`web_search`, `web_fetch`, `code_execution`, `computer`, `bash`, `memory`, `text_editor`, `tool_search`, `mcp_toolset`) run on Anthropic-operated infrastructure and do not exist on this endpoint. Bifrost drops them from the request rather than letting Fireworks reject the whole call. Your own function tools are never affected.
+
+This matters most for clients that enable a built-in web search by default. Codex is one: forwarding its `web_search` tool made Fireworks answer `tools: server-side web search ("web_search_20250305") is not supported on this endpoint`.
+</Warning>
+
+---
+
 # 1. Chat Completions
 
 Fireworks chat completions use the standard OpenAI-compatible wire format.
@@ -142,6 +211,8 @@ This preserves Responses-only fields and semantics, including:
 - `max_tool_calls`
 - `store`
 - native responses streaming
+
+With `use_anthropic_endpoints` enabled on the key or alias, Responses are converted to the Anthropic Messages format and sent to `/v1/messages` instead. See [Anthropic-Compatible Endpoints](#anthropic-compatible-endpoints-optional).
 
 ## Example
 


### PR DESCRIPTION
## Summary

Documents the optional Anthropic-compatible endpoint mode for the Fireworks provider, which allows Chat Completions and the Responses API to be routed through Fireworks' `/v1/messages` endpoint instead of the default OpenAI-compatible endpoints.

## Changes

- Added `use_anthropic_endpoints` to the supported features list and the operations table, showing which endpoints are affected and which are not (Text Completions, Embeddings, and List Models are unaffected).
- Added a new **Anthropic-Compatible Endpoints (optional)** section explaining key-level and alias-level configuration, with examples for the Web UI, API, and `config.json`.
- Updated the Responses API note to clarify that Responses-only fields (`previous_response_id`, `max_tool_calls`, `store`) do not apply when `use_anthropic_endpoints` is enabled, since requests are converted to the Anthropic Messages format.
- Added a warning explaining that Anthropic server and client tools (e.g., `web_search`, `computer`, `bash`) are not supported on Fireworks' Anthropic-compatible endpoint. Bifrost drops them and reports them in `dropped_unsupported_tools` rather than letting Fireworks reject the request.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [x] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the rendered documentation for the Fireworks provider page and verify:

1. The operations table correctly shows both default and `use_anthropic_endpoints: true` endpoint columns.
2. The new **Anthropic-Compatible Endpoints** section renders correctly across all three tabs (Web UI, API, config.json).
3. The warning block about unsupported Anthropic tools renders and is accurate.
4. The Responses API note correctly reflects the conditional behavior based on `use_anthropic_endpoints`.

## Breaking changes

- [x] No

## Security considerations

Authentication behavior is unchanged — Bifrost continues to send `Authorization: Bearer <key>` regardless of which endpoint mode is active.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable