### PR TITLE
[fix]: resolve MCP STDIO host environment references on Windows

### DIFF
--- a/core/changelog.md
+++ b/core/changelog.md
@@ -1,3 +1,4 @@
+[fix]: resolve host environment references before starting STDIO MCP clients on Windows [@mat973252-coder](https://github.com/mat973252-coder)
 - fix: fasthttp-level stale-connection retries no longer multiply `max_retries`. `contextTransport.RoundTrip` reports a failure before response headers on a freshly dialed socket with `retry=false`, so `network.StaleConnectionRetryIfErr` only walks past pooled keep-alive sockets the upstream closed while idle; an upstream that closes a fresh connection without answering now costs exactly one attempt of Bifrost's own retry budget instead of up to four. The retry backoff also ends as soon as the request context is cancelled, so a worker is freed immediately instead of after up to `retry_backoff_max` (#7035)
 [fix]: Gemini provider - preserve inline image and audio data in chat completions responses [@Atharva-Kanherkar](https://github.com/Atharva-Kanherkar)
 

--- a/core/mcp/clientmanager.go
+++ b/core/mcp/clientmanager.go
@@ -2766,23 +2766,27 @@ func (m *MCPManager) createSTDIOConnection(_ context.Context, config *schemas.MC
 
 	cmdString := fmt.Sprintf("%s %s", cmd, strings.Join(args, " "))
 
-	// Check referenced environment variables are set. Inline KEY=value
-	// assignments are passed directly to the stdio transport.
+	// Resolve referenced environment variables to KEY=value entries: bare names
+	// make the subprocess environment invalid on Windows. Keep config unchanged.
+	envs := make([]string, 0, len(config.StdioConfig.Envs))
 	for _, env := range config.StdioConfig.Envs {
 		envName, _, hasInlineValue := strings.Cut(env, "=")
 		if envName == "" {
 			return nil, nil, fmt.Errorf("environment variable name is empty for MCP client %s", config.Name)
 		}
 		if hasInlineValue {
+			envs = append(envs, env)
 			continue
 		}
-		if os.Getenv(envName) == "" {
+		value := os.Getenv(envName)
+		if value == "" {
 			return nil, nil, fmt.Errorf("environment variable %s is not set for MCP client %s", envName, config.Name)
 		}
+		envs = append(envs, envName+"="+value)
 	}
 
 	// Create STDIO transport
-	stdioTransport := transport.NewStdio(cmd, config.StdioConfig.Envs, args...)
+	stdioTransport := transport.NewStdio(cmd, envs, args...)
 
 	// Prepare connection info
 	connectionInfo := &schemas.MCPClientConnectionInfo{

--- a/core/mcp/clientmanager_test.go
+++ b/core/mcp/clientmanager_test.go
@@ -6,10 +6,13 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	mcpgo "github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/maximhq/bifrost/core/schemas"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -79,6 +82,65 @@ func TestCreateSTDIOConnectionRejectsEmptyEnvAssignmentName(t *testing.T) {
 	_, _, err := (&MCPManager{}).createSTDIOConnection(context.Background(), config, nil)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "environment variable name is empty")
+}
+
+func TestCreateSTDIOConnectionStartsWithEnvVars(t *testing.T) {
+	t.Setenv("BIFROST_STDIO_TEST_HOST", "host=value")
+	t.Setenv("BIFROST_STDIO_TEST_INLINE", "host-inline")
+	executable, err := os.Executable()
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name string
+		envs []string
+		want string
+	}{
+		{"reference", []string{"BIFROST_STDIO_TEST_HOST"}, "host=value|host-inline"},
+		{"inline", []string{"BIFROST_STDIO_TEST_INLINE=inline=value"}, "host=value|inline=value"},
+		{"mixed", []string{"BIFROST_STDIO_TEST_HOST", "BIFROST_STDIO_TEST_INLINE=inline=value"}, "host=value|inline=value"},
+		{"empty inline", []string{"BIFROST_STDIO_TEST_HOST", "BIFROST_STDIO_TEST_INLINE="}, "host=value|"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			envs := append([]string{"BIFROST_STDIO_TEST_HELPER=1"}, tc.envs...)
+			config := &schemas.MCPClientConfig{
+				Name:           "test-stdio-client",
+				ConnectionType: schemas.MCPConnectionTypeSTDIO,
+				StdioConfig: &schemas.MCPStdioConfig{
+					Command: executable,
+					Args:    []string{"-test.run=^TestSTDIOEnvHelperProcess$"},
+					Envs:    append([]string(nil), envs...),
+				},
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			conn, _, err := (&MCPManager{}).createSTDIOConnection(ctx, config, nil)
+			require.NoError(t, err)
+			assert.Equal(t, envs, config.StdioConfig.Envs, "connection setup must not resolve references in the stored config")
+			require.NoError(t, conn.Start(ctx))
+			defer func() { assert.NoError(t, conn.Close()) }()
+
+			request := mcpgo.InitializeRequest{}
+			request.Params.ProtocolVersion = mcpgo.LATEST_PROTOCOL_VERSION
+			request.Params.ClientInfo = mcpgo.Implementation{Name: "stdio-env-test", Version: "1.0.0"}
+			result, err := conn.Initialize(ctx, request)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, result.ServerInfo.Name)
+		})
+	}
+}
+
+// Run the test binary as a real STDIO MCP server so the parent checks process
+// creation and the environment actually received by the child on every platform.
+func TestSTDIOEnvHelperProcess(t *testing.T) {
+	if os.Getenv("BIFROST_STDIO_TEST_HELPER") != "1" {
+		return
+	}
+	name := os.Getenv("BIFROST_STDIO_TEST_HOST") + "|" + os.Getenv("BIFROST_STDIO_TEST_INLINE")
+	err := server.NewStdioServer(server.NewMCPServer(name, "1.0.0")).Listen(context.Background(), os.Stdin, os.Stdout)
+	if err != nil {
+		os.Exit(1)
+	}
+	os.Exit(0)
 }
 
 // TestCloseAndMarkNeedsReauth_ClosesLiveConnectionAndFlipsState covers the

--- a/tests/e2e/api/collections/provider-harness.json
+++ b/tests/e2e/api/collections/provider-harness.json
@@ -59,7 +59,7 @@
           "// Only register the content-shape test when the request actually succeeded.",
           "// Otherwise newman reports it as passing (because of an early return) which is misleading next to a failing status.",
           "var __u = (pm.request && pm.request.url && pm.request.url.toString()) || '';",
-          "var __skipShape = (__u.indexOf('/files/') !== -1 && (__u.indexOf('/content?') !== -1 || __u.slice(-8) === '/content')) || __u.indexOf('storage.googleapis.com') !== -1 || __u.indexOf('batchPredictionJobs') !== -1 || (__u.indexOf('/genai/v1beta/batches/') !== -1 && __u.indexOf(':cancel') !== -1);",
+          "var __skipShape = ((__rn.indexOf('MCP stdio-env-regression ') !== -1 && __u.indexOf('/api/mcp/') !== -1) || __u.indexOf('/files/') !== -1 && (__u.indexOf('/content?') !== -1 || __u.slice(-8) === '/content')) || __u.indexOf('storage.googleapis.com') !== -1 || __u.indexOf('batchPredictionJobs') !== -1 || (__u.indexOf('/genai/v1beta/batches/') !== -1 && __u.indexOf(':cancel') !== -1);",
           "if (pm.response.code < 400 && !__skipShape && (pm.response.headers.get('content-type') || '').indexOf('text/event-stream') === -1 && (pm.response.headers.get('content-type') || '').indexOf('vnd.amazon.eventstream') === -1 && (pm.response.headers.get('content-type') || '').indexOf('audio/') === -1) {",
           "  pm.test('Response has content (text or tool_use)', function () {",
           "    var j;",
@@ -148321,6 +148321,195 @@
               ]
             }
           }
