### PR TITLE
fix: filter credential-bearing provider response headers by classifier

### DIFF
--- a/core/providers/utils/utils.go
+++ b/core/providers/utils/utils.go
@@ -919,7 +919,10 @@ func filterHeaders(headers map[string][]string) map[string][]string {
 }
 
 // providerResponseFilterHeaders are headers to exclude when forwarding provider response headers.
-// These are transport-level headers that don't apply when re-serving the response.
+// These are transport-level headers that don't apply when re-serving the response, plus the
+// exact credential names from the /genai_passthrough leak (#3954). It is one of the two rules
+// applied by shouldFilterProviderResponseHeader; the other catches credential names this list
+// does not enumerate.
 var providerResponseFilterHeaders = map[string]bool{
 	"content-length":                   true,
 	"content-encoding":                 true,
@@ -954,8 +957,22 @@ var providerResponseFilterHeaders = map[string]bool{
 	"access-control-max-age":           true,
 }
 
+// shouldFilterProviderResponseHeader reports whether a provider response header must not be
+// re-served to the caller. The name is expected to already be lowercased.
+//
+// Two rules apply. A header is dropped when it is a transport-level or known-credential name in
+// providerResponseFilterHeaders, or when schemas.IsSensitiveHeader classifies its name as
+// credential-bearing. The second rule exists because a name-by-name denylist necessarily lags:
+// network_config.extra_headers supports arbitrary custom authentication headers, and some
+// upstreams echo request headers back (e.g. Google's file-download 302), so the set of credential
+// names that can appear in a provider response is open-ended. Sharing the classifier already used
+// by the telemetry redaction path keeps the two definitions of "credential" from diverging.
+func shouldFilterProviderResponseHeader(nameLower string) bool {
+	return providerResponseFilterHeaders[nameLower] || schemas.IsSensitiveHeader(nameLower)
+}
+
 // ExtractProviderResponseHeaders extracts and filters response headers from a
-// fasthttp response. Transport-level headers are excluded.
+// fasthttp response. Transport-level and credential-bearing headers are excluded.
 func ExtractProviderResponseHeaders(resp *fasthttp.Response) map[string]string {
 	if resp == nil {
 		return nil
@@ -963,7 +980,7 @@ func ExtractProviderResponseHeaders(resp *fasthttp.Response) map[string]string {
 	headers := make(map[string]string)
 	resp.Header.VisitAll(func(key, value []byte) {
 		k := string(key)
-		if providerResponseFilterHeaders[strings.ToLower(k)] {
+		if shouldFilterProviderResponseHeader(strings.ToLower(k)) {
 			return
 		}
 		v := string(value)
@@ -980,7 +997,8 @@ func ExtractProviderResponseHeaders(resp *fasthttp.Response) map[string]string {
 }
 
 // ExtractPassthroughProviderResponseHeaders extracts and filters response headers from a
-// fasthttp response. Transport-level headers are excluded.
+// fasthttp response. Transport-level and credential-bearing headers are excluded, except
+// content-type, which the passthrough response must retain.
 func ExtractPassthroughProviderResponseHeaders(resp *fasthttp.Response) map[string]string {
 	if resp == nil {
 		return nil
@@ -989,7 +1007,7 @@ func ExtractPassthroughProviderResponseHeaders(resp *fasthttp.Response) map[stri
 	resp.Header.VisitAll(func(key, value []byte) {
 		k := string(key)
 		kLower := strings.ToLower(k)
-		if providerResponseFilterHeaders[kLower] && kLower != "content-type" {
+		if shouldFilterProviderResponseHeader(kLower) && kLower != "content-type" {
 			return
 		}
 		v := string(value)
@@ -1006,15 +1024,15 @@ func ExtractPassthroughProviderResponseHeaders(resp *fasthttp.Response) map[stri
 }
 
 // ExtractProviderResponseHeadersFromHTTP extracts and filters response headers
-// from a standard net/http response. Transport-level headers are excluded.
-// Used by providers like Bedrock that use net/http instead of fasthttp.
+// from a standard net/http response. Transport-level and credential-bearing headers
+// are excluded. Used by providers like Bedrock that use net/http instead of fasthttp.
 func ExtractProviderResponseHeadersFromHTTP(resp *http.Response) map[string]string {
 	if resp == nil {
 		return nil
 	}
 	headers := make(map[string]string)
 	for k, values := range resp.Header {
-		if !providerResponseFilterHeaders[strings.ToLower(k)] && len(values) > 0 {
+		if !shouldFilterProviderResponseHeader(strings.ToLower(k)) && len(values) > 0 {
 			headers[k] = strings.Join(values, ", ")
 		}
 	}

--- a/core/providers/utils/utils_test.go
+++ b/core/providers/utils/utils_test.go
@@ -2046,6 +2046,139 @@ func TestExtractPassthroughProviderResponseHeaders(t *testing.T) {
 	}
 }
 
+// providerResponseSensitiveHeaderCases is shared by the three extractor tests below so the
+// paths cannot drift apart again. Every "drop" name is credential-bearing under
+// schemas.IsSensitiveHeader but absent from providerResponseFilterHeaders, which is exactly the
+// gap that let an operator's network_config.extra_headers credential reach inference callers.
+var providerResponseSensitiveHeaderCases = []struct {
+	name  string
+	value string
+	drop  bool
+	why   string
+}{
+	// Credential names the fixed list does not enumerate.
+	{"X-Provider-Secret", "provider-secret-value", true, "contains \"secret\""},
+	{"X-Auth-Token", "auth-token-value", true, "suffix \"-token\""},
+	{"X-Session_Token", "session-token-value", true, "suffix \"_token\""},
+	{"X-Custom-Api-Key", "custom-api-key-value", true, "contains \"api-key\""},
+	{"X-Proxy-Authorization-Hint", "proxy-auth-value", true, "contains \"authorization\""},
+	{"Cf-Access-Jwt-Assertion", "signed-jwt-value", true, "prefix \"cf-access-\""},
+	{"X-Amzn-Oidc-Data", "oidc-data-value", true, "prefix \"x-amzn-oidc-\""},
+	// Names already covered by the fixed list, which must keep working.
+	{"X-Goog-Api-Key", "goog-api-key-value", true, "existing denylist entry"},
+	{"Authorization", "Bearer token-value", true, "existing denylist entry"},
+	// Benign provider headers that callers rely on and must survive.
+	{"X-Request-Id", "req-789", false, "benign correlation header"},
+	{"Retry-After", "30", false, "benign retry hint"},
+	{"X-Ratelimit-Remaining-Requests", "42", false, "benign rate-limit hint"},
+}
+
+// lookupHeaderFold finds a header case-insensitively, since fasthttp canonicalizes keys.
+func lookupHeaderFold(headers map[string]string, name string) (string, bool) {
+	for k, v := range headers {
+		if strings.EqualFold(k, name) {
+			return v, true
+		}
+	}
+	return "", false
+}
+
+// assertSensitiveHeaderCases checks one extractor's output against the shared table.
+func assertSensitiveHeaderCases(t *testing.T, extractor string, headers map[string]string) {
+	t.Helper()
+	for _, tc := range providerResponseSensitiveHeaderCases {
+		got, ok := lookupHeaderFold(headers, tc.name)
+		if tc.drop && ok {
+			t.Errorf("%s: header %q (%s) leaked to the client with value %q", extractor, tc.name, tc.why, got)
+		}
+		if !tc.drop && (!ok || got != tc.value) {
+			t.Errorf("%s: benign header %q (%s) should be forwarded as %q, got %q ok=%v",
+				extractor, tc.name, tc.why, tc.value, got, ok)
+		}
+	}
+}
+
+// TestProviderResponseSensitiveHeaderCases_MatchClassifier guards the table itself: every name
+// marked drop must really be rejected by shouldFilterProviderResponseHeader, and every name
+// marked keep must really be accepted. Without this, a typo in the table would silently weaken
+// the three extractor tests below into asserting nothing.
+func TestProviderResponseSensitiveHeaderCases_MatchClassifier(t *testing.T) {
+	for _, tc := range providerResponseSensitiveHeaderCases {
+		lower := strings.ToLower(tc.name)
+		if got := shouldFilterProviderResponseHeader(lower); got != tc.drop {
+			t.Errorf("shouldFilterProviderResponseHeader(%q) = %v, want %v (%s)", lower, got, tc.drop, tc.why)
+		}
+	}
+}
+
+// TestExtractProviderResponseHeaders_StripsSensitiveCustomHeaders verifies that the response
+// filter consults schemas.IsSensitiveHeader and not just the fixed name list, so credential
+// headers the list does not enumerate stop reaching inference callers.
+func TestExtractProviderResponseHeaders_StripsSensitiveCustomHeaders(t *testing.T) {
+	resp := &fasthttp.Response{}
+	for _, tc := range providerResponseSensitiveHeaderCases {
+		resp.Header.Set(tc.name, tc.value)
+	}
+
+	assertSensitiveHeaderCases(t, "ExtractProviderResponseHeaders", ExtractProviderResponseHeaders(resp))
+}
+
+// TestExtractPassthroughProviderResponseHeaders_StripsSensitiveCustomHeaders verifies the same
+// for the passthrough variant, and that its content-type carve-out is unaffected: content-type
+// is not credential-bearing, so the added rule must not change its verdict.
+func TestExtractPassthroughProviderResponseHeaders_StripsSensitiveCustomHeaders(t *testing.T) {
+	resp := &fasthttp.Response{}
+	for _, tc := range providerResponseSensitiveHeaderCases {
+		resp.Header.Set(tc.name, tc.value)
+	}
+	resp.Header.Set("Content-Type", "application/json")
+
+	headers := ExtractPassthroughProviderResponseHeaders(resp)
+	assertSensitiveHeaderCases(t, "ExtractPassthroughProviderResponseHeaders", headers)
+
+	if v, ok := lookupHeaderFold(headers, "content-type"); !ok || v != "application/json" {
+		t.Fatalf("passthrough content-type carve-out regressed: got %q ok=%v", v, ok)
+	}
+}
+
+// TestExtractProviderResponseHeadersFromHTTP_StripsSensitiveCustomHeaders verifies the same for
+// the net/http extractor used by providers such as Bedrock, which shares the identical filter.
+func TestExtractProviderResponseHeadersFromHTTP_StripsSensitiveCustomHeaders(t *testing.T) {
+	resp := &http.Response{Header: http.Header{}}
+	for _, tc := range providerResponseSensitiveHeaderCases {
+		resp.Header.Set(tc.name, tc.value)
+	}
+
+	assertSensitiveHeaderCases(t, "ExtractProviderResponseHeadersFromHTTP", ExtractProviderResponseHeadersFromHTTP(resp))
+}
+
+// TestProviderResponseExtractors_AgreeOnSensitiveHeaders pins the three extractors to the same
+// verdict for every name in the table. They previously shared only a map literal, which is how
+// the credential rule could be added to one definition of "sensitive" (telemetry redaction) and
+// not to this one. This test fails if any future change filters one path but not the others.
+func TestProviderResponseExtractors_AgreeOnSensitiveHeaders(t *testing.T) {
+	fastResp := &fasthttp.Response{}
+	httpResp := &http.Response{Header: http.Header{}}
+	for _, tc := range providerResponseSensitiveHeaderCases {
+		fastResp.Header.Set(tc.name, tc.value)
+		httpResp.Header.Set(tc.name, tc.value)
+	}
+
+	standard := ExtractProviderResponseHeaders(fastResp)
+	passthrough := ExtractPassthroughProviderResponseHeaders(fastResp)
+	fromHTTP := ExtractProviderResponseHeadersFromHTTP(httpResp)
+
+	for _, tc := range providerResponseSensitiveHeaderCases {
+		_, inStandard := lookupHeaderFold(standard, tc.name)
+		_, inPassthrough := lookupHeaderFold(passthrough, tc.name)
+		_, inFromHTTP := lookupHeaderFold(fromHTTP, tc.name)
+		if inStandard != inPassthrough || inStandard != inFromHTTP {
+			t.Errorf("extractors disagree on %q (%s): standard=%v passthrough=%v fromHTTP=%v",
+				tc.name, tc.why, inStandard, inPassthrough, inFromHTTP)
+		}
+	}
+}
+
 func TestStripThoughtSignature(t *testing.T) {
 	cases := []struct {
 		name string


### PR DESCRIPTION
## Summary

Fixes #7120.

The three provider-response extractors filter only against `providerResponseFilterHeaders`, a fixed map of 28 exact names. Any header outside that map is re-served to the inference caller in both the HTTP response header and `extra_fields.provider_response_headers`.

The same package already imports `schemas.IsSensitiveHeader`, which recognizes credential-bearing names by substring and suffix, and whose doc comment says it exists so callers that "bypass the transport-layer security denylist" are still protected. The response path never called it, so the two disagreed:

```go
schemas.IsSensitiveHeader("x-provider-secret")      // true
providerResponseFilterHeaders["x-provider-secret"]  // false -> forwarded to the client
```

This matters because a fixed list cannot enumerate the space. `network_config.extra_headers` exists to carry custom authentication headers (#85), and some upstreams echo request headers back, which is the scenario the #3954 regression test already names for Google's file-download 302. #3955 closed that report by adding three exact names; every other credential name stayed open. #6371 later taught `IsSensitiveHeader` about `cf-access-*` and `x-amzn-oidc-*` for the connector-export path, without this path picking up the benefit.

## Changes

- Added `shouldFilterProviderResponseHeader(nameLower string) bool` in `core/providers/utils/utils.go`, which ORs the existing denylist with `schemas.IsSensitiveHeader`.
- Routed all three extractors through it: `ExtractProviderResponseHeaders`, `ExtractPassthroughProviderResponseHeaders`, and `ExtractProviderResponseHeadersFromHTTP`.
- Added tests, including one that pins all three extractors to the same verdict.

Design notes:

- **One predicate rather than three copies of `||`.** The three extractors previously shared only a map literal. That is precisely how the credential rule could be added to one definition of "sensitive" (telemetry redaction) and not to this one. `TestProviderResponseExtractors_AgreeOnSensitiveHeaders` now fails if any future change filters one path but not the others.
- **The passthrough `content-type` carve-out is untouched.** `content-type` is not credential-bearing, so `IsSensitiveHeader` returns false for it and its verdict is unchanged. The existing `TestExtractPassthroughProviderResponseHeaders` passes unmodified, and the new passthrough test re-asserts the carve-out explicitly.
- **Drop, not redact.** Consistent with how the existing denylist behaves.
- **Request path untouched.** `SetExtraHeaders` is not modified; providers still receive their configured headers. The E2E below asserts this 5/5 so the fix cannot be mistaken for breaking provider auth.

## Type of change

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore/CI

## Affected areas

- [x] Core (Go)
- [ ] Framework
- [x] Transports (HTTP)
- [ ] Plugins
- [ ] UI (React)
- [ ] Docs

## How to test

```sh
go test ./core/providers/utils/ -run 'TestExtract|TestProviderResponse' -v
```

Five new tests, all passing:

| Test | What it pins |
|---|---|
| `TestProviderResponseSensitiveHeaderCases_MatchClassifier` | the shared table itself, so a typo cannot silently weaken the others |
| `TestExtractProviderResponseHeaders_StripsSensitiveCustomHeaders` | fasthttp extractor |
| `TestExtractPassthroughProviderResponseHeaders_StripsSensitiveCustomHeaders` | passthrough extractor plus the `content-type` carve-out |
| `TestExtractProviderResponseHeadersFromHTTP_StripsSensitiveCustomHeaders` | net/http extractor |
| `TestProviderResponseExtractors_AgreeOnSensitiveHeaders` | the three cannot drift apart again |

The shared table covers seven credential names the old filter forwarded (`X-Provider-Secret`, `X-Auth-Token`, `X-Session_Token`, `X-Custom-Api-Key`, `X-Proxy-Authorization-Hint`, `Cf-Access-Jwt-Assertion`, `X-Amzn-Oidc-Data`), two the old filter already dropped (`X-Goog-Api-Key`, `Authorization`), and three benign headers that must survive (`X-Request-Id`, `Retry-After`, `X-Ratelimit-Remaining-Requests`).

**Negative check.** With the predicate body reverted to pre-fix behaviour, the new tests fail on all three extractors for all seven names, so they are not vacuous:

```text
--- FAIL: TestExtractProviderResponseHeaders_StripsSensitiveCustomHeaders
    ExtractProviderResponseHeaders: header "X-Provider-Secret" (contains "secret") leaked to the client with value "provider-secret-value"
    ExtractProviderResponseHeaders: header "X-Auth-Token" (suffix "-token") leaked to the client with value "auth-token-value"
    ... 5 more, and the same set for the passthrough and net/http extractors
```

**Existing tests.** `TestExtractProviderResponseHeaders_StripsProviderSecrets` and `TestExtractPassthroughProviderResponseHeaders` pass unmodified.

**Full core suite.** `go test ./...` under `core/` is green except `core/internal/mcptests`, which fails identically on unmodified `dev` in this environment because the MCP test-server binary is not built (`make setup-mcp-tests`). Unrelated to this change; confirmed by stashing the patch and re-running.

### End-to-end against the real gateway

Built `transports/bifrost-http` from this branch, configured a custom OpenAI-compatible provider with `network_config.extra_headers`, a loopback upstream that reflects them, `enforce_auth_on_inference=true`, and a provider-scoped virtual key. 5 trials:

```json
{
  "runs": 5,
  "http_200": 5,
  "secret_absent_from_header": 5,
  "secret_absent_from_json_metadata": 5,
  "secret_absent_from_whole_exchange": 5,
  "authorization_still_stripped": 5,
  "benign_header_still_forwarded_in_header": 5,
  "benign_header_still_forwarded_in_json": 5,
  "secret_still_reached_upstream_request": 5
}
```

Client response after the fix:

```text
HTTP/1.1 200 OK
X-Safe-Trace: CANARY_SAFE_TRACE_077
X-Bifrost-Provider: mockoai

"provider_response_headers": { "X-Safe-Trace": "CANARY_SAFE_TRACE_077" }
```

Before the fix, the same request returned `X-Provider-Secret: CANARY_ADMIN_ONLY_PROVIDER_SECRET_077` in both locations. The last row above matters as much as the first: the provider still receives its configured header, so provider authentication is not broken by the fix.

The harness and raw wire bytes for the pre-fix behaviour are at https://github.com/Atharva-Kanherkar/kairo/tree/issue/077-bifrost-custom-response-header-secret-leak/transcripts/077. All values are synthetic canaries; no real credential was used.

## Screenshots/Recordings

N/A, no UI change.

## Breaking changes

- [ ] Yes
- [x] No

Behaviour changes only for response headers whose names `IsSensitiveHeader` already classifies as credentials. If a deployment depends on reading such a header from a provider response, it would stop seeing it. That is the intent, and it matches the stated contract of the existing `TestExtractProviderResponseHeaders_StripsProviderSecrets`. Worth a changelog line; happy to add one if you would like it in this PR.

## Related issues

Fixes #7120. Completes the remediation started in #3955 for #3954. Related: #6371 (extended the classifier), #5509 (independently notes provider response headers may carry credentials), #1666 (introduced response-header forwarding), #85 (introduced `extra_headers`).

## Security considerations

Closes a credential-disclosure path from provider responses to inference callers. Severity is bounded: it needs the upstream or an intermediate proxy to reflect the configured header, and the recipient already holds a virtual key for that provider, so the escalation is use of the credential outside Bifrost's budgets, rate limits, and audit log rather than first access. The realistic population is self-hosted OpenAI-compatible servers, chained gateways, and reverse proxies with header passthrough.

The virtual key is an inference-only credential by design: `APIMiddleware` is built with `allowVirtualKeyAuth=false`, and the comment at `middlewares.go:1080` notes admin-password auth "stays exclusive to dashboard/API routes" since "a VK is not an admin/session credential". With `governance.auth_config.is_enabled=true` I confirmed 5/5 that the same key which received the secret at `POST /v1/responses` is refused `401` at `GET /api/providers`.

No new secrets, auth mechanisms, or config surface are introduced.

## Checklist

- [x] I read `docs/contributing/README.md` and followed the guidelines
- [x] I added/updated tests where appropriate
- [ ] I updated documentation where needed (no doc surface changes; happy to add a changelog entry on request)
- [x] I verified builds succeed (Go; no UI change)
- [x] I verified the CI pipeline passes locally if applicable
