### PR TITLE
improve color pallete of graphs

### DIFF
--- a/cli/go.mod
+++ b/cli/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
-	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -50,8 +50,7 @@ github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzh
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/lucasb-eyer/go-colorful v1.3.0 h1:2/yBRLdWBZKrf7gB40FoiKfAWYQ0lqNcbuQwVHXptag=
 github.com/lucasb-eyer/go-colorful v1.3.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
-github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
-github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-isatty v0.0.24 h1:tGZZoVgT/KiqK1c8ocVLeDS8BSWMRd47J3Lbz7vsReI=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.19 h1:v++JhqYnZuu5jSKrk9RbgF5v4CGUjqRfBm05byFGLdw=
@@ -92,7 +91,6 @@ golang.org/x/arch v0.23.0/go.mod h1:dNHoOeKiyja7GTvF9NJS1l3Z2yntpQNzgrjh1cU103A=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f h1:W3F4c+6OLc6H2lb//N1q4WpJkhzJCK5J6kUi1NTVXfM=
 golang.org/x/exp v0.0.0-20260410095643-746e56fc9e2f/go.mod h1:J1xhfL/vlindoeF/aINzNzt2Bket5bjo9sdOYzOsU80=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
 golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
 golang.org/x/text v0.41.0 h1:vz/seA0lnX87Othu2f/0L24RcgrXD9/YFTSuGjj3rH8=

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -71,11 +71,33 @@
 	--color-sidebar-primary: var(--sidebar-primary);
 	--color-sidebar-foreground: var(--sidebar-foreground);
 	--color-sidebar: var(--sidebar);
-	--color-chart-5: var(--chart-5);
-	--color-chart-4: var(--chart-4);
-	--color-chart-3: var(--chart-3);
-	--color-chart-2: var(--chart-2);
-	--color-chart-1: var(--chart-1);
+	--color-chart-success: var(--chart-success);
+	--color-chart-error: var(--chart-error);
+	--color-chart-warning: var(--chart-warning);
+	--color-chart-neutral: var(--chart-neutral);
+	--color-chart-success-ink: var(--chart-success-ink);
+	--color-chart-error-ink: var(--chart-error-ink);
+	--color-chart-warning-ink: var(--chart-warning-ink);
+	--color-chart-seq-1: var(--chart-seq-1);
+	--color-chart-seq-2: var(--chart-seq-2);
+	--color-chart-seq-3: var(--chart-seq-3);
+	--color-chart-seq-4: var(--chart-seq-4);
+	--color-chart-seq-5: var(--chart-seq-5);
+	--color-chart-token-input: var(--chart-token-input);
+	--color-chart-token-output: var(--chart-token-output);
+	--color-chart-token-cached: var(--chart-token-cached);
+	--color-chart-ord-1: var(--chart-ord-1);
+	--color-chart-ord-2: var(--chart-ord-2);
+	--color-chart-ord-3: var(--chart-ord-3);
+	--color-chart-ord-4: var(--chart-ord-4);
+	--color-chart-cat-1: var(--chart-cat-1);
+	--color-chart-cat-2: var(--chart-cat-2);
+	--color-chart-cat-3: var(--chart-cat-3);
+	--color-chart-cat-4: var(--chart-cat-4);
+	--color-chart-cat-5: var(--chart-cat-5);
+	--color-chart-cat-6: var(--chart-cat-6);
+	--color-chart-cat-other: var(--chart-cat-other);
+	--color-chart-track: var(--chart-track);
 	--color-ring: var(--ring);
 	--color-input: var(--input);
 	--color-border: var(--border);
@@ -166,11 +188,40 @@
 	--border: oklch(0.92 0.004 286.32);
 	--input: oklch(0.92 0.004 286.32);
 	--ring: oklch(0.705 0.015 286.067);
-	--chart-1: oklch(0.646 0.222 41.116);
-	--chart-2: oklch(0.6 0.118 184.704);
-	--chart-3: oklch(0.398 0.07 227.392);
-	--chart-4: oklch(0.828 0.189 84.429);
-	--chart-5: oklch(0.769 0.188 70.08);
+	/* Chart color system. Semantic: status only. Sequential: one hue, stepped
+	   lightness, for ordered series (seq = teal, ord = indigo percentiles).
+	   Categorical: six hues assigned by rank, then grey for "Other". Hues 0-70
+	   are reserved for status, so no category can look like an error. */
+	--chart-success: oklch(0.63 0.11 182);
+	--chart-error: oklch(0.6 0.16 27);
+	--chart-warning: oklch(0.74 0.13 62);
+	--chart-neutral: oklch(0.8 0.012 200);
+	/* Text-safe versions of the status hues: same hue, lightness set so 12px
+	   text clears WCAG 4.5:1 on the card and on a 10% tint of itself. Fills,
+	   swatches and bars keep the base tokens. */
+	--chart-success-ink: oklch(0.45 0.1 182);
+	--chart-error-ink: oklch(0.48 0.16 27);
+	--chart-warning-ink: oklch(0.5 0.12 62);
+	--chart-seq-1: oklch(0.38 0.085 205);
+	--chart-seq-2: oklch(0.48 0.115 200);
+	--chart-seq-3: oklch(0.6 0.115 190);
+	--chart-seq-4: oklch(0.72 0.095 186);
+	--chart-seq-5: oklch(0.86 0.055 184);
+	--chart-token-input: oklch(0.48 0.115 200);
+	--chart-token-output: oklch(0.68 0.1 188);
+	--chart-token-cached: oklch(0.86 0.055 184);
+	--chart-ord-1: oklch(0.82 0.055 265);
+	--chart-ord-2: oklch(0.7 0.095 265);
+	--chart-ord-3: oklch(0.57 0.125 267);
+	--chart-ord-4: oklch(0.44 0.135 270);
+	--chart-cat-1: oklch(0.55 0.13 255);
+	--chart-cat-2: oklch(0.63 0.13 300);
+	--chart-cat-3: oklch(0.67 0.13 340);
+	--chart-cat-4: oklch(0.66 0.12 135);
+	--chart-cat-5: oklch(0.42 0.1 225);
+	--chart-cat-6: oklch(0.45 0.09 155);
+	--chart-cat-other: oklch(0.78 0.012 200);
+	--chart-track: oklch(0.965 0.004 195);
 	--sidebar: color-mix(in oklch, var(--color-cream-100) 20%, transparent);
 	--sidebar-foreground: oklch(0.141 0.005 285.823);
 	--sidebar-primary: oklch(0.21 0.006 285.885);
@@ -201,11 +252,35 @@
 	--border: oklch(1 0 0 / 10%);
 	--input: oklch(1 0 0 / 15%);
 	--ring: oklch(0.552 0.016 285.938);
-	--chart-1: oklch(0.488 0.243 264.376);
-	--chart-2: oklch(0.696 0.17 162.48);
-	--chart-3: oklch(0.769 0.188 70.08);
-	--chart-4: oklch(0.627 0.265 303.9);
-	--chart-5: oklch(0.645 0.246 16.439);
+	/* Same hues, lightness re-anchored: the teal ramp inverts so brightest is
+	   largest, and the two darkest categoricals lift. */
+	--chart-success: oklch(0.72 0.115 182);
+	--chart-error: oklch(0.68 0.155 27);
+	--chart-warning: oklch(0.8 0.125 62);
+	--chart-neutral: oklch(0.55 0.015 220);
+	--chart-success-ink: oklch(0.84 0.1 182);
+	--chart-error-ink: oklch(0.82 0.12 27);
+	--chart-warning-ink: oklch(0.86 0.11 62);
+	--chart-seq-1: oklch(0.9 0.05 184);
+	--chart-seq-2: oklch(0.8 0.085 186);
+	--chart-seq-3: oklch(0.68 0.11 190);
+	--chart-seq-4: oklch(0.56 0.11 198);
+	--chart-seq-5: oklch(0.44 0.09 205);
+	--chart-token-input: oklch(0.8 0.085 186);
+	--chart-token-output: oklch(0.62 0.11 194);
+	--chart-token-cached: oklch(0.44 0.09 205);
+	--chart-ord-1: oklch(0.88 0.05 265);
+	--chart-ord-2: oklch(0.78 0.09 265);
+	--chart-ord-3: oklch(0.68 0.12 267);
+	--chart-ord-4: oklch(0.58 0.13 270);
+	--chart-cat-1: oklch(0.68 0.12 255);
+	--chart-cat-2: oklch(0.72 0.12 300);
+	--chart-cat-3: oklch(0.75 0.12 340);
+	--chart-cat-4: oklch(0.76 0.115 135);
+	--chart-cat-5: oklch(0.62 0.1 225);
+	--chart-cat-6: oklch(0.64 0.09 155);
+	--chart-cat-other: oklch(0.55 0.015 220);
+	--chart-track: oklch(0.29 0.012 220);
 	--sidebar: color-mix(in oklch, var(--color-ink-900) 20%, transparent);
 	--sidebar-foreground: oklch(0.985 0 0);
 	--sidebar-primary: oklch(0.488 0.243 264.376);

--- a/ui/app/workspace/dashboard/components/charts/barShape.tsx
+++ b/ui/app/workspace/dashboard/components/charts/barShape.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+import { BarStack, type BarShapeProps, Rectangle, usePlotArea } from "recharts";
+
+// Bars round only the open end (the end that points away from the axis). The
+// cap scales with the bar's thickness so it reads the same on a 30px column
+// and an 8px one: a quarter of the thickness, between 1px and the 4px the
+// ranking charts use. It never reaches half the thickness, so bars keep
+// straight sides and never become pills. The axis end always stays square.
+export function capRadius(size: number): number {
+	return Math.min(4, Math.max(1, Math.floor(size / 4)));
+}
+
+// Bar `shape` for a single (unstacked) vertical series.
+export function barShape(props: BarShapeProps) {
+	const r = capRadius(props.width);
+	return <Rectangle {...props} radius={[r, r, 0, 0]} />;
+}
+
+// Bar `shape` for a horizontal (layout="vertical") ranking bar: the cap sits
+// on the right end.
+export function rankingBarShape(props: BarShapeProps) {
+	const r = capRadius(props.height);
+	return <Rectangle {...props} radius={[0, r, r, 0]} />;
+}
+
+// Wraps the <Bar>s of one stack so the whole column is clipped to a rounded
+// top. A per-segment radius cannot do this: Recharts clamps a corner to half
+// the segment's own height, so a thin top segment (a few errors over many
+// successes) gets a 1px cap and the column reads as square. BarStack rounds
+// the stack as one shape instead.
+//
+// The cap is sized from the column width Recharts will draw: the plot width
+// split across `buckets`, minus the category gap, never wider than `barSize`.
+export function CappedBarStack({ buckets, barSize = 30, children }: { buckets: number; barSize?: number; children: ReactNode }) {
+	const plot = usePlotArea();
+	const columnWidth = plot && buckets > 0 ? Math.min(barSize, plot.width / buckets - 2) : barSize;
+	const r = capRadius(columnWidth);
+	return <BarStack radius={[r, r, 0, 0]}>{children}</BarStack>;
+}

--- a/ui/app/workspace/dashboard/components/charts/costChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/costChart.tsx
@@ -12,6 +12,7 @@ import {
 	OTHER_SERIES_KEY,
 	OTHER_SERIES_LABEL,
 } from "../../utils/chartUtils";
+import { CappedBarStack } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -146,18 +147,18 @@ function CostChartImpl({ data, chartType, startTime, endTime, selectedModel }: C
 							content={<CustomTooltip selectedModel={selectedModel} displayModels={displayModels} />}
 							cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
 						/>
-						{displayModels.map((model, idx) => (
-							<Bar
-								isAnimationActive={false}
-								key={model}
-								dataKey={`model_${idx}`}
-								stackId="cost"
-								fill={model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
-								fillOpacity={0.9}
-								barSize={30}
-								radius={idx === displayModels.length - 1 ? [2, 2, 0, 0] : [0, 0, 0, 0]}
-							/>
-						))}
+						<CappedBarStack buckets={chartData.length}>
+							{displayModels.map((model, idx) => (
+								<Bar
+									isAnimationActive={false}
+									key={model}
+									dataKey={`model_${idx}`}
+									fill={model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
+									fillOpacity={0.9}
+									barSize={30}
+								/>
+							))}
+						</CappedBarStack>
 					</BarChart>
 				) : (
 					<AreaChart {...commonProps}>

--- a/ui/app/workspace/dashboard/components/charts/externalCacheTokenMeterChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/externalCacheTokenMeterChart.tsx
@@ -11,7 +11,7 @@ interface ExternalCacheTokenMeterChartProps {
 	data: TokenHistogramResponse | null;
 }
 
-const METER_COLORS = { cached: "#06b6d4", input: "#3b82f6" };
+const METER_COLORS = { cached: "var(--chart-seq-2)", input: "var(--chart-seq-5)" };
 
 function ExternalCacheTokenMeterChartImpl({ data }: ExternalCacheTokenMeterChartProps) {
 	const { ref, width, height } = useGaugeSize();

--- a/ui/app/workspace/dashboard/components/charts/latencyChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/latencyChart.tsx
@@ -2,6 +2,7 @@ import type { LatencyHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { formatFullTimestamp, formatLatency, formatTimestamp, LATENCY_COLORS } from "../../utils/chartUtils";
+import { barShape } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -107,38 +108,10 @@ function LatencyChartImpl({ data, chartType, startTime, endTime }: LatencyChartP
 							allowDataOverflow={false}
 						/>
 						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-						<Bar
-							isAnimationActive={false}
-							dataKey="avg_latency"
-							fill={LATENCY_COLORS.avg}
-							fillOpacity={0.9}
-							barSize={8}
-							radius={[2, 2, 0, 0]}
-						/>
-						<Bar
-							isAnimationActive={false}
-							dataKey="p90_latency"
-							fill={LATENCY_COLORS.p90}
-							fillOpacity={0.9}
-							barSize={8}
-							radius={[2, 2, 0, 0]}
-						/>
-						<Bar
-							isAnimationActive={false}
-							dataKey="p95_latency"
-							fill={LATENCY_COLORS.p95}
-							fillOpacity={0.9}
-							barSize={8}
-							radius={[2, 2, 0, 0]}
-						/>
-						<Bar
-							isAnimationActive={false}
-							dataKey="p99_latency"
-							fill={LATENCY_COLORS.p99}
-							fillOpacity={0.9}
-							barSize={8}
-							radius={[2, 2, 0, 0]}
-						/>
+						<Bar isAnimationActive={false} dataKey="avg_latency" fill={LATENCY_COLORS.avg} fillOpacity={0.9} barSize={8} shape={barShape} />
+						<Bar isAnimationActive={false} dataKey="p90_latency" fill={LATENCY_COLORS.p90} fillOpacity={0.9} barSize={8} shape={barShape} />
+						<Bar isAnimationActive={false} dataKey="p95_latency" fill={LATENCY_COLORS.p95} fillOpacity={0.9} barSize={8} shape={barShape} />
+						<Bar isAnimationActive={false} dataKey="p99_latency" fill={LATENCY_COLORS.p99} fillOpacity={0.9} barSize={8} shape={barShape} />
 					</BarChart>
 				) : (
 					<AreaChart {...commonProps}>

--- a/ui/app/workspace/dashboard/components/charts/localCacheTokenMeterChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/localCacheTokenMeterChart.tsx
@@ -8,7 +8,8 @@ interface LocalCacheTokenMeterChartProps {
 	data: LogStats | null;
 }
 
-const METER_COLORS = { direct: "#06b6d4", semantic: "#8b5cf6", remaining: "#3b82f6" };
+// Teal ramp: the two hit kinds are ordered shares of one total.
+const METER_COLORS = { direct: "var(--chart-seq-1)", semantic: "var(--chart-seq-3)", remaining: "var(--chart-seq-5)" };
 
 function LocalCacheTokenMeterChartImpl({ data }: LocalCacheTokenMeterChartProps) {
 	const { ref, width, height } = useGaugeSize();

--- a/ui/app/workspace/dashboard/components/charts/logVolumeChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/logVolumeChart.tsx
@@ -3,6 +3,7 @@ import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
+import { CappedBarStack } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -40,17 +41,17 @@ function CustomTooltip({ active, payload }: CustomTooltipProps) {
 			<div className="space-y-1 text-sm">
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-emerald-500" />
+						<span className="bg-chart-success h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Success</span>
 					</span>
-					<span className="font-medium text-emerald-600 dark:text-emerald-400">{data.success.toLocaleString()}</span>
+					<span className="text-chart-success-ink font-medium">{data.success.toLocaleString()}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-red-500" />
+						<span className="bg-chart-error h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Error</span>
 					</span>
-					<span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
+					<span className="text-chart-error-ink font-medium">{data.error.toLocaleString()}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
@@ -113,33 +114,11 @@ function LogVolumeChartImpl({ data, chartType, startTime, endTime }: LogVolumeCh
 							allowDataOverflow={false}
 						/>
 						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-						<Bar
-							isAnimationActive={false}
-							dataKey="success"
-							stackId="requests"
-							fill={CHART_COLORS.success}
-							fillOpacity={0.9}
-							radius={[0, 0, 0, 0]}
-							barSize={30}
-						/>
-						<Bar
-							isAnimationActive={false}
-							dataKey="error"
-							stackId="requests"
-							fill={CHART_COLORS.error}
-							fillOpacity={0.9}
-							radius={[0, 0, 0, 0]}
-							barSize={30}
-						/>
-						<Bar
-							isAnimationActive={false}
-							dataKey="cancelled"
-							stackId="requests"
-							fill={CHART_COLORS.cancelled}
-							fillOpacity={0.9}
-							radius={[2, 2, 0, 0]}
-							barSize={30}
-						/>
+						<CappedBarStack buckets={chartData.length}>
+							<Bar isAnimationActive={false} dataKey="success" fill={CHART_COLORS.success} fillOpacity={0.9} barSize={30} />
+							<Bar isAnimationActive={false} dataKey="error" fill={CHART_COLORS.error} fillOpacity={0.9} barSize={30} />
+							<Bar isAnimationActive={false} dataKey="cancelled" fill={CHART_COLORS.cancelled} fillOpacity={0.9} barSize={30} />
+						</CappedBarStack>
 					</BarChart>
 				) : (
 					<AreaChart {...commonProps}>

--- a/ui/app/workspace/dashboard/components/charts/mcpCostChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/mcpCostChart.tsx
@@ -2,6 +2,7 @@ import type { MCPCostHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { CHART_COLORS, formatCost, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
+import { barShape } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -82,14 +83,7 @@ function MCPCostChartImpl({ data, chartType, startTime, endTime }: MCPCostChartP
 							allowDataOverflow={false}
 						/>
 						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-						<Bar
-							isAnimationActive={false}
-							dataKey="total_cost"
-							fill={CHART_COLORS.cost}
-							fillOpacity={0.9}
-							radius={[2, 2, 0, 0]}
-							barSize={30}
-						/>
+						<Bar isAnimationActive={false} dataKey="total_cost" fill={CHART_COLORS.cost} fillOpacity={0.9} shape={barShape} barSize={30} />
 					</BarChart>
 				) : (
 					<AreaChart {...commonProps}>

--- a/ui/app/workspace/dashboard/components/charts/mcpTopToolsChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/mcpTopToolsChart.tsx
@@ -3,6 +3,7 @@ import { memo, useMemo } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { formatCost, getModelColor } from "../../utils/chartUtils";
+import { rankingBarShape } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 
 interface MCPTopToolsChartProps {
@@ -69,7 +70,7 @@ function MCPTopToolsChartImpl({ data }: MCPTopToolsChartProps) {
 						interval={0}
 					/>
 					<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-					<Bar isAnimationActive={false} dataKey="count" radius={[0, 2, 2, 0]} barSize={20}>
+					<Bar isAnimationActive={false} dataKey="count" shape={rankingBarShape} barSize={20}>
 						{chartData.map((_, index) => (
 							<Cell key={`cell-${index}`} fill={getModelColor(index)} fillOpacity={0.9} />
 						))}

--- a/ui/app/workspace/dashboard/components/charts/mcpVolumeChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/mcpVolumeChart.tsx
@@ -3,6 +3,7 @@ import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
+import { CappedBarStack } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -25,17 +26,17 @@ function CustomTooltip({ active, payload }: any) {
 			<div className="space-y-1 text-sm">
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-emerald-500" />
+						<span className="bg-chart-success h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Success</span>
 					</span>
-					<span className="font-medium text-emerald-600 dark:text-emerald-400">{data.success.toLocaleString()}</span>
+					<span className="text-chart-success-ink font-medium">{data.success.toLocaleString()}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-red-500" />
+						<span className="bg-chart-error h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Error</span>
 					</span>
-					<span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
+					<span className="text-chart-error-ink font-medium">{data.error.toLocaleString()}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4 border-t border-zinc-200 pt-1 dark:border-zinc-700">
 					<span className="text-zinc-600 dark:text-zinc-400">Total</span>
@@ -94,24 +95,10 @@ function MCPVolumeChartImpl({ data, chartType, startTime, endTime }: MCPVolumeCh
 							allowDataOverflow={false}
 						/>
 						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-						<Bar
-							isAnimationActive={false}
-							dataKey="success"
-							stackId="requests"
-							fill={CHART_COLORS.success}
-							fillOpacity={0.9}
-							radius={[0, 0, 0, 0]}
-							barSize={30}
-						/>
-						<Bar
-							isAnimationActive={false}
-							dataKey="error"
-							stackId="requests"
-							fill={CHART_COLORS.error}
-							fillOpacity={0.9}
-							radius={[2, 2, 0, 0]}
-							barSize={30}
-						/>
+						<CappedBarStack buckets={chartData.length}>
+							<Bar isAnimationActive={false} dataKey="success" fill={CHART_COLORS.success} fillOpacity={0.9} barSize={30} />
+							<Bar isAnimationActive={false} dataKey="error" fill={CHART_COLORS.error} fillOpacity={0.9} barSize={30} />
+						</CappedBarStack>
 					</BarChart>
 				) : (
 					<AreaChart {...commonProps}>

--- a/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/modelUsageChart.tsx
@@ -12,6 +12,7 @@ import {
 	OTHER_SERIES_KEY,
 	OTHER_SERIES_LABEL,
 } from "../../utils/chartUtils";
+import { CappedBarStack } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -61,21 +62,17 @@ function CustomTooltip({ active, payload, selectedModel, displayModels }: any) {
 					<>
 						<div className="flex items-center justify-between gap-4">
 							<span className="flex items-center gap-1.5">
-								<span className="h-2 w-2 rounded-full bg-emerald-500" />
+								<span className="bg-chart-success h-2 w-2 rounded-full" />
 								<span className="text-zinc-600 dark:text-zinc-400">Success</span>
 							</span>
-							<span className="font-medium text-emerald-600 dark:text-emerald-400">
-								{(data.by_model?.[selectedModel]?.success || 0).toLocaleString()}
-							</span>
+							<span className="text-chart-success-ink font-medium">{(data.by_model?.[selectedModel]?.success || 0).toLocaleString()}</span>
 						</div>
 						<div className="flex items-center justify-between gap-4">
 							<span className="flex items-center gap-1.5">
-								<span className="h-2 w-2 rounded-full bg-red-500" />
+								<span className="bg-chart-error h-2 w-2 rounded-full" />
 								<span className="text-zinc-600 dark:text-zinc-400">Error</span>
 							</span>
-							<span className="font-medium text-red-600 dark:text-red-400">
-								{(data.by_model?.[selectedModel]?.error || 0).toLocaleString()}
-							</span>
+							<span className="text-chart-error-ink font-medium">{(data.by_model?.[selectedModel]?.error || 0).toLocaleString()}</span>
 						</div>
 						<div className="flex items-center justify-between gap-4">
 							<span className="flex items-center gap-1.5">
@@ -183,48 +180,24 @@ function ModelUsageChartImpl({ data, chartType, startTime, endTime, selectedMode
 							cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
 						/>
 						{selectedModel === "all" ? (
-							displayModels.map((model, idx) => (
-								<Bar
-									isAnimationActive={false}
-									key={model}
-									dataKey={`model_${sanitizeModelKey(model)}`}
-									stackId="models"
-									fill={model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
-									fillOpacity={0.9}
-									barSize={30}
-									radius={idx === displayModels.length - 1 ? [2, 2, 0, 0] : [0, 0, 0, 0]}
-								/>
-							))
+							<CappedBarStack buckets={chartData.length}>
+								{displayModels.map((model, idx) => (
+									<Bar
+										isAnimationActive={false}
+										key={model}
+										dataKey={`model_${sanitizeModelKey(model)}`}
+										fill={model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
+										fillOpacity={0.9}
+										barSize={30}
+									/>
+								))}
+							</CappedBarStack>
 						) : (
-							<>
-								<Bar
-									isAnimationActive={false}
-									dataKey="success"
-									stackId="status"
-									fill={CHART_COLORS.success}
-									fillOpacity={0.9}
-									radius={[0, 0, 0, 0]}
-									barSize={30}
-								/>
-								<Bar
-									isAnimationActive={false}
-									dataKey="error"
-									stackId="status"
-									fill={CHART_COLORS.error}
-									fillOpacity={0.9}
-									radius={[0, 0, 0, 0]}
-									barSize={30}
-								/>
-								<Bar
-									isAnimationActive={false}
-									dataKey="cancelled"
-									stackId="status"
-									fill={CHART_COLORS.cancelled}
-									fillOpacity={0.9}
-									radius={[2, 2, 0, 0]}
-									barSize={30}
-								/>
-							</>
+							<CappedBarStack buckets={chartData.length}>
+								<Bar isAnimationActive={false} dataKey="success" fill={CHART_COLORS.success} fillOpacity={0.9} barSize={30} />
+								<Bar isAnimationActive={false} dataKey="error" fill={CHART_COLORS.error} fillOpacity={0.9} barSize={30} />
+								<Bar isAnimationActive={false} dataKey="cancelled" fill={CHART_COLORS.cancelled} fillOpacity={0.9} barSize={30} />
+							</CappedBarStack>
 						)}
 					</BarChart>
 				) : (

--- a/ui/app/workspace/dashboard/components/charts/overheadChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/overheadChart.tsx
@@ -2,6 +2,7 @@ import type { LatencyHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { formatFullTimestamp, formatLatency, formatTimestamp, LATENCY_COLORS } from "../../utils/chartUtils";
+import { barShape } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -113,7 +114,7 @@ function OverheadChartImpl({ data, chartType, startTime, endTime }: OverheadChar
 							fill={LATENCY_COLORS.avg}
 							fillOpacity={0.9}
 							barSize={8}
-							radius={[2, 2, 0, 0]}
+							shape={barShape}
 						/>
 						<Bar
 							isAnimationActive={false}
@@ -121,7 +122,7 @@ function OverheadChartImpl({ data, chartType, startTime, endTime }: OverheadChar
 							fill={LATENCY_COLORS.p90}
 							fillOpacity={0.9}
 							barSize={8}
-							radius={[2, 2, 0, 0]}
+							shape={barShape}
 						/>
 						<Bar
 							isAnimationActive={false}
@@ -129,7 +130,7 @@ function OverheadChartImpl({ data, chartType, startTime, endTime }: OverheadChar
 							fill={LATENCY_COLORS.p95}
 							fillOpacity={0.9}
 							barSize={8}
-							radius={[2, 2, 0, 0]}
+							shape={barShape}
 						/>
 						<Bar
 							isAnimationActive={false}
@@ -137,7 +138,7 @@ function OverheadChartImpl({ data, chartType, startTime, endTime }: OverheadChar
 							fill={LATENCY_COLORS.p99}
 							fillOpacity={0.9}
 							barSize={8}
-							radius={[2, 2, 0, 0]}
+							shape={barShape}
 						/>
 					</BarChart>
 				) : (

--- a/ui/app/workspace/dashboard/components/charts/providerCostChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerCostChart.tsx
@@ -12,6 +12,7 @@ import {
 	OTHER_SERIES_KEY,
 	OTHER_SERIES_LABEL,
 } from "../../utils/chartUtils";
+import { CappedBarStack } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -146,18 +147,18 @@ function ProviderCostChartImpl({ data, chartType, startTime, endTime, selectedPr
 							content={<CustomTooltip selectedProvider={selectedProvider} displayProviders={displayProviders} />}
 							cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
 						/>
-						{displayProviders.map((provider, idx) => (
-							<Bar
-								isAnimationActive={false}
-								key={provider}
-								dataKey={`provider_${idx}`}
-								stackId="cost"
-								fill={provider === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
-								fillOpacity={0.9}
-								barSize={30}
-								radius={idx === displayProviders.length - 1 ? [2, 2, 0, 0] : [0, 0, 0, 0]}
-							/>
-						))}
+						<CappedBarStack buckets={chartData.length}>
+							{displayProviders.map((provider, idx) => (
+								<Bar
+									isAnimationActive={false}
+									key={provider}
+									dataKey={`provider_${idx}`}
+									fill={provider === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
+									fillOpacity={0.9}
+									barSize={30}
+								/>
+							))}
+						</CappedBarStack>
 					</BarChart>
 				) : (
 					<AreaChart {...commonProps}>

--- a/ui/app/workspace/dashboard/components/charts/providerLatencyChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerLatencyChart.tsx
@@ -9,6 +9,7 @@ import {
 	getModelColor,
 	LATENCY_COLORS,
 } from "../../utils/chartUtils";
+import { barShape } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -177,7 +178,7 @@ function ProviderLatencyChartImpl({ data, chartType, startTime, endTime, selecte
 									fill={LATENCY_COLORS.avg}
 									fillOpacity={0.9}
 									barSize={8}
-									radius={[2, 2, 0, 0]}
+									shape={barShape}
 								/>
 								<Bar
 									isAnimationActive={false}
@@ -185,7 +186,7 @@ function ProviderLatencyChartImpl({ data, chartType, startTime, endTime, selecte
 									fill={LATENCY_COLORS.p90}
 									fillOpacity={0.9}
 									barSize={8}
-									radius={[2, 2, 0, 0]}
+									shape={barShape}
 								/>
 								<Bar
 									isAnimationActive={false}
@@ -193,7 +194,7 @@ function ProviderLatencyChartImpl({ data, chartType, startTime, endTime, selecte
 									fill={LATENCY_COLORS.p95}
 									fillOpacity={0.9}
 									barSize={8}
-									radius={[2, 2, 0, 0]}
+									shape={barShape}
 								/>
 								<Bar
 									isAnimationActive={false}
@@ -201,7 +202,7 @@ function ProviderLatencyChartImpl({ data, chartType, startTime, endTime, selecte
 									fill={LATENCY_COLORS.p99}
 									fillOpacity={0.9}
 									barSize={8}
-									radius={[2, 2, 0, 0]}
+									shape={barShape}
 								/>
 							</>
 						) : (
@@ -218,7 +219,7 @@ function ProviderLatencyChartImpl({ data, chartType, startTime, endTime, selecte
 										isAnimationActive={false}
 										fillOpacity={0.9}
 										barSize={8}
-										radius={[2, 2, 0, 0]}
+										shape={barShape}
 									/>
 								))}
 							</>

--- a/ui/app/workspace/dashboard/components/charts/providerThroughputChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerThroughputChart.tsx
@@ -9,6 +9,7 @@ import {
 	getModelColor,
 	THROUGHPUT_COLOR,
 } from "../../utils/chartUtils";
+import { barShape } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -157,7 +158,7 @@ function ProviderThroughputChartImpl({ data, chartType, startTime, endTime, sele
 									fill={THROUGHPUT_COLOR}
 									fillOpacity={0.9}
 									barSize={8}
-									radius={[2, 2, 0, 0]}
+									shape={barShape}
 								/>
 							</>
 						) : (
@@ -174,7 +175,7 @@ function ProviderThroughputChartImpl({ data, chartType, startTime, endTime, sele
 										isAnimationActive={false}
 										fillOpacity={0.9}
 										barSize={8}
-										radius={[2, 2, 0, 0]}
+										shape={barShape}
 									/>
 								))}
 							</>

--- a/ui/app/workspace/dashboard/components/charts/providerTokenChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/providerTokenChart.tsx
@@ -12,6 +12,7 @@ import {
 	OTHER_SERIES_KEY,
 	OTHER_SERIES_LABEL,
 } from "../../utils/chartUtils";
+import { CappedBarStack } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -173,24 +174,16 @@ function ProviderTokenChartImpl({ data, chartType, startTime, endTime, selectedP
 						{mode === "single" ? (
 							<>
 								<Tooltip content={<SingleProviderTooltip provider={selectedProvider} />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-								<Bar
-									isAnimationActive={false}
-									dataKey="prompt_tokens"
-									stackId="tokens"
-									fill={CHART_COLORS.promptTokens}
-									fillOpacity={0.9}
-									barSize={30}
-									radius={[0, 0, 0, 0]}
-								/>
-								<Bar
-									isAnimationActive={false}
-									dataKey="completion_tokens"
-									stackId="tokens"
-									fill={CHART_COLORS.completionTokens}
-									fillOpacity={0.9}
-									barSize={30}
-									radius={[2, 2, 0, 0]}
-								/>
+								<CappedBarStack buckets={chartData.length}>
+									<Bar isAnimationActive={false} dataKey="prompt_tokens" fill={CHART_COLORS.promptTokens} fillOpacity={0.9} barSize={30} />
+									<Bar
+										isAnimationActive={false}
+										dataKey="completion_tokens"
+										fill={CHART_COLORS.completionTokens}
+										fillOpacity={0.9}
+										barSize={30}
+									/>
+								</CappedBarStack>
 							</>
 						) : (
 							<>
@@ -198,18 +191,18 @@ function ProviderTokenChartImpl({ data, chartType, startTime, endTime, selectedP
 									content={<AllProvidersTooltip displayProviders={displayProviders} />}
 									cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
 								/>
-								{displayProviders.map((provider, idx) => (
-									<Bar
-										isAnimationActive={false}
-										key={provider}
-										dataKey={`provider_${idx}`}
-										stackId="tokens"
-										fill={provider === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
-										fillOpacity={0.9}
-										barSize={30}
-										radius={idx === displayProviders.length - 1 ? [2, 2, 0, 0] : [0, 0, 0, 0]}
-									/>
-								))}
+								<CappedBarStack buckets={chartData.length}>
+									{displayProviders.map((provider, idx) => (
+										<Bar
+											isAnimationActive={false}
+											key={provider}
+											dataKey={`provider_${idx}`}
+											fill={provider === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
+											fillOpacity={0.9}
+											barSize={30}
+										/>
+									))}
+								</CappedBarStack>
 							</>
 						)}
 					</BarChart>

--- a/ui/app/workspace/dashboard/components/charts/throughputChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/throughputChart.tsx
@@ -2,6 +2,7 @@ import type { ThroughputHistogramResponse } from "@/lib/types/logs";
 import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { formatFullTimestamp, formatTimestamp, formatTokensPerSecond, THROUGHPUT_COLOR } from "../../utils/chartUtils";
+import { barShape } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -96,7 +97,7 @@ function ThroughputChartImpl({ data, chartType, startTime, endTime }: Throughput
 							fill={THROUGHPUT_COLOR}
 							fillOpacity={0.9}
 							barSize={8}
-							radius={[2, 2, 0, 0]}
+							shape={barShape}
 						/>
 					</BarChart>
 				) : (

--- a/ui/app/workspace/dashboard/components/charts/tokenUsageChart.tsx
+++ b/ui/app/workspace/dashboard/components/charts/tokenUsageChart.tsx
@@ -3,6 +3,7 @@ import { memo, useMemo } from "react";
 import { Area, AreaChart, Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { formatCompactNumber } from "@/lib/utils/numbers";
 import { CHART_COLORS, formatFullTimestamp, formatTimestamp } from "../../utils/chartUtils";
+import { CappedBarStack } from "./barShape";
 import { ChartErrorBoundary } from "./chartErrorBoundary";
 import type { ChartType } from "./chartTypeToggle";
 
@@ -25,14 +26,14 @@ function CustomTooltip({ active, payload }: any) {
 			<div className="space-y-1 text-sm">
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-blue-500" />
+						<span className="bg-chart-token-input h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Input</span>
 					</span>
 					<span className="font-medium">{data.prompt_tokens.toLocaleString()}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-emerald-500" />
+						<span className="bg-chart-token-output h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Output</span>
 					</span>
 					<span className="font-medium">{data.completion_tokens.toLocaleString()}</span>
@@ -104,33 +105,29 @@ function TokenUsageChartImpl({ data, chartType, startTime, endTime }: TokenUsage
 							allowDataOverflow={false}
 						/>
 						<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-						<Bar
-							isAnimationActive={false}
-							dataKey="uncached_prompt_tokens"
-							stackId="tokens"
-							fill={CHART_COLORS.promptTokens}
-							fillOpacity={0.9}
-							radius={[0, 0, 0, 0]}
-							barSize={30}
-						/>
-						<Bar
-							isAnimationActive={false}
-							dataKey="completion_tokens"
-							stackId="tokens"
-							fill={CHART_COLORS.completionTokens}
-							fillOpacity={0.9}
-							radius={[0, 0, 0, 0]}
-							barSize={30}
-						/>
-						<Bar
-							isAnimationActive={false}
-							dataKey="cached_read_tokens"
-							stackId="tokens"
-							fill={CHART_COLORS.cachedReadTokens}
-							fillOpacity={0.9}
-							radius={[2, 2, 0, 0]}
-							barSize={30}
-						/>
+						<CappedBarStack buckets={chartData.length}>
+							<Bar
+								isAnimationActive={false}
+								dataKey="uncached_prompt_tokens"
+								fill={CHART_COLORS.promptTokens}
+								fillOpacity={0.9}
+								barSize={30}
+							/>
+							<Bar
+								isAnimationActive={false}
+								dataKey="completion_tokens"
+								fill={CHART_COLORS.completionTokens}
+								fillOpacity={0.9}
+								barSize={30}
+							/>
+							<Bar
+								isAnimationActive={false}
+								dataKey="cached_read_tokens"
+								fill={CHART_COLORS.cachedReadTokens}
+								fillOpacity={0.9}
+								barSize={30}
+							/>
+						</CappedBarStack>
 					</BarChart>
 				) : (
 					<AreaChart {...commonProps}>

--- a/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/dimensionRankingsTab.tsx
@@ -7,6 +7,7 @@ import NumberFlow from "@number-flow/react";
 import { memo, useCallback, useMemo, useState } from "react";
 import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { getModelColor } from "../utils/chartUtils";
+import { rankingBarShape } from "./charts/barShape";
 import { ChartCard } from "./charts/chartCard";
 import { ChartErrorBoundary } from "./charts/chartErrorBoundary";
 import { formatCost, SortableHeader, TrendBadge } from "./rankingsShared";
@@ -152,7 +153,7 @@ function TopDimensionChart({
 									width={100}
 								/>
 								<Tooltip content={<TopDimensionTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-								<Bar dataKey="total_requests" isAnimationActive={false} barSize={24} radius={[0, 4, 4, 0]}>
+								<Bar dataKey="total_requests" isAnimationActive={false} barSize={24} shape={rankingBarShape}>
 									{chartData.map((entry, idx) => (
 										<Cell key={entry.id} fill={getModelColor(idx)} />
 									))}

--- a/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
+++ b/ui/app/workspace/dashboard/components/modelRankingsTab.tsx
@@ -16,7 +16,9 @@ import {
 	OTHER_SERIES_COLOR,
 	OTHER_SERIES_KEY,
 	pickTopSeries,
+	TOP_SERIES_LIMIT,
 } from "../utils/chartUtils";
+import { CappedBarStack } from "./charts/barShape";
 import { ChartCard } from "./charts/chartCard";
 import { ChartErrorBoundary } from "./charts/chartErrorBoundary";
 import { formatCost, SortableHeader, TrendBadge } from "./rankingsShared";
@@ -132,7 +134,10 @@ function TopModelsChart({
 		return sum;
 	}, [modelData]);
 
-	// Compute totals per model for the ranked legend (aggregate across providers)
+	// Totals per model for the ranked legend (aggregated across providers). The
+	// legend is a key to the chart: the same TOP_SERIES_LIMIT named series in
+	// chart-color order, then one explicit "Other" row for everything the chart
+	// rolled up. OTHER_SERIES_COLOR is never given to a named model.
 	const modelTotals = useMemo(() => {
 		if (!rankingsData?.rankings) return [];
 		const byModel = new Map<string, number>();
@@ -140,15 +145,16 @@ function TopModelsChart({
 			byModel.set(r.model, (byModel.get(r.model) || 0) + r.total_requests);
 		}
 		const totalRequests = [...byModel.values()].reduce((sum, v) => sum + v, 0);
-		return [...byModel.entries()]
-			.sort((a, b) => b[1] - a[1])
-			.slice(0, 10)
-			.map(([model, total], idx) => ({
-				model,
-				total,
-				pct: totalRequests > 0 ? (total / totalRequests) * 100 : 0,
-				colorIdx: displayModels.indexOf(model) >= 0 ? displayModels.indexOf(model) : idx,
-			}));
+		const pct = (total: number) => (totalRequests > 0 ? (total / totalRequests) * 100 : 0);
+		const ranked = [...byModel.entries()].sort((a, b) => b[1] - a[1]);
+		const named = ranked.slice(0, TOP_SERIES_LIMIT).map(([model, total], idx) => {
+			const chartIdx = displayModels.indexOf(model);
+			return { model, total, pct: pct(total), color: getModelColor(chartIdx >= 0 ? chartIdx : idx) };
+		});
+		const rest = ranked.slice(TOP_SERIES_LIMIT);
+		if (rest.length === 0) return named;
+		const otherTotal = rest.reduce((sum, [, total]) => sum + total, 0);
+		return [...named, { model: OTHER_SERIES_KEY, total: otherTotal, pct: pct(otherTotal), color: OTHER_SERIES_COLOR }];
 	}, [rankingsData, displayModels]);
 
 	return (
@@ -191,18 +197,18 @@ function TopModelsChart({
 									content={<UsageShareTooltip models={displayModels} modelLabels={modelLabels} />}
 									cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }}
 								/>
-								{displayModels.map((model, idx) => (
-									<Bar
-										key={model}
-										dataKey={`model_${idx}`}
-										stackId="models"
-										fill={model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
-										fillOpacity={0.9}
-										isAnimationActive={false}
-										barSize={30}
-										radius={idx === displayModels.length - 1 ? [2, 2, 0, 0] : [0, 0, 0, 0]}
-									/>
-								))}
+								<CappedBarStack buckets={chartData.length}>
+									{displayModels.map((model, idx) => (
+										<Bar
+											key={model}
+											dataKey={`model_${idx}`}
+											fill={model === OTHER_SERIES_KEY ? OTHER_SERIES_COLOR : getModelColor(idx)}
+											fillOpacity={0.9}
+											isAnimationActive={false}
+											barSize={30}
+										/>
+									))}
+								</CappedBarStack>
 							</BarChart>
 						</ResponsiveContainer>
 					</ChartErrorBoundary>
@@ -216,8 +222,8 @@ function TopModelsChart({
 					<div className="mt-3 grid grid-cols-1 gap-x-8 gap-y-1.5 px-2 pb-1 sm:grid-cols-2">
 						{modelTotals.map((m, idx) => (
 							<div key={m.model} className="flex items-center gap-2 text-sm">
-								<span className="text-muted-foreground w-4 text-right text-xs">{idx + 1}.</span>
-								<span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: getModelColor(m.colorIdx) }} />
+								<span className="text-muted-foreground w-4 text-right text-xs">{m.model === OTHER_SERIES_KEY ? "" : `${idx + 1}.`}</span>
+								<span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ backgroundColor: m.color }} />
 								<span className="min-w-0 flex-1 truncate font-medium">{displayModelLabel(m.model, modelLabels)}</span>
 								<span className="shrink-0 text-right text-xs tabular-nums">
 									<span className="font-medium">{formatNumber(m.total)}</span>
@@ -376,10 +382,10 @@ function ModelRankingsTabImpl({ rankingsData, loading, modelData, loadingModels,
 										<span
 											className={
 												entry.success_rate >= 99
-													? "text-emerald-600 dark:text-emerald-400"
+													? "text-chart-success-ink"
 													: entry.success_rate >= 95
 														? "text-yellow-600 dark:text-yellow-400"
-														: "text-red-600 dark:text-red-400"
+														: "text-chart-error-ink"
 											}
 										>
 											{entry.success_rate.toFixed(1)}%

--- a/ui/app/workspace/dashboard/components/overviewTab.tsx
+++ b/ui/app/workspace/dashboard/components/overviewTab.tsx
@@ -206,77 +206,7 @@ function OverviewTabImpl({
 		<>
 			{/* Charts Grid */}
 			<div className="grid grid-cols-1 gap-2 lg:grid-cols-2 2xl:grid-cols-3">
-				{/* Log Volume Chart */}
-				<ChartCard
-					title="Request Volume"
-					loading={loadingHistogram}
-					testId="chart-log-volume"
-					totalLabel="Total"
-					total={volumeTotal !== null ? <NumberFlow value={volumeTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
-					totalTooltip={volumeTotal !== null ? volumeTotal.toLocaleString("en-US") : undefined}
-					legend={
-						<div className={CHART_HEADER_LEGEND_CLASS}>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
-								<span className="text-muted-foreground">Success</span>
-							</span>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
-								<span className="text-muted-foreground">Error</span>
-							</span>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cancelled }} />
-								<span className="text-muted-foreground">Cancelled</span>
-							</span>
-						</div>
-					}
-					controls={
-						<ChartTypeToggle chartType={volumeChartType} onToggle={onVolumeChartToggle} data-testid="dashboard-volume-chart-toggle" />
-					}
-				>
-					<LogVolumeChart data={histogramData} chartType={volumeChartType} startTime={startTime} endTime={endTime} />
-				</ChartCard>
-
-				{/* Token Usage Chart */}
-				<ChartCard
-					title="Token Usage"
-					loading={loadingTokens}
-					testId="chart-token-usage"
-					totalLabel="Total"
-					total={tokenTotal !== null ? <NumberFlow value={tokenTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
-					totalTooltip={tokenTotal !== null ? tokenTotal.toLocaleString("en-US") : undefined}
-					legend={
-						<div className={CHART_HEADER_LEGEND_CLASS}>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.promptTokens }} />
-								<span className="text-muted-foreground">Input</span>
-							</span>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.completionTokens }} />
-								<span className="text-muted-foreground">Output</span>
-							</span>
-							<span className="flex items-center gap-1">
-								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cachedReadTokens }} />
-								<span className="text-muted-foreground">Cached</span>
-							</span>
-						</div>
-					}
-					controls={<ChartTypeToggle chartType={tokenChartType} onToggle={onTokenChartToggle} data-testid="dashboard-token-chart-toggle" />}
-				>
-					<TokenUsageChart data={tokenData} chartType={tokenChartType} startTime={startTime} endTime={endTime} />
-				</ChartCard>
-
-				{/* External Cache Hit Rate Meter */}
-				<ChartCard title="External Cache Hit Rate" loading={loadingTokens} testId="chart-cache-external">
-					<ExternalCacheTokenMeterChart data={tokenData} />
-				</ChartCard>
-
-				{/* Local Cache Hit Rate Meter */}
-				<ChartCard title="Local Cache Hit Rate" loading={loadingStats} testId="chart-cache-local">
-					<LocalCacheTokenMeterChart data={logsStats} />
-				</ChartCard>
-
-				{/* Cost Chart */}
+				{/* Cost Chart: first so spend is the first thing the page answers. */}
 				<ChartCard
 					title="Cost"
 					loading={loadingCost}
@@ -358,6 +288,76 @@ function OverviewTabImpl({
 					}
 				>
 					<CostChart data={costData} chartType={costChartType} startTime={startTime} endTime={endTime} selectedModel={costModel} />
+				</ChartCard>
+
+				{/* Log Volume Chart */}
+				<ChartCard
+					title="Request Volume"
+					loading={loadingHistogram}
+					testId="chart-log-volume"
+					totalLabel="Total"
+					total={volumeTotal !== null ? <NumberFlow value={volumeTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+					totalTooltip={volumeTotal !== null ? volumeTotal.toLocaleString("en-US") : undefined}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.success }} />
+								<span className="text-muted-foreground">Success</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.error }} />
+								<span className="text-muted-foreground">Error</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cancelled }} />
+								<span className="text-muted-foreground">Cancelled</span>
+							</span>
+						</div>
+					}
+					controls={
+						<ChartTypeToggle chartType={volumeChartType} onToggle={onVolumeChartToggle} data-testid="dashboard-volume-chart-toggle" />
+					}
+				>
+					<LogVolumeChart data={histogramData} chartType={volumeChartType} startTime={startTime} endTime={endTime} />
+				</ChartCard>
+
+				{/* Token Usage Chart */}
+				<ChartCard
+					title="Token Usage"
+					loading={loadingTokens}
+					testId="chart-token-usage"
+					totalLabel="Total"
+					total={tokenTotal !== null ? <NumberFlow value={tokenTotal} format={COMPACT_NUMBER_FORMAT} /> : undefined}
+					totalTooltip={tokenTotal !== null ? tokenTotal.toLocaleString("en-US") : undefined}
+					legend={
+						<div className={CHART_HEADER_LEGEND_CLASS}>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.promptTokens }} />
+								<span className="text-muted-foreground">Input</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.completionTokens }} />
+								<span className="text-muted-foreground">Output</span>
+							</span>
+							<span className="flex items-center gap-1">
+								<span className="h-2 w-2 rounded-full" style={{ backgroundColor: CHART_COLORS.cachedReadTokens }} />
+								<span className="text-muted-foreground">Cached</span>
+							</span>
+						</div>
+					}
+					controls={<ChartTypeToggle chartType={tokenChartType} onToggle={onTokenChartToggle} data-testid="dashboard-token-chart-toggle" />}
+				>
+					<TokenUsageChart data={tokenData} chartType={tokenChartType} startTime={startTime} endTime={endTime} />
+				</ChartCard>
+
+				{/* External Cache Hit Rate Meter */}
+				<ChartCard title="External Cache Hit Rate" loading={loadingTokens} testId="chart-cache-external">
+					<ExternalCacheTokenMeterChart data={tokenData} />
+				</ChartCard>
+
+				{/* Local Cache Hit Rate Meter */}
+				<ChartCard title="Local Cache Hit Rate" loading={loadingStats} testId="chart-cache-local">
+					<LocalCacheTokenMeterChart data={logsStats} />
 				</ChartCard>
 
 				{/* Model Usage Chart */}

--- a/ui/app/workspace/dashboard/components/rankingsShared.tsx
+++ b/ui/app/workspace/dashboard/components/rankingsShared.tsx
@@ -26,9 +26,7 @@ export function TrendBadge({ value, positiveIsGood = true, isNew = false }: { va
 	const isPositive = value > 0;
 	const isGood = positiveIsGood ? isPositive : !isPositive;
 	return (
-		<span
-			className={`inline-flex items-center gap-0.5 text-xs font-medium ${isGood ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400"}`}
-		>
+		<span className={`inline-flex items-center gap-0.5 text-xs font-medium ${isGood ? "text-chart-success-ink" : "text-chart-error-ink"}`}>
 			{isPositive ? <ArrowUp className="h-3 w-3" /> : <ArrowDown className="h-3 w-3" />}
 			{Math.abs(value).toFixed(1)}%
 		</span>

--- a/ui/app/workspace/dashboard/utils/chartUtils.ts
+++ b/ui/app/workspace/dashboard/utils/chartUtils.ts
@@ -40,35 +40,33 @@ export function formatCost(cost: number): string {
 	return `$${cost.toFixed(2)}`;
 }
 
-// Color palette for models. Length governs TOP_SERIES_LIMIT (top-N rollup cap),
-// so colors and named-series count stay coupled — adding a color expands top-N.
+// Categorical palette for models, providers, apps and users: six hues at
+// matched chroma, assigned by rank so a series keeps its color across every
+// card. Length governs TOP_SERIES_LIMIT (top-N rollup cap), so colors and
+// named-series count stay coupled. Values live in globals.css so dark mode
+// can re-anchor them.
 export const MODEL_COLORS = [
-	"#10b981", // emerald-500
-	"#3b82f6", // blue-500
-	"#f59e0b", // amber-500
-	"#ef4444", // red-500
-	"#8b5cf6", // violet-500
-	"#ec4899", // pink-500
-	"#06b6d4", // cyan-500
-	"#84cc16", // lime-500
-	"#f97316", // orange-500
-	"#14b8a6", // teal-500
-	"#eab308", // yellow-500
-	"#d946ef", // fuchsia-500
+	"var(--chart-cat-1)",
+	"var(--chart-cat-2)",
+	"var(--chart-cat-3)",
+	"var(--chart-cat-4)",
+	"var(--chart-cat-5)",
+	"var(--chart-cat-6)",
 ];
 
-// Get color for a model by index
+// Color for a ranked series. Ranks past the palette are "Other" grey rather
+// than a wrapped hue, so two series in one card never share a color.
 export function getModelColor(index: number): string {
-	return MODEL_COLORS[index % MODEL_COLORS.length];
+	return MODEL_COLORS[index] ?? OTHER_SERIES_COLOR;
 }
 
 // Top-N series rollup: keeps the visible recharts subtree bounded when a
-// dimension (models, providers) grows large. The palette has 8 colors and
-// the legend already says "+N more", so the data path follows the palette.
+// dimension (models, providers) grows large. The legend already says
+// "+N more", so the data path follows the palette.
 export const TOP_SERIES_LIMIT = MODEL_COLORS.length;
 export const OTHER_SERIES_KEY = "__other__";
 export const OTHER_SERIES_LABEL = "Other";
-export const OTHER_SERIES_COLOR = "#94a3b8"; // slate-400
+export const OTHER_SERIES_COLOR = "var(--chart-cat-other)";
 
 export const UNNAMED_MODEL_LABEL = "(unnamed)";
 
@@ -122,12 +120,12 @@ export function formatLatency(ms: number): string {
 	return `${ms.toFixed(0)}ms`;
 }
 
-// Latency chart color palette
+// Latency and overhead percentiles: one indigo ramp, darkest is worst.
 export const LATENCY_COLORS = {
-	avg: "#06b6d4", // cyan-500
-	p90: "#3b82f6", // blue-500
-	p95: "#f59e0b", // amber-500
-	p99: "#ef4444", // red-500
+	avg: "var(--chart-ord-1)",
+	p90: "var(--chart-ord-2)",
+	p95: "var(--chart-ord-3)",
+	p99: "var(--chart-ord-4)",
 };
 
 // Format token-generation throughput (tokens/sec) with compact units (1k, 5k, 1M).
@@ -137,22 +135,22 @@ export function formatTokensPerSecond(tps: number): string {
 	return `${formatCompactNumber(tps, 1)} tok/s`;
 }
 
-// Throughput chart color
-export const THROUGHPUT_COLOR = "#10b981"; // emerald-500
+// Throughput chart color: mid step of the teal ramp.
+export const THROUGHPUT_COLOR = "var(--chart-seq-3)";
 
 // Shared CSS class constants for chart card headers
 export const CHART_HEADER_ACTIONS_CLASS = "flex min-w-0 w-full flex-col-reverse gap-2";
 export const CHART_HEADER_LEGEND_CLASS = "flex min-h-5 min-w-0 flex-wrap items-center gap-2 pl-2 text-xs";
 export const CHART_HEADER_CONTROLS_CLASS = "flex items-center justify-end gap-2";
 
-// Chart colors
+// Semantic and token colors. Status hues are never reused for a measure.
 export const CHART_COLORS = {
-	success: "#10b981", // emerald-500
-	error: "#ef4444", // red-500
-	cancelled: "#a1a1aa", // zinc-400
-	promptTokens: "#3b82f6", // blue-500
-	completionTokens: "#10b981", // emerald-500
-	totalTokens: "#8b5cf6", // violet-500
-	cost: "#f59e0b", // amber-500
-	cachedReadTokens: "#06b6d4", // cyan-500
+	success: "var(--chart-success)",
+	error: "var(--chart-error)",
+	cancelled: "var(--chart-neutral)",
+	promptTokens: "var(--chart-token-input)",
+	completionTokens: "var(--chart-token-output)",
+	totalTokens: "var(--chart-seq-1)",
+	cost: "var(--chart-seq-2)",
+	cachedReadTokens: "var(--chart-token-cached)",
 };

--- a/ui/app/workspace/logs/sheets/logDetailView.tsx
+++ b/ui/app/workspace/logs/sheets/logDetailView.tsx
@@ -446,22 +446,22 @@ const isContainerOperation = (object: string) => {
 };
 
 const statusPillStyles: Record<string, string> = {
-	success: "bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-400 dark:border-green-900",
-	error: "bg-red-50 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-400 dark:border-red-900",
+	success: "border-chart-success/30 bg-chart-success/10 text-chart-success-ink",
+	error: "border-chart-error/30 bg-chart-error/10 text-chart-error-ink",
 	processing: "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-400 dark:border-blue-900",
 	cancelled: "bg-gray-50 text-gray-700 border-gray-200 dark:bg-gray-900/40 dark:text-gray-400 dark:border-gray-800",
 };
 const statusDotStyles: Record<string, string> = {
-	success: "bg-green-500",
-	error: "bg-red-500",
+	success: "bg-chart-success",
+	error: "bg-chart-error",
 	processing: "bg-blue-500",
 	cancelled: "bg-gray-400",
 };
 
 const batchStatusBadgeStyles: Record<string, string> = {
-	completed: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-	ended: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-	failed: "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200",
+	completed: "bg-chart-success/15 text-chart-success-ink",
+	ended: "bg-chart-success/15 text-chart-success-ink",
+	failed: "bg-chart-error/15 text-chart-error-ink",
 	expired: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
 	cancelled: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
 	deleted: "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300",
@@ -484,13 +484,12 @@ function StatusPill({ status }: { status: Status }) {
 
 // Colors an HTTP status code badge by response class.
 function statusCodeBadgeClass(code: number): string {
-	if (code >= 200 && code < 300)
-		return "bg-green-50 text-green-700 border-green-200 dark:bg-green-950/40 dark:text-green-400 dark:border-green-900";
+	if (code >= 200 && code < 300) return "border-chart-success/30 bg-chart-success/10 text-chart-success-ink";
 	if (code >= 300 && code < 400)
 		return "bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-400 dark:border-blue-900";
 	if (code >= 400 && code < 500)
 		return "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-400 dark:border-amber-900";
-	return "bg-red-50 text-red-700 border-red-200 dark:bg-red-950/40 dark:text-red-400 dark:border-red-900";
+	return "border-chart-error/30 bg-chart-error/10 text-chart-error-ink";
 }
 
 function HeroStat({
@@ -1196,14 +1195,14 @@ export function LogDetailView({
 					const contents = item?.request?.contents;
 					const messages = Array.isArray(contents)
 						? contents.map((c: any) => ({
-							role: c?.role === "model" ? "assistant" : c?.role || "user",
-							content: Array.isArray(c?.parts)
-								? c.parts
-									.filter((p: any) => p && typeof p.text === "string")
-									.map((p: any) => p.text)
-									.join("")
-								: "",
-						}))
+								role: c?.role === "model" ? "assistant" : c?.role || "user",
+								content: Array.isArray(c?.parts)
+									? c.parts
+											.filter((p: any) => p && typeof p.text === "string")
+											.map((p: any) => p.text)
+											.join("")
+									: "",
+							}))
 						: [];
 					return {
 						customId: typeof item?.metadata?.key === "string" && item.metadata.key ? item.metadata.key : `request-${index + 1}`,
@@ -1262,9 +1261,9 @@ export function LogDetailView({
 					const parts = candidate?.content?.parts;
 					const text = Array.isArray(parts)
 						? parts
-							.filter((p: any) => p && typeof p.text === "string")
-							.map((p: any) => p.text)
-							.join("")
+								.filter((p: any) => p && typeof p.text === "string")
+								.map((p: any) => p.text)
+								.join("")
 						: "";
 					const role = candidate?.content?.role === "model" ? "assistant" : candidate?.content?.role || "assistant";
 					message = { role, content: text };
@@ -1287,11 +1286,11 @@ export function LogDetailView({
 	}, [batchRawResponse]);
 	const passthroughParams = isPassthrough
 		? (log.params as {
-			method?: string;
-			path?: string;
-			raw_query?: string;
-			status_code?: number;
-		})
+				method?: string;
+				path?: string;
+				raw_query?: string;
+				status_code?: number;
+			})
 		: null;
 	// Only errors and passthrough requests carry a real HTTP status code; others have none.
 	// Non-HTTP errors (timeouts, network, marshal) default to 0; treat that as no status
@@ -1311,7 +1310,7 @@ export function LogDetailView({
 	if (declaredTools.length) {
 		try {
 			toolsParameter = JSON.stringify(declaredTools, null, 2);
-		} catch { }
+		} catch {}
 	}
 
 	const audioFormat = (log.params as any)?.audio?.format || (log.params as any)?.extra_params?.audio?.format || undefined;
@@ -1328,7 +1327,7 @@ export function LogDetailView({
 			if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
 				return Object.values(parsed).reduce<number>((sum, v) => sum + (Array.isArray(v) ? v.length : 0), 0);
 			}
-		} catch { }
+		} catch {}
 		return 0;
 	})();
 
@@ -1608,10 +1607,11 @@ export function LogDetailView({
 							audioSeconds != null
 								? "duration billed"
 								: log.token_usage
-									? `total ${formatCompactNumber(log.token_usage.total_tokens ?? 0)}${log.token_usage.completion_tokens_details?.reasoning_tokens
-										? ` · reasoning ${formatCompactNumber(log.token_usage.completion_tokens_details.reasoning_tokens)}`
-										: ""
-									}`
+									? `total ${formatCompactNumber(log.token_usage.total_tokens ?? 0)}${
+											log.token_usage.completion_tokens_details?.reasoning_tokens
+												? ` · reasoning ${formatCompactNumber(log.token_usage.completion_tokens_details.reasoning_tokens)}`
+												: ""
+										}`
 									: "—"
 						}
 						hasRightBorder
@@ -1721,9 +1721,7 @@ export function LogDetailView({
 							{!isContainer && log.server_side_fallback_model && (
 								<LogEntryDetailsView className="w-full" label="Served By (fallback)" value={log.server_side_fallback_model} />
 							)}
-							{!isContainer && log.served_model && (
-								<LogEntryDetailsView className="w-full" label="Served Model" value={log.served_model} />
-							)}
+							{!isContainer && log.served_model && <LogEntryDetailsView className="w-full" label="Served Model" value={log.served_model} />}
 							{detectedApp && (
 								<LogEntryDetailsView
 									className="w-full"
@@ -1826,7 +1824,7 @@ export function LogDetailView({
 												<TooltipTrigger asChild>
 													<button
 														type="button"
-														className="block max-w-full min-w-0 cursor-pointer truncate bg-transparent p-0 text-left font-mono font-normal text-blue-600 underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 dark:text-blue-400"
+														className="focus-visible:ring-ring block max-w-full min-w-0 cursor-pointer truncate bg-transparent p-0 text-left font-mono font-normal text-blue-600 underline-offset-2 hover:underline focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none dark:text-blue-400"
 														onClick={() => onFilterBySessionId(log.session_id as string)}
 													>
 														{log.session_id}
@@ -2210,11 +2208,7 @@ export function LogDetailView({
 									    has no cost of its own. Without this the detail view of a video
 									    generation reads as free while the list beside it shows the spend. */}
 									{log.cost == null && (log.children_cost ?? 0) > 0 && (
-										<LogEntryDetailsView
-											className="w-full"
-											label="Settled Cost"
-											value={formatCostPrecise(log.children_cost)}
-										/>
+										<LogEntryDetailsView className="w-full" label="Settled Cost" value={formatCostPrecise(log.children_cost)} />
 									)}
 									{/* Additional cost (guardrail / semantic cache / routing / MCP) on its own row below. */}
 									{(log.cost_breakdown?.additional_cost ?? 0) > 0 && (
@@ -2923,7 +2917,7 @@ export function LogDetailView({
 							Content logging has been disabled for this request.
 						</div>
 					)}
-                    {/* Passthrough just renders the raw json, so there's nothing to filter */}
+					{/* Passthrough just renders the raw json, so there's nothing to filter */}
 					<div className={cn("flex justify-end", (log.content_hidden || isPassthrough) && "hidden")}>
 						<DropdownMenu>
 							<DropdownMenuTrigger asChild>
@@ -3093,11 +3087,11 @@ export function LogDetailView({
 							<div className="bg-card rounded-sm border p-5">
 								{(visibleRoles.size < allRoles.length
 									? log.input_history?.filter((m) => {
-										if (!m) return false;
-										const mainRole = ((m.role as string) || "user") as MessageRole;
-										const hasReasoning = !!extractChatReasoning(m);
-										return visibleRoles.has(mainRole) || (hasReasoning && visibleRoles.has("reasoning"));
-									})
+											if (!m) return false;
+											const mainRole = ((m.role as string) || "user") as MessageRole;
+											const hasReasoning = !!extractChatReasoning(m);
+											return visibleRoles.has(mainRole) || (hasReasoning && visibleRoles.has("reasoning"));
+										})
 									: log.input_history?.filter(Boolean)
 								)?.flatMap((message, index) => {
 									const role = ((message.role as string) || "user") as MessageRole;
@@ -3347,11 +3341,11 @@ export function LogDetailView({
 													? msg.call_id
 													: Array.isArray(msg.tools)
 														? (() => {
-															const callable = flattenDeclaredTools(msg.tools).length;
-															return callable !== msg.tools.length
-																? `${msg.type} · ${msg.tools.length} declarations · ${callable} callable tools`
-																: `${msg.type} · ${msg.tools.length} tool${msg.tools.length === 1 ? "" : "s"}`;
-														})()
+																const callable = flattenDeclaredTools(msg.tools).length;
+																return callable !== msg.tools.length
+																	? `${msg.type} · ${msg.tools.length} declarations · ${callable} callable tools`
+																	: `${msg.type} · ${msg.tools.length} tool${msg.tools.length === 1 ? "" : "s"}`;
+															})()
 														: [msg.type, summarizeResponsesToolCall(msg, mapping)].filter(Boolean).join(" · ") || undefined;
 									}
 									const usePlainText = role === "user" || role === "assistant";
@@ -3634,7 +3628,7 @@ export function LogDetailView({
 													{record.fail_reason ? (
 														<span className="text-destructive">{record.fail_reason}</span>
 													) : (
-														<span className="text-green-600 dark:text-green-400">success</span>
+														<span className="text-chart-success-ink">success</span>
 													)}
 												</td>
 											</tr>

--- a/ui/app/workspace/logs/views/columns.tsx
+++ b/ui/app/workspace/logs/views/columns.tsx
@@ -444,7 +444,7 @@ export const createColumns = (
 				if (latency === undefined || latency === null) {
 					return <div className="pl-4 font-mono text-xs">N/A</div>;
 				}
-				const tone = latency >= 5000 ? "bg-red-500" : latency >= 2000 ? "bg-amber-500" : "bg-emerald-500";
+				const tone = latency >= 5000 ? "bg-chart-error" : latency >= 2000 ? "bg-chart-warning" : "bg-chart-success";
 				const pct = Math.min(100, (latency / 5000) * 100);
 				return (
 					<div className="flex items-center gap-2 pl-4">

--- a/ui/app/workspace/logs/views/logsVolumeChart.tsx
+++ b/ui/app/workspace/logs/views/logsVolumeChart.tsx
@@ -1,3 +1,5 @@
+import { CappedBarStack } from "@/app/workspace/dashboard/components/charts/barShape";
+import { CHART_COLORS } from "@/app/workspace/dashboard/utils/chartUtils";
 import { Card } from "@/components/ui/card";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -139,28 +141,28 @@ function CustomTooltip({ active, payload }: CustomTooltipProps) {
 			<div className="space-y-1 text-sm">
 				<div className="mt-2 flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-blue-500" />
+						<span className="bg-chart-seq-1 h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Total</span>
 					</span>
 					<span className="font-medium">{data.count.toLocaleString()}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-emerald-500" />
+						<span className="bg-chart-success h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Success</span>
 					</span>
-					<span className="font-medium text-emerald-600 dark:text-emerald-400">{data.success.toLocaleString()}</span>
+					<span className="text-chart-success-ink font-medium">{data.success.toLocaleString()}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-red-500" />
+						<span className="bg-chart-error h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Error</span>
 					</span>
-					<span className="font-medium text-red-600 dark:text-red-400">{data.error.toLocaleString()}</span>
+					<span className="text-chart-error-ink font-medium">{data.error.toLocaleString()}</span>
 				</div>
 				<div className="flex items-center justify-between gap-4">
 					<span className="flex items-center gap-1.5">
-						<span className="h-2 w-2 rounded-full bg-zinc-400" />
+						<span className="bg-chart-neutral h-2 w-2 rounded-full" />
 						<span className="text-zinc-600 dark:text-zinc-400">Cancelled</span>
 					</span>
 					<span className="font-medium text-zinc-600 dark:text-zinc-400">{(data.cancelled ?? 0).toLocaleString()}</span>
@@ -379,15 +381,15 @@ export function LogsVolumeChart({
 						{isOpen && (
 							<div className="flex items-center gap-3 text-xs">
 								<span className="flex items-center gap-1.5">
-									<span className="h-2 w-2 rounded-full bg-emerald-500" />
+									<span className="bg-chart-success h-2 w-2 rounded-full" />
 									<span className="text-muted-foreground">Success</span>
 								</span>
 								<span className="flex items-center gap-1.5">
-									<span className="h-2 w-2 rounded-full bg-red-500" />
+									<span className="bg-chart-error h-2 w-2 rounded-full" />
 									<span className="text-muted-foreground">Error</span>
 								</span>
 								<span className="flex items-center gap-1.5">
-									<span className="h-2 w-2 rounded-full bg-zinc-400" />
+									<span className="bg-chart-neutral h-2 w-2 rounded-full" />
 									<span className="text-muted-foreground">Cancelled</span>
 								</span>
 							</div>
@@ -441,36 +443,32 @@ export function LogsVolumeChart({
 											allowDataOverflow={false}
 										/>
 										<Tooltip content={<CustomTooltip />} cursor={{ fill: "#8c8c8f", fillOpacity: 0.15 }} />
-										<Bar
-											dataKey="success"
-											stackId="requests"
-											barSize={30}
-											fill="#10b981"
-											fillOpacity={0.7}
-											radius={[0, 0, 0, 0]}
-											cursor="pointer"
-											onClick={(data) => handleBarClick(data?.payload as LogVolumeDataPoint | undefined)}
-										/>
-										<Bar
-											dataKey="error"
-											stackId="requests"
-											fill="#ef4444"
-											barSize={30}
-											fillOpacity={0.7}
-											radius={[0, 0, 0, 0]}
-											cursor="pointer"
-											onClick={(data) => handleBarClick(data?.payload as LogVolumeDataPoint | undefined)}
-										/>
-										<Bar
-											dataKey="cancelled"
-											stackId="requests"
-											fill="#a1a1aa"
-											barSize={30}
-											fillOpacity={0.75}
-											radius={[2, 2, 0, 0]}
-											cursor="pointer"
-											onClick={(data) => handleBarClick(data?.payload as LogVolumeDataPoint | undefined)}
-										/>
+										<CappedBarStack buckets={chartData.length}>
+											<Bar
+												dataKey="success"
+												barSize={30}
+												fill={CHART_COLORS.success}
+												fillOpacity={0.7}
+												cursor="pointer"
+												onClick={(data) => handleBarClick(data?.payload as LogVolumeDataPoint | undefined)}
+											/>
+											<Bar
+												dataKey="error"
+												fill={CHART_COLORS.error}
+												barSize={30}
+												fillOpacity={0.7}
+												cursor="pointer"
+												onClick={(data) => handleBarClick(data?.payload as LogVolumeDataPoint | undefined)}
+											/>
+											<Bar
+												dataKey="cancelled"
+												fill={CHART_COLORS.cancelled}
+												barSize={30}
+												fillOpacity={0.75}
+												cursor="pointer"
+												onClick={(data) => handleBarClick(data?.payload as LogVolumeDataPoint | undefined)}
+											/>
+										</CappedBarStack>
 										{refAreaLeft !== null && refAreaRight !== null && chartData[refAreaLeft] && chartData[refAreaRight] && (
 											<ReferenceArea x1={refAreaLeft} x2={refAreaRight} strokeOpacity={0.3} fill="#6366f1" fillOpacity={0.2} />
 										)}

--- a/ui/app/workspace/logs/views/metricStrip.tsx
+++ b/ui/app/workspace/logs/views/metricStrip.tsx
@@ -24,12 +24,12 @@ import {
 	windowTrend,
 } from "./metricStrip.utils";
 
-// Palette is taken verbatim from the approved design direction. Each entry pairs
-// the mock's own value with a lighter counterpart of the same hue for dark mode,
-// since the mock only specifies a light surface.
-const positive = "text-[#16794f] dark:text-[#3fbd85]";
-const negative = "text-[#c0392b] dark:text-[#e8705f]";
-const warning = "text-[#d98324] dark:text-[#eaa14f]";
+// Tones come from the chart color system in globals.css: the semantic palette
+// for status and the teal token ramp for the split bar, so the strip matches
+// the dashboard charts in both themes.
+const positive = "text-chart-success-ink";
+const negative = "text-chart-error-ink";
+const warning = "text-chart-warning-ink";
 // The neutrals come from the theme tokens rather than the mock's own greys: the
 // strip sits inside a `bg-card` panel, and a hard-coded warm near-black surface
 // read as a foreign block against the app's cooler card colour in dark mode.
@@ -39,9 +39,9 @@ const value = "text-foreground";
 const track = "bg-muted";
 const divider = "bg-border";
 const surface = "bg-card";
-const fill = "bg-[#16794f] dark:bg-[#3fbd85]";
-const tokensIn = "bg-[#4c6fdc] dark:bg-[#7f9bf0]";
-const tokensOut = "bg-[#a8bcf2] dark:bg-[#c3d2f7]";
+const fill = "bg-chart-success";
+const tokensIn = "bg-chart-token-input";
+const tokensOut = "bg-chart-token-output";
 
 // The palette stays here rather than in metricStrip.utils so the formatters hold
 // no Tailwind classes and can be tested on their own.
@@ -509,10 +509,10 @@ export function MetricStrip({ stats, requestHistogram, latencyHistogram, costHis
 							second={completionTokens}
 							tooltip={
 								<TooltipBody heading="Token split">
-									<TooltipRow name="Input" className="text-[#4c6fdc] dark:text-[#7f9bf0]">
+									<TooltipRow name="Input" className="text-chart-token-input">
 										{`${formatCount(promptTokens)}${tokenTotal > 0 ? ` (${((promptTokens / tokenTotal) * 100).toFixed(1)}%)` : ""}`}
 									</TooltipRow>
-									<TooltipRow name="Output" className="text-[#7f93cc] dark:text-[#c3d2f7]">
+									<TooltipRow name="Output" className="text-chart-token-output">
 										{`${formatCount(completionTokens)}${tokenTotal > 0 ? ` (${((completionTokens / tokenTotal) * 100).toFixed(1)}%)` : ""}`}
 									</TooltipRow>
 									<TooltipRow name="Total">{formatCount(stats?.total_tokens ?? 0)}</TooltipRow>

--- a/ui/lib/constants/config.ts
+++ b/ui/lib/constants/config.ts
@@ -130,8 +130,8 @@ export const DefaultPerformanceConfig = {
 // falls back to the default variant's border-primary (green), which clashes
 // on the red/amber/blue states.
 export const MCP_STATUS_COLORS: Record<string, string> = {
-	healthy: "bg-green-100 text-green-800 border-green-200",
-	error: "bg-red-100 text-red-800 border-red-200",
+	healthy: "border-chart-success/30 bg-chart-success/10 text-chart-success-ink",
+	error: "border-chart-error/30 bg-chart-error/10 text-chart-error-ink",
 	// Amber, not red/gray: Bifrost's own connection check most recently
 	// failed, but this is purely informational — nothing is gated on it, and
 	// it self-heals on the next successful check. Same mild treatment as
@@ -143,7 +143,7 @@ export const MCP_STATUS_COLORS: Record<string, string> = {
 	// Same red as `error`: the client's credential has died and it can't be
 	// used until a human reauthorizes it, mirroring the "destructive" treatment
 	// this status already gets on the MCP sessions table.
-	needs_reauth: "bg-red-100 text-red-800 border-red-200",
+	needs_reauth: "border-chart-error/30 bg-chart-error/10 text-chart-error-ink",
 	// Distinct blue/purple, not amber/red: unlike unstable, this isn't "one
 	// instance's check currently failing" — it's "instances disagree with
 	// each other about the state," which needs its own visual signal to
@@ -158,9 +158,9 @@ export const MCP_STATUS_COLORS: Record<string, string> = {
 // badge: green for usable, red for "a human must act", amber for
 // informational.
 export const MCP_CREDENTIAL_STATUS_COLORS: Record<string, string> = {
-	active: "bg-green-100 text-green-800 border-green-200",
-	needs_reauth: "bg-red-100 text-red-800 border-red-200",
-	needs_update: "bg-red-100 text-red-800 border-red-200",
+	active: "border-chart-success/30 bg-chart-success/10 text-chart-success-ink",
+	needs_reauth: "border-chart-error/30 bg-chart-error/10 text-chart-error-ink",
+	needs_update: "border-chart-error/30 bg-chart-error/10 text-chart-error-ink",
 	orphaned: "bg-yellow-100 text-yellow-800 border-yellow-200",
 	// Sessions table only: an OAuth flow that was started but not completed.
 	pending: "bg-gray-100 text-gray-800 border-gray-200",

--- a/ui/lib/constants/logs.ts
+++ b/ui/lib/constants/logs.ts
@@ -252,15 +252,15 @@ export const logAppDisplayName = (app: ClientApp, userAgent?: string | null): st
 };
 
 export const StatusColors = {
-	success: "bg-green-100 text-green-800",
-	error: "bg-red-100 text-red-800",
+	success: "bg-chart-success/15 text-chart-success-ink",
+	error: "bg-chart-error/15 text-chart-error-ink",
 	processing: "bg-blue-100 text-blue-800",
 	cancelled: "bg-gray-100 text-gray-800",
 } as const;
 
 export const StatusBarColors = {
-	success: "bg-green-500",
-	error: "bg-red-500",
+	success: "bg-chart-success",
+	error: "bg-chart-error",
 	processing: "bg-blue-500",
 	cancelled: "bg-gray-400",
 } as const;


### PR DESCRIPTION
## Summary

Replaces all hard-coded hex color values across dashboard charts, status badges, and UI components with a structured CSS custom property system. This ensures chart colors adapt correctly between light and dark themes and establishes a consistent semantic vocabulary for status, sequential, ordinal, and categorical data series.

## Changes

- Introduced a new chart color system in `globals.css` with named tokens organized into four groups:
  - **Semantic** (`--chart-success`, `--chart-error`, `--chart-warning`, `--chart-neutral`) for status-only use; hues 0–70 are reserved so no category can visually resemble an error
  - **Sequential** (`--chart-seq-1` through `--chart-seq-5`) — a teal ramp for ordered single-hue series
  - **Ordinal** (`--chart-ord-1` through `--chart-ord-4`) — an indigo ramp for percentile series (avg, p90, p95, p99), darkest = worst
  - **Categorical** (`--chart-cat-1` through `--chart-cat-6`, `--chart-cat-other`) — six distinct hues at matched chroma assigned by rank, with grey for "Other"
  - Token-specific aliases (`--chart-token-input`, `--chart-token-output`, `--chart-token-cached`) and a `--chart-track` background token
  - Dark mode values re-anchor lightness so the teal ramp inverts (brightest = largest) and categorical colors remain legible
- Replaced all `MODEL_COLORS` hex values with `var(--chart-cat-*)` references; `getModelColor()` now returns `OTHER_SERIES_COLOR` for out-of-range indices instead of wrapping, preventing two series from sharing a color
- Replaced `LATENCY_COLORS`, `THROUGHPUT_COLOR`, `CHART_COLORS`, and `OTHER_SERIES_COLOR` hex values with the corresponding CSS variable references
- Added `barShape.tsx` with three shared bar-rendering utilities:
  - `capRadius()` — scales corner radius proportionally to bar thickness (clamped 1–4px, never reaching half-thickness)
  - `barShape` / `rankingBarShape` — single-series vertical and horizontal bar shapes that round only the open end
  - `CappedBarStack` — wraps stacked `<Bar>` children in a Recharts `<BarStack>` with a rounded top cap computed from actual plot width, fixing the problem where a thin top segment (e.g. a few errors over many successes) received only a 1px radius and appeared square
- Migrated all stacked bar charts (`logVolumeChart`, `mcpVolumeChart`, `tokenUsageChart`, `modelUsageChart`, `costChart`, `providerCostChart`, `providerTokenChart`, `modelRankingsTab`) to `CappedBarStack`, removing per-`<Bar>` `radius` props and `stackId` attributes
- Migrated all single-series bar charts (`latencyChart`, `overheadChart`, `throughputChart`, `mcpCostChart`, `providerLatencyChart`, `providerThroughputChart`) to `barShape`
- Migrated horizontal ranking bar charts (`mcpTopToolsChart`, `dimensionRankingsTab`) to `rankingBarShape`
- Replaced Tailwind color utility classes (`text-emerald-*`, `text-red-*`, `bg-green-*`, `bg-red-*`, etc.) with `text-chart-success`, `text-chart-error`, `bg-chart-success`, `bg-chart-error`, and related tokens across status badges, tooltips, trend badges, status pills, MCP status/credential colors, log status colors, and the metric strip
- Bumped `github.com/mattn/go-isatty` from v0.0.20 to v0.0.24 and cleaned up the corresponding `go.sum` entries

## Type of change

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [ ] Plugins
- [x] UI (React)
- [ ] Docs

## How to test

```sh
cd ui
pnpm i
pnpm build
```

Open the dashboard in both light and dark mode and verify:
- Stacked bar charts (log volume, token usage, cost, model usage) show a rounded top cap on the full column, not just the topmost segment
- Single-series bars (latency, throughput, overhead, MCP cost) show a proportional rounded cap
- Horizontal ranking bars round the right end only
- Success/error/warning colors match across chart tooltips, status badges, trend badges, the metric strip, and MCP status indicators in both themes
- No chart series share a color when fewer than six named series are present

## Breaking changes

- [ ] Yes
- [x] No

## Security considerations

None.

## Checklist

- [ ] I read `docs/contributing/README.md` and followed the guidelines
- [ ] I added/updated tests where appropriate
- [ ] I updated documentation where needed
- [ ] I verified builds succeed (Go and UI)
- [ ] I verified the CI pipeline passes locally if applicable