+        }
+      ]
+    },
+    {
+      "name": "84. MCP STDIO host environment references (stdio-env-regression)",
+      "description": "Regression related to #5671 and host-env passthrough from PR #3995: bare environment names reached exec.Cmd.Env and Windows rejected process creation with The parameter is incorrect. This provider-independent, zero-LLM chain creates a real Node STDIO MCP subprocess, checks tool discovery and the received environment, then deletes its unique client. Requires a gateway with dashboard authentication, mcpAdminSession set to an authenticated local admin session, and node on the gateway PATH (override mcpStdioNodeCommand if necessary). Run with PROVIDER=mcp PARALLEL=0 FEATURE=stdio-env-regression INCLUDE_PREVIEW=1 HARNESS_MAX_REQUESTS=4. The 500 creation response is the regression signature and must not be skipped as infrastructure noise. Go tests cover the same subprocess path without external tools.",
+      "item": [
+        {
+          "name": "[PREVIEW] MCP stdio-env-regression create client",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (!pm.variables.get('mcpAdminSession')) { throw new Error('Set mcpAdminSession to an authenticated local admin session'); }",
+                  "pm.collectionVariables.set('mcpStdioClientId', pm.variables.replaceIn('{{$guid}}').replace(/-/g, ''));",
+                  "pm.collectionVariables.set('mcpStdioCreated', '0');",
+                  "if (!pm.variables.get('mcpStdioNodeCommand')) { pm.collectionVariables.set('mcpStdioNodeCommand', 'node'); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('MCP operation succeeded', function () {",
+                  "  pm.expect(pm.response.code, pm.response.text()).to.equal(200);",
+                  "  pm.expect(pm.response.json().status).to.equal('success');",
+                  "});",
+                  "if (pm.response.code === 200 && pm.response.json().status === 'success') { pm.collectionVariables.set('mcpStdioCreated', '1'); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{mcpAdminSession}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"client_id\": \"{{mcpStdioClientId}}\",\n  \"name\": \"stdio_env_{{mcpStdioClientId}}\",\n  \"connection_type\": \"stdio\",\n  \"auth_type\": \"none\",\n  \"stdio_config\": {\n    \"command\": \"{{mcpStdioNodeCommand}}\",\n    \"args\": [\n      \"-e\",\n      \"const r=require('readline').createInterface({input:process.stdin});r.on('line',line=>{const q=JSON.parse(line);if(q.id===undefined)return;let result={};if(q.method==='initialize')result={protocolVersion:q.params.protocolVersion,capabilities:{tools:{}},serverInfo:{name:'stdio-env-fixture',version:'1.0.0'}};else if(q.method==='tools/list')result={tools:[{name:'env_probe',description:process.env.PATH&&process.env.BIFROST_STDIO_HARNESS_VALUE==='inline=value'&&process.env.BIFROST_STDIO_HARNESS_EMPTY===''?'env-ok':'env-invalid',inputSchema:{type:'object',properties:{}}}]};else if(q.method!=='ping'){process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:q.id,error:{code:-32601,message:'Method not found'}})+'\\\\n');return;}process.stdout.write(JSON.stringify({jsonrpc:'2.0',id:q.id,result})+'\\\\n');});\"\n    ],\n    \"envs\": [\n      \"PATH\",\n      \"BIFROST_STDIO_HARNESS_VALUE=inline=value\",\n      \"BIFROST_STDIO_HARNESS_EMPTY=\"\n    ]\n  },\n  \"tools_to_execute\": [\n    \"*\"\n  ]\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": "{{baseUrl}}/api/mcp/client"
+          },
+          "response": []
+        },
+        {
+          "name": "[PREVIEW] MCP stdio-env-regression verify child environment",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.collectionVariables.get('mcpStdioCreated') !== '1') { pm.execution.skipRequest(); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('STDIO child is healthy with the expected environment', function () {",
+                  "  pm.expect(pm.response.code, pm.response.text()).to.equal(200);",
+                  "  var clients = pm.response.json().clients;",
+                  "  pm.expect(clients).to.have.lengthOf(1);",
+                  "  pm.expect(clients[0].state).to.equal('healthy');",
+                  "  pm.expect(clients[0].config.stdio_config.envs).to.include('PATH');",
+                  "  var tools = clients[0].tools;",
+                  "  pm.expect(tools).to.have.lengthOf(1);",
+                  "  pm.expect(tools[0].description).to.equal('env-ok');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{mcpAdminSession}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/api/mcp/clients?server={{mcpStdioClientId}}"
+          },
+          "response": []
+        },
+        {
+          "name": "[PREVIEW] MCP stdio-env-regression delete client",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.collectionVariables.get('mcpStdioCreated') !== '1') { pm.execution.skipRequest(); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('MCP operation succeeded', function () {",
+                  "  pm.expect(pm.response.code, pm.response.text()).to.equal(200);",
+                  "  pm.expect(pm.response.json().status).to.equal('success');",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{mcpAdminSession}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/api/mcp/client/{{mcpStdioClientId}}"
+          },
+          "response": []
+        },
+        {
+          "name": "[PREVIEW] MCP stdio-env-regression verify cleanup",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "if (pm.collectionVariables.get('mcpStdioCreated') !== '1') { pm.execution.skipRequest(); }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('Regression client was removed', function () {",
+                  "  pm.expect(pm.response.code, pm.response.text()).to.equal(200);",
+                  "  pm.expect(pm.response.json().clients).to.have.lengthOf(0);",
+                  "});"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{mcpAdminSession}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": "{{baseUrl}}/api/mcp/clients?server={{mcpStdioClientId}}"
+          },
+          "response": []
         }
       ]
     }


