### PR TITLE
fix(openai): tolerate common /v1/models shapes and decode compressed bodies

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -581,7 +581,7 @@ func (bifrost *Bifrost) ListAllModels(ctx *schemas.BifrostContext, req *schemas.
 						errType == "provider_blocked"
 					if !isExpected {
 						providerErr = bifrostErr
-						bifrost.logger.Warn("failed to list models for provider %s: %s", providerKey, bifrostErr.GetErrorString())
+						bifrost.logger.Warn("failed to list models for provider %s: %s", providerKey, bifrostErr.GetErrorStringWithCause())
 					}
 					// Collect key statuses from error (failure case)
 					if len(bifrostErr.ExtraFields.KeyStatuses) > 0 {

--- a/core/providers/openai/models_test.go
+++ b/core/providers/openai/models_test.go
@@ -1,11 +1,16 @@
 package openai
 
 import (
+	"bytes"
+	"compress/gzip"
+	"compress/zlib"
 	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/andybalholm/brotli"
+	"github.com/klauspost/compress/zstd"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/require"
 	"github.com/valyala/fasthttp"
@@ -17,23 +22,47 @@ func TestListModelsByKeyResponseShapes(t *testing.T) {
 	tests := []struct {
 		name        string
 		body        string
-		wantID      string
+		wantIDs     []string
 		wantOwnedBy string
+		wantCreated int64
 		wantContext int
 	}{
 		{
 			name:        "OpenAI envelope",
 			body:        `{"object":"list","data":[{"id":"gpt-5","owned_by":"openai","context_window":128000}]}`,
-			wantID:      "test/gpt-5",
+			wantIDs:     []string{"test/gpt-5"},
 			wantOwnedBy: "openai",
 			wantContext: 128000,
 		},
 		{
 			name:        "Together array",
 			body:        `[{"id":"zai-org/GLM-5.2","organization":"Z.ai","context_length":131072}]`,
-			wantID:      "test/zai-org/GLM-5.2",
+			wantIDs:     []string{"test/zai-org/GLM-5.2"},
 			wantOwnedBy: "Z.ai",
 			wantContext: 131072,
+		},
+		{
+			name:    "models key instead of data",
+			body:    `{"models":[{"id":"gemini-3-pro"}]}`,
+			wantIDs: []string{"test/gemini-3-pro"},
+		},
+		{
+			name:    "bare array of ids",
+			body:    `["gpt-5","gpt-5-mini"]`,
+			wantIDs: []string{"test/gpt-5", "test/gpt-5-mini"},
+		},
+		{
+			name:    "ids inside data",
+			body:    `{"object":"list","data":["glm-4.6","glm-4.5-air"]}`,
+			wantIDs: []string{"test/glm-4.6", "test/glm-4.5-air"},
+		},
+		{
+			name:        "quoted scalars",
+			body:        `{"object":"list","data":[{"id":"kimi-k2","owned_by":"moonshot","created":"1760000000","context_window":"256000"}]}`,
+			wantIDs:     []string{"test/kimi-k2"},
+			wantOwnedBy: "moonshot",
+			wantCreated: 1760000000,
+			wantContext: 256000,
 		},
 	}
 
@@ -59,10 +88,224 @@ func TestListModelsByKeyResponseShapes(t *testing.T) {
 			)
 
 			require.Nil(t, bifrostErr)
-			require.Len(t, response.Data, 1)
-			require.Equal(t, test.wantID, response.Data[0].ID)
-			require.Equal(t, schemas.Ptr(test.wantOwnedBy), response.Data[0].OwnedBy)
-			require.Equal(t, schemas.Ptr(test.wantContext), response.Data[0].ContextLength)
+			require.Len(t, response.Data, len(test.wantIDs))
+
+			gotIDs := make([]string, 0, len(response.Data))
+			for _, model := range response.Data {
+				gotIDs = append(gotIDs, model.ID)
+			}
+			require.Equal(t, test.wantIDs, gotIDs)
+
+			if test.wantOwnedBy != "" {
+				require.Equal(t, schemas.Ptr(test.wantOwnedBy), response.Data[0].OwnedBy)
+			}
+			if test.wantCreated != 0 {
+				require.Equal(t, schemas.Ptr(test.wantCreated), response.Data[0].Created)
+			}
+			if test.wantContext != 0 {
+				require.Equal(t, schemas.Ptr(test.wantContext), response.Data[0].ContextLength)
+			}
+		})
+	}
+}
+
+// Compatible shapes are tolerated, but a body that is not a model list at all still
+// has to fail: answering with an empty catalog would hide the provider from callers.
+func TestListModelsByKeyUnrecognisedResponseStillFails(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "truncated JSON",
+			body: `{"object":"list","data":[{"id":`,
+		},
+		{
+			name: "data keyed by model id",
+			body: `{"object":"list","data":{"gpt-5":{"id":"gpt-5"}}}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(test.body))
+			}))
+			defer server.Close()
+
+			response, bifrostErr := ListModelsByKey(
+				schemas.NewBifrostContext(context.Background(), schemas.NoDeadline),
+				&fasthttp.Client{},
+				server.URL,
+				schemas.Key{Models: schemas.WhiteList{"*"}},
+				false,
+				nil,
+				schemas.ModelProvider("test"),
+				false,
+				false,
+			)
+
+			require.Nil(t, response)
+			require.NotNil(t, bifrostErr)
+			require.NotNil(t, bifrostErr.Error)
+			require.Equal(t, schemas.ErrProviderResponseUnmarshal, bifrostErr.Error.Message)
+		})
+	}
+}
+
+// Providers are free to answer with a compressed body: fasthttp neither sends an
+// Accept-Encoding nor decompresses on its own, so the list models path has to decode
+// explicitly. Undecoded bytes surface as `invalid char '\x1f\x8b'` unmarshal errors.
+func TestListModelsByKeyDecodesCompressedResponses(t *testing.T) {
+	t.Parallel()
+
+	const modelsBody = `{"object":"list","data":[{"id":"gpt-5","owned_by":"openai"},{"id":"gpt-5-mini"}]}`
+
+	tests := []struct {
+		name     string
+		encoding string
+		encode   func(*testing.T, []byte) []byte
+	}{
+		{
+			name:     "gzip",
+			encoding: "gzip",
+			encode: func(t *testing.T, payload []byte) []byte {
+				t.Helper()
+				var buf bytes.Buffer
+				writer := gzip.NewWriter(&buf)
+				_, err := writer.Write(payload)
+				require.NoError(t, err)
+				require.NoError(t, writer.Close())
+				return buf.Bytes()
+			},
+		},
+		{
+			name:     "deflate",
+			encoding: "deflate",
+			encode: func(t *testing.T, payload []byte) []byte {
+				t.Helper()
+				var buf bytes.Buffer
+				writer := zlib.NewWriter(&buf)
+				_, err := writer.Write(payload)
+				require.NoError(t, err)
+				require.NoError(t, writer.Close())
+				return buf.Bytes()
+			},
+		},
+		{
+			name:     "brotli",
+			encoding: "br",
+			encode: func(t *testing.T, payload []byte) []byte {
+				t.Helper()
+				var buf bytes.Buffer
+				writer := brotli.NewWriter(&buf)
+				_, err := writer.Write(payload)
+				require.NoError(t, err)
+				require.NoError(t, writer.Close())
+				return buf.Bytes()
+			},
+		},
+		{
+			name:     "zstd",
+			encoding: "zstd",
+			encode: func(t *testing.T, payload []byte) []byte {
+				t.Helper()
+				var buf bytes.Buffer
+				writer, err := zstd.NewWriter(&buf)
+				require.NoError(t, err)
+				_, err = writer.Write(payload)
+				require.NoError(t, err)
+				require.NoError(t, writer.Close())
+				return buf.Bytes()
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			compressed := test.encode(t, []byte(modelsBody))
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Encoding", test.encoding)
+				_, _ = w.Write(compressed)
+			}))
+			defer server.Close()
+
+			response, bifrostErr := ListModelsByKey(
+				schemas.NewBifrostContext(context.Background(), schemas.NoDeadline),
+				&fasthttp.Client{},
+				server.URL,
+				schemas.Key{Models: schemas.WhiteList{"*"}},
+				false,
+				nil,
+				schemas.ModelProvider("test"),
+				false,
+				false,
+			)
+
+			require.Nil(t, bifrostErr)
+			require.NotNil(t, response)
+			require.Len(t, response.Data, 2)
+			require.Equal(t, "test/gpt-5", response.Data[0].ID)
+			require.Equal(t, "test/gpt-5-mini", response.Data[1].ID)
+		})
+	}
+}
+
+// A body that claims a compression it does not carry, or one this build cannot
+// decode, must be reported as a decode failure instead of a bogus unmarshal error.
+func TestListModelsByKeyReportsUndecodableBodies(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		contentEncoding string
+		body            []byte
+	}{
+		{
+			name:            "corrupt gzip",
+			contentEncoding: "gzip",
+			body:            []byte(`{"object":"list","data":[{"id":"gpt-5"}]}`),
+		},
+		{
+			name:            "unsupported encoding",
+			contentEncoding: "compress",
+			body:            []byte(`{"object":"list","data":[{"id":"gpt-5"}]}`),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Encoding", test.contentEncoding)
+				_, _ = w.Write(test.body)
+			}))
+			defer server.Close()
+
+			response, bifrostErr := ListModelsByKey(
+				schemas.NewBifrostContext(context.Background(), schemas.NoDeadline),
+				&fasthttp.Client{},
+				server.URL,
+				schemas.Key{Models: schemas.WhiteList{"*"}},
+				false,
+				nil,
+				schemas.ModelProvider("test"),
+				false,
+				false,
+			)
+
+			require.Nil(t, response)
+			require.NotNil(t, bifrostErr)
+			require.NotNil(t, bifrostErr.Error)
+			require.Equal(t, schemas.ErrProviderResponseDecode, bifrostErr.Error.Message)
 		})
 	}
 }

--- a/core/providers/openai/openai.go
+++ b/core/providers/openai/openai.go
@@ -173,8 +173,12 @@ func ListModelsByKey(
 		return nil, providerUtils.SetErrorLatency(bifrostErr, latency)
 	}
 
-	// Copy response body before releasing
-	responseBody := append([]byte(nil), resp.Body()...)
+	// Decode the response body (handles gzip/deflate/br/zstd Content-Encoding)
+	// before releasing the response.
+	responseBody, decodeErr := providerUtils.CheckAndDecodeBody(resp)
+	if decodeErr != nil {
+		return nil, providerUtils.SetErrorLatency(providerUtils.NewBifrostOperationError(schemas.ErrProviderResponseDecode, decodeErr), latency)
+	}
 
 	openaiResponse := &OpenAIListModelsResponse{}
 

--- a/core/providers/openai/types.go
+++ b/core/providers/openai/types.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/bytedance/sonic"
@@ -1021,35 +1022,170 @@ type OpenAIListModelsResponse struct {
 	Data   []OpenAIModel `json:"data"`
 }
 
-// UnmarshalJSON accepts both OpenAI envelopes and compatible top-level model arrays.
+// UnmarshalJSON accepts the shapes OpenAI-compatible endpoints return for list-models.
+//
+// Apart from the OpenAI envelope, upstreams hand back bare arrays, id-only entries, a
+// "models" key instead of "data", and scalar fields that are quoted on one endpoint and
+// numeric on the next. None of those differences change which models a caller can reach,
+// so they are normalized here rather than failing the whole request with
+// "failed to unmarshal response from provider API":
+//
+//	{"object":"list","data":[{"id":"gpt-5"}]}   OpenAI envelope
+//	[{"id":"gpt-5"}]                            bare array (Together, vLLM, ...)
+//	["gpt-5","gpt-5-mini"]                      bare array of ids
+//	{"models":[{"id":"gpt-5"}]}                 "models" instead of "data"
 func (response *OpenAIListModelsResponse) UnmarshalJSON(data []byte) error {
-	type envelope OpenAIListModelsResponse
-
-	trimmed := bytes.TrimSpace(data)
-	if len(trimmed) == 0 || trimmed[0] != '[' {
-		return sonic.Unmarshal(trimmed, (*envelope)(response))
+	payload := bytes.TrimSpace(data)
+	if len(payload) == 0 {
+		return nil
 	}
 
-	var models []struct {
-		OpenAIModel
-		Organization  string `json:"organization"`
-		ContextLength *int   `json:"context_length,omitempty"`
+	entries := payload
+	if payload[0] != '[' {
+		var envelope struct {
+			Object string          `json:"object"`
+			Data   json.RawMessage `json:"data"`
+			Models json.RawMessage `json:"models"`
+		}
+		if err := sonic.Unmarshal(payload, &envelope); err != nil {
+			return err
+		}
+		response.Object = envelope.Object
+
+		switch {
+		case hasJSONValue(envelope.Data):
+			entries = envelope.Data
+		case hasJSONValue(envelope.Models):
+			entries = envelope.Models
+		default:
+			return nil
+		}
 	}
-	if err := sonic.Unmarshal(trimmed, &models); err != nil {
+
+	models, err := decodeOpenAIModels(entries)
+	if err != nil {
 		return err
 	}
-
-	response.Data = make([]OpenAIModel, len(models))
-	for i, model := range models {
-		response.Data[i] = model.OpenAIModel
-		if response.Data[i].OwnedBy == "" {
-			response.Data[i].OwnedBy = model.Organization
-		}
-		if response.Data[i].ContextWindow == nil {
-			response.Data[i].ContextWindow = model.ContextLength
-		}
-	}
+	response.Data = models
 	return nil
+}
+
+// hasJSONValue reports whether a raw JSON field carried anything at all, so that an
+// explicit null falls through to the next candidate key.
+func hasJSONValue(raw json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) > 0 && !bytes.Equal(trimmed, []byte("null"))
+}
+
+// decodeOpenAIModels decodes a JSON array of model entries. An entry is normally an
+// object, but id-only string entries are in use as well.
+func decodeOpenAIModels(entries []byte) ([]OpenAIModel, error) {
+	var rawEntries []json.RawMessage
+	if err := sonic.Unmarshal(bytes.TrimSpace(entries), &rawEntries); err != nil {
+		return nil, err
+	}
+
+	models := make([]OpenAIModel, 0, len(rawEntries))
+	for _, rawEntry := range rawEntries {
+		entry := bytes.TrimSpace(rawEntry)
+		if len(entry) == 0 {
+			continue
+		}
+
+		if entry[0] == '"' {
+			id := jsonScalarString(entry)
+			if strings.TrimSpace(id) == "" {
+				continue
+			}
+			models = append(models, OpenAIModel{ID: id, Object: "model"})
+			continue
+		}
+
+		var decoded struct {
+			ID            json.RawMessage `json:"id"`
+			Object        string          `json:"object"`
+			OwnedBy       json.RawMessage `json:"owned_by"`
+			Organization  json.RawMessage `json:"organization"`
+			Created       json.RawMessage `json:"created"`
+			Active        *bool           `json:"active"`
+			ContextWindow json.RawMessage `json:"context_window"`
+			ContextLength json.RawMessage `json:"context_length"`
+		}
+		if err := sonic.Unmarshal(entry, &decoded); err != nil {
+			return nil, err
+		}
+
+		model := OpenAIModel{
+			ID:      jsonScalarString(decoded.ID),
+			Object:  decoded.Object,
+			OwnedBy: jsonScalarString(decoded.OwnedBy),
+			Active:  decoded.Active,
+		}
+		if model.OwnedBy == "" {
+			model.OwnedBy = jsonScalarString(decoded.Organization)
+		}
+		if created, ok := jsonScalarInt64(decoded.Created); ok {
+			model.Created = &created
+		}
+		if window, ok := jsonScalarInt(decoded.ContextWindow); ok {
+			model.ContextWindow = &window
+		} else if window, ok := jsonScalarInt(decoded.ContextLength); ok {
+			model.ContextWindow = &window
+		}
+
+		models = append(models, model)
+	}
+
+	return models, nil
+}
+
+// jsonScalarString reads a JSON scalar as a string. Compatible endpoints quote fields
+// such as id and owned_by inconsistently; null and structured values read as empty.
+func jsonScalarString(raw json.RawMessage) string {
+	value := bytes.TrimSpace(raw)
+	if len(value) == 0 || bytes.Equal(value, []byte("null")) {
+		return ""
+	}
+	if value[0] == '"' {
+		var decoded string
+		if err := sonic.Unmarshal(value, &decoded); err != nil {
+			return ""
+		}
+		return decoded
+	}
+	return string(value)
+}
+
+// jsonScalarInt64 reads a JSON number, or a number quoted as a string, as an int64.
+func jsonScalarInt64(raw json.RawMessage) (int64, bool) {
+	number, ok := jsonScalarNumber(raw)
+	if !ok {
+		return 0, false
+	}
+	if parsed, err := strconv.ParseInt(number, 10, 64); err == nil {
+		return parsed, true
+	}
+	// Counts such as 1.28e5 are still counts.
+	parsed, err := strconv.ParseFloat(number, 64)
+	if err != nil {
+		return 0, false
+	}
+	return int64(parsed), true
+}
+
+// jsonScalarInt reads a JSON number, or a number quoted as a string, as an int.
+func jsonScalarInt(raw json.RawMessage) (int, bool) {
+	parsed, ok := jsonScalarInt64(raw)
+	return int(parsed), ok
+}
+
+// jsonScalarNumber returns the digits behind a JSON number, quoted or not.
+func jsonScalarNumber(raw json.RawMessage) (string, bool) {
+	number := strings.TrimSpace(jsonScalarString(raw))
+	if number == "" {
+		return "", false
+	}
+	return number, true
 }
 
 // OpenAIImageGenerationRequest is the struct for Image Generation requests by OpenAI.

--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -3921,13 +3921,11 @@ func extractSuccessfulListModelsResponses(results chan schemas.ListModelsByKeyRe
 
 	for result := range results {
 		if result.Err != nil {
-			errMsg := "unknown error"
-			if errorField := result.Err.Error; errorField != nil {
-				if errorField.Message != "" {
-					errMsg = errorField.Message
-				} else if errorField.Error != nil {
-					errMsg = errorField.Error.Error()
-				}
+			// Log the cause too: the message alone ("failed to unmarshal response from
+			// provider API") leaves nothing to act on.
+			errMsg := result.Err.GetErrorStringWithCause()
+			if errMsg == "" {
+				errMsg = "unknown error"
 			}
 			getLogger().Warn(fmt.Sprintf("failed to list models with key %s: %s", result.KeyID, errMsg))
 			keyStatuses = append(keyStatuses, schemas.KeyStatus{

--- a/core/schemas/bifrost.go
+++ b/core/schemas/bifrost.go
@@ -2032,6 +2032,31 @@ func (e *BifrostError) GetErrorString() string {
 	}
 }
 
+// GetErrorStringWithCause appends the underlying cause to the message when the error
+// carries one. GetErrorString stays message-only because it is surfaced to callers;
+// logs want the cause as well, since that is what turns an error like
+// "failed to unmarshal response from provider API" into something a reader can act on.
+func (e *BifrostError) GetErrorStringWithCause() string {
+	if e == nil {
+		return ""
+	}
+
+	message := e.GetErrorString()
+	if e.Error == nil || e.Error.Error == nil {
+		return message
+	}
+
+	cause := e.Error.Error.Error()
+	if cause == "" || cause == message {
+		return message
+	}
+	if message == "" {
+		return cause
+	}
+
+	return message + ": " + cause
+}
+
 // StreamControl represents stream control options.
 type StreamControl struct {
 	LogError   *bool `json:"log_error,omitempty"`   // Optional: Controls logging of error

--- a/core/schemas/errorstring_test.go
+++ b/core/schemas/errorstring_test.go
@@ -1,0 +1,54 @@
+package schemas
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetErrorStringWithCause(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  *BifrostError
+		want string
+	}{
+		{
+			name: "appends the cause to the message",
+			err: &BifrostError{Error: &ErrorField{
+				Message: ErrProviderResponseUnmarshal,
+				Error:   errors.New("Syntax error at index 1: invalid char"),
+			}},
+			want: ErrProviderResponseUnmarshal + ": Syntax error at index 1: invalid char",
+		},
+		{
+			name: "message without a cause",
+			err:  &BifrostError{Error: &ErrorField{Message: "rate limit exceeded"}},
+			want: "rate limit exceeded",
+		},
+		{
+			name: "cause already part of the message",
+			err:  &BifrostError{Error: &ErrorField{Message: "upstream said no", Error: errors.New("upstream said no")}},
+			want: "upstream said no",
+		},
+		{
+			name: "status code fallback keeps the cause",
+			err: &BifrostError{
+				StatusCode: Ptr(404),
+				Error:      &ErrorField{Error: errors.New("unknown path /v1/models")},
+			},
+			want: "endpoint not found: unknown path /v1/models",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, test.want, test.err.GetErrorStringWithCause())
+		})
+	}
+
+	require.Equal(t, "", (*BifrostError)(nil).GetErrorStringWithCause())
+}


### PR DESCRIPTION
## Summary

A Docker deployment with several custom OpenAI-compatible providers fails the model list for
each of them, repeating on every model-sync tick:

```
WRN failed to list models with key <uuid>: failed to unmarshal response from provider API
WRN failed to list models for provider BigModel: failed to unmarshal response from provider API
```

The upstreams answer `200 OK`, so this is not an auth or status problem: `GET /v1/models` is
not standardized in practice, and Bifrost fails the whole request when the body is not the
exact OpenAI envelope. This PR normalizes the shapes those endpoints return, and logs the
parser's cause when a body still cannot be read.

The same log line also comes out of a second, unrelated bug: `ListModelsByKey` was the only
list-models path that read `resp.Body()` without decoding it, so an upstream that answers with
`Content-Encoding: gzip` (or `deflate`/`br`/`zstd`) failed on the compressed bytes. That is
fixed here too.

## Changes

`core/providers/openai/openai.go` - `ListModelsByKey` now reads the body through
`providerUtils.CheckAndDecodeBody` instead of copying `resp.Body()` directly, matching the
other ~40 call sites in the same package and every other OpenAI-compatible provider that
routes through it (Ollama, vLLM, SGL, Bedrock Mantle, GitHub Copilot). Compression is only
negotiated when an upstream sends it unprompted - fasthttp sends no `Accept-Encoding` - but
several gateways and reverse proxies do. A body that claims a compression the server did not
apply, or one Bifrost cannot decode, now returns `ErrProviderResponseDecode` with the decoder's
cause instead of a misleading unmarshal error on `\x1f\x8b`.

`core/providers/openai/types.go` - `OpenAIListModelsResponse.UnmarshalJSON` now accepts, on
top of the OpenAI envelope and the bare array (#6712):

- `{"models":[...]}` (Gemini-style) as an alias for `"data"`
- id-only entries: `["gpt-5","gpt-5-mini"]` and `{"data":["gpt-5"]}`
- quoted scalars: `"created":"1760000000"`, `"context_window":"256000"`

A body that is not a model list still returns the unmarshal error. The goal is to read what
the provider sent, not to turn failures into empty catalogs.

`core/schemas/bifrost.go` - new `BifrostError.GetErrorStringWithCause()`. `GetErrorString()`
stays message-only because it is what callers receive; the cause is what makes a log line
actionable.

`core/providers/utils/utils.go`, `core/bifrost.go` - the two list-models warnings use it, so
the failure above now reads:

```
failed to list models with key <uuid>: failed to unmarshal response from provider API: Syntax error at index 1: invalid char
```

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
cd core
go test ./providers/openai/... ./schemas/... -run 'ListModels|GetErrorString'
go test ./providers/vllm/... ./providers/ollama/... ./providers/sgl/...
go build ./...
go vet ./providers/openai/ ./schemas/
```

`models_test.go` drives every accepted shape through `ListModelsByKey` against an `httptest`
upstream (red on main, green here), pins that a truncated body or an object-keyed `data` still
fail with `ErrProviderResponseUnmarshal`, and covers gzip/deflate/br/zstd round-trips plus two
undecodable bodies. The compression cases fail on `main` with
`failed to unmarshal response from provider API: Syntax error at index 1: invalid char \x1f\x8b`.
`errorstring_test.go` covers the new helper.

Only Go was built: no UI, transports or config files are touched.

Harness: no `provider-harness.json` case. The harness drives real provider APIs through the
gateway, so it cannot make an upstream return `{"data":["gpt-5"]}`, and the collection has no
mock-upstream path. The `httptest` cases cover the same wire path (`ListModelsByKey` ->
`HandleProviderResponse` -> `ToBifrostListModelsResponse`).

## Screenshots/Recordings

Not a UI change.

## Breaking changes

- [ ] Yes
- [x] No

`GetErrorString()` is unchanged; the new method is additive, and the log lines only gain the
cause.

## Related issues

Shape of `failed to unmarshal response from provider API` reported by a Docker deployment with
custom providers; same family as #2651 and #6712. If a deployment still fails after this,
the new log line now names the parser error, and the exact body would be the next thing to
check.

## Security considerations

None. The appended cause is the JSON parser's error message, not the response body, so no
provider payload or credential reaches the logs.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable
