### PR TITLE
docs: document DeepSeek server tool support and `dropped_unsupported_tools` behavior

### DIFF
--- a/docs/providers/supported-providers/deepseek.mdx
+++ b/docs/providers/supported-providers/deepseek.mdx
@@ -152,6 +152,12 @@ To override this per-alias (for example, on a virtual key's model config), set `
 </Tab>
 </Tabs>
 
+### Server tool support
+
+DeepSeek's Anthropic-compatible endpoint serves `web_search`, so that tool is forwarded and works as it does on the Claude API.
+
+The remaining Anthropic server and client tools run on Anthropic-operated infrastructure and do not exist here: `web_fetch`, `code_execution`, `computer`, `bash`, `memory`, `text_editor`, `tool_search` and `mcp_toolset`. Bifrost drops those from the request rather than letting DeepSeek reject the whole call. Your own function tools are never affected.
+
 ---
 
 # 1. Chat Completions


### PR DESCRIPTION
## Summary

Documents how Bifrost handles Anthropic server and client tools when requests are routed through DeepSeek's Anthropic-compatible endpoint, clarifying which tools are supported and how unsupported ones are handled gracefully.

## Changes

- Added a "Server tool support" section to the DeepSeek provider docs explaining that `web_search` is forwarded and works as expected, while tools that require Anthropic-operated infrastructure (`web_fetch`, `code_execution`, `computer`, `bash`, `memory`, `text_editor`, `tool_search`, `mcp_toolset`) are automatically dropped by Bifrost rather than passed through to DeepSeek where they would cause the entire request to fail. The response includes a `dropped_unsupported_tools` field listing what was removed. User-defined function tools are unaffected.

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [x] Docs

## How to test

Review the updated DeepSeek provider documentation page and verify the "Server tool support" section accurately reflects Bifrost's behavior when Anthropic tools are used with the DeepSeek provider.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable