### PR TITLE
feat(mcp-usage-guide): add OAuth and IdP token auth methods alongside virtual key

### DIFF
--- a/core/schemas/secretvar.go
+++ b/core/schemas/secretvar.go
@@ -286,6 +286,22 @@ func (e *SecretVar) Redacted() *SecretVar {
 	return &SecretVar{Val: prefix + middle + suffix, ref: e.ref, SecretType: e.SecretType}
 }
 
+// RedactedIfSecret returns a copy holding the literal value when the SecretVar
+// is plain text, and a Redacted copy when it is env/vault-backed. Use it for
+// fields that are identifiers or network addresses rather than credentials — a
+// region or a service URL is not worth hiding, but the resolved contents of a
+// secret reference still are. Like Redacted it always returns a fresh pointer,
+// so a redacted API response never aliases the live config.
+func (e *SecretVar) RedactedIfSecret() *SecretVar {
+	if e == nil {
+		return nil
+	}
+	if e.IsFromSecret() {
+		return e.Redacted()
+	}
+	return e.Clone()
+}
+
 // FullyRedacted returns a copy of the SecretVar with Val replaced by a fixed placeholder
 // so no substring of the original value is exposed. Use for API responses where
 // Redacted is unsafe (e.g. literal proxy passwords). secretRef and secretType are

--- a/core/schemas/secretvar_test.go
+++ b/core/schemas/secretvar_test.go
@@ -811,3 +811,67 @@ func TestSecretVar_MarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestSecretVar_RedactedIfSecret(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var ev *SecretVar
+		if got := ev.RedactedIfSecret(); got != nil {
+			t.Fatalf("expected nil, got %+v", got)
+		}
+	})
+
+	t.Run("literal value is surfaced in plaintext", func(t *testing.T) {
+		for _, val := range []string{"", "us-east-1", "https://vllm.internal.example.com:8000"} {
+			e := &SecretVar{Val: val, SecretType: SecretTypePlainText}
+			got := e.RedactedIfSecret()
+			if got.GetValue() != val {
+				t.Errorf("RedactedIfSecret().GetValue() = %q, want %q", got.GetValue(), val)
+			}
+		}
+	})
+
+	t.Run("env-backed value is masked and keeps its reference", func(t *testing.T) {
+		e := &SecretVar{Val: "us-east-1", ref: "env.AWS_REGION", SecretType: SecretTypeEnv}
+		got := e.RedactedIfSecret()
+		if got.GetValue() == "us-east-1" {
+			t.Error("RedactedIfSecret() surfaced the resolved value of an env reference")
+		}
+		if !got.IsRedacted() {
+			t.Errorf("RedactedIfSecret().IsRedacted() = false for %q", got.GetValue())
+		}
+		if got.GetRawRef() != "env.AWS_REGION" {
+			t.Errorf("RedactedIfSecret().GetRawRef() = %q, want %q", got.GetRawRef(), "env.AWS_REGION")
+		}
+	})
+
+	t.Run("vault-backed value is masked and keeps its reference", func(t *testing.T) {
+		e := &SecretVar{Val: "https://mcp.internal.example.com/mcp", ref: "vault.bifrost/mcp-url", SecretType: SecretTypeVault}
+		got := e.RedactedIfSecret()
+		if got.GetValue() == e.Val {
+			t.Error("RedactedIfSecret() surfaced the resolved value of a vault reference")
+		}
+		if got.GetRawRef() != "vault.bifrost/mcp-url" {
+			t.Errorf("RedactedIfSecret().GetRawRef() = %q, want %q", got.GetRawRef(), "vault.bifrost/mcp-url")
+		}
+	})
+
+	t.Run("returns a fresh pointer so callers cannot reach the original", func(t *testing.T) {
+		e := &SecretVar{Val: "us-east-1", SecretType: SecretTypePlainText}
+		got := e.RedactedIfSecret()
+		if got == e {
+			t.Fatal("RedactedIfSecret() aliased the original SecretVar")
+		}
+		got.Val = "eu-west-1"
+		if e.Val != "us-east-1" {
+			t.Errorf("mutating the copy changed the original to %q", e.Val)
+		}
+	})
+
+	t.Run("does not mutate the original", func(t *testing.T) {
+		e := &SecretVar{Val: "actual-secret-value", ref: "env.SOME_URL", SecretType: SecretTypeEnv}
+		_ = e.RedactedIfSecret()
+		if e.Val != "actual-secret-value" {
+			t.Errorf("original Val mutated to %q", e.Val)
+		}
+	})
+}

--- a/framework/configstore/clientconfig.go
+++ b/framework/configstore/clientconfig.go
@@ -584,11 +584,8 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 		// Redact Azure key config if present
 		if key.AzureKeyConfig != nil {
 			azureConfig := &schemas.AzureKeyConfig{}
-			if key.AzureKeyConfig.Endpoint.IsFromSecret() {
-				azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.Redacted()
-			} else {
-				azureConfig.Endpoint = key.AzureKeyConfig.Endpoint
-			}
+			// The endpoint is a hostname, not a credential — surface it in plaintext.
+			azureConfig.Endpoint = *key.AzureKeyConfig.Endpoint.RedactedIfSecret()
 			if key.AzureKeyConfig.ClientID != nil {
 				azureConfig.ClientID = key.AzureKeyConfig.ClientID.Redacted()
 			}
@@ -609,7 +606,8 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			vertexConfig := &schemas.VertexKeyConfig{}
 			vertexConfig.ProjectID = *key.VertexKeyConfig.ProjectID.Redacted()
 			vertexConfig.ProjectNumber = *key.VertexKeyConfig.ProjectNumber.Redacted()
-			vertexConfig.Region = *key.VertexKeyConfig.Region.Redacted()
+			// The region is a public identifier, not a credential — surface it in plaintext.
+			vertexConfig.Region = *key.VertexKeyConfig.Region.RedactedIfSecret()
 			vertexConfig.AuthCredentials = *key.VertexKeyConfig.AuthCredentials.Redacted()
 			vertexConfig.ForceSingleRegion = key.VertexKeyConfig.ForceSingleRegion
 			redactedConfig.Keys[i].VertexKeyConfig = vertexConfig
@@ -623,8 +621,9 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			if key.BedrockKeyConfig.SessionToken != nil {
 				bedrockConfig.SessionToken = key.BedrockKeyConfig.SessionToken.Redacted()
 			}
+			// The region is a public identifier, not a credential — surface it in plaintext.
 			if key.BedrockKeyConfig.Region != nil {
-				bedrockConfig.Region = key.BedrockKeyConfig.Region.Redacted()
+				bedrockConfig.Region = key.BedrockKeyConfig.Region.RedactedIfSecret()
 			}
 			if key.BedrockKeyConfig.ARN != nil {
 				bedrockConfig.ARN = key.BedrockKeyConfig.ARN.Redacted()
@@ -664,8 +663,9 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			if key.BedrockMantleKeyConfig.SessionToken != nil {
 				mantleConfig.SessionToken = key.BedrockMantleKeyConfig.SessionToken.Redacted()
 			}
+			// The region is a public identifier, not a credential — surface it in plaintext.
 			if key.BedrockMantleKeyConfig.Region != nil {
-				mantleConfig.Region = key.BedrockMantleKeyConfig.Region.Redacted()
+				mantleConfig.Region = key.BedrockMantleKeyConfig.Region.RedactedIfSecret()
 			}
 			if key.BedrockMantleKeyConfig.RoleARN != nil {
 				mantleConfig.RoleARN = key.BedrockMantleKeyConfig.RoleARN.Redacted()
@@ -691,7 +691,8 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			vllmConfig := &schemas.VLLMKeyConfig{
 				ModelName: key.VLLMKeyConfig.ModelName,
 			}
-			vllmConfig.URL = *key.VLLMKeyConfig.URL.Redacted()
+			// The URL is a service address, not a credential — surface it in plaintext.
+			vllmConfig.URL = *key.VLLMKeyConfig.URL.RedactedIfSecret()
 			redactedConfig.Keys[i].VLLMKeyConfig = vllmConfig
 		}
 
@@ -704,13 +705,15 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 
 		if key.OllamaKeyConfig != nil {
 			ollamaConfig := &schemas.OllamaKeyConfig{}
-			ollamaConfig.URL = *key.OllamaKeyConfig.URL.Redacted()
+			// The URL is a service address, not a credential — surface it in plaintext.
+			ollamaConfig.URL = *key.OllamaKeyConfig.URL.RedactedIfSecret()
 			redactedConfig.Keys[i].OllamaKeyConfig = ollamaConfig
 		}
 
 		if key.SGLKeyConfig != nil {
 			sglConfig := &schemas.SGLKeyConfig{}
-			sglConfig.URL = *key.SGLKeyConfig.URL.Redacted()
+			// The URL is a service address, not a credential — surface it in plaintext.
+			sglConfig.URL = *key.SGLKeyConfig.URL.RedactedIfSecret()
 			redactedConfig.Keys[i].SGLKeyConfig = sglConfig
 		}
 
@@ -722,11 +725,7 @@ func (p *ProviderConfig) Redacted() *ProviderConfig {
 			}
 			// The workspace URL is a hostname, not a credential — surface it in
 			// plaintext so the UI can round-trip it, mirroring the Azure endpoint.
-			if key.DatabricksKeyConfig.WorkspaceURL.IsFromSecret() {
-				databricksConfig.WorkspaceURL = *key.DatabricksKeyConfig.WorkspaceURL.Redacted()
-			} else {
-				databricksConfig.WorkspaceURL = key.DatabricksKeyConfig.WorkspaceURL
-			}
+			databricksConfig.WorkspaceURL = *key.DatabricksKeyConfig.WorkspaceURL.RedactedIfSecret()
 			if key.DatabricksKeyConfig.ClientID != nil {
 				databricksConfig.ClientID = key.DatabricksKeyConfig.ClientID.Redacted()
 			}

--- a/framework/configstore/clientconfig_redaction_test.go
+++ b/framework/configstore/clientconfig_redaction_test.go
@@ -228,3 +228,97 @@ func TestProviderConfig_Redacted_FullJSONHasNoLeakedEnvSecrets(t *testing.T) {
 			"env var reference %q missing from redacted JSON output", ref)
 	}
 }
+
+// TestProviderConfig_Redacted_SurfacesLiteralIdentifiers pins the rule that a
+// region or a self-hosted service URL is an identifier, not a credential: when
+// it is stored as a literal it must read back verbatim so the update form shows
+// something an operator can actually read.
+func TestProviderConfig_Redacted_SurfacesLiteralIdentifiers(t *testing.T) {
+	config := ProviderConfig{
+		Keys: []schemas.Key{{
+			ID:    "k1",
+			Name:  "test",
+			Value: schemas.SecretVar{Val: ""},
+			VertexKeyConfig: &schemas.VertexKeyConfig{
+				Region: *schemas.NewSecretVar("us-central1"),
+			},
+			BedrockKeyConfig: &schemas.BedrockKeyConfig{
+				AccessKey: schemas.SecretVar{Val: ""},
+				SecretKey: schemas.SecretVar{Val: ""},
+				Region:    schemas.NewSecretVar("us-east-1"),
+			},
+			BedrockMantleKeyConfig: &schemas.BedrockMantleKeyConfig{
+				AccessKey: schemas.SecretVar{Val: ""},
+				SecretKey: schemas.SecretVar{Val: ""},
+				Region:    schemas.NewSecretVar("us-east-1"),
+			},
+			VLLMKeyConfig: &schemas.VLLMKeyConfig{
+				URL: *schemas.NewSecretVar("http://vllm.internal.example.com:8000"),
+			},
+			OllamaKeyConfig: &schemas.OllamaKeyConfig{
+				URL: *schemas.NewSecretVar("http://ollama.internal.example.com:11434"),
+			},
+			SGLKeyConfig: &schemas.SGLKeyConfig{
+				URL: *schemas.NewSecretVar("http://sgl.internal.example.com:30000"),
+			},
+		}},
+	}
+
+	redacted := config.Redacted()
+	require.NotNil(t, redacted)
+	require.Len(t, redacted.Keys, 1)
+	key := redacted.Keys[0]
+
+	assert.Equal(t, "us-central1", key.VertexKeyConfig.Region.GetValue())
+	assert.Equal(t, "us-east-1", key.BedrockKeyConfig.Region.GetValue())
+	assert.Equal(t, "us-east-1", key.BedrockMantleKeyConfig.Region.GetValue())
+	assert.Equal(t, "http://vllm.internal.example.com:8000", key.VLLMKeyConfig.URL.GetValue())
+	assert.Equal(t, "http://ollama.internal.example.com:11434", key.OllamaKeyConfig.URL.GetValue())
+	assert.Equal(t, "http://sgl.internal.example.com:30000", key.SGLKeyConfig.URL.GetValue())
+
+	// The redacted copy must not alias the live config: these are pointer
+	// fields, and an API response handing out the live SecretVar would let a
+	// caller edit the running configuration.
+	assert.NotSame(t, config.Keys[0].BedrockKeyConfig.Region, key.BedrockKeyConfig.Region)
+	assert.NotSame(t, config.Keys[0].BedrockMantleKeyConfig.Region, key.BedrockMantleKeyConfig.Region)
+}
+
+// TestProviderConfig_Redacted_MasksSecretBackedIdentifiers is the other half of
+// the rule: an operator who deliberately sourced a region or URL from env/vault
+// still gets the resolved value masked, with the reference intact for the UI.
+func TestProviderConfig_Redacted_MasksSecretBackedIdentifiers(t *testing.T) {
+	t.Setenv("LEAK_TEST_REGION", "ap-southeast-2")
+	t.Setenv("LEAK_TEST_VLLM_URL", "http://vllm-secret.internal.example.com:8000")
+
+	config := ProviderConfig{
+		Keys: []schemas.Key{{
+			ID:    "k1",
+			Name:  "test",
+			Value: schemas.SecretVar{Val: ""},
+			BedrockKeyConfig: &schemas.BedrockKeyConfig{
+				AccessKey: schemas.SecretVar{Val: ""},
+				SecretKey: schemas.SecretVar{Val: ""},
+				Region:    schemas.NewSecretVar("env.LEAK_TEST_REGION"),
+			},
+			VLLMKeyConfig: &schemas.VLLMKeyConfig{
+				URL: *schemas.NewSecretVar("env.LEAK_TEST_VLLM_URL"),
+			},
+		}},
+	}
+	require.Equal(t, "ap-southeast-2", config.Keys[0].BedrockKeyConfig.Region.GetValue(),
+		"setup: region should resolve from the environment")
+
+	redacted := config.Redacted()
+	data, err := json.Marshal(redacted)
+	require.NoError(t, err)
+	jsonStr := string(data)
+
+	for _, secret := range []string{"ap-southeast-2", "vllm-secret.internal.example.com"} {
+		assert.NotContains(t, jsonStr, secret,
+			"resolved env value %q leaked into redacted JSON output", secret)
+	}
+	for _, ref := range []string{"env.LEAK_TEST_REGION", "env.LEAK_TEST_VLLM_URL"} {
+		assert.Contains(t, jsonStr, ref,
+			"env var reference %q missing from redacted JSON output", ref)
+	}
+}

--- a/transports/bifrost-http/lib/config.go
+++ b/transports/bifrost-http/lib/config.go
@@ -6905,7 +6905,8 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 			}
 			if key.AzureKeyConfig != nil {
 				cfg := *key.AzureKeyConfig // safe copy
-				cfg.Endpoint = *cfg.Endpoint.Redacted()
+				// The endpoint is a hostname, not a credential — surface it in plaintext.
+				cfg.Endpoint = *cfg.Endpoint.RedactedIfSecret()
 				cfg.ClientID = cfg.ClientID.Redacted()
 				cfg.ClientSecret = cfg.ClientSecret.Redacted()
 				cfg.TenantID = cfg.TenantID.Redacted()
@@ -6916,7 +6917,8 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 				cfg.ARN = key.BedrockKeyConfig.ARN.Redacted()
 				cfg.AccessKey = *cfg.AccessKey.Redacted()
 				cfg.ExternalID = cfg.ExternalID.Redacted()
-				cfg.Region = cfg.Region.Redacted()
+				// The region is a public identifier, not a credential — surface it in plaintext.
+				cfg.Region = cfg.Region.RedactedIfSecret()
 				cfg.RoleARN = cfg.RoleARN.Redacted()
 				cfg.RoleSessionName = cfg.RoleSessionName.Redacted()
 				cfg.SecretKey = *cfg.SecretKey.Redacted()
@@ -6928,7 +6930,8 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 				cfg.AccessKey = *cfg.AccessKey.Redacted()
 				cfg.SecretKey = *cfg.SecretKey.Redacted()
 				cfg.SessionToken = cfg.SessionToken.Redacted()
-				cfg.Region = cfg.Region.Redacted()
+				// The region is a public identifier, not a credential — surface it in plaintext.
+				cfg.Region = cfg.Region.RedactedIfSecret()
 				cfg.RoleARN = cfg.RoleARN.Redacted()
 				cfg.ExternalID = cfg.ExternalID.Redacted()
 				cfg.RoleSessionName = cfg.RoleSessionName.Redacted()
@@ -6938,7 +6941,8 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 				cfg := *key.VertexKeyConfig // safe copy
 				cfg.ProjectID = *cfg.ProjectID.Redacted()
 				cfg.ProjectNumber = *cfg.ProjectNumber.Redacted()
-				cfg.Region = *cfg.Region.Redacted()
+				// The region is a public identifier, not a credential — surface it in plaintext.
+				cfg.Region = *cfg.Region.RedactedIfSecret()
 				cfg.AuthCredentials = *cfg.AuthCredentials.Redacted()
 				configStoreKey.VertexKeyConfig = &cfg
 			}
