### PR TITLE
fix: handle incomplete fallback errors

### DIFF
--- a/core/bifrost.go
+++ b/core/bifrost.go
@@ -5180,7 +5180,11 @@ func (bifrost *Bifrost) prepareFallbackRequest(req *schemas.BifrostRequest, fall
 // shouldContinueWithFallbacks processes errors from fallback attempts
 // Returns true if we should continue with more fallbacks, false if we should stop
 func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, fallbackErr *schemas.BifrostError) bool {
-	if fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
+	if fallbackErr == nil {
+		return false
+	}
+
+	if fallbackErr.Error != nil && fallbackErr.Error.Type != nil && *fallbackErr.Error.Type == schemas.RequestCancelled {
 		return false
 	}
 
@@ -5189,7 +5193,7 @@ func (bifrost *Bifrost) shouldContinueWithFallbacks(fallback schemas.Fallback, f
 		return false
 	}
 
-	bifrost.logger.Debug("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.Error.Message)
+	bifrost.logger.Debug("Fallback provider %s failed: %s", fallback.Provider, fallbackErr.GetErrorString())
 	return true
 }
 

--- a/core/bifrost_test.go
+++ b/core/bifrost_test.go
@@ -3392,6 +3392,25 @@ func TestClearCtxForFallback_DropsCallerSuppliedKey(t *testing.T) {
 	}
 }
 
+func TestShouldContinueWithFallbacksHandlesIncompleteBifrostError(t *testing.T) {
+	statusCode := http.StatusServiceUnavailable
+	bifrost := &Bifrost{logger: NewDefaultLogger(schemas.LogLevelError)}
+	fallback := schemas.Fallback{Provider: schemas.Anthropic}
+	fallbackErr := &schemas.BifrostError{StatusCode: &statusCode}
+
+	if !bifrost.shouldContinueWithFallbacks(fallback, fallbackErr) {
+		t.Fatal("incomplete plugin error should allow the next fallback")
+	}
+}
+
+func TestShouldContinueWithFallbacksStopsOnNilError(t *testing.T) {
+	bifrost := &Bifrost{logger: NewDefaultLogger(schemas.LogLevelError)}
+	fallback := schemas.Fallback{Provider: schemas.Anthropic}
+	if bifrost.shouldContinueWithFallbacks(fallback, nil) {
+		t.Fatal("nil error should stop fallback processing")
+	}
+}
+
 // TestSelectKeyFromProviderForModelWithPool_SkipKeySelectionGatedOnBaseProvider verifies that the
 // Claude Code OAuth key-selection skip applies only when the attempt resolved to Anthropic. A
 // governance routing rule can rewrite provider/model after the transport set the flag, and every


### PR DESCRIPTION
## Summary

Fixes a nil-pointer panic in fallback processing when a plugin returns an incomplete `BifrostError` whose nested `Error` field is nil.

Instead of crashing the request worker, Bifrost now safely evaluates the error and continues to the next fallback when allowed.

## Changes

- Added a nil check for `fallbackErr`.
- Guarded access to `fallbackErr.Error.Type`.
- Replaced direct access to `fallbackErr.Error.Message` with the nil-safe `GetErrorString()` helper.
- Preserved existing behavior for cancelled requests and `AllowFallbacks == false`.
- Added regression tests covering incomplete and nil fallback errors.

The fix is intentionally scoped to the fallback decision helper and does not change the `BifrostError` schema or plugin API.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the regression tests:

```sh
cd core
go test . -run '^TestShouldContinueWithFallbacks' -count=1
```

Expected outcome: both tests pass without a nil-pointer panic.

Run the complete core package test suite:

```sh
cd core
go test . -count=1
```

Optionally verify that all core subpackages compile:

```sh
cd core
go test ./... -run '^$' -count=1
```

No new configuration or environment variables were added.

## Screenshots/Recordings

Not applicable. This change does not affect the UI.

## Breaking changes

- [ ] Yes
- [x] No

## Related issues

Closes #6967

## Security considerations

No known security implications. The change only hardens error handling against incomplete errors returned by plugins.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable