### PR TITLE
fix(governance): preserve caller-facing model authorization across routing

### DIFF
--- a/plugins/governance/loadbalance_test.go
+++ b/plugins/governance/loadbalance_test.go
@@ -81,6 +81,34 @@ func TestLoadBalanceProvider_UnprefixedModelLoadBalances(t *testing.T) {
 	assert.Equal(t, "openai/gpt-4o", got)
 }
 
+// A routing rule may replace the caller-facing alias after PreRequestHook. Provider candidacy
+// and the routing allowlist still come from that alias, while the selected provider receives the
+// physical model. Otherwise #7112 can fail before the final governance evaluation even runs.
+func TestLoadBalanceProvider_UsesCallerFacingModelAfterRoutingRewrite(t *testing.T) {
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-lb", "LB VK", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("vllm", []string{"my.alias"}),
+	})
+	p := newLoadBalanceTestPlugin(t, vk)
+	ctx := lbCtx()
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Model: "my.alias"},
+	}
+
+	require.NoError(t, p.PreRequestHook(ctx, req))
+	req.SetModel("physical-model") // routing rule target
+
+	p.PublishRoutingAllowlist(ctx, "physical-model")
+	allowed, ok := ctx.Value(schemas.BifrostContextKeyRoutingAllowedProviders).([]schemas.ModelProvider)
+	require.True(t, ok)
+	assert.Equal(t, []schemas.ModelProvider{schemas.VLLM}, allowed)
+
+	require.NoError(t, p.LoadBalanceProvider(ctx, req))
+	provider, model, _ := req.GetRequestFields()
+	assert.Equal(t, schemas.VLLM, provider)
+	assert.Equal(t, "physical-model", model)
+}
+
 // TestLoadBalanceProvider_UnknownPrefixIsTreatedAsModelNamespace verifies that a
 // "/" prefix that is not a known provider (e.g. a HuggingFace-style namespace) is
 // kept as part of the model name and load balancing still applies.