@@ -6947,23 +6951,27 @@ func (c *Config) GetAllKeys() ([]configstoreTables.TableKey, error) {
 			}
 			if key.VLLMKeyConfig != nil {
 				cfg := *key.VLLMKeyConfig // safe copy
-				cfg.URL = *cfg.URL.Redacted()
+				// The URL is a service address, not a credential — surface it in plaintext.
+				cfg.URL = *cfg.URL.RedactedIfSecret()
 				configStoreKey.VLLMKeyConfig = &cfg
 			}
 			if key.OllamaKeyConfig != nil {
 				cfg := *key.OllamaKeyConfig // safe copy
-				cfg.URL = *cfg.URL.Redacted()
+				// The URL is a service address, not a credential — surface it in plaintext.
+				cfg.URL = *cfg.URL.RedactedIfSecret()
 				configStoreKey.OllamaKeyConfig = &cfg
 			}
 			if key.SGLKeyConfig != nil {
 				cfg := *key.SGLKeyConfig // safe copy
-				cfg.URL = *cfg.URL.Redacted()
+				// The URL is a service address, not a credential — surface it in plaintext.
+				cfg.URL = *cfg.URL.RedactedIfSecret()
 				configStoreKey.SGLKeyConfig = &cfg
 			}
 
 			if key.DatabricksKeyConfig != nil {
 				cfg := *key.DatabricksKeyConfig // safe copy
-				cfg.WorkspaceURL = *cfg.WorkspaceURL.Redacted()
+				// The workspace URL is a hostname, not a credential — surface it in plaintext.
+				cfg.WorkspaceURL = *cfg.WorkspaceURL.RedactedIfSecret()
 				cfg.ClientID = cfg.ClientID.Redacted()
 				cfg.ClientSecret = cfg.ClientSecret.Redacted()
 				configStoreKey.DatabricksKeyConfig = &cfg
@@ -7351,15 +7359,19 @@ func (c *Config) EnableMCPClient(ctx context.Context, id string) error {
 }
 
 // RedactMCPClientConfig creates a redacted copy of a MCPClientConfig configuration.
-// Connection strings and headers are redacted for safe external exposure.
+// Credentials — headers, OAuth client secrets and the TLS CA cert — are redacted
+// for safe external exposure.
 func (c *Config) RedactMCPClientConfig(config *schemas.MCPClientConfig) *schemas.MCPClientConfig {
 	// Create an actual copy of the struct (not just a pointer copy)
 	// This prevents modifying the original config when redacting
 	configCopy := *config
 
-	// Redact connection string if present
+	// The connection string is a server address, not a credential — surface it
+	// in plaintext so operators can see which host a client points at. Anything
+	// secret about the connection lives in Headers or the OAuth block below,
+	// which stay redacted.
 	if config.ConnectionString != nil {
-		configCopy.ConnectionString = config.ConnectionString.Redacted()
+		configCopy.ConnectionString = config.ConnectionString.RedactedIfSecret()
 	}
 
 	// Redact Header values if present

--- a/transports/bifrost-http/lib/mcpredaction_test.go
+++ b/transports/bifrost-http/lib/mcpredaction_test.go
@@ -1,0 +1,84 @@
+package lib
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRedactMCPClientConfig_SurfacesLiteralConnectionString pins the security
+// boundary of the MCP redaction: the connection string is a server address and
+// reads back verbatim, while everything that actually authenticates the
+// connection stays masked.
+func TestRedactMCPClientConfig_SurfacesLiteralConnectionString(t *testing.T) {
+	c := &Config{}
+
+	config := &schemas.MCPClientConfig{
+		ID:                "mcp-1",
+		Name:              "self",
+		ConnectionType:    schemas.MCPConnectionTypeHTTP,
+		ConnectionString:  schemas.NewSecretVar("https://mcp.internal.example.com/mcp"),
+		OauthClientID:     schemas.NewSecretVar("oauth-client-id-value"),
+		OauthClientSecret: schemas.NewSecretVar("oauth-client-secret-value"),
+		Headers: map[string]schemas.SecretVar{
+			"Authorization": *schemas.NewSecretVar("Bearer super-secret-token"),
+		},
+		TokenExchange: &schemas.MCPTokenExchangeConfig{
+			Audience:     "api://example",
+			ClientID:     schemas.NewSecretVar("exchange-client-id-value"),
+			ClientSecret: schemas.NewSecretVar("exchange-client-secret-value"),
+		},
+		TLSConfig: &schemas.MCPTLSConfig{
+			CACertPEM: schemas.NewSecretVar("-----BEGIN CERTIFICATE-----secret-pem-body-----END CERTIFICATE-----"),
+		},
+	}
+
+	redacted := c.RedactMCPClientConfig(config)
+	require.NotNil(t, redacted)
+
+	assert.Equal(t, "https://mcp.internal.example.com/mcp", redacted.ConnectionString.GetValue(),
+		"the connection target is an address, not a credential")
+
+	// Everything below is a credential and must not survive the round-trip.
+	assert.True(t, redacted.OauthClientID.IsRedacted(), "oauth_client_id leaked")
+	assert.True(t, redacted.OauthClientSecret.IsRedacted(), "oauth_client_secret leaked")
+	redactedHeader := redacted.Headers["Authorization"]
+	assert.NotContains(t, redactedHeader.GetValue(), "super-secret-token", "header value leaked")
+	assert.True(t, redacted.TokenExchange.ClientID.IsRedacted(), "token_exchange.client_id leaked")
+	assert.True(t, redacted.TokenExchange.ClientSecret.IsRedacted(), "token_exchange.client_secret leaked")
+	assert.NotContains(t, redacted.TLSConfig.CACertPEM.GetValue(), "secret-pem-body",
+		"tls_config.ca_cert_pem leaked")
+
+	// The live config must be untouched — the runtime dials from it.
+	liveHeader := config.Headers["Authorization"]
+	assert.Equal(t, "Bearer super-secret-token", liveHeader.GetValue())
+	assert.Equal(t, "oauth-client-secret-value", config.OauthClientSecret.GetValue())
+	assert.NotSame(t, config.ConnectionString, redacted.ConnectionString,
+		"redacted copy must not alias the live connection string")
+}
+
+// TestRedactMCPClientConfig_MasksSecretBackedConnectionString covers the other
+// half: a connection string sourced from env/vault keeps its resolved value
+// hidden and its reference intact for the UI to render.
+func TestRedactMCPClientConfig_MasksSecretBackedConnectionString(t *testing.T) {
+	t.Setenv("MCP_REDACTION_TEST_URL", "https://mcp-secret.internal.example.com/mcp")
+
+	c := &Config{}
+	connectionString := schemas.NewSecretVar("env.MCP_REDACTION_TEST_URL")
+	require.Equal(t, "https://mcp-secret.internal.example.com/mcp", connectionString.GetValue(),
+		"setup: connection string should resolve from the environment")
+
+	redacted := c.RedactMCPClientConfig(&schemas.MCPClientConfig{
+		ID:               "mcp-1",
+		Name:             "self",
+		ConnectionType:   schemas.MCPConnectionTypeHTTP,
+		ConnectionString: connectionString,
+	})
+
+	assert.NotContains(t, redacted.ConnectionString.GetValue(), "mcp-secret.internal.example.com",
+		"resolved env value leaked through connection_string")
+	assert.Equal(t, "env.MCP_REDACTION_TEST_URL", redacted.ConnectionString.GetRawRef(),
+		"secret ref must be preserved so the UI can show it")
+}

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/commandBuilders.ts
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/commandBuilders.ts
@@ -1,34 +1,29 @@
 import type { CoreConfig } from "@/lib/types/config";
-import type { VirtualKey } from "@/lib/types/governance";
 import type { MCPClient } from "@/lib/types/mcp";
 import type { ClaudeScope } from "./types";
-import { encodeBase64, getExternalBaseUrl, getIncludeClients, getRegistrationName, quoteShellValue, quoteTomlString } from "./utils";
+import { encodeBase64, getExternalBaseUrl, getRegistrationName, quoteShellValue, quoteTomlString } from "./utils";
+
+/**
+ * Shared shape of every builder. `headers` is already resolved by the caller from
+ * the chosen authentication method and server scope, and is empty when the client
+ * authenticates through the OAuth consent flow.
+ */
+interface BuildArgs {
+	clientConfig?: CoreConfig;
+	headers: Record<string, string>;
+	selectedServers?: MCPClient[];
+}
 
 // ── Claude Code ────────────────────────────────────────────────────────
 
-export function buildClaudeCodeCommand({
-	clientConfig,
-	scope,
-	selectedServers,
-	virtualKey,
-}: {
-	clientConfig?: CoreConfig;
-	scope: ClaudeScope;
-	selectedServers?: MCPClient[];
-	virtualKey: VirtualKey;
-}): string {
+export function buildClaudeCodeCommand({ clientConfig, headers, scope, selectedServers }: BuildArgs & { scope: ClaudeScope }): string {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
 
-	const lines = [
-		`claude mcp add --transport http ${quoteShellValue(registrationName)} --scope ${scope} ${quoteShellValue(gatewayUrl)} \\`,
-		`  --header ${quoteShellValue(`x-bf-vk: ${virtualKey.value}`)}`,
-	];
-
-	const includeClients = getIncludeClients(selectedServers);
-	if (includeClients) {
+	const lines = [`claude mcp add --transport http ${quoteShellValue(registrationName)} --scope ${scope} ${quoteShellValue(gatewayUrl)}`];
+	for (const [name, value] of Object.entries(headers)) {
 		lines[lines.length - 1] += " \\";
-		lines.push(`  --header ${quoteShellValue(`x-bf-mcp-include-clients: ${includeClients}`)}`);
+		lines.push(`  --header ${quoteShellValue(`${name}: ${value}`)}`);
 	}
 
 	return lines.join("\n");
@@ -36,55 +31,34 @@ export function buildClaudeCodeCommand({
 
 // ── Codex ──────────────────────────────────────────────────────────────
 
-export function buildCodexConfig({
-	clientConfig,
-	selectedServers,
-	virtualKey,
-}: {
-	clientConfig?: CoreConfig;
-	selectedServers?: MCPClient[];
-	virtualKey: VirtualKey;
-}): string {
+export function buildCodexConfig({ clientConfig, headers, selectedServers }: BuildArgs): string {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const includeClients = getIncludeClients(selectedServers);
 
-	const headerEntries = [`"x-bf-vk" = ${quoteTomlString(virtualKey.value)}`];
-	if (includeClients) {
-		headerEntries.push(`"x-bf-mcp-include-clients" = ${quoteTomlString(includeClients)}`);
+	const lines = [`[mcp_servers.${quoteTomlString(registrationName)}]`, `url = ${quoteTomlString(gatewayUrl)}`];
+
+	const headerEntries = Object.entries(headers).map(([name, value]) => `${quoteTomlString(name)} = ${quoteTomlString(value)}`);
+	if (headerEntries.length > 0) {
+		lines.push(`http_headers = { ${headerEntries.join(", ")} }`);
 	}
 
-	return [
-		`[mcp_servers.${quoteTomlString(registrationName)}]`,
-		`url = ${quoteTomlString(gatewayUrl)}`,
-		`http_headers = { ${headerEntries.join(", ")} }`,
-	].join("\n");
+	return lines.join("\n");
 }
 
 // ── Cursor ─────────────────────────────────────────────────────────────
 
-function buildCursorServer({
-	clientConfig,
-	selectedServers,
-	virtualKey,
-}: {
-	clientConfig?: CoreConfig;
-	selectedServers?: MCPClient[];
-	virtualKey: VirtualKey;
-}): { name: string; server: { url: string; headers: Record<string, string> } } {
+function buildCursorServer({ clientConfig, headers, selectedServers }: BuildArgs): {
+	name: string;
+	server: { url: string; headers?: Record<string, string> };
+} {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
-	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
-
-	const includeClients = getIncludeClients(selectedServers);
-	if (includeClients) {
-		headers["x-bf-mcp-include-clients"] = includeClients;
-	}
-
-	return { name: registrationName, server: { url: gatewayUrl, headers } };
+	return {
+		name: getRegistrationName(selectedServers),
+		server: { url: gatewayUrl, ...(hasHeaders(headers) ? { headers } : {}) },
+	};
 }
 
-export function buildCursorConfig(args: { clientConfig?: CoreConfig; selectedServers?: MCPClient[]; virtualKey: VirtualKey }): string {
+export function buildCursorConfig(args: BuildArgs): string {
 	const { name, server } = buildCursorServer(args);
 	return JSON.stringify({ mcpServers: { [name]: server } }, null, 2);
 }
@@ -93,7 +67,7 @@ export function buildCursorConfig(args: { clientConfig?: CoreConfig; selectedSer
  * Cursor deeplink encodes the inner server config (not wrapped in `mcpServers`) as base64.
  * See https://cursor.com/docs/mcp.md (MCP Install Links).
  */
-export function buildCursorDeeplink(args: { clientConfig?: CoreConfig; selectedServers?: MCPClient[]; virtualKey: VirtualKey }): string {
+export function buildCursorDeeplink(args: BuildArgs): string {
 	const { name, server } = buildCursorServer(args);
 	const encodedConfig = encodeBase64(JSON.stringify(server));
 	if (!encodedConfig) return "";
@@ -102,30 +76,16 @@ export function buildCursorDeeplink(args: { clientConfig?: CoreConfig; selectedS
 
 // ── Windsurf ───────────────────────────────────────────────────────────
 
-export function buildWindsurfConfig({
-	clientConfig,
-	selectedServers,
-	virtualKey,
-}: {
-	clientConfig?: CoreConfig;
-	selectedServers?: MCPClient[];
-	virtualKey: VirtualKey;
-}): string {
+export function buildWindsurfConfig({ clientConfig, headers, selectedServers }: BuildArgs): string {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
-
-	const includeClients = getIncludeClients(selectedServers);
-	if (includeClients) {
-		headers["x-bf-mcp-include-clients"] = includeClients;
-	}
 
 	return JSON.stringify(
 		{
 			mcpServers: {
 				[registrationName]: {
 					serverUrl: gatewayUrl,
-					headers,
+					...(hasHeaders(headers) ? { headers } : {}),
 				},
 			},
 		},
@@ -136,28 +96,18 @@ export function buildWindsurfConfig({
 
 // ── VS Code ────────────────────────────────────────────────────────────
 
-function buildVSCodeServer({
-	clientConfig,
-	selectedServers,
-	virtualKey,
-}: {
-	clientConfig?: CoreConfig;
-	selectedServers?: MCPClient[];
-	virtualKey: VirtualKey;
-}): { name: string; server: { type: "http"; url: string; headers: Record<string, string> } } {
+function buildVSCodeServer({ clientConfig, headers, selectedServers }: BuildArgs): {
+	name: string;
+	server: { type: "http"; url: string; headers?: Record<string, string> };
+} {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
-	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
-
-	const includeClients = getIncludeClients(selectedServers);
-	if (includeClients) {
-		headers["x-bf-mcp-include-clients"] = includeClients;
-	}
-
-	return { name: registrationName, server: { type: "http", url: gatewayUrl, headers } };
+	return {
+		name: getRegistrationName(selectedServers),
+		server: { type: "http", url: gatewayUrl, ...(hasHeaders(headers) ? { headers } : {}) },
+	};
 }
 
-export function buildVSCodeConfig(args: { clientConfig?: CoreConfig; selectedServers?: MCPClient[]; virtualKey: VirtualKey }): string {
+export function buildVSCodeConfig(args: BuildArgs): string {
 	const { name, server } = buildVSCodeServer(args);
 	return JSON.stringify({ servers: { [name]: server } }, null, 2);
 }
@@ -167,7 +117,7 @@ export function buildVSCodeConfig(args: { clientConfig?: CoreConfig; selectedSer
  * in `servers`) as a URL-encoded JSON string.
  * See https://code.visualstudio.com/api/extension-guides/ai/mcp#create-an-mcp-installation-url
  */
-export function buildVSCodeDeeplink(args: { clientConfig?: CoreConfig; selectedServers?: MCPClient[]; virtualKey: VirtualKey }): string {
+export function buildVSCodeDeeplink(args: BuildArgs): string {
 	const { name, server } = buildVSCodeServer(args);
 	return `vscode:mcp/install?${encodeURIComponent(JSON.stringify({ name, ...server }))}`;
 }
@@ -179,23 +129,9 @@ export function buildVSCodeDeeplink(args: { clientConfig?: CoreConfig; selectedS
  * with `url` and `headers`. Config lives in `opencode.json`.
  * See https://opencode.ai/docs/mcp-servers.md
  */
-export function buildOpenCodeConfig({
-	clientConfig,
-	selectedServers,
-	virtualKey,
-}: {
-	clientConfig?: CoreConfig;
-	selectedServers?: MCPClient[];
-	virtualKey: VirtualKey;
-}): string {
+export function buildOpenCodeConfig({ clientConfig, headers, selectedServers }: BuildArgs): string {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
-
-	const includeClients = getIncludeClients(selectedServers);
-	if (includeClients) {
-		headers["x-bf-mcp-include-clients"] = includeClients;
-	}
 
 	return JSON.stringify(
 		{
@@ -205,7 +141,7 @@ export function buildOpenCodeConfig({
 					type: "remote",
 					url: gatewayUrl,
 					enabled: true,
-					headers,
+					...(hasHeaders(headers) ? { headers } : {}),
 				},
 			},
 		},
@@ -216,34 +152,25 @@ export function buildOpenCodeConfig({
 
 // ── Antigravity ────────────────────────────────────────────────────────
 
-export function buildAntigravityConfig({
-	clientConfig,
-	selectedServers,
-	virtualKey,
-}: {
-	clientConfig?: CoreConfig;
-	selectedServers?: MCPClient[];
-	virtualKey: VirtualKey;
-}): string {
+export function buildAntigravityConfig({ clientConfig, headers, selectedServers }: BuildArgs): string {
 	const gatewayUrl = `${getExternalBaseUrl(clientConfig)}/mcp`;
 	const registrationName = getRegistrationName(selectedServers);
-	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
-
-	const includeClients = getIncludeClients(selectedServers);
-	if (includeClients) {
-		headers["x-bf-mcp-include-clients"] = includeClients;
-	}
 
 	return JSON.stringify(
 		{
 			mcpServers: {
 				[registrationName]: {
 					serverUrl: gatewayUrl,
-					headers,
+					...(hasHeaders(headers) ? { headers } : {}),
 				},
 			},
 		},
 		null,
 		2,
 	);
+}
+
+/** Omit the `headers` key entirely rather than emitting an empty object. */
+function hasHeaders(headers: Record<string, string>): boolean {
+	return Object.keys(headers).length > 0;
 }

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/antigravityHarnessInstall.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/antigravityHarnessInstall.tsx
@@ -13,21 +13,23 @@ export function AntigravityIcon({ className }: { className?: string }) {
 export function AntigravityHarnessInstall({
 	canGenerateCommand,
 	clientConfig,
+	emptyMessage,
+	headers,
 	platform,
 	selectedServers,
 	serverScope,
-	virtualKey,
 }: HarnessInstallProps) {
 	const configPath = `${getUserHomePrefix(platform)}/.gemini/antigravity/mcp_config.json`;
 
-	const config = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildAntigravityConfig({
-			clientConfig,
-			selectedServers: serverScope === "selected" ? selectedServers : undefined,
-			virtualKey,
-		});
-	}, [clientConfig, selectedServers, serverScope, virtualKey]);
+	const config = useMemo(
+		() =>
+			buildAntigravityConfig({
+				clientConfig,
+				headers,
+				selectedServers: serverScope === "selected" ? selectedServers : undefined,
+			}),
+		[clientConfig, headers, selectedServers, serverScope],
+	);
 
 	return (
 		<HarnessCommandSection
@@ -35,7 +37,7 @@ export function AntigravityHarnessInstall({
 			command={config}
 			controls={null}
 			copySuccessMessage="Config copied"
-			emptyMessage={virtualKey ? "Select servers or use Gateway root." : "Select a virtual key to generate the config."}
+			emptyMessage={emptyMessage}
 			harnessName="Antigravity"
 			label="Config"
 			logoSrc="/images/harness/antigravity.svg"

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/claudeCodeHarnessInstall.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/claudeCodeHarnessInstall.tsx
@@ -8,21 +8,23 @@ import { getRegistrationLabel } from "../utils";
 export function ClaudeCodeHarnessInstall({
 	canGenerateCommand,
 	clientConfig,
+	emptyMessage,
+	headers,
 	selectedServers,
 	serverScope,
-	virtualKey,
 }: HarnessInstallProps) {
 	const [scope, setScope] = useState<ClaudeScope>("local");
 
-	const command = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildClaudeCodeCommand({
-			clientConfig,
-			scope,
-			selectedServers: serverScope === "selected" ? selectedServers : undefined,
-			virtualKey,
-		});
-	}, [clientConfig, scope, selectedServers, serverScope, virtualKey]);
+	const command = useMemo(
+		() =>
+			buildClaudeCodeCommand({
+				clientConfig,
+				headers,
+				scope,
+				selectedServers: serverScope === "selected" ? selectedServers : undefined,
+			}),
+		[clientConfig, headers, scope, selectedServers, serverScope],
+	);
 
 	return (
 		<HarnessCommandSection
@@ -40,7 +42,7 @@ export function ClaudeCodeHarnessInstall({
 					</SelectContent>
 				</Select>
 			}
-			emptyMessage={virtualKey ? "Select servers or use Gateway root." : "Select a virtual key to generate the command."}
+			emptyMessage={emptyMessage}
 			harnessName="Claude Code"
 			logoSrc="/images/harness/claudecode.svg"
 			registrationLabel={getRegistrationLabel(serverScope, selectedServers)}

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/codexHarnessInstall.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/codexHarnessInstall.tsx
@@ -8,21 +8,23 @@ import { getRegistrationLabel, getUserHomePrefix } from "../utils";
 export function CodexHarnessInstall({
 	canGenerateCommand,
 	clientConfig,
+	emptyMessage,
+	headers,
 	platform,
 	selectedServers,
 	serverScope,
-	virtualKey,
 }: HarnessInstallProps) {
 	const [configScope, setConfigScope] = useState<CodexConfigScope>("user");
 
-	const config = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildCodexConfig({
-			clientConfig,
-			selectedServers: serverScope === "selected" ? selectedServers : undefined,
-			virtualKey,
-		});
-	}, [clientConfig, selectedServers, serverScope, virtualKey]);
+	const config = useMemo(
+		() =>
+			buildCodexConfig({
+				clientConfig,
+				headers,
+				selectedServers: serverScope === "selected" ? selectedServers : undefined,
+			}),
+		[clientConfig, headers, selectedServers, serverScope],
+	);
 
 	const configPath = configScope === "project" ? ".codex/config.toml" : `${getUserHomePrefix(platform)}/.codex/config.toml`;
 
@@ -43,7 +45,7 @@ export function CodexHarnessInstall({
 					</Select>
 				}
 				copySuccessMessage="Config copied"
-				emptyMessage={virtualKey ? "Select servers or use Gateway root." : "Select a virtual key to generate the config."}
+				emptyMessage={emptyMessage}
 				harnessName="Codex"
 				label="config.toml"
 				logoSrc="/images/harness/codex.svg"

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/cursorHarnessInstall.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/cursorHarnessInstall.tsx
@@ -8,31 +8,26 @@ import { getRegistrationLabel, getUserHomePrefix } from "../utils";
 export function CursorHarnessInstall({
 	canGenerateCommand,
 	clientConfig,
+	emptyMessage,
+	headers,
 	platform,
 	selectedServers,
 	serverScope,
-	virtualKey,
 }: HarnessInstallProps) {
 	const [configScope, setConfigScope] = useState<CursorConfigScope>("global");
 
 	const serverArgs = useMemo(
 		() => ({
 			clientConfig,
+			headers,
 			selectedServers: serverScope === "selected" ? selectedServers : undefined,
-			virtualKey: virtualKey!,
 		}),
-		[clientConfig, selectedServers, serverScope, virtualKey],
+		[clientConfig, headers, selectedServers, serverScope],
 	);
 
-	const config = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildCursorConfig(serverArgs);
-	}, [serverArgs, virtualKey]);
+	const config = useMemo(() => buildCursorConfig(serverArgs), [serverArgs]);
 
-	const deeplink = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildCursorDeeplink(serverArgs);
-	}, [serverArgs, virtualKey]);
+	const deeplink = useMemo(() => buildCursorDeeplink(serverArgs), [serverArgs]);
 
 	const configPath = configScope === "project" ? ".cursor/mcp.json" : `${getUserHomePrefix(platform)}/.cursor/mcp.json`;
 
@@ -53,7 +48,7 @@ export function CursorHarnessInstall({
 			}
 			copySuccessMessage="Config copied"
 			deeplink={deeplink}
-			emptyMessage={virtualKey ? "Select servers or use Gateway root." : "Select a virtual key to generate the config."}
+			emptyMessage={emptyMessage}
 			harnessName="Cursor"
 			label="Config"
 			logoSrc="/images/harness/cursor.svg"

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/opencodeHarnessInstall.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/opencodeHarnessInstall.tsx
@@ -7,10 +7,11 @@ import { getRegistrationLabel } from "../utils";
 export function OpenCodeHarnessInstall({
 	canGenerateCommand,
 	clientConfig,
+	emptyMessage,
+	headers,
 	platform,
 	selectedServers,
 	serverScope,
-	virtualKey,
 }: HarnessInstallProps) {
 	const configPath = {
 		linux: "~/.config/opencode/opencode.json",
@@ -18,14 +19,15 @@ export function OpenCodeHarnessInstall({
 		windows: "%APPDATA%/opencode/opencode.json",
 	}[platform];
 
-	const config = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildOpenCodeConfig({
-			clientConfig,
-			selectedServers: serverScope === "selected" ? selectedServers : undefined,
-			virtualKey,
-		});
-	}, [clientConfig, selectedServers, serverScope, virtualKey]);
+	const config = useMemo(
+		() =>
+			buildOpenCodeConfig({
+				clientConfig,
+				headers,
+				selectedServers: serverScope === "selected" ? selectedServers : undefined,
+			}),
+		[clientConfig, headers, selectedServers, serverScope],
+	);
 
 	return (
 		<HarnessCommandSection
@@ -33,7 +35,7 @@ export function OpenCodeHarnessInstall({
 			command={config}
 			controls={null}
 			copySuccessMessage="Config copied"
-			emptyMessage={virtualKey ? "Select servers or use Gateway root." : "Select a virtual key to generate the config."}
+			emptyMessage={emptyMessage}
 			harnessName="OpenCode"
 			label="Config"
 			logoSrc="/images/harness/opencode.svg"

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/vscodeHarnessInstall.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/vscodeHarnessInstall.tsx
@@ -8,31 +8,26 @@ import { getRegistrationLabel } from "../utils";
 export function VSCodeHarnessInstall({
 	canGenerateCommand,
 	clientConfig,
+	emptyMessage,
+	headers,
 	platform,
 	selectedServers,
 	serverScope,
-	virtualKey,
 }: HarnessInstallProps) {
 	const [configScope, setConfigScope] = useState<VSCodeConfigScope>("workspace");
 
 	const serverArgs = useMemo(
 		() => ({
 			clientConfig,
+			headers,
 			selectedServers: serverScope === "selected" ? selectedServers : undefined,
-			virtualKey: virtualKey!,
 		}),
-		[clientConfig, selectedServers, serverScope, virtualKey],
+		[clientConfig, headers, selectedServers, serverScope],
 	);
 
-	const config = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildVSCodeConfig(serverArgs);
-	}, [serverArgs, virtualKey]);
+	const config = useMemo(() => buildVSCodeConfig(serverArgs), [serverArgs]);
 
-	const deeplink = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildVSCodeDeeplink(serverArgs);
-	}, [serverArgs, virtualKey]);
+	const deeplink = useMemo(() => buildVSCodeDeeplink(serverArgs), [serverArgs]);
 
 	const userConfigPath = {
 		linux: "~/.config/Code/User/mcp.json",
@@ -58,7 +53,7 @@ export function VSCodeHarnessInstall({
 			}
 			copySuccessMessage="Config copied"
 			deeplink={deeplink}
-			emptyMessage={virtualKey ? "Select servers or use Gateway root." : "Select a virtual key to generate the config."}
+			emptyMessage={emptyMessage}
 			harnessName="VS Code"
 			label="Config"
 			logoSrc="/images/harness/vscode.svg"

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/windsurfHarnessInstall.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/harnesses/windsurfHarnessInstall.tsx
@@ -7,21 +7,23 @@ import { getRegistrationLabel, getUserHomePrefix } from "../utils";
 export function WindsurfHarnessInstall({
 	canGenerateCommand,
 	clientConfig,
+	emptyMessage,
+	headers,
 	platform,
 	selectedServers,
 	serverScope,
-	virtualKey,
 }: HarnessInstallProps) {
 	const configPath = `${getUserHomePrefix(platform)}/.codeium/windsurf/mcp_config.json`;
 
-	const config = useMemo(() => {
-		if (!virtualKey) return "";
-		return buildWindsurfConfig({
-			clientConfig,
-			selectedServers: serverScope === "selected" ? selectedServers : undefined,
-			virtualKey,
-		});
-	}, [clientConfig, selectedServers, serverScope, virtualKey]);
+	const config = useMemo(
+		() =>
+			buildWindsurfConfig({
+				clientConfig,
+				headers,
+				selectedServers: serverScope === "selected" ? selectedServers : undefined,
+			}),
+		[clientConfig, headers, selectedServers, serverScope],
+	);
 
 	return (
 		<HarnessCommandSection
@@ -29,7 +31,7 @@ export function WindsurfHarnessInstall({
 			command={config}
 			controls={null}
 			copySuccessMessage="Config copied"
-			emptyMessage={virtualKey ? "Select servers or use Gateway root." : "Select a virtual key to generate the config."}
+			emptyMessage={emptyMessage}
 			harnessName="Windsurf (Devin)"
 			label="Config"
 			logoSrc="/images/harness/windsurf.svg"

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/mcpUsageGuideSheet.tsx
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/mcpUsageGuideSheet.tsx
@@ -4,20 +4,44 @@ import { SearchSelect } from "@/components/ui/searchSelect";
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from "@/components/ui/sheet";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useDebouncedValue } from "@/hooks/useDebounce";
+import { IS_ENTERPRISE } from "@/lib/constants/config";
 import { useGetCoreConfigQuery, useGetMCPClientsQuery, useGetVirtualKeysQuery } from "@/lib/store";
 import { cn } from "@/lib/utils";
-import { Check, Globe2, KeyRound, Server, SquareTerminal } from "lucide-react";
+import { useGetSCIMProvidersQuery } from "@enterprise/lib/store/apis/scimApi";
+import { Link } from "@tanstack/react-router";
+import { Check, Fingerprint, Globe2, KeyRound, Server, ShieldCheck, SquareTerminal } from "lucide-react";
 import { parseAsArrayOf, parseAsBoolean, parseAsString, parseAsStringLiteral, useQueryStates } from "nuqs";
 import { useEffect, useMemo, useState } from "react";
 import { HARNESSES } from "./harnesses";
 import { PlatformSelect } from "./platformSelect";
-import type { HarnessID, HarnessPlatform, ServerScope, VirtualKeyOption } from "./types";
-import { isClientAllowedForVirtualKey, maskSecret } from "./utils";
+import type { AuthMethod, HarnessID, HarnessPlatform, ServerScope, VirtualKeyOption } from "./types";
+import { buildMCPHeaders, isClientAllowedForVirtualKey, maskSecret } from "./utils";
 
 // Literal value sets driving the URL-persisted enums.
 const HARNESS_IDS = HARNESSES.map((h) => h.id);
 const HARNESS_PLATFORMS: HarnessPlatform[] = ["macos", "windows", "linux"];
 const SERVER_SCOPES: ServerScope[] = ["all", "selected"];
+const AUTH_METHODS: AuthMethod[] = ["virtual_key", "oauth", "idp_token"];
+
+const AUTH_METHOD_COPY: Record<AuthMethod, { label: string; icon: typeof KeyRound; description: string }> = {
+	virtual_key: {
+		label: "Virtual key",
+		icon: KeyRound,
+		description: "The client sends a virtual key header. Governance, budgets and tool access follow the key you pick below.",
+	},
+	oauth: {
+		label: "OAuth",
+		icon: ShieldCheck,
+		description:
+			"No credential in the config. The client discovers the gateway, opens Bifrost's consent page in a browser, and holds a short-lived token of its own.",
+	},
+	idp_token: {
+		label: "Identity provider",
+		icon: Fingerprint,
+		description:
+			"The client sends its caller's own SSO access token. Replace the placeholder with a token from your identity provider; the request is attributed to that user.",
+	},
+};
 
 export function MCPUsageGuideSheet() {
 	// ── URL-persisted settings (survive refresh) ─────────────────────────
@@ -29,6 +53,7 @@ export function MCPUsageGuideSheet() {
 			harness: parseAsStringLiteral(HARNESS_IDS).withDefault("claude-code"),
 			platform: parseAsStringLiteral(HARNESS_PLATFORMS).withDefault("macos"),
 			scope: parseAsStringLiteral(SERVER_SCOPES).withDefault("all"),
+			auth: parseAsStringLiteral(AUTH_METHODS).withDefault("virtual_key"),
 			vk: parseAsString,
 			servers: parseAsArrayOf(parseAsString).withDefault([]),
 		},
@@ -49,13 +74,16 @@ export function MCPUsageGuideSheet() {
 
 	// ── Queries ──────────────────────────────────────────────────────────
 	const { data: bifrostConfig } = useGetCoreConfigQuery({ fromDB: true }, { skip: !open });
+	// The identity-provider path is enterprise-only and needs an enabled provider to
+	// authenticate against. The SCIM query is stubbed to [] in OSS builds.
+	const { data: scimProviders } = useGetSCIMProvidersQuery(undefined, { skip: !open || !IS_ENTERPRISE });
 	const { data: virtualKeysData, isFetching: isFetchingVirtualKeys } = useGetVirtualKeysQuery(
 		{ limit: 50, search: debouncedVirtualKeySearch || undefined },
-		{ skip: !open },
+		{ skip: !open || urlState.auth !== "virtual_key" },
 	);
 	const { data: mcpClientsData, isFetching: isFetchingMCPClients } = useGetMCPClientsQuery(
 		{ limit: 50 },
-		{ skip: !open || !selectedVirtualKey, refetchOnMountOrArgChange: true },
+		{ skip: !open || urlState.auth !== "virtual_key" || !selectedVirtualKey, refetchOnMountOrArgChange: true },
 	);
 
 	// ── Derived data ─────────────────────────────────────────────────────
@@ -85,9 +113,58 @@ export function MCPUsageGuideSheet() {
 		[allowedMCPClients, urlState.servers],
 	);
 
-	const canGenerateCommand = !!selectedVirtualKey && (serverScope === "all" || selectedServers.length > 0);
+	// ── Authentication method ────────────────────────────────────────────
+	// Which credentials /mcp accepts is a server setting, so only the methods the
+	// gateway is actually configured for can produce a working config:
+	//   headers → virtual key and (enterprise) identity-provider token
+	//   both    → all three
+	//   oauth   → OAuth only; header credentials are rejected outright
+	const serverAuthMode = bifrostConfig?.client_config?.mcp_server_auth_mode ?? "headers";
+	const idpConfigured = !!scimProviders?.some((provider) => (provider as { enabled?: boolean }).enabled);
+
+	const availableAuthMethods = useMemo<AuthMethod[]>(() => {
+		const methods: AuthMethod[] = [];
+		if (serverAuthMode !== "oauth") methods.push("virtual_key");
+		if (serverAuthMode !== "headers") methods.push("oauth");
+		if (serverAuthMode !== "oauth" && IS_ENTERPRISE && idpConfigured) methods.push("idp_token");
+		return methods;
+	}, [idpConfigured, serverAuthMode]);
+
+	// The identity-provider card stays visible without an enabled provider so the
+	// method is discoverable, just disabled with the reason.
+	const visibleAuthMethods = useMemo<AuthMethod[]>(() => {
+		const methods: AuthMethod[] = ["virtual_key", "oauth"];
+		if (IS_ENTERPRISE) methods.push("idp_token");
+		return methods;
+	}, []);
+
+	const authMethod = availableAuthMethods.includes(urlState.auth) ? urlState.auth : (availableAuthMethods[0] ?? "virtual_key");
+	const usesVirtualKey = authMethod === "virtual_key";
+
+	const headers = useMemo(
+		() =>
+			buildMCPHeaders({
+				authMethod,
+				selectedServers: serverScope === "selected" ? selectedServers : undefined,
+				virtualKey: selectedVirtualKey,
+			}),
+		[authMethod, selectedServers, serverScope, selectedVirtualKey],
+	);
+
+	const canGenerateCommand = usesVirtualKey ? !!selectedVirtualKey && (serverScope === "all" || selectedServers.length > 0) : true;
+	const emptyMessage = selectedVirtualKey ? "Select servers or use Gateway root." : "Select a virtual key to continue.";
 
 	// ── Effects ──────────────────────────────────────────────────────────
+	// Keep the URL honest when the stored method is not one the gateway accepts
+	// (config changed, or a shared link from a differently configured instance).
+	// Waits for both sources availability is derived from, so a link carrying a
+	// still-valid method is not rewritten while the config is in flight.
+	useEffect(() => {
+		if (!open || !bifrostConfig || (IS_ENTERPRISE && !scimProviders)) return;
+		if (availableAuthMethods.length === 0 || availableAuthMethods.includes(urlState.auth)) return;
+		setUrlState({ auth: availableAuthMethods[0] });
+	}, [availableAuthMethods, bifrostConfig, open, scimProviders, setUrlState, urlState.auth]);
+
 	// Resolve the persisted virtual-key id into its full object, otherwise
 	// fall back to auto-selecting the first active key. Auto-selection is kept
 	// transient (not written to the URL) so it re-resolves on every open.
@@ -162,60 +239,107 @@ export function MCPUsageGuideSheet() {
 							</Tabs>
 						</section>
 
-						{/* ── Virtual key picker ─────────────────────────── */}
+						{/* ── Authentication method ──────────────────────── */}
 						<section className="flex flex-col gap-2 transition-[border-color,background-color] duration-150 ease-out">
 							<div className="flex items-center gap-2 text-sm font-medium">
-								<span>Virtual key</span>
+								<span>Authentication</span>
 							</div>
-							<SearchSelect<VirtualKeyOption>
-								async
-								open={virtualKeySelectOpen}
-								onOpenChange={setVirtualKeySelectOpen}
-								options={virtualKeyOptions}
-								onSearchChange={setVirtualKeySearch}
-								isSearching={isFetchingVirtualKeys}
-								isLoading={isFetchingVirtualKeys && virtualKeyOptions.length === 0}
-								onValueSelect={(option) => {
-									setSelectedVirtualKey(option.virtualKey);
-									// Switching keys clears server selection and resets the scope.
-									setUrlState({ vk: option.virtualKey.id, servers: [], scope: "all" });
-									setVirtualKeySelectOpen(false);
-								}}
-								label={
-									<Button
-										type="button"
-										variant="outline"
-										className="h-9 w-full justify-start bg-transparent"
-										data-testid="mcp-usage-guide-vk-select"
-									>
-										<KeyRound className="text-muted-foreground size-4" />
-										<span className="truncate">{selectedVirtualKey?.name ?? "Search virtual keys"}</span>
-										{selectedVirtualKey && (
-											<span className="text-muted-foreground ml-auto hidden font-mono text-xs sm:inline">
-												{maskSecret(selectedVirtualKey.value)}
-											</span>
-										)}
-									</Button>
-								}
-								entryView={(option) => (
-									<div className="flex min-w-0 flex-1 items-center gap-2">
-										<div className="flex min-w-0 flex-col">
-											<span className="truncate font-medium">{option.label}</span>
-											<span className="text-muted-foreground text-xs">{maskSecret(option.virtualKey.value)}</span>
-										</div>
-										{selectedVirtualKey?.id === option.virtualKey.id && <Check className="ml-auto size-4 text-green-600" />}
-									</div>
-								)}
-								searchPlaceholder="Search virtual keys..."
-								emptyMessage="No active virtual keys found."
-								align="start"
-								className="w-full"
-								contentClassName="w-[var(--radix-popover-trigger-width)]"
-							/>
+							<div className={cn("grid gap-2", visibleAuthMethods.length > 2 ? "sm:grid-cols-3" : "sm:grid-cols-2")}>
+								{visibleAuthMethods.map((method) => {
+									const { label, icon: Icon } = AUTH_METHOD_COPY[method];
+									const disabled = !availableAuthMethods.includes(method);
+									return (
+										<button
+											key={method}
+											type="button"
+											disabled={disabled}
+											onClick={() => setUrlState({ auth: method })}
+											className={cn(
+												"flex h-9 items-center gap-2 rounded-sm border px-3 py-2 text-left text-sm transition-[background-color,border-color,transform] duration-150 ease-out hover:bg-accent active:scale-[0.99]",
+												authMethod === method && "border-primary bg-primary/5",
+												disabled && "pointer-events-none opacity-50",
+											)}
+											data-testid={`mcp-usage-guide-auth-${method}`}
+										>
+											<Icon className="text-muted-foreground size-4 shrink-0" />
+											<span className="truncate font-medium">{label}</span>
+											{authMethod === method && <Check className="ml-auto size-4 shrink-0 text-green-600" />}
+										</button>
+									);
+								})}
+							</div>
+							<p className="text-muted-foreground text-xs">{AUTH_METHOD_COPY[authMethod].description}</p>
+							{!availableAuthMethods.includes("oauth") && (
+								<p className="text-muted-foreground text-xs">
+									OAuth is off for this gateway. Switch the MCP server auth mode to <span className="font-medium">both</span> or{" "}
+									<span className="font-medium">oauth</span> under{" "}
+									<Link to="/workspace/config/mcp-gateway" className="text-primary underline">
+										MCP settings
+									</Link>{" "}
+									to offer it.
+								</p>
+							)}
+							{IS_ENTERPRISE && !idpConfigured && (
+								<p className="text-muted-foreground text-xs">Identity provider login needs an enabled SSO/SCIM provider.</p>
+							)}
 						</section>
 
+						{/* ── Virtual key picker ─────────────────────────── */}
+						{usesVirtualKey && (
+							<section className="flex flex-col gap-2 transition-[border-color,background-color] duration-150 ease-out">
+								<div className="flex items-center gap-2 text-sm font-medium">
+									<span>Virtual key</span>
+								</div>
+								<SearchSelect<VirtualKeyOption>
+									async
+									open={virtualKeySelectOpen}
+									onOpenChange={setVirtualKeySelectOpen}
+									options={virtualKeyOptions}
+									onSearchChange={setVirtualKeySearch}
+									isSearching={isFetchingVirtualKeys}
+									isLoading={isFetchingVirtualKeys && virtualKeyOptions.length === 0}
+									onValueSelect={(option) => {
+										setSelectedVirtualKey(option.virtualKey);
+										// Switching keys clears server selection and resets the scope.
+										setUrlState({ vk: option.virtualKey.id, servers: [], scope: "all" });
+										setVirtualKeySelectOpen(false);
+									}}
+									label={
+										<Button
+											type="button"
+											variant="outline"
+											className="h-9 w-full justify-start bg-transparent"
+											data-testid="mcp-usage-guide-vk-select"
+										>
+											<KeyRound className="text-muted-foreground size-4" />
+											<span className="truncate">{selectedVirtualKey?.name ?? "Search virtual keys"}</span>
+											{selectedVirtualKey && (
+												<span className="text-muted-foreground ml-auto hidden font-mono text-xs sm:inline">
+													{maskSecret(selectedVirtualKey.value)}
+												</span>
+											)}
+										</Button>
+									}
+									entryView={(option) => (
+										<div className="flex min-w-0 flex-1 items-center gap-2">
+											<div className="flex min-w-0 flex-col">
+												<span className="truncate font-medium">{option.label}</span>
+												<span className="text-muted-foreground text-xs">{maskSecret(option.virtualKey.value)}</span>
+											</div>
+											{selectedVirtualKey?.id === option.virtualKey.id && <Check className="ml-auto size-4 text-green-600" />}
+										</div>
+									)}
+									searchPlaceholder="Search virtual keys..."
+									emptyMessage="No active virtual keys found."
+									align="start"
+									className="w-full"
+									contentClassName="w-[var(--radix-popover-trigger-width)]"
+								/>
+							</section>
+						)}
+
 						{/* ── Server scope selector ──────────────────────── */}
-						{selectedVirtualKey && (
+						{usesVirtualKey && selectedVirtualKey && (
 							<section className="flex flex-col gap-2 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none">
 								<div className="flex items-center gap-2 text-sm font-medium">
 									<span>Server access</span>
@@ -269,7 +393,7 @@ export function MCPUsageGuideSheet() {
 						)}
 
 						{/* ── Platform selector ───────────────────────────── */}
-						{selectedVirtualKey && activeHarness.usesPlatform && (
+						{canGenerateCommand && activeHarness.usesPlatform && (
 							<section className="flex flex-col gap-2 transition-[opacity,transform] duration-200 ease-out motion-reduce:transition-none">
 								<div className="flex items-center gap-2 text-sm font-medium">
 									<span>Platform</span>
@@ -282,10 +406,11 @@ export function MCPUsageGuideSheet() {
 						<activeHarness.Install
 							canGenerateCommand={canGenerateCommand}
 							clientConfig={bifrostConfig?.client_config}
+							emptyMessage={emptyMessage}
+							headers={headers}
 							platform={platform}
-							selectedServers={selectedServers}
-							serverScope={serverScope}
-							virtualKey={selectedVirtualKey}
+							selectedServers={usesVirtualKey ? selectedServers : []}
+							serverScope={usesVirtualKey ? serverScope : "all"}
 						/>
 					</div>
 				</SheetContent>

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/types.ts
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/types.ts
@@ -12,6 +12,15 @@ export type HarnessPlatform = "macos" | "windows" | "linux";
 export type VSCodeConfigScope = "workspace" | "user";
 export type ServerScope = "all" | "selected";
 
+/**
+ * How the generated client config authenticates to Bifrost's /mcp endpoint.
+ * Mirrors the inbound credentials the gateway accepts (see mcp_server_auth_mode):
+ *  - virtual_key: x-bf-vk header
+ *  - oauth: no credential in the config; the client runs the browser consent flow
+ *  - idp_token: the caller's own identity-provider bearer, enterprise + SSO only
+ */
+export type AuthMethod = "virtual_key" | "oauth" | "idp_token";
+
 export interface VirtualKeyOption extends SearchSelectOption {
 	virtualKey: VirtualKey;
 }
@@ -19,10 +28,13 @@ export interface VirtualKeyOption extends SearchSelectOption {
 export interface HarnessInstallProps {
 	canGenerateCommand: boolean;
 	clientConfig?: CoreConfig;
+	/** Shown in place of the code block while the selections are incomplete. */
+	emptyMessage: string;
+	/** Request headers the generated config must carry; empty for the OAuth flow. */
+	headers: Record<string, string>;
 	platform: HarnessPlatform;
 	selectedServers: MCPClient[];
 	serverScope: ServerScope;
-	virtualKey?: VirtualKey;
 }
 
 export interface HarnessCommandSectionProps {

--- a/ui/app/workspace/mcp-registry/views/mcpUsageGuide/utils.ts
+++ b/ui/app/workspace/mcp-registry/views/mcpUsageGuide/utils.ts
@@ -1,7 +1,7 @@
 import type { CoreConfig } from "@/lib/types/config";
 import type { VirtualKey } from "@/lib/types/governance";
 import type { MCPClient } from "@/lib/types/mcp";
-import type { HarnessPlatform, ServerScope } from "./types";
+import type { AuthMethod, HarnessPlatform, ServerScope } from "./types";
 
 /** Default port Bifrost serves on; used when guessing the gateway URL in local dev. */
 const DEFAULT_BIFROST_PORT = "8080";
@@ -99,4 +99,34 @@ export function getIncludeClients(selectedServers?: MCPClient[]): string | undef
 
 export function getUserHomePrefix(platform: HarnessPlatform): string {
 	return platform === "windows" ? "%USERPROFILE%" : "~";
+}
+
+/** Stand-in for the identity-provider bearer the user pastes into their own config. */
+export const IDP_TOKEN_PLACEHOLDER = "<YOUR_IDP_ACCESS_TOKEN>";
+
+/**
+ * Headers the generated client config must send, derived from the chosen
+ * authentication method. OAuth clients carry no credential at all: the token
+ * arrives from the consent flow, and sending a virtual key alongside it is
+ * rejected by the gateway as conflicting credentials. The server filter is a
+ * credential-free header, but it is only offered on the virtual-key path, where
+ * the allowed server list can be resolved from the key.
+ */
+export function buildMCPHeaders({
+	authMethod,
+	selectedServers,
+	virtualKey,
+}: {
+	authMethod: AuthMethod;
+	selectedServers?: MCPClient[];
+	virtualKey?: VirtualKey;
+}): Record<string, string> {
+	if (authMethod === "oauth") return {};
+	if (authMethod === "idp_token") return { Authorization: `Bearer ${IDP_TOKEN_PLACEHOLDER}` };
+
+	if (!virtualKey) return {};
+	const headers: Record<string, string> = { "x-bf-vk": virtualKey.value };
+	const includeClients = getIncludeClients(selectedServers);
+	if (includeClients) headers["x-bf-mcp-include-clients"] = includeClients;
+	return headers;
 }


### PR DESCRIPTION
## Summary

The MCP usage guide sheet previously required a virtual key for every client config it generated. This PR introduces a proper authentication method selector — **Virtual key**, **OAuth**, and **Identity provider** — so users can generate configs that match how their gateway is actually configured. The command builders are refactored to accept a pre-resolved `headers` map instead of a raw `VirtualKey`, decoupling credential construction from config rendering.

## Changes

- Added an `AuthMethod` type (`virtual_key` | `oauth` | `idp_token`) and a `BuildArgs` interface that replaces the per-builder `virtualKey` parameter with a generic `headers: Record<string, string>`.
- Introduced `buildMCPHeaders()` in `utils.ts` to centralize credential resolution: OAuth returns an empty map, identity-provider returns a `Bearer <placeholder>` `Authorization` header, and virtual key returns the existing `x-bf-vk` (plus optional `x-bf-mcp-include-clients`) headers.
- All command builders (`buildClaudeCodeCommand`, `buildCodexConfig`, `buildCursorConfig`, `buildCursorDeeplink`, `buildWindsurfConfig`, `buildVSCodeConfig`, `buildVSCodeDeeplink`, `buildOpenCodeConfig`, `buildAntigravityConfig`) now iterate over the resolved `headers` map rather than constructing headers themselves. The `headers` key is omitted entirely from JSON/TOML output when the map is empty (OAuth flow).
- The usage guide sheet reads `mcp_server_auth_mode` from the gateway config and the list of enabled SCIM providers to determine which auth methods are actually available, then renders only those as selectable. The URL state gains an `auth` parameter that is corrected automatically if the stored value is no longer valid.
- The virtual key picker and server scope selector are now conditionally rendered only when the virtual key auth method is active.
- `HarnessInstallProps` replaces `virtualKey?: VirtualKey` with `headers: Record<string, string>` and adds `emptyMessage: string`, moving the empty-state message logic up to the sheet so harness components no longer need to know which auth method is in use.
- The platform selector is now shown whenever `canGenerateCommand` is true, not only when a virtual key is selected.

## Type of change

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

1. Open the MCP usage guide sheet on a gateway configured with `mcp_server_auth_mode = headers`. Verify only **Virtual key** and **Identity provider** (enterprise with SSO enabled) are selectable; **OAuth** is visible but disabled with a link to MCP settings.
2. Switch to a gateway with `mcp_server_auth_mode = oauth`. Verify only **OAuth** is selectable and the generated configs contain no credential headers.
3. Switch to `mcp_server_auth_mode = both`. Verify all three methods are available and selecting **OAuth** produces a config with no headers, **Virtual key** produces `x-bf-vk`, and **Identity provider** produces `Authorization: Bearer <YOUR_IDP_ACCESS_TOKEN>`.
4. Confirm the virtual key picker and server scope selector are hidden when OAuth or identity provider is selected.
5. Confirm the platform selector appears for harnesses that use it regardless of auth method.
6. Share a URL with `auth=oauth` to a gateway that only supports headers; verify the URL is corrected to `virtual_key` after the config loads.

```sh
cd ui
pnpm i
pnpm build
pnpm test
```

## Screenshots/Recordings

Before: The sheet always showed a virtual key picker and generated configs only when a key was selected.

After: An authentication method selector appears first. Choosing OAuth hides the key picker and generates a credential-free config immediately. Choosing Identity provider generates a config with a bearer token placeholder.

## Breaking changes

- [x] Yes
- [ ] No

`HarnessInstallProps` no longer includes `virtualKey`; it now requires `headers` and `emptyMessage`. Any custom harness components implementing this interface must be updated to accept the new props.

## Related issues

## Security considerations

The identity-provider path emits `<YOUR_IDP_ACCESS_TOKEN>` as a literal placeholder rather than any real credential, making it safe to display and copy. OAuth configs carry no credential at all. Virtual key values continue to be masked in the picker UI. The available auth methods are gated on the server's `mcp_server_auth_mode` setting, preventing users from generating configs that the gateway would reject.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable