### PR TITLE
fix: prevent governance cleanup dump race

### DIFF
--- a/plugins/governance/tracker.go
+++ b/plugins/governance/tracker.go
@@ -3,6 +3,7 @@ package governance
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -177,6 +178,12 @@ func (t *UsageTracker) resetWorker(ctx context.Context) {
 	for {
 		select {
 		case <-t.resetTicker.C:
+			// Cleanup cancels trackerCtx before waiting for this worker. If a
+			// queued tick wins the select alongside done, do not start another
+			// reset cycle during shutdown.
+			if ctx.Err() != nil {
+				return
+			}
 			t.resetExpiredCounters(ctx)
 
 		case <-t.done:
@@ -197,25 +204,49 @@ func (t *UsageTracker) resetWorker(ctx context.Context) {
 // boundary falls further behind, so the only symptom is a stale last_reset.
 // The overrun warning below exists to make that state say so out loud.
 func (t *UsageTracker) resetExpiredCounters(ctx context.Context) {
+	if ctx.Err() != nil {
+		return
+	}
 	start := time.Now()
 
 	// ==== PART 1: Reset Rate Limits ====
 	resetRateLimits := t.store.ResetExpiredRateLimitsInMemory(ctx, true)
 	if err := t.store.ResetExpiredRateLimits(ctx, resetRateLimits); err != nil {
+		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
+			return
+		}
 		t.logger.Error("failed to reset expired rate limits: %v", err)
+	}
+	if ctx.Err() != nil {
+		return
 	}
 
 	// ==== PART 2: Reset Budgets ====
 	resetBudgets := t.store.ResetExpiredBudgetsInMemory(ctx, true)
 	if err := t.store.ResetExpiredBudgets(ctx, resetBudgets); err != nil {
+		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
+			return
+		}
 		t.logger.Error("failed to reset expired budgets: %v", err)
+	}
+	if ctx.Err() != nil {
+		return
 	}
 
 	// ==== PART 3: Dump all rate limits and budgets to database ====
 	if err := t.store.DumpRateLimits(ctx, nil, nil); err != nil {
+		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
+			return
+		}
 		t.logger.Error("failed to dump rate limits to database: %v", err)
 	}
+	if ctx.Err() != nil {
+		return
+	}
 	if err := t.store.DumpBudgets(ctx, nil); err != nil {
+		if ctx.Err() != nil && errors.Is(err, context.Canceled) {
+			return
+		}
 		t.logger.Error("failed to dump budgets to database: %v", err)
 	}
 
@@ -369,25 +400,28 @@ func (t *UsageTracker) validateStartupResetDurations(ctx context.Context) []erro
 
 // Cleanup stops all background workers and flushes pending operations
 func (t *UsageTracker) Cleanup() error {
-	// Final flush of in-memory deltas to DB before shutdown. Without this,
-	// any deltas accumulated since the last `workerInterval` tick are lost.
+	// Stop and join the periodic worker before taking the final snapshots. A
+	// final dump must be the last database writer: otherwise an in-flight cycle
+	// can be cancelled after mutating in-memory reset state, or can race the
+	// final rate-limit dump with a stale snapshot.
+	if t.trackerCancel != nil {
+		t.trackerCancel()
+	}
+	if t.resetTicker != nil {
+		t.resetTicker.Stop()
+	}
+	close(t.done)
+	t.wg.Wait()
+
+	// Flush all in-memory state after the worker has fully stopped. The plugin
+	// waits for its asynchronous accounting goroutines before calling Cleanup,
+	// so these snapshots include every accepted update since the last tick.
 	if err := t.store.DumpBudgets(context.Background(), nil); err != nil {
 		t.logger.Error("final budget dump on shutdown failed: %v", err)
 	}
 	if err := t.store.DumpRateLimits(context.Background(), nil, nil); err != nil {
 		t.logger.Error("final rate-limit dump on shutdown failed: %v", err)
 	}
-
-	// Stop background workers
-	if t.trackerCancel != nil {
-		t.trackerCancel()
-	}
-	close(t.done)
-	if t.resetTicker != nil {
-		t.resetTicker.Stop()
-	}
-	// Wait for workers to finish
-	t.wg.Wait()
 
 	t.logger.Debug("usage tracker cleanup completed")
 	return nil

--- a/plugins/governance/tracker_test.go
+++ b/plugins/governance/tracker_test.go
@@ -2,6 +2,8 @@ package governance
 
 import (
 	"context"
+	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -282,4 +284,89 @@ func TestUsageTracker_Cleanup(t *testing.T) {
 	// Should cleanup without error
 	err = tracker.Cleanup()
 	assert.NoError(t, err, "Cleanup should succeed")
+}
+
+type cleanupOrderingStore struct {
+	GovernanceStore
+	periodicEntered       chan struct{}
+	periodicExited        chan struct{}
+	finalDumped           chan struct{}
+	finalBeforeWorkerExit atomic.Bool
+}
+
+func (s *cleanupOrderingStore) ResetExpiredRateLimitsInMemory(context.Context, bool, ...string) []*configstoreTables.TableRateLimit {
+	return nil
+}
+
+func (s *cleanupOrderingStore) ResetExpiredBudgetsInMemory(context.Context, bool, ...string) []*configstoreTables.TableBudget {
+	return nil
+}
+
+func (s *cleanupOrderingStore) ResetExpiredRateLimits(context.Context, []*configstoreTables.TableRateLimit) error {
+	return nil
+}
+
+func (s *cleanupOrderingStore) ResetExpiredBudgets(context.Context, []*configstoreTables.TableBudget) error {
+	return nil
+}
+
+func (s *cleanupOrderingStore) DumpBudgets(context.Context, map[string]float64) error {
+	return nil
+}
+
+func (s *cleanupOrderingStore) DumpRateLimits(ctx context.Context, _ map[string]int64, _ map[string]int64) error {
+	if ctx.Done() == nil {
+		select {
+		case <-s.periodicExited:
+		default:
+			s.finalBeforeWorkerExit.Store(true)
+		}
+		close(s.finalDumped)
+		return nil
+	}
+
+	close(s.periodicEntered)
+	<-ctx.Done()
+	close(s.periodicExited)
+	return fmt.Errorf("failed to dump rate limits to database: failed to dump 4 rate limits: %w", ctx.Err())
+}
+
+// Cleanup must first cancel and join an in-flight periodic dump, then take the
+// final snapshot. Cancellation is expected during shutdown and must not be
+// reported as a database failure.
+func TestUsageTracker_CleanupWaitsForPeriodicDumpBeforeFinalFlush(t *testing.T) {
+	store := &cleanupOrderingStore{
+		periodicEntered: make(chan struct{}),
+		periodicExited:  make(chan struct{}),
+		finalDumped:     make(chan struct{}),
+	}
+	logger := NewMockLogger()
+	tracker := NewUsageTracker(context.Background(), store, nil, nil, logger)
+
+	// Enter the same reset cycle as resetWorker without waiting for the
+	// production ten-second ticker, and account for it in the worker wait group.
+	tracker.wg.Add(1)
+	go func() {
+		defer tracker.wg.Done()
+		tracker.resetExpiredCounters(tracker.trackerCtx)
+	}()
+
+	select {
+	case <-store.periodicEntered:
+	case <-time.After(time.Second):
+		t.Fatal("periodic dump did not start")
+	}
+
+	require.NoError(t, tracker.Cleanup())
+	assert.False(t, store.finalBeforeWorkerExit.Load(), "final dump raced the periodic worker")
+	select {
+	case <-store.finalDumped:
+	default:
+		t.Fatal("final rate-limit dump was not called")
+	}
+
+	logger.mu.Lock()
+	defer logger.mu.Unlock()
+	assert.NotContains(t, logger.errors, "failed to dump rate limits to database: %v",
+		"shutdown cancellation must not be logged as a database failure")
 }


### PR DESCRIPTION
## Summary

Fixes a shutdown lifecycle race in the governance usage tracker.

`UsageTracker.Cleanup()` previously performed its final budget and rate-limit dumps before stopping the periodic reset worker. If the worker was already dumping rate limits, `trackerCancel()` could cancel its in-flight database operation and produce:

```text
failed to dump rate limits to database: failed to dump rate limits to database: failed to dump 4 rate limits: context canceled
```

The previous ordering also meant the final dump was not guaranteed to be the tracker's last database writer.

## Changes

- Cancel and stop the periodic tracker worker before taking final database snapshots.
- Wait for the worker to exit before running `DumpBudgets` and `DumpRateLimits`.
- Prevent a queued ticker event from starting another reset cycle during shutdown.
- Stop the current reset cycle when the tracker context is canceled.
- Treat `context.Canceled` as an expected shutdown result only when the tracker context has actually been canceled.
- Add a deterministic regression test covering:
  - an in-flight periodic rate-limit dump;
  - final dump ordering;
  - suppression of the expected shutdown cancellation error.

The final dumps continue to use an independent background context because the worker context has already been canceled.

No changelog, documentation, configuration, or UI changes are included.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

The issue was reproduced before the fix using a controlled governance store that blocked the periodic `DumpRateLimits` call until `trackerCancel()` was invoked. It reproduced the same nested `context canceled` error observed in production.

Run the regression test:

```sh
cd plugins/governance
go test -run TestUsageTracker_CleanupWaitsForPeriodicDumpBeforeFinalFlush -count=1 -v .
```

Expected result:

```text
--- PASS: TestUsageTracker_CleanupWaitsForPeriodicDumpBeforeFinalFlush
```

Run the governance test suite:

```sh
cd plugins/governance
go test -count=1 .
```

Validated result:

```text
ok github.com/maximhq/bifrost/plugins/governance
```

Run the regression test with the race detector:

```sh
cd plugins/governance
go test -race -run TestUsageTracker_CleanupWaitsForPeriodicDumpBeforeFinalFlush -count=1 .
```

Validated result:

```text
ok github.com/maximhq/bifrost/plugins/governance
```

No new configs or environment variables were added.

## Screenshots/Recordings

Not applicable.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #7099

Related to #3548 and #3550.

## Security considerations

No security implications.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed (not applicable)
- [x] I verified builds succeed (Go and UI)
- [x] I verified the affected governance test suite passes locally