### PR DESCRIPTION
## Summary

STDIO MCP clients configured with host environment references such as `envs: ["PATH"]` fail to start on Windows with `fork/exec ...: The parameter is incorrect`. Bifrost validates the variable but forwards its bare name to mcp-go, which appends it directly to `exec.Cmd.Env`.

## Changes

- Resolve references into `KEY=value` entries in a separate slice, preserving the stored config, inline assignments, explicit empty values, and existing validation.
- Add real subprocess regressions to the existing MCP test file, plus an opt-in HTTP harness chain that creates, verifies, and removes a Node STDIO client.
- Add the core changelog entry.

## Type of change

- [x] Bug fix

## Affected areas

- [x] Core (Go): `core/mcp`, `core/changelog.md`
- HTTP regression coverage: `tests/e2e/api/collections/provider-harness.json`

## How to test

```sh
# From a configured local Go workspace
go test ./core/mcp -count=1

# Requires dashboard authentication, an authenticated mcpAdminSession in ENV_FILE,
# and Node on the gateway PATH. No LLM requests are made.
make run-provider-harness-test APP_DIR=tests/integrations/python CI=1 \
  PROVIDER=mcp PARALLEL=0 FEATURE=stdio-env-regression INCLUDE_PREVIEW=1 \
  COMPAT=off HARNESS_MAX_REQUESTS=4 DB_VERIFY=0 ENV_FILE=<local-environment.json>
```

Verified with Go 1.27.1 on Windows. The MCP package passes; focused subprocess tests also pass on Linux via WSL. Collection augmentation and filtering retain exactly four requests. Independent code and harness review completed, and `git diff --check` passes.

| Regression | Before | After |
|---|---|---|
| Windows MCP subprocess | Reference-bearing cases fail at process start; inline-only control passes | All cases pass and initialization confirms the received environment |
| Live Windows HTTP harness | Creation returns the expected 500 with `The parameter is incorrect`; dependent requests skip | 4 requests and 8 assertions pass, including tool discovery and cleanup |

The live run used locally built pre-fix and post-fix gateways with `APP_DIR=tests/integrations/python`. Local dashboard authentication was temporarily enabled and the unrelated SSE fixture removed; provider configuration was retained and the original config restored afterward. UI behavior was not tested. `[PREVIEW]` keeps this fixture-dependent chain opt-in.

## Breaking changes

- [x] No

## Related issues

Related to #5671 and host-env passthrough introduced by #3995. This fixes the reproducible bare-reference case; #5671's example omits `envs`, so this PR does not claim to resolve every scenario in that issue.

## Security considerations

Resolved environment values are kept out of the stored client config and connection metadata. The change preserves the transport's existing environment inheritance. No credentials or local runtime artifacts are included.

## Checklist

- [x] Followed the current contribution guide (`docs/contributing/raising-a-pr.mdx`; the template's README path no longer exists).
- [x] Added regression tests and the core changelog entry.
- [x] Verified the scoped Go tests, local Windows HTTP build, and live harness red/green results.
- [ ] Full CI suite / UI build (not run locally; no UI changes).