--- a/plugins/governance/main.go
+++ b/plugins/governance/main.go
@@ -25,7 +25,9 @@ import (
 const PluginName = "governance"
 
 const (
-	governanceRejectedContextKey schemas.BifrostContextKey = "bf-governance-rejected"
+	governanceRejectedContextKey        schemas.BifrostContextKey = "bf-governance-rejected"
+	governanceRequestedModelContextKey  schemas.BifrostContextKey = "bf-governance-requested-model"
+	governanceCallerFallbacksContextKey schemas.BifrostContextKey = "bf-governance-caller-fallbacks"
 
 	VirtualKeyPrefix = "sk-bf-"
 )
@@ -58,7 +60,8 @@ type BaseGovernancePlugin interface {
 	Cleanup() error
 	GetGovernanceStore() GovernanceStore
 	// Routing collaboration: the routing plugin calls these after evaluating routing rules,
-	// so the allowlist and the load balancer both act on the post-rule provider/model.
+	// so provider calls use the post-rule provider/model while access policy continues to use
+	// the caller-facing model captured before the rewrite.
 	// ResolveAccess answers what a request may reach, resolving it once and recording it on the
 	// request's grant so every later reader sees the same answer. A request context that carries no
 	// grant is a wiring fault, and is reported as one.
@@ -376,9 +379,10 @@ func (p *GovernancePlugin) GetBudgetAndRateLimitStatus(ctx *schemas.BifrostConte
 	return p.store.GetBudgetAndRateLimitStatus(ctx, provider, model, budgetBaselines, tokenBaselines, requestBaselines)
 }
 
-// LoadBalanceProvider picks a weighted provider among those the request may reach for req.Model
-// and mutates req.Provider/req.Model with the refined provider/model. Also populates req.Fallbacks
-// from the remaining weighted providers if no fallbacks were configured by the caller.
+// LoadBalanceProvider picks a weighted provider among those the request may reach for its
+// caller-facing model and mutates req.Provider/req.Model with the refined physical provider/model.
+// It also populates req.Fallbacks from the remaining weighted providers if no fallbacks were
+// configured by the caller.
 //
 // Candidacy comes from the request's grants, so a request that holds providers without presenting
 // a key is balanced across them too. Everything it needs comes off the request: the grants say
@@ -421,14 +425,15 @@ func (p *GovernancePlugin) LoadBalanceProvider(ctx *schemas.BifrostContext, req 
 	// Candidates are the provider configs that permit this model: model allowance, blacklists
 	// and composition already applied. Everything below is about which of them may serve the
 	// request right now, and which one gets it.
-	candidates := access.ProvidersForModel(modelStr)
+	accessModel := accessModelForRequest(ctx, modelStr, existingFallbacks)
+	candidates := access.ProvidersForModel(accessModel)
 	serving := make(map[string]struct{}, len(candidates))
 	for _, candidate := range candidates {
 		serving[candidate.Provider] = struct{}{}
 	}
 	for _, availableProvider := range configuredProviders {
 		if _, ok := serving[availableProvider]; !ok {
-			ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("Provider %s excluded: model %s is not permitted", availableProvider, modelStr))
+			ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo, fmt.Sprintf("Provider %s excluded: model %s is not permitted", availableProvider, accessModel))
 		}
 	}
 
@@ -437,7 +442,7 @@ func (p *GovernancePlugin) LoadBalanceProvider(ctx *schemas.BifrostContext, req 
 		// Whether a candidate can be afforded right now is the store's answer, because the store
 		// owns what pays for it. Load balancing passes the candidate and does not need to know
 		// whether a key, a team or something else is funding it.
-		if decision, err := p.store.CheckProviderCandidateExclusion(ctx, access, candidate, modelStr); err != nil || decision != DecisionAllow {
+		if decision, err := checkProviderCandidateExclusion(ctx, p.store, access, candidate, modelStr, accessModel); err != nil || decision != DecisionAllow {
 			ctx.AppendRoutingEngineLog(schemas.RoutingEngineGovernance, schemas.LogLevelInfo,
 				fmt.Sprintf("Provider %s excluded: %s", candidate.Provider, candidateExclusionReason(decision, err)))
 			continue
@@ -564,7 +569,7 @@ func candidateExclusionReason(decision Decision, err error) string {
 }
 
 // PublishRoutingAllowlist records, for downstream routing layers, which of the providers the
-// request may reach permit modelStr. It is a coarse provider gate
+// request may reach permit the caller-facing model. It is a coarse provider gate
 // (BifrostContextKeyRoutingAllowedProviders) layered on top of the model catalog checks those
 // layers already run: its purpose is to stop a later routing layer (load balancing,
 // model-catalog resolution) from selecting a provider the request may not use for this model,
@@ -586,7 +591,7 @@ func (p *GovernancePlugin) PublishRoutingAllowlist(ctx *schemas.BifrostContext, 
 		// with no grant is refused by evaluation, which is the place to say so.
 		return
 	}
-	ctx.SetValue(schemas.BifrostContextKeyRoutingAllowedProviders, modelProviders(access.GrantedProvidersForModel(modelStr)))
+	ctx.SetValue(schemas.BifrostContextKeyRoutingAllowedProviders, modelProviders(access.GrantedProvidersForModel(accessModelForRequest(ctx, modelStr, nil))))
 }
 
 // namedProjectNothingScoped reports whether the request named a project and ended up scoped by
@@ -654,7 +659,7 @@ func (p *GovernancePlugin) Evaluate(ctx *schemas.BifrostContext, evaluationReque
 	// A settling error is held rather than refused on the spot: the ordering below puts identity
 	// refusals first, and a caller whose credential is dead must be told that before anything about
 	// how the request would have been funded.
-	limits, limitsErr := resolveLimits(ctx, p.store, evaluationRequest.Provider, evaluationRequest.Model)
+	limits, limitsErr := resolveLimits(ctx, p.store, evaluationRequest.Provider, evaluationRequest.Model, evaluationRequest.modelForAccess())
 
 	// The order of everything below is load bearing:
 	//
@@ -998,18 +1003,31 @@ func (p *GovernancePlugin) modelMatcher() grant.ModelMatcher {
 // composes several possible payers settles there on who pays, and this only records the answer. An
 // error is a request whose payers cannot be settled at all; nothing is recorded for it, and the
 // funnel refuses it rather than serving it against half an answer.
-func resolveLimits(ctx *schemas.BifrostContext, store GovernanceStore, provider schemas.ModelProvider, model string) (schemas.Limits, error) {
+func resolveLimits(ctx *schemas.BifrostContext, store GovernanceStore, provider schemas.ModelProvider, model, accessModel string) (schemas.Limits, error) {
 	g := ctx.Grant()
 	if g == nil {
 		return nil, nil
 	}
-	budgets, rateLimits, err := store.GatherLimits(ctx, g.Access(), provider, model)
+	var budgets, rateLimits []schemas.Limit
+	var err error
+	if accessAware, ok := store.(AccessModelLimitGatherer); ok {
+		budgets, rateLimits, err = accessAware.GatherLimitsForAccessModel(ctx, g.Access(), provider, model, accessModel)
+	} else {
+		budgets, rateLimits, err = store.GatherLimits(ctx, g.Access(), provider, model)
+	}
 	if err != nil {
 		return nil, err
 	}
 	limits := grant.NewLimits(budgets, rateLimits)
 	g.SetLimits(limits)
 	return limits, nil
+}
+
+func checkProviderCandidateExclusion(ctx *schemas.BifrostContext, store GovernanceStore, access schemas.Access, candidate schemas.ProviderCandidate, model, accessModel string) (Decision, error) {
+	if accessAware, ok := store.(AccessModelCandidateChecker); ok {
+		return accessAware.CheckProviderCandidateExclusionForAccessModel(ctx, access, candidate, model, accessModel)
+	}
+	return store.CheckProviderCandidateExclusion(ctx, access, candidate, model)
 }
 
 // PreRequestHook is the per-request governance phase: it resolves the request's access, completes
@@ -1019,7 +1037,8 @@ func resolveLimits(ctx *schemas.BifrostContext, store GovernanceStore, provider 
 // It deliberately runs before the routing plugin so a routing rule evaluates against a fully
 // stamped context. The provider allowlist and load balancing that used to live here now run
 // from the routing plugin after rule evaluation, through PublishRoutingAllowlist and
-// LoadBalanceProvider, because both must act on the post-rule model.
+// LoadBalanceProvider. They use the post-rule model for provider execution and limits, while
+// retaining this caller-facing name for model access policy.
 //
 // Realtime + generic streaming bypass handleRequest (see core/bifrost.go
 // RunRealtimeTurnPreHooks / RunStreamPreHooks) and are still handled at HTTPTransportPreHook.
@@ -1027,6 +1046,19 @@ func (p *GovernancePlugin) PreRequestHook(ctx *schemas.BifrostContext, req *sche
 	if req.RequestType == schemas.PassthroughRequest || req.RequestType == schemas.PassthroughStreamRequest {
 		return nil
 	}
+
+	// Preserve the caller-facing model before the routing plugin can rewrite the request.
+	// Access controls use this name; provider calls and model-scoped limits continue to use
+	// the routed physical model. Large-payload requests carry the model in metadata because
+	// their body has not been parsed into req.
+	_, requestedModel, requestedFallbacks := req.GetRequestFields()
+	if requestedModel == "" {
+		if metadata, _ := ctx.Value(schemas.BifrostContextKeyLargePayloadMetadata).(*schemas.LargePayloadMetadata); metadata != nil {
+			_, requestedModel = schemas.ParseModelString(metadata.Model, "")
+		}
+	}
+	ctx.SetValue(governanceRequestedModelContextKey, requestedModel)
+	ctx.SetValue(governanceCallerFallbacksContextKey, provenanceForCallerFallbacks(requestedFallbacks))
 
 	// The request's provider is a fact access resolution needs to apply provider-scoped grants, and it
 	// rides on the request, not the context. Stamp it before resolving so the resolved access reflects
@@ -1089,12 +1121,14 @@ func (p *GovernancePlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.
 		return req, &schemas.LLMPluginShortCircuit{Error: headerErr}, nil
 	}
 	// Getting provider and mode from the request
-	provider, model, _ := req.GetRequestFields()
+	provider, model, fallbacks := req.GetRequestFields()
 	// Create request context for evaluation
 	evaluationRequest := &EvaluationRequest{
 		RequestType: req.RequestType,
 		Provider:    provider,
-		Model:       model}
+		Model:       model,
+		AccessModel: accessModelForRequest(ctx, model, fallbacks),
+	}
 	// A batch create fans out to many completions, each naming its own model, so
 	// every model it will run is evaluated before the request itself. Each pass
 	// settles that model's limits on the access and checks them; the request's own
@@ -1104,6 +1138,7 @@ func (p *GovernancePlugin) PreLLMHook(ctx *schemas.BifrostContext, req *schemas.
 		for _, batchModel := range BatchCreateModels(req, model) {
 			batchEvaluationRequest := *evaluationRequest
 			batchEvaluationRequest.Model = batchModel
+			batchEvaluationRequest.AccessModel = batchModel
 			_, bifrostError := p.Evaluate(ctx, &batchEvaluationRequest)
 			if bifrostError != nil {
 				return req, &schemas.LLMPluginShortCircuit{

--- a/plugins/governance/modelprovidergovernance_test.go
+++ b/plugins/governance/modelprovidergovernance_test.go
@@ -2186,7 +2186,7 @@ func TestPostMCPHook_TracksVirtualKeyUsageWhenUserIDPresent(t *testing.T) {
 	// Evaluating the tool call settles the limits it answers to, and billing reads them from there.
 	// Tool execution names no provider and no model, so what it answers to is whatever funds the
 	// holder.
-	settled, settleErr := resolveLimits(ctx, store, "", "")
+	settled, settleErr := resolveLimits(ctx, store, "", "", "")
 	require.NoError(t, settleErr)
 	require.NotNil(t, settled)
 	resp := &schemas.BifrostMCPResponse{
@@ -2226,7 +2226,7 @@ func TestPostMCPHook_SkipVirtualKeyUsageTrackingFlag(t *testing.T) {
 	ctx := resolverCtx(store, "sk-bf-test")
 	ctx.SetValue(schemas.BifrostContextKeyUserID, "user1")
 	ctx.SetValue(schemas.BifrostContextKeySkipVirtualKeyUsageTracking, true)
-	settled, settleErr := resolveLimits(ctx, store, "", "")
+	settled, settleErr := resolveLimits(ctx, store, "", "", "")
 	require.NoError(t, settleErr)
 	require.NotNil(t, settled)
 	resp := &schemas.BifrostMCPResponse{

--- a/plugins/governance/permits_test.go
+++ b/plugins/governance/permits_test.go
@@ -734,7 +734,7 @@ func TestResolveAccessHoldsAcrossAttempts(t *testing.T) {
 	// A permit widened while the first attempt was in flight, and the next attempt starting.
 	store.scoping = permitWithProviders("other", "o1", "Other", "anthropic")
 	store.mode = grant.Union
-	resolveLimits(ctx, store, schemas.Anthropic, "claude-sonnet-4")
+	resolveLimits(ctx, store, schemas.Anthropic, "claude-sonnet-4", "claude-sonnet-4")
 
 	second, err := plugin.ResolveAccess(ctx)
 

--- a/plugins/governance/resolver.go
+++ b/plugins/governance/resolver.go
@@ -2,6 +2,8 @@
 package governance
 
 import (
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
 	"strings"
 
@@ -36,6 +38,87 @@ type EvaluationRequest struct {
 	RequestType schemas.RequestType   `json:"request_type"`
 	Provider    schemas.ModelProvider `json:"provider"`
 	Model       string                `json:"model"`
+	// AccessModel is the caller-facing model before routing or key-alias resolution.
+	// It is used only for provider/model/key authorization; Model remains the physical
+	// model used for limits, accounting, and the provider request.
+	AccessModel string `json:"-"`
+}
+
+func (r *EvaluationRequest) modelForAccess() string {
+	if r != nil && r.AccessModel != "" {
+		return r.AccessModel
+	}
+	if r == nil {
+		return ""
+	}
+	return r.Model
+}
+
+// callerFallbackProvenance is the fixed-size identity of the fallback list that arrived with
+// the request. The list itself can grow with request content and therefore must not be retained
+// in BifrostContext.
+type callerFallbackProvenance struct {
+	present bool
+	digest  [sha256.Size]byte
+}
+
+func fingerprintFallbacks(fallbacks []schemas.Fallback) [sha256.Size]byte {
+	hasher := sha256.New()
+	var length [binary.MaxVarintLen64]byte
+
+	writeLength := func(value uint64) {
+		n := binary.PutUvarint(length[:], value)
+		_, _ = hasher.Write(length[:n])
+	}
+	writeString := func(value string) {
+		writeLength(uint64(len(value)))
+		_, _ = hasher.Write([]byte(value))
+	}
+
+	writeLength(uint64(len(fallbacks)))
+	for _, fallback := range fallbacks {
+		writeString(string(fallback.Provider))
+		writeString(fallback.Model)
+	}
+
+	var digest [sha256.Size]byte
+	_ = hasher.Sum(digest[:0])
+	return digest
+}
+
+func provenanceForCallerFallbacks(fallbacks []schemas.Fallback) callerFallbackProvenance {
+	if len(fallbacks) == 0 {
+		return callerFallbackProvenance{}
+	}
+	return callerFallbackProvenance{
+		present: true,
+		digest:  fingerprintFallbacks(fallbacks),
+	}
+}
+
+// accessModelForRequest returns the model name whose use the caller authorized.
+// PreRequestHook records it before routing rules run. ResolvedAlias covers callers
+// that enter an attempt-level hook without the normal request hook in front of it.
+func accessModelForRequest(ctx *schemas.BifrostContext, fallback string, currentFallbacks []schemas.Fallback) string {
+	if ctx != nil {
+		// A fallback already present when the request entered the pipeline is caller-controlled,
+		// so it must keep its own model authorization boundary. Fallbacks added later by routing
+		// or governance are operator-controlled implementations of the caller-facing primary alias.
+		// Compare fixed-size fingerprints because routing rules can replace a non-empty caller list;
+		// remembering only that the caller supplied something would misclassify the replacement.
+		fallbackIndex, _ := ctx.Value(schemas.BifrostContextKeyFallbackIndex).(int)
+		provenance, _ := ctx.Value(governanceCallerFallbacksContextKey).(callerFallbackProvenance)
+		if fallbackIndex > 0 && provenance.present && provenance.digest == fingerprintFallbacks(currentFallbacks) {
+			return fallback
+		}
+		if requested, ok := ctx.Value(governanceRequestedModelContextKey).(string); ok && requested != "" {
+			return requested
+		}
+		if alias := schemas.GetResolvedAlias(ctx); alias != nil && alias.Key != "" {
+			return alias.Key
+		}
+	}
+	return fallback
 }
 
 // EvaluationResult is a governance verdict: whether the request may proceed, and why not when it
@@ -91,7 +174,8 @@ func (r *BudgetResolver) evaluateAccess(ctx *schemas.BifrostContext, evaluationR
 	// picked, so the provider allowlist carries no meaning for them.
 	skipProviderCheck := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipProviderCheck)
 
-	requestType, provider, model := evaluationRequest.RequestType, evaluationRequest.Provider, evaluationRequest.Model
+	requestType, provider := evaluationRequest.RequestType, evaluationRequest.Provider
+	accessModel := evaluationRequest.modelForAccess()
 
 	// A caller with no provider config for this provider also has no model allowlist for it,
 	// since allowed models hang off a provider config. When the provider gate is skipped the
@@ -115,16 +199,16 @@ func (r *BudgetResolver) evaluateAccess(ctx *schemas.BifrostContext, evaluationR
 	// still carries a model allowlist that would deny the request one step later.
 	skipModelCheck := bifrost.GetBoolFromContext(ctx, schemas.BifrostContextKeySkipModelCheck)
 	checkModelIfPresent := IsModelCheckedWhenPresent(requestType)
-	if !skipModelCheck && !providerUnconfigured && (IsModelRequiredForRequest(requestType) || (checkModelIfPresent && model != "")) && !access.IsModelAllowed(string(provider), model) {
+	if !skipModelCheck && !providerUnconfigured && (IsModelRequiredForRequest(requestType) || (checkModelIfPresent && accessModel != "")) && !access.IsModelAllowed(string(provider), accessModel) {
 		return &EvaluationResult{
 			Decision: DecisionModelBlocked,
-			Reason:   denialReason(fmt.Sprintf("Model '%s' is not allowed", model), access.DeniedPermitsForModel(string(provider), model)),
+			Reason:   denialReason(fmt.Sprintf("Model '%s' is not allowed", accessModel), access.DeniedPermitsForModel(string(provider), accessModel)),
 		}
 	}
 
 	// Publish the provider keys the request may use, when its access restricts them at all.
 	// Downstream key selection consumes plain key ids, so it never has to know what a permit is.
-	if keyIDs, restricted := access.KeysForModel(string(provider), model); restricted {
+	if keyIDs, restricted := access.KeysForModel(string(provider), accessModel); restricted {
 		ctx.SetValue(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys, keyIDs)
 	}
 

--- a/plugins/governance/resolver_test.go
+++ b/plugins/governance/resolver_test.go
@@ -161,6 +161,280 @@ func TestBudgetResolver_EvaluateRequest_ModelBlocked(t *testing.T) {
 	assertDecision(t, DecisionModelBlocked, result)
 }
 
+// TestGovernancePlugin_PreLLMHook_UsesCallerFacingModelAfterRoutingRewrite
+// reproduces #7112: routing runs after governance's PreRequestHook and may
+// replace the caller-facing alias with the physical model before PreLLMHook.
+// Both sides of model access policy must remain scoped to what the caller requested.
+func TestGovernancePlugin_PreLLMHook_UsesCallerFacingModelAfterRoutingRewrite(t *testing.T) {
+	tests := []struct {
+		name              string
+		requestedModel    string
+		allowedModels     schemas.WhiteList
+		blacklistedModels schemas.BlackList
+		wantBlocked       bool
+	}{
+		{
+			name:           "allowed alias admits routed physical model",
+			requestedModel: "my.alias",
+			allowedModels:  schemas.WhiteList{"my.alias"},
+		},
+		{
+			name:              "physical-model blacklist does not block allowed alias",
+			requestedModel:    "my.alias",
+			allowedModels:     schemas.WhiteList{"my.alias"},
+			blacklistedModels: schemas.BlackList{"physical-model"},
+		},
+		{
+			name:              "alias blacklist blocks routed physical model",
+			requestedModel:    "my.alias",
+			allowedModels:     schemas.WhiteList{"*"},
+			blacklistedModels: schemas.BlackList{"my.alias"},
+			wantBlocked:       true,
+		},
+		{
+			name:           "direct physical request is not authorized by alias grant",
+			requestedModel: "physical-model",
+			allowedModels:  schemas.WhiteList{"my.alias"},
+			wantBlocked:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := NewMockLogger()
+			providerConfig := buildProviderConfig("vllm", tt.allowedModels)
+			providerConfig.BlacklistedModels = tt.blacklistedModels
+			vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", []configstoreTables.TableVirtualKeyProviderConfig{providerConfig})
+			store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+				VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+			}, nil, nil)
+			require.NoError(t, err)
+
+			plugin := &GovernancePlugin{
+				store:    store,
+				resolver: NewBudgetResolver(store, nil, logger, nil),
+				logger:   logger,
+			}
+			ctx := presentCtx("sk-bf-test")
+			req := &schemas.BifrostRequest{
+				RequestType: schemas.ChatCompletionRequest,
+				ChatRequest: &schemas.BifrostChatRequest{
+					Provider: schemas.VLLM,
+					Model:    tt.requestedModel,
+				},
+			}
+
+			require.NoError(t, plugin.PreRequestHook(ctx, req))
+			req.SetModel("physical-model") // routing rule target
+
+			_, shortCircuit, hookErr := plugin.PreLLMHook(ctx, req)
+			require.NoError(t, hookErr)
+			if !tt.wantBlocked {
+				require.Nil(t, shortCircuit, "access must be evaluated against the caller-facing model")
+				return
+			}
+			require.NotNil(t, shortCircuit)
+			require.NotNil(t, shortCircuit.Error)
+			require.NotNil(t, shortCircuit.Error.Type)
+			assert.Equal(t, string(DecisionModelBlocked), *shortCircuit.Error.Type)
+			assert.Contains(t, shortCircuit.Error.GetErrorString(), tt.requestedModel)
+			if tt.requestedModel != "physical-model" {
+				assert.NotContains(t, shortCircuit.Error.GetErrorString(), "physical-model")
+			}
+		})
+	}
+}
+
+// Large-payload requests can reach PreRequestHook with an empty request model because only the
+// small metadata prefix has been parsed. The caller-facing alias captured from that metadata must
+// still authorize the routed physical model and select the keys attached to the alias permit.
+func TestGovernancePlugin_PreLLMHook_LargePayloadAliasSelectsAuthorizedKeys(t *testing.T) {
+	logger := NewMockLogger()
+	providerConfig := buildProviderConfig("vllm", []string{"my.alias"})
+	providerConfig.Keys = []configstoreTables.TableKey{{KeyID: "vllm-alias-key"}}
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", []configstoreTables.TableVirtualKeyProviderConfig{providerConfig})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{
+		store:    store,
+		resolver: NewBudgetResolver(store, nil, logger, nil),
+		logger:   logger,
+	}
+	ctx := presentCtx("sk-bf-test")
+	ctx.SetValue(schemas.BifrostContextKeyLargePayloadMetadata, &schemas.LargePayloadMetadata{Model: "vllm/my.alias"})
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Provider: schemas.VLLM},
+	}
+
+	require.NoError(t, plugin.PreRequestHook(ctx, req))
+	req.SetModel("physical-model")
+
+	_, shortCircuit, hookErr := plugin.PreLLMHook(ctx, req)
+	require.NoError(t, hookErr)
+	require.Nil(t, shortCircuit)
+	assert.Equal(t, []string{"vllm-alias-key"}, ctx.Value(schemas.BifrostContextKeyGovernanceIncludeOnlyKeys))
+}
+
+type accessModelAwareStoreProbe struct {
+	GovernanceStore
+	limitModel           string
+	limitAccessModel     string
+	candidateModel       string
+	candidateAccessModel string
+}
+
+func (s *accessModelAwareStoreProbe) GatherLimitsForAccessModel(_ *schemas.BifrostContext, _ schemas.Access, _ schemas.ModelProvider, model, accessModel string) ([]schemas.Limit, []schemas.Limit, error) {
+	s.limitModel = model
+	s.limitAccessModel = accessModel
+	return nil, nil, nil
+}
+
+func (s *accessModelAwareStoreProbe) CheckProviderCandidateExclusionForAccessModel(_ *schemas.BifrostContext, _ schemas.Access, _ schemas.ProviderCandidate, model, accessModel string) (Decision, error) {
+	s.candidateModel = model
+	s.candidateAccessModel = accessModel
+	return DecisionAllow, nil
+}
+
+// Stores can opt into the split identity without changing GovernanceStore: the physical model is
+// used for charging while the caller-facing alias is used to select the permit that funds it.
+// Existing stores remain source-compatible and continue through the legacy methods.
+func TestAccessModelAwareStoreReceivesPhysicalAndCallerModels(t *testing.T) {
+	store := &accessModelAwareStoreProbe{}
+	ctx := emptyCtx()
+
+	_, err := resolveLimits(ctx, store, schemas.VLLM, "physical-model", "my.alias")
+	require.NoError(t, err)
+	assert.Equal(t, "physical-model", store.limitModel)
+	assert.Equal(t, "my.alias", store.limitAccessModel)
+
+	decision, err := checkProviderCandidateExclusion(ctx, store, nil, schemas.ProviderCandidate{Provider: "vllm"}, "physical-model", "my.alias")
+	require.NoError(t, err)
+	assert.Equal(t, DecisionAllow, decision)
+	assert.Equal(t, "physical-model", store.candidateModel)
+	assert.Equal(t, "my.alias", store.candidateAccessModel)
+}
+
+// Authorizing through an alias must not detach the request from the limits owned by the
+// authorizing provider permit. The alias selects the payer; the routed physical model remains
+// the identity used for model-scoped limits and provider accounting.
+func TestGovernancePlugin_PreLLMHook_RoutedAliasKeepsProviderPermitLimits(t *testing.T) {
+	logger := NewMockLogger()
+	exhausted := buildBudgetWithUsage("vllm-budget", 5, 5, "1h")
+	providerConfig := buildProviderConfigWithBudgets("vllm", []string{"my.alias"}, []configstoreTables.TableBudget{*exhausted})
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", []configstoreTables.TableVirtualKeyProviderConfig{providerConfig})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+		Budgets:     []configstoreTables.TableBudget{*exhausted},
+	}, nil, nil)
+	require.NoError(t, err)
+
+	plugin := &GovernancePlugin{
+		store:    store,
+		resolver: NewBudgetResolver(store, nil, logger, nil),
+		logger:   logger,
+	}
+	ctx := presentCtx("sk-bf-test")
+	req := &schemas.BifrostRequest{
+		RequestType: schemas.ChatCompletionRequest,
+		ChatRequest: &schemas.BifrostChatRequest{Provider: schemas.VLLM, Model: "my.alias"},
+	}
+
+	require.NoError(t, plugin.PreRequestHook(ctx, req))
+	req.SetModel("physical-model")
+
+	_, shortCircuit, hookErr := plugin.PreLLMHook(ctx, req)
+	require.NoError(t, hookErr)
+	require.NotNil(t, shortCircuit)
+	require.NotNil(t, shortCircuit.Error)
+	require.NotNil(t, shortCircuit.Error.Type)
+	assert.Equal(t, string(DecisionBudgetExceeded), *shortCircuit.Error.Type)
+}
+
+// The caller-facing primary alias is not authority to run an arbitrary model supplied in the
+// request's fallback list. Server-generated fallbacks implement the primary alias and inherit it;
+// caller-provided fallbacks remain independently authorized.
+func TestGovernancePlugin_PreLLMHook_CallerProvidedFallbackKeepsOwnAccessModel(t *testing.T) {
+	logger := NewMockLogger()
+	vk := buildVirtualKeyWithProviders("vk1", "sk-bf-test", "Test VK", []configstoreTables.TableVirtualKeyProviderConfig{
+		buildProviderConfig("vllm", []string{"my.alias"}),
+	})
+	store, err := NewLocalGovernanceStore(context.Background(), logger, nil, &configstore.GovernanceConfig{
+		VirtualKeys: []configstoreTables.TableVirtualKey{*vk},
+	}, nil, nil)
+	require.NoError(t, err)
+	plugin := &GovernancePlugin{
+		store:    store,
+		resolver: NewBudgetResolver(store, nil, logger, nil),
+		logger:   logger,
+	}
+
+	t.Run("caller-provided fallback is checked as itself", func(t *testing.T) {
+		ctx := presentCtx("sk-bf-test")
+		req := &schemas.BifrostRequest{
+			RequestType: schemas.ChatCompletionRequest,
+			ChatRequest: &schemas.BifrostChatRequest{
+				Provider:  schemas.VLLM,
+				Model:     "my.alias",
+				Fallbacks: []schemas.Fallback{{Provider: schemas.VLLM, Model: "forbidden-model"}},
+			},
+		}
+		require.NoError(t, plugin.PreRequestHook(ctx, req))
+		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, 1)
+		req.SetModel("forbidden-model")
+
+		_, shortCircuit, hookErr := plugin.PreLLMHook(ctx, req)
+		require.NoError(t, hookErr)
+		require.NotNil(t, shortCircuit)
+		require.NotNil(t, shortCircuit.Error)
+		require.NotNil(t, shortCircuit.Error.Type)
+		assert.Equal(t, string(DecisionModelBlocked), *shortCircuit.Error.Type)
+		assert.Contains(t, shortCircuit.Error.GetErrorString(), "forbidden-model")
+	})
+
+	t.Run("server-generated fallback inherits primary alias", func(t *testing.T) {
+		ctx := presentCtx("sk-bf-test")
+		req := &schemas.BifrostRequest{
+			RequestType: schemas.ChatCompletionRequest,
+			ChatRequest: &schemas.BifrostChatRequest{Provider: schemas.VLLM, Model: "my.alias"},
+		}
+		require.NoError(t, plugin.PreRequestHook(ctx, req))
+		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, 1)
+		req.SetModel("physical-fallback-model")
+
+		_, shortCircuit, hookErr := plugin.PreLLMHook(ctx, req)
+		require.NoError(t, hookErr)
+		require.Nil(t, shortCircuit)
+	})
+
+	t.Run("routing replacement inherits primary alias", func(t *testing.T) {
+		ctx := presentCtx("sk-bf-test")
+		req := &schemas.BifrostRequest{
+			RequestType: schemas.ChatCompletionRequest,
+			ChatRequest: &schemas.BifrostChatRequest{
+				Provider:  schemas.VLLM,
+				Model:     "my.alias",
+				Fallbacks: []schemas.Fallback{{Provider: schemas.VLLM, Model: "caller-fallback"}},
+			},
+		}
+		require.NoError(t, plugin.PreRequestHook(ctx, req))
+
+		// Routing rules replace the entire caller fallback list. The replacement is an
+		// operator-controlled implementation of the primary alias, not authority supplied
+		// by the caller for this physical model.
+		req.SetFallbacks([]schemas.Fallback{{Provider: schemas.VLLM, Model: "physical-rule-fallback"}})
+		ctx.SetValue(schemas.BifrostContextKeyFallbackIndex, 1)
+		req.SetModel("physical-rule-fallback")
+
+		_, shortCircuit, hookErr := plugin.PreLLMHook(ctx, req)
+		require.NoError(t, hookErr)
+		require.Nil(t, shortCircuit)
+	})
+}
+
 // TestBudgetResolver_EvaluateRequest_SkipProviderCheckAllowsUnconfiguredProvider verifies
 // that skipProviderCheck drops the provider allowlist, and drops the model allowlist with
 // it when the VK has no config for that provider. Callers that are evaluated but never

--- a/plugins/governance/store.go
+++ b/plugins/governance/store.go
@@ -118,6 +118,21 @@ type BudgetAndRateLimitStatus struct {
 	RateLimitRequestPercentUsed float64 `json:"rate_limit_request_percent_used"` // 0-100, >100 means exhausted
 }
 
+// AccessModelLimitGatherer is the optional GovernanceStore capability for requests whose
+// caller-facing authorization name differs from the physical model sent to the provider.
+// Custom stores that select permit-funded limits by model should implement it. Keeping it
+// separate from GovernanceStore preserves source compatibility with existing implementations.
+type AccessModelLimitGatherer interface {
+	GatherLimitsForAccessModel(ctx *schemas.BifrostContext, access schemas.Access, provider schemas.ModelProvider, model, accessModel string) (budgets []schemas.Limit, rateLimits []schemas.Limit, err error)
+}
+
+// AccessModelCandidateChecker is the load-balancing counterpart to
+// AccessModelLimitGatherer. The physical model selects model-scoped limits; accessModel selects
+// the permits that authorize and fund the candidate.
+type AccessModelCandidateChecker interface {
+	CheckProviderCandidateExclusionForAccessModel(ctx *schemas.BifrostContext, access schemas.Access, candidate schemas.ProviderCandidate, model, accessModel string) (Decision, error)
+}
+
 // GovernanceStore defines the interface for governance data access and policy evaluation.
 //
 // Error semantics contract:
@@ -1389,8 +1404,18 @@ func recordVirtualKeyIdentity(ctx *schemas.BifrostContext, virtualKey *configsto
 // model on the candidate's provider is funded on it, and a candidate is affordable only when all of
 // them have room), and which per-model configs cover the pair on this provider and no other.
 func (gs *LocalGovernanceStore) CheckProviderCandidateExclusion(ctx *schemas.BifrostContext, access schemas.Access, candidate schemas.ProviderCandidate, model string) (Decision, error) {
+	return gs.CheckProviderCandidateExclusionForAccessModel(ctx, access, candidate, model, model)
+}
+
+// CheckProviderCandidateExclusionForAccessModel keeps authorization and charging identities
+// separate: permits are selected by the caller-facing accessModel, while provider-scoped model
+// limits are selected by the physical model that the candidate would serve.
+func (gs *LocalGovernanceStore) CheckProviderCandidateExclusionForAccessModel(ctx *schemas.BifrostContext, access schemas.Access, candidate schemas.ProviderCandidate, model, accessModel string) (Decision, error) {
 	if spendingChecksSkipped(ctx) {
 		return DecisionAllow, nil
+	}
+	if accessModel == "" {
+		accessModel = model
 	}
 
 	provider := schemas.ModelProvider(candidate.Provider)
@@ -1399,7 +1424,7 @@ func (gs *LocalGovernanceStore) CheckProviderCandidateExclusion(ctx *schemas.Bif
 	budgets = append(budgets, modelBudgets...)
 	rateLimits = append(rateLimits, modelRateLimits...)
 	if access != nil {
-		for _, permit := range access.PermitsForModel(candidate.Provider, model) {
+		for _, permit := range access.PermitsForModel(candidate.Provider, accessModel) {
 			permitBudgets, permitRateLimits := gs.PermitProviderLimits(ctx, permit, provider)
 			budgets = append(budgets, permitBudgets...)
 			rateLimits = append(rateLimits, permitRateLimits...)
@@ -4620,6 +4645,15 @@ func (gs *LocalGovernanceStore) updateRateLimitReferences(ctx context.Context, r
 // store resolves one permit per credential, so there is nothing to pick between, and one limit
 // reached twice is still one limit once the list is settled.
 func (gs *LocalGovernanceStore) GatherLimits(ctx *schemas.BifrostContext, access schemas.Access, provider schemas.ModelProvider, model string) (budgets []schemas.Limit, rateLimits []schemas.Limit, err error) {
+	return gs.GatherLimitsForAccessModel(ctx, access, provider, model, model)
+}
+
+// GatherLimitsForAccessModel gathers physical-model limits while attributing provider-level
+// permit funding to the caller-facing model that authorized the request.
+func (gs *LocalGovernanceStore) GatherLimitsForAccessModel(ctx *schemas.BifrostContext, access schemas.Access, provider schemas.ModelProvider, model, accessModel string) (budgets []schemas.Limit, rateLimits []schemas.Limit, err error) {
+	if accessModel == "" {
+		accessModel = model
+	}
 	budgets, rateLimits = gs.GlobalProviderLimits(ctx, provider)
 	globalModelBudgets, globalModelRateLimits := gs.GlobalModelLimits(ctx, provider, model)
 	budgets = append(budgets, globalModelBudgets...)
@@ -4642,7 +4676,7 @@ func (gs *LocalGovernanceStore) GatherLimits(ctx *schemas.BifrostContext, access
 		budgets = append(budgets, modelBudgets...)
 		rateLimits = append(rateLimits, modelRateLimits...)
 	}
-	for _, permit := range access.PermitsForModel(string(provider), model) {
+	for _, permit := range access.PermitsForModel(string(provider), accessModel) {
 		providerBudgets, providerRateLimits := gs.PermitProviderLimits(ctx, permit, provider)
 		budgets = append(budgets, providerBudgets...)
 		rateLimits = append(rateLimits, providerRateLimits...)
@@ -4651,7 +4685,7 @@ func (gs *LocalGovernanceStore) GatherLimits(ctx *schemas.BifrostContext, access
 }
 
 func (gs *LocalGovernanceStore) GetBudgetAndRateLimitStatus(ctx *schemas.BifrostContext, provider schemas.ModelProvider, model string, budgetBaselines map[string]float64, tokenBaselines map[string]int64, requestBaselines map[string]int64) *BudgetAndRateLimitStatus {
-	budgets, rateLimits, _ := gs.GatherLimits(ctx, ctx.Grant().Access(), provider, model)
+	budgets, rateLimits, _ := gs.GatherLimitsForAccessModel(ctx, ctx.Grant().Access(), provider, model, accessModelForRequest(ctx, model, nil))
 	status := &BudgetAndRateLimitStatus{}
 
 	for _, limit := range budgets {

--- a/plugins/governance/test_utils.go
+++ b/plugins/governance/test_utils.go
@@ -389,7 +389,7 @@ func evaluateGrantedRequest(r *BudgetResolver, ctx *schemas.BifrostContext, acce
 	}
 	// Evaluate settles the limits on the grant before any check runs; a test reaching the resolver
 	// directly has to do the same, or it checks an attempt nothing has been settled for.
-	limits, err := resolveLimits(ctx, r.store, provider, model)
+	limits, err := resolveLimits(ctx, r.store, provider, model, model)
 	if err != nil {
 		return &EvaluationResult{Decision: DecisionAccessBlocked, Reason: err.Error()}
 	}
@@ -414,7 +414,7 @@ func resolveLimitsForTest(r *BudgetResolver, ctx *schemas.BifrostContext, provid
 // settleAttemptLimits is resolveLimits for a test driving a store directly, dropping the settling
 // error: the store under test resolves one permit per credential and never fails to settle.
 func settleAttemptLimits(ctx *schemas.BifrostContext, store GovernanceStore, provider schemas.ModelProvider, model string) schemas.Limits {
-	limits, _ := resolveLimits(ctx, store, provider, model)
+	limits, _ := resolveLimits(ctx, store, provider, model, model)
 	return limits
 }
 

--- a/tests/e2e/api/collections/bifrost-routing-wiring.postman_collection.json
+++ b/tests/e2e/api/collections/bifrost-routing-wiring.postman_collection.json
@@ -17098,6 +17098,402 @@
       ]
     },
     {
+      "name": "Routing-rule alias remains the governance boundary (#7112)",
+      "description": "Regression #7112: governance captures the caller-facing alias before a routing rule rewrites it to a physical provider/model. A VK that allows only the alias must admit the request, while the provider still receives the physical target.",
+      "item": [
+        {
+          "id": "rt-routing-rule-alias-governance-7112-01-add-provider",
+          "name": "01. add provider [routing-rule-alias-governance-7112]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete routing rule [routing-rule-alias-governance-7112]\";",
+                  "pm.test(\"01. add provider [routing-rule-alias-governance-7112]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"provider\":\"catwiring-rt-routing-rule-alias-governance-7112-{{run_id}}\",\"custom_provider_config\":{\"base_provider_type\":\"openai\",\"is_key_less\":false}}"
+            }
+          }
+        },
+        {
+          "id": "rt-routing-rule-alias-governance-7112-02-add-key",
+          "name": "02. add key k1 [routing-rule-alias-governance-7112]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var acceptable = [200,201];",
+                  "var cleanupReq = \"cleanup: delete routing rule [routing-rule-alias-governance-7112]\";",
+                  "pm.test(\"02. add key k1 [routing-rule-alias-governance-7112]\", function () {",
+                  "  pm.expect(acceptable, 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (acceptable.indexOf(pm.response.code) < 0) { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/providers/catwiring-rt-routing-rule-alias-governance-7112-{{run_id}}/keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "providers",
+                "catwiring-rt-routing-rule-alias-governance-7112-{{run_id}}",
+                "keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"id\":\"k1-{{run_id}}\",\"name\":\"catwiring-rt-routing-rule-alias-governance-7112-k1-{{run_id}}\",\"models\":[\"*\"],\"enabled\":true,\"value\":\"env.OPENAI_API_KEY\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-routing-rule-alias-governance-7112-03-create-vk",
+          "name": "03. create vk [routing-rule-alias-governance-7112]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete routing rule [routing-rule-alias-governance-7112]\";",
+                  "var ok = pm.response.code === 200 || pm.response.code === 201;",
+                  "pm.test(\"03. create vk [routing-rule-alias-governance-7112]\", function () {",
+                  "  pm.expect([200, 201], 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (ok) {",
+                  "  var vk = (pm.response.json() || {}).virtual_key || {};",
+                  "  pm.collectionVariables.set('vkval_routing-rule-alias-governance-7112', vk.value || '');",
+                  "  pm.collectionVariables.set('vkid_routing-rule-alias-governance-7112', vk.id || '');",
+                  "} else { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/governance/virtual-keys",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "governance",
+                "virtual-keys"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"catwiring-rtvk-routing-rule-alias-governance-7112-{{run_id}}\",\"is_active\":true,\"provider_configs\":[{\"provider\":\"catwiring-rt-routing-rule-alias-governance-7112-{{run_id}}\",\"key_ids\":[\"*\"],\"allowed_models\":[\"catwiring-rule-alias-{{run_id}}\"],\"blacklisted_models\":[],\"weight\":1}]}"
+            }
+          }
+        },
+        {
+          "id": "rt-routing-rule-alias-governance-7112-04-create-routing-rule",
+          "name": "04. create routing rule [routing-rule-alias-governance-7112]",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var cleanupReq = \"cleanup: delete routing rule [routing-rule-alias-governance-7112]\";",
+                  "var ok = pm.response.code === 200 || pm.response.code === 201;",
+                  "pm.test(\"04. create routing rule [routing-rule-alias-governance-7112]\", function () {",
+                  "  pm.expect([200, 201], 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+                  "});",
+                  "if (ok) {",
+                  "  var rule = (pm.response.json() || {}).rule || {};",
+                  "  pm.collectionVariables.set('ruleid_routing-rule-alias-governance-7112', rule.id || '');",
+                  "} else { pm.execution.setNextRequest(cleanupReq); }"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/routing/rules",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "routing",
+                "rules"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"name\":\"catwiring-rtrule-routing-rule-alias-governance-7112-{{run_id}}\",\"enabled\":true,\"cel_expression\":\"model == 'catwiring-rule-alias-{{run_id}}'\",\"targets\":[{\"provider\":\"catwiring-rt-routing-rule-alias-governance-7112-{{run_id}}\",\"model\":\"gpt-4o-mini\",\"weight\":1}],\"scope\":\"global\"}"
+            }
+          }
+        },
+        {
+          "id": "rt-routing-rule-alias-governance-7112-05-route",
+          "name": "05. caller alias routes to physical model under VK alias grant (#7112) [routing-rule-alias-governance-7112]",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var pollKey = '__poll_' + pm.info.requestName;",
+                  "var attempt = parseInt(pm.collectionVariables.get(pollKey) || '0', 10);",
+                  "pm.collectionVariables.set('__cur_poll_key', pollKey);",
+                  "pm.collectionVariables.set('__cur_poll_attempt', String(attempt));",
+                  "if (attempt === 0) { var __ws = Date.now(); while (Date.now() - __ws < 1000) {} }"
+                ]
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "var maxAttempts = 8;",
+                  "var pollKey = pm.collectionVariables.get('__cur_poll_key');",
+                  "var attempt = parseInt(pm.collectionVariables.get('__cur_poll_attempt') || '0', 10);",
+                  "var cleanupReq = \"cleanup: delete routing rule [routing-rule-alias-governance-7112]\";",
+                  "function assertNow() {",
+                  "  if (pm.response.code !== 200) { throw new Error('route status ' + pm.response.code + ' body ' + pm.response.text()); }",
+                  "  var body = pm.response.json();",
+                  "  if (!body.choices || body.choices.length === 0) { throw new Error('no choices'); }",
+                  "  var ri = (body.extra_fields || {}).routing_info || {};",
+                  "  var providerName = 'catwiring-rt-routing-rule-alias-governance-7112-' + pm.variables.get('run_id');",
+                  "  if (ri.provider !== providerName) { throw new Error('routing_info.provider=' + ri.provider + ' expected ' + providerName); }",
+                  "  var expectedKey = 'catwiring-rt-routing-rule-alias-governance-7112-k1-' + pm.variables.get('run_id');",
+                  "  if (ri.key !== expectedKey) { throw new Error('routing_info.key=' + ri.key + ' expected ' + expectedKey); }",
+                  "  if (ri.model !== \"gpt-4o-mini\") { throw new Error('routing_info.model=' + ri.model); }",
+                  "}",
+                  "var ok = true, errMsg = '';",
+                  "try { assertNow(); } catch (e) { ok = false; errMsg = e.message; }",
+                  "if (ok) {",
+                  "  pm.collectionVariables.set(pollKey, '0');",
+                  "  pm.test(\"05. caller alias routes to physical model under VK alias grant (#7112) [routing-rule-alias-governance-7112]\", function () { pm.expect(true, 'assertion satisfied').to.be.true; });",
+                  "} else if (attempt < maxAttempts) {",
+                  "  pm.collectionVariables.set(pollKey, String(attempt + 1));",
+                  "  var sleepMs = Math.min(250 * Math.pow(2, attempt), 4000);",
+                  "  var start = Date.now(); while (Date.now() - start < sleepMs) {}",
+                  "  pm.execution.setNextRequest(pm.info.requestName);",
+                  "} else {",
+                  "  pm.collectionVariables.set(pollKey, '0');",
+                  "  pm.test(\"05. caller alias routes to physical model under VK alias grant (#7112) [routing-rule-alias-governance-7112]\", function () { throw new Error(errMsg); });",
+                  "  pm.execution.setNextRequest(cleanupReq);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "x-bf-vk",
+                "value": "{{vkval_routing-rule-alias-governance-7112}}"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/v1/chat/completions",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "v1",
+                "chat",
+                "completions"
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\"model\":\"catwiring-rule-alias-{{run_id}}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with the single word: ok.\"}],\"max_tokens\":5}"
+            }
+          }
+        },
+        {
+          "name": "Cleanup",
+          "item": [
+            {
+              "id": "rt-routing-rule-alias-governance-7112-cleanup-rule",
+              "name": "cleanup: delete routing rule [routing-rule-alias-governance-7112]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete routing rule [routing-rule-alias-governance-7112]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/routing/rules/{{ruleid_routing-rule-alias-governance-7112}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "routing",
+                    "rules",
+                    "{{ruleid_routing-rule-alias-governance-7112}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-routing-rule-alias-governance-7112-cleanup-vk",
+              "name": "cleanup: delete vk [routing-rule-alias-governance-7112]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete vk [routing-rule-alias-governance-7112]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/governance/virtual-keys/{{vkid_routing-rule-alias-governance-7112}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "governance",
+                    "virtual-keys",
+                    "{{vkid_routing-rule-alias-governance-7112}}"
+                  ]
+                }
+              }
+            },
+            {
+              "id": "rt-routing-rule-alias-governance-7112-cleanup-provider-self",
+              "name": "cleanup: delete provider [routing-rule-alias-governance-7112]",
+              "event": [
+                {
+                  "listen": "test",
+                  "script": {
+                    "type": "text/javascript",
+                    "exec": [
+                      "pm.test(\"cleanup: delete provider [routing-rule-alias-governance-7112]\", function () {",
+                      "  pm.expect([200, 204, 404], 'cleanup status ' + pm.response.code).to.include(pm.response.code);",
+                      "});"
+                    ]
+                  }
+                }
+              ],
+              "request": {
+                "method": "DELETE",
+                "header": [],
+                "url": {
+                  "raw": "{{base_url}}/api/providers/catwiring-rt-routing-rule-alias-governance-7112-{{run_id}}",
+                  "host": [
+                    "{{base_url}}"
+                  ],
+                  "path": [
+                    "api",
+                    "providers",
+                    "catwiring-rt-routing-rule-alias-governance-7112-{{run_id}}"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      ],
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "type": "text/javascript",
+            "exec": [
+              "var required = [];",
+              "for (var i = 0; i < required.length; i++) {",
+              "  var v = required[i];",
+              "  if (!pm.variables.get(v) && !pm.environment.get(v)) {",
+              "    console.log('SKIP: missing ' + v);",
+              "    pm.execution.skipRequest();",
+              "    return;",
+              "  }",
+              "}"
+            ]
+          }
+        }
+      ]
+    },
+    {
       "name": "Alias name not whitelisted is blocked",
       "description": "The VK whitelists the resolved model id, but the request uses the alias name; the alias isn't in allowed_models, so the provider is pruned from the routing allowlist and core rejects with a 'provider not permitted' 400 (intended).",
       "item": [

--- a/tests/e2e/api/runners/build-routing-wiring.mjs
+++ b/tests/e2e/api/runners/build-routing-wiring.mjs
@@ -167,6 +167,9 @@ function routeAssertLines(sid, step, jsNameOf) {
       lines.push(`var expectedKey = ${jsKeyName(sid, step.expectKeyId)};`);
       lines.push("if (ri.key !== expectedKey) { throw new Error('routing_info.key=' + ri.key + ' expected ' + expectedKey); }");
     }
+    if (step.expectModel != null) {
+      lines.push(`if (ri.model !== ${JSON.stringify(step.expectModel)}) { throw new Error('routing_info.model=' + ri.model); }`);
+    }
     if (step.expectResolvedModelId != null) {
       lines.push(
         `if (!ri.resolved_key_alias || ri.resolved_key_alias.model_id !== ${JSON.stringify(step.expectResolvedModelId)}) { throw new Error('resolved_key_alias=' + JSON.stringify(ri.resolved_key_alias)); }`
@@ -296,6 +299,22 @@ function captureVkTest(testname, sid, cleanupName) {
   ];
 }
 
+// Capture a routing rule id so the scenario can remove its global rule before deleting the VK
+// and provider it references.
+function captureRoutingRuleTest(testname, sid, cleanupName) {
+  return [
+    `var cleanupReq = ${JSON.stringify(cleanupName)};`,
+    "var ok = pm.response.code === 200 || pm.response.code === 201;",
+    `pm.test(${JSON.stringify(testname)}, function () {`,
+    "  pm.expect([200, 201], 'status ' + pm.response.code + ' body ' + pm.response.text()).to.include(pm.response.code);",
+    "});",
+    "if (ok) {",
+    "  var rule = (pm.response.json() || {}).rule || {};",
+    `  pm.collectionVariables.set('ruleid_${sid}', rule.id || '');`,
+    "} else { pm.execution.setNextRequest(cleanupReq); }",
+  ];
+}
+
 // --------------------------------------------------------------------------- //
 // Step expansion
 // --------------------------------------------------------------------------- //
@@ -305,12 +324,13 @@ function expandScenario(sc) {
   const seg = providerSeg(sid);
   const cleanupProvider = `cleanup: delete provider [${sid}]`;
   const cleanupVk = `cleanup: delete vk [${sid}]`;
+  const cleanupRule = `cleanup: delete routing rule [${sid}]`;
   // A failing step jumps to the FIRST cleanup item so the whole teardown runs in
-  // order. When the scenario has a VK, that first item is the VK delete (the
-  // provider delete follows it); jumping straight to the provider delete would
-  // skip the VK and leak it.
+  // order. A routing rule is removed before the VK and providers it references;
+  // jumping to a later cleanup item would skip earlier resources and leak them.
   const hasVkScenario = sc.steps.some((s) => s.type === "createVK");
-  const cleanupTarget = hasVkScenario ? cleanupVk : cleanupProvider;
+  const hasRuleScenario = sc.steps.some((s) => s.type === "createRoutingRule");
+  const cleanupTarget = hasRuleScenario ? cleanupRule : hasVkScenario ? cleanupVk : cleanupProvider;
   // A scenario may stand up more than one provider (e.g. governance LB across
   // providers). ref "self" is the scenario's primary provider; any other ref
   // gets its own run-scoped name. All created providers are torn down.
@@ -342,6 +362,7 @@ function expandScenario(sc) {
   let counter = 0;
   let ordinal = 0;
   let hasVk = false;
+  let hasRule = false;
   const nextId = (tag) => `rt-${sid}-${String(++counter).padStart(2, "0")}-${tag}`;
   const uniq = (label) => `${String(++ordinal).padStart(2, "0")}. ${label} [${sid}]`;
 
@@ -389,6 +410,25 @@ function expandScenario(sc) {
         const name = uniq("create vk");
         items.push(item(nextId("create-vk"), name, request("POST", url(["api", "governance", "virtual-keys"]), body),
           events(null, captureVkTest(name, sid, cleanupTarget))));
+        break;
+      }
+      case "createRoutingRule": {
+        hasRule = true;
+        const targets = (step.targets || []).map((target) => ({
+          provider: nameOf(target.providerRef),
+          model: target.model,
+          weight: target.weight ?? 1,
+        }));
+        const body = {
+          name: `catwiring-rtrule-${sid}-{{run_id}}`,
+          enabled: true,
+          cel_expression: step.celExpression,
+          targets,
+          scope: "global",
+        };
+        const name = uniq("create routing rule");
+        items.push(item(nextId("create-routing-rule"), name, request("POST", url(["api", "routing", "rules"]), body),
+          events(null, captureRoutingRuleTest(name, sid, cleanupTarget))));
         break;
       }
       case "route": {
@@ -520,6 +560,11 @@ function expandScenario(sc) {
   }
 
   const cleanupItems = [];
+  if (hasRule) {
+    cleanupItems.push(item(`rt-${sid}-cleanup-rule`, cleanupRule,
+      request("DELETE", url(["api", "routing", "rules", `{{ruleid_${sid}}}`]), null),
+      events(null, cleanupTest(cleanupRule))));
+  }
   if (hasVk) {
     cleanupItems.push(item(`rt-${sid}-cleanup-vk`, cleanupVk,
       request("DELETE", url(["api", "governance", "virtual-keys", `{{vkid_${sid}}}`]), null),
@@ -964,6 +1009,31 @@ const SCENARIOS = [
       { type: "addProvider", keys: [key({ id: "k1", models: ["catwiring-alias-{{run_id}}"], aliases: { "catwiring-alias-{{run_id}}": MODEL_B } })] },
       { type: "createVK", providerConfigs: [vkProvider({ allowedModels: ["catwiring-alias-{{run_id}}"] })] },
       { type: "route", model: "catwiring-alias-{{run_id}}", expectStatus: 200, expectResolvedModelId: MODEL_B, waitSeconds: 1, label: "alias routes, resolves to model id" },
+      { type: "cleanup" },
+    ],
+  },
+  {
+    id: "routing-rule-alias-governance-7112",
+    title: "Routing-rule alias remains the governance boundary (#7112)",
+    description: "Regression #7112: governance captures the caller-facing alias before a routing rule rewrites it to a physical provider/model. A VK that allows only the alias must admit the request, while the provider still receives the physical target.",
+    steps: [
+      { type: "addProvider", keys: [key({ id: "k1", models: ["*"] })] },
+      { type: "createVK", providerConfigs: [vkProvider({ allowedModels: ["catwiring-rule-alias-{{run_id}}"] })] },
+      {
+        type: "createRoutingRule",
+        celExpression: "model == 'catwiring-rule-alias-{{run_id}}'",
+        targets: [{ providerRef: "self", model: MODEL_B, weight: 1 }],
+      },
+      {
+        type: "route",
+        model: "catwiring-rule-alias-{{run_id}}",
+        bareModel: true,
+        expectStatus: 200,
+        expectKeyId: "k1",
+        expectModel: MODEL_B,
+        waitSeconds: 1,
+        label: "caller alias routes to physical model under VK alias grant (#7112)",
+      },
       { type: "cleanup" },
     ],
   },


### PR DESCRIPTION
## Summary

Fixes #7112 by preserving the caller-facing model as the governance authorization boundary when routing rules rewrite it to a physical provider/model.

Previously, a virtual key could allow an alias such as `my.alias`, but governance would evaluate the routed `physical-model` and incorrectly reject the request as `model_blocked`.

## Changes

- Capture the caller-facing model in `PreRequestHook` before routing mutations occur.
- Read the original model from `LargePayloadMetadata` when the parsed request does not contain it.
- Introduce a separate `AccessModel` for provider, model, and key authorization.
- Continue using the physical `Model` for provider execution, model-scoped limits, and accounting.
- Use the caller-facing model when publishing routing provider allowlists and selecting load-balancing candidates.
- Preserve provider-funded budget and rate-limit attribution by selecting permits with the access model while evaluating physical-model limits.
- Distinguish caller-provided fallbacks from routing/governance-generated fallbacks:
  - Caller fallbacks remain independently authorized.
  - Operator-generated fallbacks inherit the primary alias authorization.
  - A fixed-size SHA-256 fingerprint identifies the original fallback list without storing request-sized data in `BifrostContext`.
  - Requests without caller fallbacks avoid the fingerprinting path.
- Add the optional `AccessModelLimitGatherer` and `AccessModelCandidateChecker` interfaces for custom governance stores.
  - The existing `GovernanceStore` method set remains unchanged for source compatibility.
- Add regression tests covering model allowlists, blacklists, provider allowlists, key restrictions, budgets, large payloads, and fallback provenance.
- Add a generated Postman regression scenario for #7112.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [ ] Core (Go)
- [ ] Transports (HTTP)
- [ ] Providers/Integrations
- [x] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

Run the Governance tests, including the race detector and static analysis:

```sh
cd plugins/governance

go test ./...
go test -race ./...
go vet ./...
```

Expected outcome: all Governance tests and static checks pass.

Run the Routing plugin tests and static analysis:

```sh
cd plugins/routing

go test ./...
go vet ./...
```

Expected outcome: all Routing, complexity, and rules package tests pass.

Validate the generated Postman collection:

```sh
node --check tests/e2e/api/runners/build-routing-wiring.mjs

node tests/e2e/api/runners/build-routing-wiring.mjs \
  --out /tmp/bifrost-routing-wiring.json

cmp \
  /tmp/bifrost-routing-wiring.json \
  tests/e2e/api/collections/bifrost-routing-wiring.postman_collection.json
```

Expected outcome:

- The builder passes the syntax check.
- It generates 40 scenarios.
- The #7112 scenario contains 8 executable requests.
- `cmp` reports no differences.

Focused regression coverage verifies that:

- An allowed alias can route to a physical model.
- An unauthorized direct physical-model request remains blocked.
- Alias and physical-model blacklists are applied to the correct identity.
- Provider allowlists and load-balancing candidates use the caller-facing alias.
- Provider key restrictions are selected from the alias permit.
- Physical-model limits and accounting remain attached to the physical model.
- Large-payload requests preserve the alias from metadata.
- Caller-provided fallbacks remain independently authorized.
- Server and routing-generated fallbacks inherit the primary alias.
- Routing replacement of a caller fallback list is not misclassified.

No new configuration or environment variables are introduced.

The live paid-provider Postman scenario was not executed because no `HARNESS_MAX_REQUESTS` ceiling was supplied.

## Screenshots/Recordings

Not applicable; this PR does not change the UI.

## Breaking changes

- [ ] Yes
- [x] No

The existing `GovernanceStore` interface is unchanged. Custom stores may optionally implement `AccessModelLimitGatherer` and `AccessModelCandidateChecker` to support separate caller-facing and physical model identities.

## Related issues

Closes #7112

## Security considerations

This change preserves the caller-facing model as the authorization boundary without granting access to arbitrary physical models.

- Direct requests for unauthorized physical models remain blocked.
- Caller-provided fallbacks cannot inherit authorization from the primary alias.
- Alias blacklists and provider key restrictions remain enforced.
- Operator-generated routing targets and fallbacks may inherit the authorized alias.
- Only a fixed-size fallback fingerprint is stored in `BifrostContext`; the fallback list and other request-sized data are not retained.
- No secrets or PII are added to logs or context.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [x] I updated documentation where needed
- [x] I verified builds succeed (Go and UI)
- [x] I verified the CI pipeline passes locally if applicable